### PR TITLE
feat(org): add asset access toggle

### DIFF
--- a/api/pkg/org/application/assets/assets.go
+++ b/api/pkg/org/application/assets/assets.go
@@ -139,6 +139,7 @@ type UpdateServerParams struct {
 	Name           *string
 	Description    *string
 	NotesForAgents *string
+	Enabled        *bool
 	Address        *string
 	Port           *uint16
 	User           *string
@@ -165,6 +166,9 @@ func (s *Service) UpdateServer(ctx context.Context, orgID string, id asset.ID, p
 	}
 	if p.NotesForAgents != nil {
 		a.NotesForAgents = strings.TrimSpace(*p.NotesForAgents)
+	}
+	if p.Enabled != nil {
+		a.Disabled = !*p.Enabled
 	}
 	if p.Address != nil {
 		address := strings.TrimSpace(*p.Address)
@@ -364,7 +368,14 @@ func (s *Service) Authorize(ctx context.Context, orgID, agentID string, assetID 
 		}
 		return asset.Asset{}, err
 	}
-	return s.assets.Get(ctx, orgID, assetID)
+	a, err := s.assets.Get(ctx, orgID, assetID)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	if a.Disabled {
+		return asset.Asset{}, fmt.Errorf("asset %q is disabled", a.Name)
+	}
+	return a, nil
 }
 
 func (s *Service) AuthorizeRef(ctx context.Context, orgID, agentID, idOrName string) (asset.Asset, error) {

--- a/api/pkg/org/application/assets/assets_test.go
+++ b/api/pkg/org/application/assets/assets_test.go
@@ -2,6 +2,7 @@ package assets
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +41,7 @@ func TestCreateServerEncryptsPrivateKey(t *testing.T) {
 	require.Equal(t, uint16(22), a.Config.Server.Port)
 	require.Equal(t, "ssh-ed25519 public", a.Config.Server.PublicKey)
 	require.Equal(t, "encrypted-private", a.Config.Server.EncryptedPrivateKey)
+	require.False(t, a.Disabled)
 }
 
 func TestLinkDerivesAndRevokesServerTools(t *testing.T) {
@@ -62,4 +64,36 @@ func TestLinkDerivesAndRevokesServerTools(t *testing.T) {
 	for _, name := range ServerTools {
 		require.NotContains(t, bot.Tools, name)
 	}
+}
+
+func TestAuthorizeRequiresLinkAndEnabledAsset(t *testing.T) {
+	svc, _, orgID := newTestService(t)
+	ctx := context.Background()
+	a, err := svc.CreateServer(ctx, orgID, CreateServerParams{
+		Name: "production", Address: "10.0.0.8", User: "ubuntu",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.Authorize(ctx, orgID, "b-agent", a.ID)
+	require.ErrorContains(t, err, "not linked")
+
+	_, err = svc.Link(ctx, orgID, a.ID, "b-agent")
+	require.NoError(t, err)
+	enabled := false
+	a, err = svc.UpdateServer(ctx, orgID, a.ID, UpdateServerParams{Enabled: &enabled})
+	require.NoError(t, err)
+	require.True(t, a.Disabled)
+
+	linked, err := svc.ListForAgent(ctx, orgID, "b-agent")
+	require.NoError(t, err)
+	require.Len(t, linked, 1)
+	_, err = svc.AuthorizeRef(ctx, orgID, "b-agent", "production")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "asset \"production\" is disabled"), err.Error())
+
+	enabled = true
+	_, err = svc.UpdateServer(ctx, orgID, a.ID, UpdateServerParams{Enabled: &enabled})
+	require.NoError(t, err)
+	_, err = svc.AuthorizeRef(ctx, orgID, "b-agent", "production")
+	require.NoError(t, err)
 }

--- a/api/pkg/org/domain/asset/asset.go
+++ b/api/pkg/org/domain/asset/asset.go
@@ -43,6 +43,7 @@ type Asset struct {
 	Name           string    `json:"name" gorm:"not null;uniqueIndex:idx_asset_org_name,priority:2"`
 	Description    string    `json:"description,omitempty" gorm:"not null;default:''"`
 	NotesForAgents string    `json:"notes_for_agents,omitempty" gorm:"not null;default:''"`
+	Disabled       bool      `json:"disabled" gorm:"not null;default:false"`
 	Kind           Kind      `json:"kind" gorm:"not null;index"`
 	Config         Config    `json:"config" gorm:"serializer:json;type:jsonb;not null"`
 	CreatedAt      time.Time `json:"created_at"`

--- a/api/pkg/org/infrastructure/assetssh/client.go
+++ b/api/pkg/org/infrastructure/assetssh/client.go
@@ -141,6 +141,10 @@ func (c *Client) Health(ctx context.Context, orgID, idOrName string) Health {
 		h.Error = err.Error()
 		return h
 	}
+	if a.Disabled {
+		h.Error = fmt.Sprintf("asset %q is disabled", a.Name)
+		return h
+	}
 	server, err := serverConfig(a)
 	if err != nil {
 		h.Error = err.Error()

--- a/api/pkg/org/infrastructure/assetssh/client_test.go
+++ b/api/pkg/org/infrastructure/assetssh/client_test.go
@@ -1,10 +1,24 @@
 package assetssh
 
 import (
+	"context"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/org/domain/asset"
 	"github.com/stretchr/testify/require"
 )
+
+type healthAssets struct{ value asset.Asset }
+
+func (a healthAssets) Resolve(context.Context, string, string) (asset.Asset, error) {
+	return a.value, nil
+}
+
+func (a healthAssets) AuthorizeRef(context.Context, string, string, string) (asset.Asset, error) {
+	return a.value, nil
+}
+
+func (healthAssets) PinHostKey(context.Context, string, asset.ID, string) error { return nil }
 
 func TestBuildRemoteCommandQuotesEveryValue(t *testing.T) {
 	got, err := buildRemoteCommand(RunRequest{
@@ -26,4 +40,24 @@ func TestBuildRemoteCommandRejectsInvalidEnvironmentName(t *testing.T) {
 func TestBuildRemoteCommandRejectsRelativeWorkingDirectory(t *testing.T) {
 	_, err := buildRemoteCommand(RunRequest{Cmd: "echo", Cwd: "tmp"})
 	require.EqualError(t, err, "invalid server command cwd: path must be absolute and contain no NUL")
+}
+
+func TestHealthDoesNotConnectToDisabledAsset(t *testing.T) {
+	assets := healthAssets{value: asset.Asset{
+		ID: "a-disabled", OrganizationID: "org-1", Name: "disabled-server", Disabled: true,
+		Kind: asset.KindServer, Config: asset.Config{Server: &asset.Server{
+			Address: "192.0.2.1", Port: 22, User: "root", AuthType: asset.AuthPassword,
+			EncryptedPassword: "secret",
+		}},
+	}}
+	client, err := New(assets, func(string) ([]byte, error) {
+		t.Fatal("disabled asset credentials must not be decrypted")
+		return nil, nil
+	}, func() string { return "command" })
+	require.NoError(t, err)
+
+	health := client.Health(context.Background(), "org-1", "disabled-server")
+	require.Equal(t, `asset "disabled-server" is disabled`, health.Error)
+	require.False(t, health.TCPReachable)
+	require.False(t, health.SSHReachable)
 }

--- a/api/pkg/org/infrastructure/assetssh/proxy_test.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy_test.go
@@ -31,12 +31,20 @@ func (p *proxyAssets) AuthorizeRef(_ context.Context, orgID, agentID, ref string
 	if !p.allowed || orgID != p.value.OrganizationID || agentID != "agent-1" || (ref != p.value.ID && ref != p.value.Name) {
 		return asset.Asset{}, errors.New("asset is not linked to agent")
 	}
+	if p.value.Disabled {
+		return asset.Asset{}, errors.New("asset is disabled")
+	}
 	return p.value, nil
 }
 func (*proxyAssets) PinHostKey(context.Context, string, asset.ID, string) error { return nil }
 func (p *proxyAssets) setAllowed(value bool) {
 	p.mu.Lock()
 	p.allowed = value
+	p.mu.Unlock()
+}
+func (p *proxyAssets) setDisabled(value bool) {
+	p.mu.Lock()
+	p.value.Disabled = value
 	p.mu.Unlock()
 }
 
@@ -92,6 +100,14 @@ func TestProxyCertificateEnforcesAgentLinkAndAssetUsername(t *testing.T) {
 	}
 	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "staging"}, cert); err == nil {
 		t.Fatal("certificate accepted for a different asset username")
+	}
+	assets.setDisabled(true)
+	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "production"}, cert); err == nil {
+		t.Fatal("certificate remained usable after the asset was disabled")
+	}
+	assets.setDisabled(false)
+	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "production"}, cert); err != nil {
+		t.Fatalf("certificate did not become usable after the asset was re-enabled: %v", err)
 	}
 	assets.setAllowed(false)
 	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "production"}, cert); err == nil {

--- a/api/pkg/org/interfaces/mcptools/assets.go
+++ b/api/pkg/org/interfaces/mcptools/assets.go
@@ -34,6 +34,7 @@ type assetView struct {
 	Name           string           `json:"name"`
 	Description    string           `json:"description,omitempty"`
 	NotesForAgents string           `json:"notes_for_agents,omitempty"`
+	Enabled        bool             `json:"enabled"`
 	Kind           asset.Kind       `json:"kind"`
 	Server         *assetServerView `json:"server,omitempty"`
 }
@@ -55,18 +56,25 @@ type assetSSHAccessView struct {
 }
 
 func viewAsset(a asset.Asset) assetView {
-	view := assetView{ID: a.ID, Name: a.Name, Description: a.Description, NotesForAgents: a.NotesForAgents, Kind: a.Kind}
+	view := assetView{ID: a.ID, Name: a.Name, Description: a.Description, NotesForAgents: a.NotesForAgents, Enabled: !a.Disabled, Kind: a.Kind}
 	if a.Config.Server != nil {
+		capabilities := []string{
+			"run_commands", "manage_detached_commands", "read_write_files", "ssh_via_helix_proxy",
+		}
+		sshAccess := assetSSHAccessView{
+			Available: true, Tool: string(ServerSSHAccessName), Target: a.Name + "@<helix-ssh-proxy>",
+			Instructions: "Call server_ssh_access to mint a short-lived identity and receive the exact SSH setup command.",
+		}
+		if a.Disabled {
+			capabilities = nil
+			sshAccess.Available = false
+			sshAccess.Instructions = "This asset is disabled. An organization owner must enable it before agents can use MCP or SSH access."
+		}
 		view.Server = &assetServerView{
 			Address: a.Config.Server.Address, Port: a.Config.Server.Port,
 			User: a.Config.Server.User, AuthType: a.Config.Server.AuthType,
-			Capabilities: []string{
-				"run_commands", "manage_detached_commands", "read_write_files", "ssh_via_helix_proxy",
-			},
-			SSHAccess: assetSSHAccessView{
-				Available: true, Tool: string(ServerSSHAccessName), Target: a.Name + "@<helix-ssh-proxy>",
-				Instructions: "Call server_ssh_access to mint a short-lived identity and receive the exact SSH setup command.",
-			},
+			Capabilities: capabilities,
+			SSHAccess:    sshAccess,
 		}
 	}
 	return view
@@ -90,7 +98,7 @@ const ListAssetsName tool.Name = "list_assets"
 func (t *ListAssets) Name() tool.Name                 { return ListAssetsName }
 func (t *ListAssets) InputSchema() *jsonschema.Schema { return mustSchema[struct{}]() }
 func (t *ListAssets) Description() string {
-	return "List server assets linked to this agent, including connection coordinates, operator notes, command/file capabilities, and SSH proxy guidance."
+	return "List server assets linked to this agent, including enabled or disabled status, connection coordinates, operator notes, command/file capabilities, and SSH proxy guidance."
 }
 func (t *ListAssets) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	orgID, agentID, err := assetCaller(inv, ListAssetsName)

--- a/api/pkg/org/interfaces/mcptools/assets_test.go
+++ b/api/pkg/org/interfaces/mcptools/assets_test.go
@@ -76,6 +76,9 @@ func TestAssetDiscoveryOnlyReturnsLinkedAssetsAndAgentNotes(t *testing.T) {
 	if strings.Contains(string(raw), "encrypted") {
 		t.Fatalf("encrypted credential leaked through list_assets: %s", raw)
 	}
+	if !listed.Assets[0].Enabled {
+		t.Fatalf("new asset unexpectedly disabled: %s", raw)
+	}
 
 	raw, err = (&GetAsset{deps: deps}).Invoke(ctx, tool.Invocation{Caller: caller, Args: json.RawMessage(`{"asset":"production"}`)})
 	if err != nil {
@@ -83,6 +86,25 @@ func TestAssetDiscoveryOnlyReturnsLinkedAssetsAndAgentNotes(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"name":"production"`) {
 		t.Fatalf("get_asset did not resolve by name: %s", raw)
+	}
+
+	enabled := false
+	if _, err := svc.UpdateServer(ctx, "org-1", a.ID, assetapp.UpdateServerParams{Enabled: &enabled}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = (&ListAssets{deps: deps}).Invoke(ctx, tool.Invocation{Caller: caller, Args: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &listed); err != nil {
+		t.Fatal(err)
+	}
+	if listed.Assets[0].Enabled || listed.Assets[0].Server.SSHAccess.Available || len(listed.Assets[0].Server.Capabilities) != 0 {
+		t.Fatalf("disabled asset advertised as usable: %s", raw)
+	}
+	_, err = (&GetAsset{deps: deps}).Invoke(ctx, tool.Invocation{Caller: caller, Args: json.RawMessage(`{"asset":"production"}`)})
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("disabled asset remained callable: %v", err)
 	}
 
 	_, err = (&GetAsset{deps: deps}).Invoke(ctx, tool.Invocation{

--- a/api/pkg/org/interfaces/mcptools/manage_assets.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets.go
@@ -35,6 +35,7 @@ type managedAssetView struct {
 	Name           string             `json:"name"`
 	Description    string             `json:"description,omitempty"`
 	NotesForAgents string             `json:"notes_for_agents,omitempty"`
+	Enabled        bool               `json:"enabled"`
 	Kind           asset.Kind         `json:"kind"`
 	Server         *managedServerView `json:"server,omitempty"`
 	AgentIDs       []string           `json:"agent_ids"`
@@ -103,7 +104,7 @@ func managedAsset(t Deps, ctx context.Context, orgID string, value asset.Asset) 
 	view := managedAssetView{
 		ID: value.ID, OrganizationID: orgID, Name: value.Name,
 		Description: value.Description, NotesForAgents: value.NotesForAgents,
-		Kind: value.Kind, AgentIDs: agentIDs,
+		Enabled: !value.Disabled, Kind: value.Kind, AgentIDs: agentIDs,
 		CreatedAt: value.CreatedAt, UpdatedAt: value.UpdatedAt,
 	}
 	if value.Config.Server != nil {
@@ -296,6 +297,7 @@ type updateServerAssetArgs struct {
 	Name           *string         `json:"name,omitempty"`
 	Description    *string         `json:"description,omitempty"`
 	NotesForAgents *string         `json:"notes_for_agents,omitempty"`
+	Enabled        *bool           `json:"enabled,omitempty"`
 	Address        *string         `json:"address,omitempty"`
 	Port           *uint16         `json:"port,omitempty"`
 	User           *string         `json:"user,omitempty"`
@@ -309,7 +311,7 @@ func (t *UpdateServerAsset) InputSchema() *jsonschema.Schema {
 	return mustSchema[updateServerAssetArgs]()
 }
 func (t *UpdateServerAsset) Description() string {
-	return "Patch a server asset by ID or name. Only supplied fields change. Switching to ssh_key generates a new key and returns its install_command; switching to password requires password."
+	return "Patch a server asset by ID or name. Only supplied fields change. Set enabled=false to block agent MCP and proxy SSH access without removing agent links. Switching to ssh_key generates a new key and returns its install_command; switching to password requires password."
 }
 func (t *UpdateServerAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	var args updateServerAssetArgs
@@ -326,6 +328,7 @@ func (t *UpdateServerAsset) Invoke(ctx context.Context, inv tool.Invocation) (js
 	}
 	value, err := t.deps.Assets.UpdateServer(ctx, orgID, current.ID, assetapp.UpdateServerParams{
 		Name: args.Name, Description: args.Description, NotesForAgents: args.NotesForAgents,
+		Enabled: args.Enabled,
 		Address: args.Address, Port: args.Port, User: args.User, AuthType: args.AuthType,
 		Password: args.Password, HostKey: args.HostKey,
 	})

--- a/api/pkg/org/interfaces/mcptools/manage_assets_test.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets_test.go
@@ -101,6 +101,25 @@ func TestChiefOfStaffManagesServerAssetLifecycle(t *testing.T) {
 	assert.Equal(t, "Primary production API", updated.Asset.Description)
 	require.NotNil(t, updated.Asset.Server)
 	assert.Equal(t, "10.0.0.9", updated.Asset.Server.Address)
+	assert.True(t, updated.Asset.Enabled)
+
+	raw = invokeManagedAssetTool(t, &UpdateServerAsset{deps: deps}, caller,
+		`{"asset":"production","enabled":false}`)
+	require.NoError(t, json.Unmarshal(raw, &updated))
+	assert.False(t, updated.Asset.Enabled)
+	linkedAssets, err := service.ListForAgent(ctx, "org-1", "chief-of-staff")
+	require.NoError(t, err)
+	require.Len(t, linkedAssets, 1)
+	_, err = service.AuthorizeRef(ctx, "org-1", "chief-of-staff", "production")
+	require.ErrorContains(t, err, "disabled")
+
+	// Exercise the immediately following normal operation: re-enable the asset
+	// and verify that the existing link becomes usable again.
+	raw = invokeManagedAssetTool(t, &UpdateServerAsset{deps: deps}, caller,
+		`{"asset":"production","enabled":true}`)
+	require.NoError(t, json.Unmarshal(raw, &updated))
+	_, err = service.AuthorizeRef(ctx, "org-1", "chief-of-staff", "production")
+	require.NoError(t, err)
 
 	raw = invokeManagedAssetTool(t, &GetAssetHealth{deps: deps}, caller,
 		`{"asset":"production"}`)

--- a/api/pkg/org/interfaces/server/api/assets.go
+++ b/api/pkg/org/interfaces/server/api/assets.go
@@ -30,6 +30,7 @@ type AssetDTO struct {
 	Name           string          `json:"name"`
 	Description    string          `json:"description,omitempty"`
 	NotesForAgents string          `json:"notes_for_agents,omitempty"`
+	Enabled        bool            `json:"enabled"`
 	Kind           asset.Kind      `json:"kind"`
 	Server         *ServerAssetDTO `json:"server,omitempty"`
 	AgentIDs       []string        `json:"agent_ids"`
@@ -71,6 +72,7 @@ type UpdateAssetRequest struct {
 	Name           *string                   `json:"name,omitempty"`
 	Description    *string                   `json:"description,omitempty"`
 	NotesForAgents *string                   `json:"notes_for_agents,omitempty"`
+	Enabled        *bool                     `json:"enabled,omitempty"`
 	Server         *UpdateServerAssetRequest `json:"server,omitempty"`
 }
 
@@ -113,7 +115,7 @@ func (a *apiHandler) assetDTO(ctxOrg string, value asset.Asset, agentIDs []strin
 	dto := AssetDTO{
 		ID: value.ID, OrganizationID: ctxOrg, Name: value.Name,
 		Description: value.Description, NotesForAgents: value.NotesForAgents,
-		Kind: value.Kind, AgentIDs: agentIDs, CreatedAt: value.CreatedAt, UpdatedAt: value.UpdatedAt,
+		Enabled: !value.Disabled, Kind: value.Kind, AgentIDs: agentIDs, CreatedAt: value.CreatedAt, UpdatedAt: value.UpdatedAt,
 	}
 	if value.Config.Server != nil {
 		s := value.Config.Server
@@ -258,7 +260,7 @@ func (a *apiHandler) updateAsset(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	params := assetapp.UpdateServerParams{Name: req.Name, Description: req.Description, NotesForAgents: req.NotesForAgents}
+	params := assetapp.UpdateServerParams{Name: req.Name, Description: req.Description, NotesForAgents: req.NotesForAgents, Enabled: req.Enabled}
 	if req.Server != nil {
 		params.Address = req.Server.Address
 		params.Port = req.Server.Port

--- a/api/pkg/org/interfaces/server/api/assets_test.go
+++ b/api/pkg/org/interfaces/server/api/assets_test.go
@@ -32,6 +32,7 @@ func TestAssetsAPIKeyAuthCreateUpdateAndSecretRedaction(t *testing.T) {
 	require.Equal(t, "a-test-id", dto.ID)
 	require.Equal(t, "ssh-ed25519 public-key", dto.Server.PublicKey)
 	require.Equal(t, "Do not restart during deploys.", dto.NotesForAgents)
+	require.True(t, dto.Enabled)
 
 	address := "prod.internal"
 	port := uint16(2222)
@@ -45,6 +46,12 @@ func TestAssetsAPIKeyAuthCreateUpdateAndSecretRedaction(t *testing.T) {
 	require.Equal(t, "prod.internal", dto.Server.Address)
 	require.Equal(t, uint16(2222), dto.Server.Port)
 	require.Equal(t, notes, dto.NotesForAgents)
+
+	enabled := false
+	disabled := do(t, h, http.MethodPatch, "/assets/"+dto.ID, orgapi.UpdateAssetRequest{Enabled: &enabled})
+	require.Equal(t, http.StatusOK, disabled.Code, disabled.Body.String())
+	decode(t, disabled, &dto)
+	require.False(t, dto.Enabled)
 
 	listed := do(t, h, http.MethodGet, "/assets", nil)
 	require.Equal(t, http.StatusOK, listed.Code, listed.Body.String())

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -22879,6 +22879,9 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -23825,6 +23828,9 @@ const docTemplate = `{
             "properties": {
                 "description": {
                     "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -22875,6 +22875,9 @@
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -23821,6 +23824,9 @@
             "properties": {
                 "description": {
                     "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -98,6 +98,8 @@ definitions:
         type: string
       description:
         type: string
+      enabled:
+        type: boolean
       id:
         type: string
       kind:
@@ -784,6 +786,8 @@ definitions:
     properties:
       description:
         type: string
+      enabled:
+        type: boolean
       name:
         type: string
       notes_for_agents:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -73,6 +73,7 @@ export interface ApiAssetDTO {
   agent_ids?: string[];
   created_at?: string;
   description?: string;
+  enabled?: boolean;
   id?: string;
   kind?: AssetKind;
   name?: string;
@@ -523,6 +524,7 @@ export interface ApiTransportRequestField {
 
 export interface ApiUpdateAssetRequest {
   description?: string;
+  enabled?: boolean;
   name?: string;
   notes_for_agents?: string;
   server?: ApiUpdateServerAssetRequest;

--- a/frontend/src/components/helix-org/AssetConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/AssetConfigDrawer.tsx
@@ -10,7 +10,9 @@ import ListItemText from '@mui/material/ListItemText'
 import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined'
@@ -85,6 +87,7 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
   const [form, setForm] = useState<AssetForm>(emptyForm)
   const [savedForm, setSavedForm] = useState<AssetForm | null>(null)
   const [created, setCreated] = useState<AssetDTO | null>(null)
+  const [enabled, setEnabled] = useState(true)
   const isEdit = Boolean(asset)
 
   useEffect(() => {
@@ -93,6 +96,7 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
     setForm(next)
     setSavedForm(asset ? next : null)
     setCreated(null)
+    setEnabled(asset?.enabled !== false)
   }, [asset, open])
 
   const dirty = !isEdit || !savedForm || JSON.stringify(form) !== JSON.stringify(savedForm)
@@ -106,12 +110,13 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
 
   const currentPublicKey = created?.server?.public_key ?? asset?.server?.public_key
   const healthStatus = useMemo(() => {
+    if (!enabled) return <Chip label="Disabled" color="default" size="small" />
     if (!isEdit) return null
     const reachable = Boolean(health?.tcp_reachable && health?.ssh_reachable)
     return (
       <Chip label={reachable ? 'Connected' : 'Connection degraded'} color={reachable ? 'success' : 'warning'} size="small" />
     )
-  }, [health, isEdit])
+  }, [enabled, health, isEdit])
 
   const submit = async () => {
     if (!canSubmit) {
@@ -134,6 +139,7 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
           notes_for_agents: form.notes.trim(),
         })
         setCreated(value)
+        setEnabled(value.enabled !== false)
         if (value.id) onCreated?.(value.id)
         snackbar.success(`Added asset ${value.name}`)
         return
@@ -173,6 +179,20 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
     snackbar.success('Public key copied')
   }
 
+  const toggleEnabled = async (nextEnabled: boolean) => {
+    const current = created ?? asset
+    if (!current?.id) return
+    setEnabled(nextEnabled)
+    try {
+      const updated = await updateAsset.mutateAsync({ id: current.id, enabled: nextEnabled })
+      if (created) setCreated(updated)
+      snackbar.success(`${current.name ?? current.id} ${nextEnabled ? 'enabled' : 'disabled'}`)
+    } catch (err: any) {
+      setEnabled(!nextEnabled)
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'Could not update asset access')
+    }
+  }
+
   return (
     <HelixOrgSideDrawer
       open={open}
@@ -186,7 +206,43 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
           id={created?.id || asset?.id || 'new asset'}
           idAction={(created?.id || asset?.id) ? <CopyButtonWithCheck text={(created?.id || asset?.id) ?? ''} /> : undefined}
           icon={<DnsOutlinedIcon sx={{ fontSize: 20 }} />}
-          status={healthStatus ?? <Chip label="Server" size="small" sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)', border: '1px solid rgba(255,255,255,0.22)' }} />}
+          status={(
+            <Stack direction="row" spacing={0.75} alignItems="center">
+              {healthStatus ?? <Chip label="Server" size="small" sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)', border: '1px solid rgba(255,255,255,0.22)' }} />}
+              {(created || asset) && (
+                <Tooltip
+                  arrow
+                  placement="bottom-end"
+                  title={(
+                    <Box sx={{ maxWidth: 280, py: 0.25 }}>
+                      <Typography variant="subtitle2" color="inherit">
+                        {enabled ? 'Disable asset access' : 'Enable asset access'}
+                      </Typography>
+                      <Typography variant="caption" color="inherit" sx={{ display: 'block', mt: 0.25, opacity: 0.85 }}>
+                        {enabled
+                          ? 'Blocks agents from using this asset through MCP or proxy SSH. Agent assignments stay connected.'
+                          : 'Allows assigned agents to use this asset through MCP and proxy SSH again.'}
+                      </Typography>
+                    </Box>
+                  )}
+                >
+                  <span>
+                    <Switch
+                      size="small"
+                      checked={enabled}
+                      disabled={updateAsset.isPending}
+                      onChange={(event) => void toggleEnabled(event.target.checked)}
+                      inputProps={{ 'aria-label': enabled ? 'Disable asset access' : 'Enable asset access' }}
+                      sx={{
+                        '& .MuiSwitch-switchBase.Mui-checked': { color: 'common.white' },
+                        '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': { backgroundColor: 'common.white' },
+                      }}
+                    />
+                  </span>
+                </Tooltip>
+              )}
+            </Stack>
+          )}
         >
           {(created || asset) && <Chip label={`${form.agentIDs.length} allowed agents`} size="small" sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)' }} />}
         </HelixOrgOverviewCard>

--- a/frontend/src/components/widgets/SimpleTable.tsx
+++ b/frontend/src/components/widgets/SimpleTable.tsx
@@ -32,6 +32,9 @@ const SimpleTable: FC<{
   onRowClick?: {
     (row: Record<string, any>): void,
   },
+  onRowContextMenu?: {
+    (event: React.MouseEvent<HTMLTableRowElement>, row: Record<string, any>): void,
+  },
   getActions?: {
     (row: Record<string, any>): JSX.Element,
   },
@@ -53,6 +56,7 @@ const SimpleTable: FC<{
   actionsFieldClassname,
   loading = false,
   onRowClick,
+  onRowContextMenu,
   getActions,
   getRowId,
 }) => {
@@ -110,6 +114,7 @@ const SimpleTable: FC<{
                 if(!onRowClick) return
                 onRowClick(dataRow)
               }}
+              onContextMenu={e => onRowContextMenu?.(e, dataRow)}
               tabIndex={-1}
               key={ i }
               id={ getRowId?.(dataRow) }

--- a/frontend/src/pages/HelixOrgAssets.tsx
+++ b/frontend/src/pages/HelixOrgAssets.tsx
@@ -9,8 +9,10 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import AddIcon from '@mui/icons-material/Add'
+import BlockOutlinedIcon from '@mui/icons-material/BlockOutlined'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 
 import AssetConfigDrawer from '../components/helix-org/AssetConfigDrawer'
@@ -27,6 +29,7 @@ import {
   useDeleteAsset,
   useListAssets,
   useListHelixOrgBots,
+  useUpdateAsset,
 } from '../services/helixOrgService'
 
 const AssetStatusBadge: FC<{ enabled: boolean; health?: AssetHealthDTO }> = ({ enabled, health }) => {
@@ -44,11 +47,13 @@ const HelixOrgAssets: FC = () => {
   const assetIDs = useMemo(() => assets.filter((asset) => asset.enabled !== false).map((asset) => asset.id ?? '').filter(Boolean), [assets])
   const health = useAssetHealth(assetIDs, { refetchInterval: 15000 })
   const deleteAsset = useDeleteAsset()
+  const updateAsset = useUpdateAsset()
 
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [editing, setEditing] = useState<AssetDTO>()
   const [deleting, setDeleting] = useState<AssetDTO>()
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [anchorPosition, setAnchorPosition] = useState<{ top: number; left: number }>()
   const [currentAsset, setCurrentAsset] = useState<AssetDTO>()
 
   const openCreate = () => {
@@ -63,13 +68,35 @@ const HelixOrgAssets: FC = () => {
 
   const openMenu = (event: MouseEvent<HTMLElement>, asset: AssetDTO) => {
     event.stopPropagation()
+    setAnchorPosition(undefined)
     setAnchorEl(event.currentTarget)
+    setCurrentAsset(asset)
+  }
+
+  const openContextMenu = (event: MouseEvent<HTMLTableRowElement>, asset: AssetDTO) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setAnchorEl(null)
+    setAnchorPosition({ top: event.clientY, left: event.clientX })
     setCurrentAsset(asset)
   }
 
   const closeMenu = () => {
     setAnchorEl(null)
+    setAnchorPosition(undefined)
     setCurrentAsset(undefined)
+  }
+
+  const toggleAssetAccess = async (asset: AssetDTO) => {
+    if (!asset.id) return
+    const enabled = asset.enabled === false
+    closeMenu()
+    try {
+      await updateAsset.mutateAsync({ id: asset.id, enabled })
+      snackbar.success(`${asset.name ?? asset.id} ${enabled ? 'enabled' : 'disabled'}`)
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'Could not update asset access')
+    }
   }
 
   const confirmDelete = async () => {
@@ -169,12 +196,19 @@ const HelixOrgAssets: FC = () => {
                 ]}
                 data={tableData}
                 getActions={getActions}
+                onRowContextMenu={(event, row) => openContextMenu(event, row._data as AssetDTO)}
               />
             )}
           </Stack>
         </Container>
 
-        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
+        <Menu
+          anchorEl={anchorEl}
+          anchorReference={anchorPosition ? 'anchorPosition' : 'anchorEl'}
+          anchorPosition={anchorPosition}
+          open={Boolean(anchorEl || anchorPosition)}
+          onClose={closeMenu}
+        >
           <MenuItem
             onClick={(event) => {
               event.stopPropagation()
@@ -183,8 +217,21 @@ const HelixOrgAssets: FC = () => {
               if (asset) openEdit(asset)
             }}
           >
-            <EditOutlinedIcon sx={{ mr: 1, fontSize: 20 }} />
-            Edit
+            <InfoOutlinedIcon sx={{ mr: 1, fontSize: 20 }} />
+            Details
+          </MenuItem>
+          <MenuItem
+            disabled={updateAsset.isPending}
+            onClick={(event) => {
+              event.stopPropagation()
+              const asset = currentAsset
+              if (asset) void toggleAssetAccess(asset)
+            }}
+          >
+            {currentAsset?.enabled === false
+              ? <CheckCircleOutlineIcon sx={{ mr: 1, fontSize: 20 }} />
+              : <BlockOutlinedIcon sx={{ mr: 1, fontSize: 20 }} />}
+            {currentAsset?.enabled === false ? 'Enable access' : 'Disable access'}
           </MenuItem>
           <MenuItem
             onClick={(event) => {

--- a/frontend/src/pages/HelixOrgAssets.tsx
+++ b/frontend/src/pages/HelixOrgAssets.tsx
@@ -29,7 +29,8 @@ import {
   useListHelixOrgBots,
 } from '../services/helixOrgService'
 
-const AssetStatusBadge: FC<{ health?: AssetHealthDTO }> = ({ health }) => {
+const AssetStatusBadge: FC<{ enabled: boolean; health?: AssetHealthDTO }> = ({ enabled, health }) => {
+  if (!enabled) return <Chip size="small" label="Disabled" color="default" />
   if (!health) return <Chip size="small" label="Checking" color="default" />
   if (health.tcp_reachable && health.ssh_reachable) return <Chip size="small" label="Connected" color="success" />
   return <Chip size="small" label="Connection degraded" color="warning" />
@@ -40,7 +41,7 @@ const HelixOrgAssets: FC = () => {
   const breadcrumbs = useHelixOrgBreadcrumbs()
   const { data: assets = [], isLoading } = useListAssets()
   const { data: agents = [] } = useListHelixOrgBots()
-  const assetIDs = useMemo(() => assets.map((asset) => asset.id ?? '').filter(Boolean), [assets])
+  const assetIDs = useMemo(() => assets.filter((asset) => asset.enabled !== false).map((asset) => asset.id ?? '').filter(Boolean), [assets])
   const health = useAssetHealth(assetIDs, { refetchInterval: 15000 })
   const deleteAsset = useDeleteAsset()
 
@@ -114,7 +115,7 @@ const HelixOrgAssets: FC = () => {
         {asset.server ? `${asset.server.user}@${asset.server.address}:${asset.server.port ?? 22}` : '—'}
       </Typography>
     ),
-    status: <AssetStatusBadge health={asset.id ? health[asset.id] : undefined} />,
+    status: <AssetStatusBadge enabled={asset.enabled !== false} health={asset.id ? health[asset.id] : undefined} />,
     agents: <Typography variant="body2" color="text.secondary">{asset.agent_ids?.length ?? 0}</Typography>,
     updated: (
       <Typography variant="body2" color="text.secondary">

--- a/frontend/src/pages/HelixOrgChart.refresh.test.ts
+++ b/frontend/src/pages/HelixOrgChart.refresh.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { Node } from '@xyflow/react'
+
+import { reconcileGraphNodes } from './HelixOrgChart'
+
+describe('org chart refresh reconciliation', () => {
+  it('preserves measured handle geometry while applying refreshed server data', () => {
+    const current: Node[] = [{
+      id: 'bot:report',
+      type: 'bot',
+      position: { x: 10, y: 20 },
+      measured: { width: 440, height: 192 },
+      selected: true,
+      data: { status: 'stopped' },
+    }]
+    const refreshed: Node[] = [{
+      id: 'bot:report',
+      type: 'bot',
+      position: { x: 30, y: 40 },
+      data: { status: 'running' },
+    }]
+
+    expect(reconcileGraphNodes(current, refreshed)).toEqual([{
+      ...refreshed[0],
+      measured: { width: 440, height: 192 },
+      selected: true,
+    }])
+  })
+
+  it('keeps the live position while a refresh lands during a drag', () => {
+    const current: Node[] = [{
+      id: 'bot:report',
+      position: { x: 55, y: 65 },
+      dragging: true,
+      data: {},
+    }]
+    const refreshed: Node[] = [{
+      id: 'bot:report',
+      position: { x: 10, y: 20 },
+      data: { status: 'running' },
+    }]
+
+    expect(reconcileGraphNodes(current, refreshed)[0]).toMatchObject({
+      position: { x: 55, y: 65 },
+      dragging: true,
+      data: { status: 'running' },
+    })
+  })
+})

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -56,7 +56,6 @@ import {
   useEdgesState,
   useNodesState,
   useReactFlow,
-  useUpdateNodeInternals,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 
@@ -349,6 +348,25 @@ const fallbackSizeForNode = (n: Node): { w: number; h: number } => {
     return { w: PROC_W, h: procNodeHeight(outs) }
   }
   return { w: BOT_W, h: BOT_H }
+}
+
+// Server refreshes replace the graph projection, but React Flow adds measured
+// node geometry to its controlled node objects after rendering. Dropping that
+// geometry clears the internal handle bounds, so every edge becomes
+// temporarily unresolvable. In a background tab the re-measure animation
+// frame may not run until much later, leaving the chart with no visible edges.
+export const reconcileGraphNodes = (current: Node[], computed: Node[]): Node[] => {
+  const currentByID = new Map(current.map((node) => [node.id, node]))
+  return computed.map((node) => {
+    const previous = currentByID.get(node.id)
+    if (!previous) return node
+    return {
+      ...node,
+      ...(previous.measured ? { measured: previous.measured } : {}),
+      ...(previous.selected !== undefined ? { selected: previous.selected } : {}),
+      ...(previous.dragging ? { position: previous.position, dragging: true } : {}),
+    }
+  })
 }
 
 // Invisible handles on all four sides so the user can still drag a
@@ -1755,7 +1773,6 @@ const ChartCanvas: FC<{
   // Canonical org id (not the URL slug) so a rename doesn't lose the camera.
   const orgId = account.organizationTools.organization?.id ?? ''
   const { fitView, screenToFlowPosition, setViewport } = useReactFlow()
-  const updateNodeInternals = useUpdateNodeInternals()
   // Apply camera once after the first graph build: restore this user's
   // saved pan/zoom for the org, or fitView when nothing is stored yet.
   // Node-drag persistence must not re-run this (would yank the camera).
@@ -1784,10 +1801,9 @@ const ChartCanvas: FC<{
   )
 
   useEffect(() => {
-    setNodes(computedNodes)
+    setNodes((current) => reconcileGraphNodes(current, computedNodes))
     setEdges(computedEdges)
     const nodeIds = computedNodes.map((node) => node.id)
-    requestAnimationFrame(() => updateNodeInternals(nodeIds))
     if (fitViewRequest !== fitViewRequestRef.current) {
       fitViewRequestRef.current = fitViewRequest
       requestAnimationFrame(() => fitView({ padding: 0.2, duration: 250 }))
@@ -1808,7 +1824,7 @@ const ChartCanvas: FC<{
         fitView({ padding: 0.2, duration: 250 })
       }
     })
-  }, [computedNodes, computedEdges, fitView, fitViewRequest, setViewport, setNodes, setEdges, updateNodeInternals, userId, orgId])
+  }, [computedNodes, computedEdges, fitView, fitViewRequest, setViewport, setNodes, setEdges, userId, orgId])
 
   // Personal camera: pan/zoom only — node layout is server-side shared.
   const onMoveEnd = useCallback(

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -98,6 +98,8 @@ definitions:
         type: string
       description:
         type: string
+      enabled:
+        type: boolean
       id:
         type: string
       kind:
@@ -784,6 +786,8 @@ definitions:
     properties:
       description:
         type: string
+      enabled:
+        type: boolean
       name:
         type: string
       notes_for_agents:

--- a/openapi.json
+++ b/openapi.json
@@ -27442,6 +27442,9 @@
                     "description": {
                         "type": "string"
                     },
+                    "enabled": {
+                        "type": "boolean"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -28388,6 +28391,9 @@
                 "properties": {
                     "description": {
                         "type": "string"
+                    },
+                    "enabled": {
+                        "type": "boolean"
                     },
                     "name": {
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -22875,6 +22875,9 @@
                 "description": {
                     "type": "string"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -23821,6 +23824,9 @@
             "properties": {
                 "description": {
                     "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"


### PR DESCRIPTION
## Summary
- add an enabled switch and explanatory tooltip to the asset overview card
- add Details, Enable/Disable access, and Delete actions on right-click and the vertical-dot menu
- preserve agent assignments while disabled and show disabled assets in MCP discovery
- centrally reject disabled or unlinked assets for MCP operations, certificate minting, and SSH proxy authorization
- skip connection health checks for disabled assets

## Testing
- go test ./pkg/org/application/assets ./pkg/org/interfaces/mcptools ./pkg/org/interfaces/server/api ./pkg/org/infrastructure/assetssh ./pkg/org/infrastructure/persistence/gorm
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- cd frontend && yarn build
- live browser: create asset, verify switch tooltip, disable, re-enable, and persisted status
- live browser: right-click asset, verify Details and state-aware access action, disable then re-enable, and delete test asset
- proxy test: reject an already minted certificate after disable and after agent unlink; accept it again after re-enable

## CI
- Drone build 3199 passed
- GitHub CodeQL analysis passed for Go, JavaScript/TypeScript, and Python