### PR TITLE
feat(org): audit MCP and asset SSH activity

### DIFF
--- a/api/pkg/org/domain/audit/audit.go
+++ b/api/pkg/org/domain/audit/audit.go
@@ -106,14 +106,24 @@ func redactValue(raw json.RawMessage) (json.RawMessage, bool) {
 }
 
 func sensitiveKey(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized := strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, strings.TrimSpace(key))
 	switch normalized {
-	case "authorization", "credential", "credentials", "encrypted_password", "encrypted_private_key", "password", "private_key", "secret", "token":
+	case "auth", "authorization", "credential", "credentials", "encryptedpassword", "encryptedprivatekey", "password", "passphrase", "privatekey", "secret", "token":
 		return true
 	default:
-		return strings.HasSuffix(normalized, "_password") ||
-			strings.HasSuffix(normalized, "_private_key") ||
-			strings.HasSuffix(normalized, "_secret") ||
-			strings.HasSuffix(normalized, "_token")
+		return strings.HasSuffix(normalized, "apikey") ||
+			strings.HasSuffix(normalized, "password") ||
+			strings.HasSuffix(normalized, "passphrase") ||
+			strings.HasSuffix(normalized, "privatekey") ||
+			strings.HasSuffix(normalized, "secret") ||
+			strings.HasSuffix(normalized, "token")
 	}
 }

--- a/api/pkg/org/domain/audit/audit.go
+++ b/api/pkg/org/domain/audit/audit.go
@@ -1,0 +1,119 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+type EventType string
+
+const (
+	EventMCPCall       EventType = "mcp_call"
+	EventSSHConnection EventType = "ssh_connection"
+	EventSSHCommand    EventType = "ssh_command"
+)
+
+type Status string
+
+const (
+	StatusAttempted Status = "attempted"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+)
+
+type ActorType string
+
+const (
+	ActorBot  ActorType = "bot"
+	ActorUser ActorType = "user"
+)
+
+type Metadata struct {
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	AssetRef      string          `json:"asset_ref,omitempty"`
+	Command       string          `json:"command,omitempty"`
+	CommandID     string          `json:"command_id,omitempty"`
+	Error         string          `json:"error,omitempty"`
+	RemoteAddress string          `json:"remote_address,omitempty"`
+	LocalAddress  string          `json:"local_address,omitempty"`
+	SSHUser       string          `json:"ssh_user,omitempty"`
+	ClientVersion string          `json:"client_version,omitempty"`
+	DurationMS    int64           `json:"duration_ms,omitempty"`
+}
+
+type Entry struct {
+	OrganizationID string
+	ProjectID      string
+	UserID         string
+	ActorID        string
+	ActorType      ActorType
+	AssetID        string
+	EventType      EventType
+	Action         string
+	Status         Status
+	Metadata       Metadata
+}
+
+type Recorder interface {
+	Record(ctx context.Context, entry Entry) error
+}
+
+type ProjectResolver func(ctx context.Context, orgID, actorID string) (string, error)
+
+func RedactArguments(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	redacted, ok := redactValue(raw)
+	if !ok {
+		return json.RawMessage(`{}`)
+	}
+	return redacted
+}
+
+func redactValue(raw json.RawMessage) (json.RawMessage, bool) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err == nil && object != nil {
+		for key, value := range object {
+			if sensitiveKey(key) {
+				object[key] = json.RawMessage(`"[REDACTED]"`)
+				continue
+			}
+			if child, ok := redactValue(value); ok {
+				object[key] = child
+			}
+		}
+		out, err := json.Marshal(object)
+		return out, err == nil
+	}
+
+	var array []json.RawMessage
+	if err := json.Unmarshal(raw, &array); err == nil && array != nil {
+		for idx, value := range array {
+			if child, ok := redactValue(value); ok {
+				array[idx] = child
+			}
+		}
+		out, err := json.Marshal(array)
+		return out, err == nil
+	}
+
+	if json.Valid(raw) {
+		return append(json.RawMessage(nil), raw...), true
+	}
+	return nil, false
+}
+
+func sensitiveKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	switch normalized {
+	case "authorization", "credential", "credentials", "encrypted_password", "encrypted_private_key", "password", "private_key", "secret", "token":
+		return true
+	default:
+		return strings.HasSuffix(normalized, "_password") ||
+			strings.HasSuffix(normalized, "_private_key") ||
+			strings.HasSuffix(normalized, "_secret") ||
+			strings.HasSuffix(normalized, "_token")
+	}
+}

--- a/api/pkg/org/domain/audit/audit_test.go
+++ b/api/pkg/org/domain/audit/audit_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestRedactArguments(t *testing.T) {
-	raw := json.RawMessage(`{"name":"production","password":"hunter2","nested":{"api_token":"token-value","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"key-value","safe":true}]}`)
+	raw := json.RawMessage(`{"name":"production","password":"hunter2","apiKey":"key-value","nested":{"api_token":"token-value","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"key-value","safe":true},{"ssh-private-key":"key-value","dbPassphrase":"phrase"}]}`)
 
 	redacted := RedactArguments(raw)
 
-	require.JSONEq(t, `{"name":"production","password":"[REDACTED]","nested":{"api_token":"[REDACTED]","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"[REDACTED]","safe":true}]}`, string(redacted))
+	require.JSONEq(t, `{"name":"production","password":"[REDACTED]","apiKey":"[REDACTED]","nested":{"api_token":"[REDACTED]","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"[REDACTED]","safe":true},{"ssh-private-key":"[REDACTED]","dbPassphrase":"[REDACTED]"}]}`, string(redacted))
 }
 
 func TestRedactArgumentsInvalidJSON(t *testing.T) {

--- a/api/pkg/org/domain/audit/audit_test.go
+++ b/api/pkg/org/domain/audit/audit_test.go
@@ -1,0 +1,20 @@
+package audit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactArguments(t *testing.T) {
+	raw := json.RawMessage(`{"name":"production","password":"hunter2","nested":{"api_token":"token-value","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"key-value","safe":true}]}`)
+
+	redacted := RedactArguments(raw)
+
+	require.JSONEq(t, `{"name":"production","password":"[REDACTED]","nested":{"api_token":"[REDACTED]","public_key":"ssh-ed25519 AAAA"},"items":[{"private_key":"[REDACTED]","safe":true}]}`, string(redacted))
+}
+
+func TestRedactArgumentsInvalidJSON(t *testing.T) {
+	require.JSONEq(t, `{}`, string(RedactArguments(json.RawMessage(`not-json`))))
+}

--- a/api/pkg/org/infrastructure/assetssh/client.go
+++ b/api/pkg/org/infrastructure/assetssh/client.go
@@ -16,9 +16,11 @@ import (
 	"time"
 
 	"github.com/pkg/sftp"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 )
 
 type Assets interface {
@@ -83,14 +85,22 @@ type FileEntry struct {
 }
 
 type Client struct {
-	assets  Assets
-	decrypt Decrypt
-	newID   func() string
-	now     func() time.Time
-	timeout time.Duration
+	assets   Assets
+	decrypt  Decrypt
+	newID    func() string
+	now      func() time.Time
+	timeout  time.Duration
+	audit    orgaudit.Recorder
+	projects orgaudit.ProjectResolver
 
 	mu       sync.RWMutex
 	commands map[commandKey]*trackedCommand
+}
+
+func (c *Client) WithAudit(recorder orgaudit.Recorder, projects orgaudit.ProjectResolver) *Client {
+	c.audit = recorder
+	c.projects = projects
+	return c
 }
 
 type commandKey struct{ orgID, assetID, commandID string }
@@ -188,11 +198,15 @@ func (c *Client) Run(ctx context.Context, orgID, agentID, idOrName string, req R
 	}
 	client, err := c.dial(ctx, a)
 	if err != nil {
+		c.recordConnection(ctx, orgID, agentID, a, orgaudit.StatusFailed, err)
+		c.recordCommand(ctx, orgID, agentID, a.ID, "", remote, orgaudit.StatusFailed, err)
 		return Command{}, err
 	}
+	c.recordConnection(ctx, orgID, agentID, a, orgaudit.StatusSucceeded, nil)
 	session, err := client.NewSession()
 	if err != nil {
 		_ = client.Close()
+		c.recordCommand(ctx, orgID, agentID, a.ID, "", remote, orgaudit.StatusFailed, err)
 		return Command{}, fmt.Errorf("create SSH session: %w", err)
 	}
 	tracked := &trackedCommand{command: Command{
@@ -210,8 +224,10 @@ func (c *Client) Run(ctx context.Context, orgID, agentID, idOrName string, req R
 		_ = session.Close()
 		_ = client.Close()
 		c.finish(tracked, err)
+		c.recordCommand(ctx, orgID, agentID, a.ID, tracked.command.ID, remote, orgaudit.StatusFailed, err)
 		return tracked.snapshot(), fmt.Errorf("start server command: %w", err)
 	}
+	c.recordCommand(ctx, orgID, agentID, a.ID, tracked.command.ID, remote, orgaudit.StatusAttempted, nil)
 	if req.Detached {
 		go func() {
 			err := session.Wait()
@@ -328,7 +344,7 @@ func (c *Client) ListFiles(ctx context.Context, orgID, agentID, idOrName, direct
 		return nil, err
 	}
 	var entries []FileEntry
-	err = c.withSFTP(ctx, a, func(client *sftp.Client) error {
+	err = c.withSFTP(ctx, orgID, agentID, a, func(client *sftp.Client) error {
 		infos, err := client.ReadDir(directory)
 		if err != nil {
 			return err
@@ -361,7 +377,7 @@ func (c *Client) ReadFile(ctx context.Context, orgID, agentID, idOrName, filenam
 		maxBytes = 1024 * 1024
 	}
 	var data []byte
-	err = c.withSFTP(ctx, a, func(client *sftp.Client) error {
+	err = c.withSFTP(ctx, orgID, agentID, a, func(client *sftp.Client) error {
 		file, err := client.Open(filename)
 		if err != nil {
 			return err
@@ -391,7 +407,7 @@ func (c *Client) WriteFile(ctx context.Context, orgID, agentID, idOrName, filena
 	if err != nil {
 		return err
 	}
-	return c.withSFTP(ctx, a, func(client *sftp.Client) error {
+	return c.withSFTP(ctx, orgID, agentID, a, func(client *sftp.Client) error {
 		if err := client.MkdirAll(path.Dir(filename)); err != nil {
 			return fmt.Errorf("create parent directories: %w", err)
 		}
@@ -415,11 +431,13 @@ func (c *Client) WriteFile(ctx context.Context, orgID, agentID, idOrName, filena
 	})
 }
 
-func (c *Client) withSFTP(ctx context.Context, a asset.Asset, fn func(*sftp.Client) error) error {
+func (c *Client) withSFTP(ctx context.Context, orgID, agentID string, a asset.Asset, fn func(*sftp.Client) error) error {
 	client, err := c.dial(ctx, a)
 	if err != nil {
+		c.recordConnection(ctx, orgID, agentID, a, orgaudit.StatusFailed, err)
 		return err
 	}
+	c.recordConnection(ctx, orgID, agentID, a, orgaudit.StatusSucceeded, nil)
 	defer client.Close()
 	sftpClient, err := sftp.NewClient(client)
 	if err != nil {
@@ -427,6 +445,64 @@ func (c *Client) withSFTP(ctx context.Context, a asset.Asset, fn func(*sftp.Clie
 	}
 	defer sftpClient.Close()
 	return fn(sftpClient)
+}
+
+func (c *Client) recordConnection(ctx context.Context, orgID, agentID string, a asset.Asset, status orgaudit.Status, connectionErr error) {
+	server, _ := serverConfig(a)
+	metadata := orgaudit.Metadata{RemoteAddress: serverAddress(server), SSHUser: server.User}
+	if connectionErr != nil {
+		metadata.Error = connectionErr.Error()
+	}
+	c.recordAudit(ctx, orgaudit.Entry{
+		OrganizationID: orgID,
+		ProjectID:      c.projectID(ctx, orgID, agentID),
+		ActorID:        agentID,
+		ActorType:      orgaudit.ActorBot,
+		AssetID:        string(a.ID),
+		EventType:      orgaudit.EventSSHConnection,
+		Action:         "connect",
+		Status:         status,
+		Metadata:       metadata,
+	})
+}
+
+func (c *Client) recordCommand(ctx context.Context, orgID, agentID string, assetID asset.ID, commandID, command string, status orgaudit.Status, commandErr error) {
+	metadata := orgaudit.Metadata{Command: command, CommandID: commandID}
+	if commandErr != nil {
+		metadata.Error = commandErr.Error()
+	}
+	c.recordAudit(ctx, orgaudit.Entry{
+		OrganizationID: orgID,
+		ProjectID:      c.projectID(ctx, orgID, agentID),
+		ActorID:        agentID,
+		ActorType:      orgaudit.ActorBot,
+		AssetID:        string(assetID),
+		EventType:      orgaudit.EventSSHCommand,
+		Action:         "exec",
+		Status:         status,
+		Metadata:       metadata,
+	})
+}
+
+func (c *Client) projectID(ctx context.Context, orgID, agentID string) string {
+	if c.projects == nil {
+		return ""
+	}
+	projectID, err := c.projects(ctx, orgID, agentID)
+	if err != nil {
+		log.Error().Err(err).Str("organization_id", orgID).Str("actor_id", agentID).Msg("failed to resolve org audit project")
+		return ""
+	}
+	return projectID
+}
+
+func (c *Client) recordAudit(ctx context.Context, entry orgaudit.Entry) {
+	if c.audit == nil {
+		return
+	}
+	if err := c.audit.Record(ctx, entry); err != nil {
+		log.Error().Err(err).Str("organization_id", entry.OrganizationID).Str("event_type", string(entry.EventType)).Msg("failed to create org audit log")
+	}
 }
 
 func (c *Client) dial(ctx context.Context, a asset.Asset) (*ssh.Client, error) {

--- a/api/pkg/org/infrastructure/assetssh/client_test.go
+++ b/api/pkg/org/infrastructure/assetssh/client_test.go
@@ -2,10 +2,16 @@ package assetssh
 
 import (
 	"context"
+	"net"
+	"strconv"
 	"testing"
+	"time"
 
+	helixcrypto "github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 type healthAssets struct{ value asset.Asset }
@@ -60,4 +66,53 @@ func TestHealthDoesNotConnectToDisabledAsset(t *testing.T) {
 	require.Equal(t, `asset "disabled-server" is disabled`, health.Error)
 	require.False(t, health.TCPReachable)
 	require.False(t, health.SSHReachable)
+}
+
+func TestRunAuditsSSHConnectionAndCommand(t *testing.T) {
+	privateKey, publicKey, err := helixcrypto.GenerateSSHKeyPair("ed25519")
+	require.NoError(t, err)
+	authorizedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	require.NoError(t, err)
+	upstreamAddress, commands, stopUpstream := startProxyTestUpstream(t, authorizedKey)
+	t.Cleanup(stopUpstream)
+	host, rawPort, err := net.SplitHostPort(upstreamAddress)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(rawPort)
+	require.NoError(t, err)
+
+	assets := &proxyAssets{allowed: true, value: asset.Asset{
+		ID: "a-prod", OrganizationID: "org-1", Name: "production", Kind: asset.KindServer,
+		Config: asset.Config{Server: &asset.Server{
+			Address: host, Port: uint16(port), User: "ubuntu", AuthType: asset.AuthSSHKey,
+			PublicKey: publicKey, EncryptedPrivateKey: privateKey,
+		}},
+	}}
+	auditLog := newRecordingAudit()
+	client, err := New(assets, func(ciphertext string) ([]byte, error) { return []byte(ciphertext), nil }, func() string { return "command-1" })
+	require.NoError(t, err)
+	client.WithAudit(auditLog, func(context.Context, string, string) (string, error) { return "project-1", nil })
+
+	command, err := client.Run(context.Background(), "org-1", "agent-1", "production", RunRequest{Cmd: "printf", Args: []string{"client-ok"}})
+	require.NoError(t, err)
+	require.Equal(t, CommandFinished, command.Status)
+	select {
+	case remote := <-commands:
+		require.Equal(t, `'printf' 'client-ok'`, remote)
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream did not receive direct command")
+	}
+
+	audited := make(map[orgaudit.EventType]orgaudit.Entry)
+	for len(audited) < 2 {
+		select {
+		case entry := <-auditLog.entries:
+			audited[entry.EventType] = entry
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for direct SSH audit entries: %+v", audited)
+		}
+	}
+	require.Equal(t, "project-1", audited[orgaudit.EventSSHConnection].ProjectID)
+	require.Equal(t, orgaudit.StatusSucceeded, audited[orgaudit.EventSSHConnection].Status)
+	require.Equal(t, "command-1", audited[orgaudit.EventSSHCommand].Metadata.CommandID)
+	require.Equal(t, `'printf' 'client-ok'`, audited[orgaudit.EventSSHCommand].Metadata.Command)
 }

--- a/api/pkg/org/infrastructure/assetssh/proxy.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy.go
@@ -16,7 +16,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/ssh"
+
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 )
 
 const (
@@ -90,9 +93,11 @@ func (i *Issuer) Mint(ctx context.Context, orgID, agentID, assetRef string) (Pro
 }
 
 type Proxy struct {
-	assets Assets
-	client *Client
-	config *ssh.ServerConfig
+	assets   Assets
+	client   *Client
+	config   *ssh.ServerConfig
+	audit    orgaudit.Recorder
+	projects orgaudit.ProjectResolver
 }
 
 func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, error) {
@@ -127,10 +132,14 @@ func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, erro
 		}
 		a, err := assets.AuthorizeRef(context.Background(), orgID, agentID, assetID)
 		if err != nil {
-			return nil, fmt.Errorf("authorize asset proxy: %w", err)
+			authErr := fmt.Errorf("authorize asset proxy: %w", err)
+			p.recordRejectedConnection(meta, orgID, agentID, assetID, authErr)
+			return nil, authErr
 		}
 		if meta.User() != a.Name {
-			return nil, errors.New("SSH username must match the linked asset name")
+			authErr := errors.New("SSH username must match the linked asset name")
+			p.recordRejectedConnection(meta, orgID, agentID, assetID, authErr)
+			return nil, authErr
 		}
 		return &ssh.Permissions{Extensions: map[string]string{
 			certOrgID: orgID, certAgentID: agentID, certAssetID: assetID,
@@ -138,6 +147,12 @@ func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, erro
 	}}
 	p.config.AddHostKey(host)
 	return p, nil
+}
+
+func (p *Proxy) WithAudit(recorder orgaudit.Recorder, projects orgaudit.ProjectResolver) *Proxy {
+	p.audit = recorder
+	p.projects = projects
+	return p
 }
 
 func (p *Proxy) Serve(ctx context.Context, address string) error {
@@ -173,6 +188,7 @@ func (p *Proxy) handle(ctx context.Context, raw net.Conn) {
 		return
 	}
 	defer conn.Close()
+	p.recordConnection(ctx, conn, orgaudit.StatusSucceeded, nil)
 	go ssh.DiscardRequests(requests)
 	for newChannel := range channels {
 		if newChannel.ChannelType() != "session" {
@@ -205,7 +221,7 @@ func (p *Proxy) proxySession(ctx context.Context, conn *ssh.ServerConn, incoming
 
 	go func() { _, _ = io.Copy(upstreamChannel, clientChannel) }()
 	go func() { _, _ = io.Copy(clientChannel.Stderr(), upstreamChannel.Stderr()) }()
-	go forwardRequests(clientRequests, upstreamChannel)
+	go p.forwardClientRequests(ctx, conn.Permissions.Extensions, clientRequests, upstreamChannel)
 	upstreamRequestsDone := make(chan struct{})
 	go func() {
 		forwardRequests(upstreamRequests, clientChannel)
@@ -213,6 +229,119 @@ func (p *Proxy) proxySession(ctx context.Context, conn *ssh.ServerConn, incoming
 	}()
 	_, _ = io.Copy(clientChannel, upstreamChannel)
 	<-upstreamRequestsDone
+}
+
+func (p *Proxy) forwardClientRequests(ctx context.Context, permissions map[string]string, requests <-chan *ssh.Request, channel ssh.Channel) {
+	for request := range requests {
+		ok, err := channel.SendRequest(request.Type, request.WantReply, request.Payload)
+		if request.Type == "exec" {
+			command, decodeErr := decodeExecRequest(request.Payload)
+			status := orgaudit.StatusAttempted
+			commandErr := err
+			if decodeErr != nil {
+				status = orgaudit.StatusFailed
+				commandErr = decodeErr
+			} else if err != nil || !ok {
+				status = orgaudit.StatusFailed
+				if commandErr == nil {
+					commandErr = errors.New("upstream SSH server rejected command")
+				}
+			}
+			metadata := orgaudit.Metadata{Command: command}
+			if commandErr != nil {
+				metadata.Error = commandErr.Error()
+			}
+			p.recordAudit(ctx, orgaudit.Entry{
+				OrganizationID: permissions[certOrgID],
+				ProjectID:      p.projectID(ctx, permissions[certOrgID], permissions[certAgentID]),
+				ActorID:        permissions[certAgentID],
+				ActorType:      orgaudit.ActorBot,
+				AssetID:        permissions[certAssetID],
+				EventType:      orgaudit.EventSSHCommand,
+				Action:         "exec",
+				Status:         status,
+				Metadata:       metadata,
+			})
+		}
+		if request.WantReply {
+			_ = request.Reply(ok && err == nil, nil)
+		}
+	}
+}
+
+func decodeExecRequest(payload []byte) (string, error) {
+	var request struct {
+		Command string
+	}
+	if err := ssh.Unmarshal(payload, &request); err != nil {
+		return "", fmt.Errorf("decode SSH exec request: %w", err)
+	}
+	return request.Command, nil
+}
+
+func (p *Proxy) recordConnection(ctx context.Context, conn *ssh.ServerConn, status orgaudit.Status, connectionErr error) {
+	permissions := conn.Permissions.Extensions
+	metadata := orgaudit.Metadata{
+		RemoteAddress: conn.RemoteAddr().String(),
+		LocalAddress:  conn.LocalAddr().String(),
+		SSHUser:       conn.User(),
+		ClientVersion: string(conn.ClientVersion()),
+	}
+	if connectionErr != nil {
+		metadata.Error = connectionErr.Error()
+	}
+	p.recordAudit(ctx, orgaudit.Entry{
+		OrganizationID: permissions[certOrgID],
+		ProjectID:      p.projectID(ctx, permissions[certOrgID], permissions[certAgentID]),
+		ActorID:        permissions[certAgentID],
+		ActorType:      orgaudit.ActorBot,
+		AssetID:        permissions[certAssetID],
+		EventType:      orgaudit.EventSSHConnection,
+		Action:         "connect",
+		Status:         status,
+		Metadata:       metadata,
+	})
+}
+
+func (p *Proxy) recordRejectedConnection(meta ssh.ConnMetadata, orgID, agentID, assetID string, connectionErr error) {
+	p.recordAudit(context.Background(), orgaudit.Entry{
+		OrganizationID: orgID,
+		ProjectID:      p.projectID(context.Background(), orgID, agentID),
+		ActorID:        agentID,
+		ActorType:      orgaudit.ActorBot,
+		AssetID:        assetID,
+		EventType:      orgaudit.EventSSHConnection,
+		Action:         "connect",
+		Status:         orgaudit.StatusFailed,
+		Metadata: orgaudit.Metadata{
+			RemoteAddress: meta.RemoteAddr().String(),
+			LocalAddress:  meta.LocalAddr().String(),
+			SSHUser:       meta.User(),
+			ClientVersion: string(meta.ClientVersion()),
+			Error:         connectionErr.Error(),
+		},
+	})
+}
+
+func (p *Proxy) projectID(ctx context.Context, orgID, agentID string) string {
+	if p.projects == nil {
+		return ""
+	}
+	projectID, err := p.projects(ctx, orgID, agentID)
+	if err != nil {
+		log.Error().Err(err).Str("organization_id", orgID).Str("actor_id", agentID).Msg("failed to resolve org audit project")
+		return ""
+	}
+	return projectID
+}
+
+func (p *Proxy) recordAudit(ctx context.Context, entry orgaudit.Entry) {
+	if p.audit == nil {
+		return
+	}
+	if err := p.audit.Record(ctx, entry); err != nil {
+		log.Error().Err(err).Str("organization_id", entry.OrganizationID).Str("event_type", string(entry.EventType)).Msg("failed to create org audit log")
+	}
 }
 
 func forwardRequests(requests <-chan *ssh.Request, channel ssh.Channel) {

--- a/api/pkg/org/infrastructure/assetssh/proxy.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy.go
@@ -234,6 +234,9 @@ func (p *Proxy) proxySession(ctx context.Context, conn *ssh.ServerConn, incoming
 func (p *Proxy) forwardClientRequests(ctx context.Context, permissions map[string]string, requests <-chan *ssh.Request, channel ssh.Channel) {
 	for request := range requests {
 		ok, err := channel.SendRequest(request.Type, request.WantReply, request.Payload)
+		if request.WantReply {
+			_ = request.Reply(ok && err == nil, nil)
+		}
 		if request.Type == "exec" {
 			command, decodeErr := decodeExecRequest(request.Payload)
 			status := orgaudit.StatusAttempted
@@ -262,9 +265,6 @@ func (p *Proxy) forwardClientRequests(ctx context.Context, permissions map[strin
 				Status:         status,
 				Metadata:       metadata,
 			})
-		}
-		if request.WantReply {
-			_ = request.Reply(ok && err == nil, nil)
 		}
 	}
 }

--- a/api/pkg/org/infrastructure/assetssh/proxy_test.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 type recordingAudit struct {
-	entries chan orgaudit.Entry
+	entries      chan orgaudit.Entry
+	beforeRecord func(orgaudit.Entry)
 }
 
 func newRecordingAudit() *recordingAudit {
@@ -26,6 +27,9 @@ func newRecordingAudit() *recordingAudit {
 }
 
 func (r *recordingAudit) Record(_ context.Context, entry orgaudit.Entry) error {
+	if r.beforeRecord != nil {
+		r.beforeRecord(entry)
+	}
 	r.entries <- entry
 	return nil
 }
@@ -211,6 +215,17 @@ func TestProxyForwardsAuthorizedAgentSessionAndRejectsRevokedLink(t *testing.T) 
 		t.Fatal(err)
 	}
 	auditLog := newRecordingAudit()
+	auditStarted := make(chan struct{})
+	auditRelease := make(chan struct{})
+	var releaseAudit sync.Once
+	release := func() { releaseAudit.Do(func() { close(auditRelease) }) }
+	t.Cleanup(release)
+	auditLog.beforeRecord = func(entry orgaudit.Entry) {
+		if entry.EventType == orgaudit.EventSSHCommand {
+			close(auditStarted)
+			<-auditRelease
+		}
+	}
 	proxy.WithAudit(auditLog, func(_ context.Context, orgID, agentID string) (string, error) {
 		if orgID != "org-1" || agentID != "agent-1" {
 			return "", errors.New("unexpected audit project scope")
@@ -239,11 +254,34 @@ func TestProxyForwardsAuthorizedAgentSessionAndRejectsRevokedLink(t *testing.T) 
 		cancel()
 		t.Fatal(err)
 	}
-	output, err := session.CombinedOutput("printf proxy-ok")
-	if err != nil {
-		cancel()
-		t.Fatal(err)
+	type commandResult struct {
+		output []byte
+		err    error
 	}
+	resultCh := make(chan commandResult, 1)
+	go func() {
+		output, err := session.CombinedOutput("printf proxy-ok")
+		resultCh <- commandResult{output: output, err: err}
+	}()
+	select {
+	case <-auditStarted:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("SSH command audit did not start")
+	}
+	var output []byte
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			cancel()
+			t.Fatalf("SSH command failed while audit persistence was blocked: %v", result.err)
+		}
+		output = result.output
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("SSH command reply was blocked by audit persistence")
+	}
+	release()
 	_ = proxyClient.Close()
 	if string(output) != "proxied:printf proxy-ok" {
 		t.Fatalf("proxy output = %q", output)

--- a/api/pkg/org/infrastructure/assetssh/proxy_test.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy_test.go
@@ -14,7 +14,21 @@ import (
 
 	helixcrypto "github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 )
+
+type recordingAudit struct {
+	entries chan orgaudit.Entry
+}
+
+func newRecordingAudit() *recordingAudit {
+	return &recordingAudit{entries: make(chan orgaudit.Entry, 16)}
+}
+
+func (r *recordingAudit) Record(_ context.Context, entry orgaudit.Entry) error {
+	r.entries <- entry
+	return nil
+}
 
 type proxyAssets struct {
 	value   asset.Asset
@@ -95,6 +109,8 @@ func TestProxyCertificateEnforcesAgentLinkAndAssetUsername(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	auditLog := newRecordingAudit()
+	proxy.WithAudit(auditLog, func(context.Context, string, string) (string, error) { return "project-1", nil })
 	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "production"}, cert); err != nil {
 		t.Fatalf("valid certificate rejected: %v", err)
 	}
@@ -112,6 +128,14 @@ func TestProxyCertificateEnforcesAgentLinkAndAssetUsername(t *testing.T) {
 	assets.setAllowed(false)
 	if _, err := proxy.config.PublicKeyCallback(connMetadata{user: "production"}, cert); err == nil {
 		t.Fatal("certificate remained usable after the agent link was revoked")
+	}
+	select {
+	case entry := <-auditLog.entries:
+		if entry.EventType != orgaudit.EventSSHConnection || entry.Status != orgaudit.StatusFailed || entry.OrganizationID != "org-1" || entry.ProjectID != "project-1" || entry.AssetID != "a-prod" || entry.Metadata.SSHUser != "production" {
+			t.Fatalf("unexpected rejected connection audit: %+v", entry)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rejected SSH connection was not audited")
 	}
 }
 
@@ -186,6 +210,13 @@ func TestProxyForwardsAuthorizedAgentSessionAndRejectsRevokedLink(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	auditLog := newRecordingAudit()
+	proxy.WithAudit(auditLog, func(_ context.Context, orgID, agentID string) (string, error) {
+		if orgID != "org-1" || agentID != "agent-1" {
+			return "", errors.New("unexpected audit project scope")
+		}
+		return "project-1", nil
+	})
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -224,6 +255,27 @@ func TestProxyForwardsAuthorizedAgentSessionAndRejectsRevokedLink(t *testing.T) 
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("upstream did not receive proxied command")
+	}
+
+	audited := make(map[orgaudit.EventType]orgaudit.Entry)
+	for len(audited) < 2 {
+		select {
+		case entry := <-auditLog.entries:
+			audited[entry.EventType] = entry
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for SSH audit entries: %+v", audited)
+		}
+	}
+	connection := audited[orgaudit.EventSSHConnection]
+	if connection.OrganizationID != "org-1" || connection.ProjectID != "project-1" || connection.ActorID != "agent-1" || connection.AssetID != "a-prod" || connection.Status != orgaudit.StatusSucceeded {
+		t.Fatalf("unexpected connection audit: %+v", connection)
+	}
+	if connection.Metadata.RemoteAddress == "" || connection.Metadata.SSHUser != "production" {
+		t.Fatalf("connection metadata missing: %+v", connection.Metadata)
+	}
+	commandAudit := audited[orgaudit.EventSSHCommand]
+	if commandAudit.Metadata.Command != "printf proxy-ok" || commandAudit.Status != orgaudit.StatusAttempted {
+		t.Fatalf("unexpected command audit: %+v", commandAudit)
 	}
 
 	assets.setAllowed(false)

--- a/api/pkg/org/interfaces/server/mcp.go
+++ b/api/pkg/org/interfaces/server/mcp.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
+	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
@@ -108,7 +111,7 @@ func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
 			s.logger.Info("mcp.unknown_tool_on_bot", "bot", botID, "tool", toolName)
 			continue
 		}
-		registerToolForBot(srv, t, caller, s.logger.With("bot", botID, "tool", toolName))
+		s.registerToolForBot(srv, t, caller, s.logger.With("bot", botID, "tool", toolName))
 	}
 
 	if s.prompts != nil {
@@ -128,7 +131,7 @@ func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
 // the right Invocation without re-querying the store. Authorisation is
 // by virtue of the tool appearing in the Bot's Tools; there is no
 // separate tool record to consult at call time.
-func registerToolForBot(srv *mcp.Server, t tool.Tool, caller tool.Caller, logger interface {
+func (s *Server) registerToolForBot(srv *mcp.Server, t tool.Tool, caller tool.Caller, logger interface {
 	Info(msg string, args ...any)
 }) {
 	srv.AddTool(&mcp.Tool{
@@ -140,20 +143,85 @@ func registerToolForBot(srv *mcp.Server, t tool.Tool, caller tool.Caller, logger
 		if len(args) == 0 {
 			args = json.RawMessage(`{}`)
 		}
+		auditEntry := s.newMCPAuditEntry(ctx, caller, string(t.Name()), args)
+		started := time.Now()
 		result, err := t.Invoke(ctx, tool.Invocation{
 			Caller: caller,
 			Args:   args,
 		})
 		if err != nil {
+			auditEntry.Status = orgaudit.StatusFailed
+			auditEntry.Metadata.Error = err.Error()
+			auditEntry.Metadata.DurationMS = time.Since(started).Milliseconds()
+			s.recordAudit(ctx, auditEntry)
 			logger.Info("mcp.tool_error", "err", err.Error())
 			out := &mcp.CallToolResult{}
 			out.SetError(err)
 			return out, nil
 		}
+		auditEntry.Status = orgaudit.StatusSucceeded
+		auditEntry.Metadata.DurationMS = time.Since(started).Milliseconds()
+		s.recordAudit(ctx, auditEntry)
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: string(result)}},
 		}, nil
 	})
+}
+
+type mcpAuditArgs struct {
+	ProjectID string `json:"project_id"`
+	Asset     string `json:"asset"`
+	AssetID   string `json:"asset_id"`
+}
+
+func (s *Server) newMCPAuditEntry(ctx context.Context, caller tool.Caller, action string, args json.RawMessage) orgaudit.Entry {
+	entry := orgaudit.Entry{
+		OrganizationID: caller.OrganizationID(),
+		UserID:         runtimehelix.UserIDFromContext(ctx),
+		ActorID:        caller.ID(),
+		ActorType:      orgaudit.ActorBot,
+		EventType:      orgaudit.EventMCPCall,
+		Action:         action,
+		Status:         orgaudit.StatusAttempted,
+		Metadata: orgaudit.Metadata{
+			Arguments: orgaudit.RedactArguments(args),
+		},
+	}
+	var parsed mcpAuditArgs
+	if err := json.Unmarshal(args, &parsed); err == nil {
+		entry.ProjectID = parsed.ProjectID
+		entry.Metadata.AssetRef = parsed.Asset
+		if entry.Metadata.AssetRef == "" {
+			entry.Metadata.AssetRef = parsed.AssetID
+		}
+	}
+	if entry.ProjectID == "" && s.projects != nil {
+		projectID, err := s.projects(ctx, entry.OrganizationID, entry.ActorID)
+		if err != nil {
+			s.logger.Info("mcp.audit_project_error", "bot", entry.ActorID, "err", err.Error())
+		} else {
+			entry.ProjectID = projectID
+		}
+	}
+	if entry.Metadata.AssetRef != "" && s.assets != nil {
+		value, err := s.assets.Get(ctx, entry.OrganizationID, asset.ID(entry.Metadata.AssetRef))
+		if err != nil {
+			value, err = s.assets.GetByName(ctx, entry.OrganizationID, entry.Metadata.AssetRef)
+		}
+		if err == nil {
+			entry.AssetID = string(value.ID)
+		}
+	}
+	return entry
+}
+
+func (s *Server) recordAudit(ctx context.Context, entry orgaudit.Entry) {
+	if s.audit == nil {
+		return
+	}
+	if err := s.audit.Record(ctx, entry); err != nil {
+		s.logger.Error("mcp.audit_write_error", "event_type", entry.EventType, "action", entry.Action, "err", err.Error())
+	}
 }
 
 // registerPromptForBot binds a single prompt onto the per-bot MCP

--- a/api/pkg/org/interfaces/server/mcp_audit_test.go
+++ b/api/pkg/org/interfaces/server/mcp_audit_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+func TestNewMCPAuditEntryResolvesAssetAndRedactsSecrets(t *testing.T) {
+	st := orgmemory.New()
+	value, err := asset.New(
+		"asset-1",
+		"org-1",
+		"production",
+		"",
+		"",
+		asset.KindServer,
+		asset.Config{Server: &asset.Server{
+			Address:             "10.0.0.8",
+			Port:                22,
+			User:                "ubuntu",
+			AuthType:            asset.AuthSSHKey,
+			PublicKey:           "ssh-ed25519 AAAA",
+			EncryptedPrivateKey: "encrypted",
+		}},
+		time.Now().UTC(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, st.Assets.Create(context.Background(), value))
+
+	server := &Server{assets: st.Assets}
+	entry := server.newMCPAuditEntry(
+		context.Background(),
+		botCaller{id: "bot-1", orgID: "org-1"},
+		"update_server_asset",
+		json.RawMessage(`{"asset":"production","project_id":"project-1","password":"secret-value"}`),
+	)
+
+	require.Equal(t, "asset-1", entry.AssetID)
+	require.Equal(t, "production", entry.Metadata.AssetRef)
+	require.Equal(t, "project-1", entry.ProjectID)
+	require.JSONEq(t, `{"asset":"production","project_id":"project-1","password":"[REDACTED]"}`, string(entry.Metadata.Arguments))
+}

--- a/api/pkg/org/interfaces/server/server.go
+++ b/api/pkg/org/interfaces/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
@@ -32,6 +33,9 @@ type Server struct {
 	registry   *mcptools.Registry
 	prompts    *prompts.Registry
 	logger     *slog.Logger
+	audit      orgaudit.Recorder
+	projects   orgaudit.ProjectResolver
+	assets     store.Assets
 }
 
 // New returns a Server bound to the read facade, the publishing service,
@@ -72,7 +76,15 @@ func NewFromStore(s *store.Store, registry *mcptools.Registry, broadcaster *wake
 	if dispatcher != nil {
 		pd.Dispatcher = dispatcher
 	}
-	return New(q, publishing.New(pd), registry, logger)
+	server := New(q, publishing.New(pd), registry, logger)
+	server.assets = s.Assets
+	return server
+}
+
+func (s *Server) WithAudit(recorder orgaudit.Recorder, projects orgaudit.ProjectResolver) *Server {
+	s.audit = recorder
+	s.projects = projects
+	return s
 }
 
 // WithPrompts attaches a prompts.Registry so the per-bot MCP server

--- a/api/pkg/org/interfaces/server/server_test.go
+++ b/api/pkg/org/interfaces/server/server_test.go
@@ -9,15 +9,26 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 	"github.com/helixml/helix/api/pkg/org/interfaces/server"
 )
+
+type auditRecorder struct {
+	entries chan orgaudit.Entry
+}
+
+func (r *auditRecorder) Record(_ context.Context, entry orgaudit.Entry) error {
+	r.entries <- entry
+	return nil
+}
 
 // newTestServer seeds a CEO Bot whose Tools list both ping and
 // create_bot — but only ping is actually registered with the server.
@@ -118,6 +129,42 @@ func TestMCPListToolsFromBot(t *testing.T) {
 	}
 	if !got["ping"] {
 		t.Errorf("ping missing from bot-derived list: %+v", got)
+	}
+}
+
+func TestMCPToolCallIsAudited(t *testing.T) {
+	st := orggorm.GetOrgTestDB(t)
+	reg := mcptools.NewRegistry()
+	require.NoError(t, reg.Register(mcptools.Ping{}))
+	recorder := &auditRecorder{entries: make(chan orgaudit.Entry, 1)}
+	orgServer := server.NewFromStore(st, reg, nil, nil, nil).WithAudit(
+		recorder,
+		func(context.Context, string, string) (string, error) { return "project-1", nil },
+	)
+	httpServer := httptest.NewServer(orgServer.Handler())
+	t.Cleanup(httpServer.Close)
+
+	bot, err := orgchart.NewNode("b-audited", "# Audited", []tool.Name{mcptools.PingName}, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.NoError(t, st.Nodes.Create(context.Background(), bot))
+	session := connectMCP(t, httpServer.URL, bot.ID)
+	_, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      mcptools.PingName,
+		Arguments: map[string]string{"message": "hello"},
+	})
+	require.NoError(t, err)
+
+	select {
+	case entry := <-recorder.entries:
+		require.Equal(t, "org-test", entry.OrganizationID)
+		require.Equal(t, "project-1", entry.ProjectID)
+		require.Equal(t, "b-audited", entry.ActorID)
+		require.Equal(t, orgaudit.EventMCPCall, entry.EventType)
+		require.Equal(t, mcptools.PingName, entry.Action)
+		require.Equal(t, orgaudit.StatusSucceeded, entry.Status)
+		require.JSONEq(t, `{"message":"hello"}`, string(entry.Metadata.Arguments))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for MCP audit entry")
 	}
 }
 

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -58,6 +58,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/services"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -948,6 +949,16 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	if err != nil {
 		return nil, fmt.Errorf("init asset SSH proxy: %w", err)
 	}
+	orgAudit := services.NewOrgAuditLogService(helixStore)
+	auditProjects := func(ctx context.Context, orgID, actorID string) (string, error) {
+		state, err := runtimehelix.LoadState(ctx, st, orgID, orgchart.NodeID(actorID))
+		if err != nil {
+			return "", err
+		}
+		return state.ProjectID, nil
+	}
+	assetSSH.WithAudit(orgAudit, auditProjects)
+	assetSSHProxy.WithAudit(orgAudit, auditProjects)
 	deps.Assets = assetsSvc
 	deps.AssetSSH = assetSSH
 	deps.AssetSSHIssuer = assetSSHIssuer
@@ -958,7 +969,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {
 		return nil, fmt.Errorf("register helix-org builtins: %w", err)
 	}
-	orgServer := helixorgserver.NewFromStore(st, reg, bc, dispatcher, logger).WithPrompts(promptReg)
+	orgServer := helixorgserver.NewFromStore(st, reg, bc, dispatcher, logger).
+		WithPrompts(promptReg).
+		WithAudit(orgAudit, auditProjects)
 
 	slackAutoRouter := &slackAutoRouter{procs: svc.Processors, routes: slackRouteReconciler, logger: logger}
 	apiDeps := helixorgapi.Deps{

--- a/api/pkg/services/org_audit_log_service.go
+++ b/api/pkg/services/org_audit_log_service.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type OrgAuditLogStore interface {
+	CreateOrgAuditLog(ctx context.Context, entry *types.OrgAuditLog) error
+}
+
+type OrgAuditLogService struct {
+	store OrgAuditLogStore
+	now   func() time.Time
+	newID func() string
+}
+
+func NewOrgAuditLogService(store OrgAuditLogStore) *OrgAuditLogService {
+	return &OrgAuditLogService{
+		store: store,
+		now:   func() time.Time { return time.Now().UTC() },
+		newID: uuid.NewString,
+	}
+}
+
+func (s *OrgAuditLogService) Record(ctx context.Context, entry orgaudit.Entry) error {
+	return s.store.CreateOrgAuditLog(ctx, &types.OrgAuditLog{
+		ID:             s.newID(),
+		OrganizationID: entry.OrganizationID,
+		ProjectID:      entry.ProjectID,
+		UserID:         entry.UserID,
+		ActorID:        entry.ActorID,
+		ActorType:      types.OrgAuditActorType(entry.ActorType),
+		AssetID:        entry.AssetID,
+		EventType:      types.OrgAuditEventType(entry.EventType),
+		Action:         entry.Action,
+		Status:         types.OrgAuditStatus(entry.Status),
+		Metadata: types.OrgAuditMetadata{
+			Arguments:     entry.Metadata.Arguments,
+			AssetRef:      entry.Metadata.AssetRef,
+			Command:       entry.Metadata.Command,
+			CommandID:     entry.Metadata.CommandID,
+			Error:         entry.Metadata.Error,
+			RemoteAddress: entry.Metadata.RemoteAddress,
+			LocalAddress:  entry.Metadata.LocalAddress,
+			SSHUser:       entry.Metadata.SSHUser,
+			ClientVersion: entry.Metadata.ClientVersion,
+			DurationMS:    entry.Metadata.DurationMS,
+		},
+		CreatedAt: s.now(),
+	})
+}

--- a/api/pkg/services/org_audit_log_service_test.go
+++ b/api/pkg/services/org_audit_log_service_test.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type orgAuditStore struct {
+	entry *types.OrgAuditLog
+}
+
+func (s *orgAuditStore) CreateOrgAuditLog(_ context.Context, entry *types.OrgAuditLog) error {
+	s.entry = entry
+	return nil
+}
+
+func TestOrgAuditLogServiceRecord(t *testing.T) {
+	store := &orgAuditStore{}
+	service := NewOrgAuditLogService(store)
+	createdAt := time.Date(2026, time.August, 2, 12, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return createdAt }
+	service.newID = func() string { return "audit-1" }
+
+	err := service.Record(context.Background(), orgaudit.Entry{
+		OrganizationID: "org-1",
+		ProjectID:      "project-1",
+		UserID:         "user-1",
+		ActorID:        "bot-1",
+		ActorType:      orgaudit.ActorBot,
+		AssetID:        "asset-1",
+		EventType:      orgaudit.EventSSHCommand,
+		Action:         "exec",
+		Status:         orgaudit.StatusSucceeded,
+		Metadata: orgaudit.Metadata{
+			Command:   "uname -a",
+			CommandID: "command-1",
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "audit-1", store.entry.ID)
+	require.Equal(t, "org-1", store.entry.OrganizationID)
+	require.Equal(t, "project-1", store.entry.ProjectID)
+	require.Equal(t, "user-1", store.entry.UserID)
+	require.Equal(t, "bot-1", store.entry.ActorID)
+	require.Equal(t, types.OrgAuditActorBot, store.entry.ActorType)
+	require.Equal(t, "asset-1", store.entry.AssetID)
+	require.Equal(t, types.OrgAuditEventSSHCommand, store.entry.EventType)
+	require.Equal(t, types.OrgAuditStatusSucceeded, store.entry.Status)
+	require.Equal(t, "uname -a", store.entry.Metadata.Command)
+	require.Equal(t, createdAt, store.entry.CreatedAt)
+}

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -214,6 +214,7 @@ func (s *PostgresStore) runMigrations() error {
 		&types.TopUp{},
 		&types.Project{},
 		&types.ProjectAuditLog{}, // Audit trail for project activity
+		&types.OrgAuditLog{},     // Audit trail for Helix org activity
 		&types.SampleProject{},
 		&types.SpecTask{},
 		&types.SpecTaskWorkSession{},

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -764,6 +764,10 @@ type Store interface {
 	CreateProjectAuditLog(ctx context.Context, log *types.ProjectAuditLog) error
 	ListProjectAuditLogs(ctx context.Context, filters *types.ProjectAuditLogFilters) (*types.ProjectAuditLogResponse, error)
 
+	// Org Audit Log methods - append-only audit trail for Helix org activity
+	CreateOrgAuditLog(ctx context.Context, log *types.OrgAuditLog) error
+	ListOrgAuditLogs(ctx context.Context, filters *types.OrgAuditLogFilters) (*types.OrgAuditLogResponse, error)
+
 	// Sample Project methods
 	CreateSampleProject(ctx context.Context, sample *types.SampleProject) (*types.SampleProject, error)
 	GetSampleProject(ctx context.Context, id string) (*types.SampleProject, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -687,6 +687,20 @@ func (mr *MockStoreMockRecorder) CreateOAuthRequestToken(ctx, token any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOAuthRequestToken", reflect.TypeOf((*MockStore)(nil).CreateOAuthRequestToken), ctx, token)
 }
 
+// CreateOrgAuditLog mocks base method.
+func (m *MockStore) CreateOrgAuditLog(ctx context.Context, log *types.OrgAuditLog) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrgAuditLog", ctx, log)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrgAuditLog indicates an expected call of CreateOrgAuditLog.
+func (mr *MockStoreMockRecorder) CreateOrgAuditLog(ctx, log any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrgAuditLog", reflect.TypeOf((*MockStore)(nil).CreateOrgAuditLog), ctx, log)
+}
+
 // CreateOrganization mocks base method.
 func (m *MockStore) CreateOrganization(ctx context.Context, org *types.Organization) (*types.Organization, error) {
 	m.ctrl.T.Helper()
@@ -4760,6 +4774,21 @@ func (m *MockStore) ListOAuthProviders(ctx context.Context, query *ListOAuthProv
 func (mr *MockStoreMockRecorder) ListOAuthProviders(ctx, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOAuthProviders", reflect.TypeOf((*MockStore)(nil).ListOAuthProviders), ctx, query)
+}
+
+// ListOrgAuditLogs mocks base method.
+func (m *MockStore) ListOrgAuditLogs(ctx context.Context, filters *types.OrgAuditLogFilters) (*types.OrgAuditLogResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOrgAuditLogs", ctx, filters)
+	ret0, _ := ret[0].(*types.OrgAuditLogResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOrgAuditLogs indicates an expected call of ListOrgAuditLogs.
+func (mr *MockStoreMockRecorder) ListOrgAuditLogs(ctx, filters any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrgAuditLogs", reflect.TypeOf((*MockStore)(nil).ListOrgAuditLogs), ctx, filters)
 }
 
 // ListOrganizationInvitations mocks base method.

--- a/api/pkg/store/store_org_audit_logs.go
+++ b/api/pkg/store/store_org_audit_logs.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func (s *PostgresStore) CreateOrgAuditLog(ctx context.Context, entry *types.OrgAuditLog) error {
+	if err := s.gdb.WithContext(ctx).Create(entry).Error; err != nil {
+		return fmt.Errorf("failed to create org audit log: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListOrgAuditLogs(ctx context.Context, filters *types.OrgAuditLogFilters) (*types.OrgAuditLogResponse, error) {
+	var logs []*types.OrgAuditLog
+	var total int64
+
+	db := s.gdb.WithContext(ctx).Model(&types.OrgAuditLog{})
+	if filters != nil {
+		if filters.OrganizationID != "" {
+			db = db.Where("organization_id = ?", filters.OrganizationID)
+		}
+		if filters.ProjectID != "" {
+			db = db.Where("project_id = ?", filters.ProjectID)
+		}
+		if filters.UserID != "" {
+			db = db.Where("user_id = ?", filters.UserID)
+		}
+		if filters.ActorID != "" {
+			db = db.Where("actor_id = ?", filters.ActorID)
+		}
+		if filters.AssetID != "" {
+			db = db.Where("asset_id = ?", filters.AssetID)
+		}
+		if filters.EventType != "" {
+			db = db.Where("event_type = ?", filters.EventType)
+		}
+		if filters.Action != "" {
+			db = db.Where("action = ?", filters.Action)
+		}
+		if filters.Status != "" {
+			db = db.Where("status = ?", filters.Status)
+		}
+		if filters.StartDate != nil {
+			db = db.Where("created_at >= ?", *filters.StartDate)
+		}
+		if filters.EndDate != nil {
+			db = db.Where("created_at <= ?", *filters.EndDate)
+		}
+		if filters.Search != "" {
+			query := "%" + filters.Search + "%"
+			db = db.Where("action ILIKE ? OR CAST(metadata AS TEXT) ILIKE ?", query, query)
+		}
+	}
+
+	if err := db.Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("failed to count org audit logs: %w", err)
+	}
+
+	limit := 50
+	offset := 0
+	if filters != nil {
+		if filters.Limit > 0 && filters.Limit <= 100 {
+			limit = filters.Limit
+		}
+		if filters.Offset > 0 {
+			offset = filters.Offset
+		}
+	}
+	if err := db.Order("created_at DESC").Limit(limit).Offset(offset).Find(&logs).Error; err != nil {
+		return nil, fmt.Errorf("failed to list org audit logs: %w", err)
+	}
+
+	return &types.OrgAuditLogResponse{Logs: logs, Total: total, Limit: limit, Offset: offset}, nil
+}

--- a/api/pkg/store/store_org_audit_logs_test.go
+++ b/api/pkg/store/store_org_audit_logs_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"time"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func (suite *PostgresStoreTestSuite) TestPostgresStore_OrgAuditLogs() {
+	orgID := "org_" + system.GenerateUUID()
+	otherOrgID := "org_" + system.GenerateUUID()
+	createdAt := time.Now().UTC()
+	entries := []*types.OrgAuditLog{
+		{
+			ID: "org_audit_" + system.GenerateUUID(), OrganizationID: orgID,
+			ProjectID: "project-1", ActorID: "bot-1", ActorType: types.OrgAuditActorBot,
+			AssetID: "asset-1", EventType: types.OrgAuditEventSSHCommand, Action: "exec",
+			Status:   types.OrgAuditStatusAttempted,
+			Metadata: types.OrgAuditMetadata{Command: "uname -a"}, CreatedAt: createdAt,
+		},
+		{
+			ID: "org_audit_" + system.GenerateUUID(), OrganizationID: orgID,
+			ActorID: "bot-1", ActorType: types.OrgAuditActorBot,
+			EventType: types.OrgAuditEventMCPCall, Action: "list_assets",
+			Status: types.OrgAuditStatusSucceeded, CreatedAt: createdAt.Add(time.Second),
+		},
+		{
+			ID: "org_audit_" + system.GenerateUUID(), OrganizationID: otherOrgID,
+			ActorID: "bot-2", ActorType: types.OrgAuditActorBot,
+			AssetID: "asset-1", EventType: types.OrgAuditEventSSHCommand, Action: "exec",
+			Status:   types.OrgAuditStatusAttempted,
+			Metadata: types.OrgAuditMetadata{Command: "hostname"}, CreatedAt: createdAt.Add(2 * time.Second),
+		},
+	}
+	for _, entry := range entries {
+		suite.Require().NoError(suite.db.CreateOrgAuditLog(suite.ctx, entry))
+	}
+	suite.T().Cleanup(func() {
+		ids := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			ids = append(ids, entry.ID)
+		}
+		_ = suite.db.gdb.WithContext(suite.ctx).Where("id IN ?", ids).Delete(&types.OrgAuditLog{}).Error
+	})
+
+	response, err := suite.db.ListOrgAuditLogs(suite.ctx, &types.OrgAuditLogFilters{
+		OrganizationID: orgID,
+		AssetID:        "asset-1",
+		EventType:      types.OrgAuditEventSSHCommand,
+		Search:         "uname",
+	})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), response.Total)
+	suite.Require().Len(response.Logs, 1)
+	suite.Equal("project-1", response.Logs[0].ProjectID)
+	suite.Equal("uname -a", response.Logs[0].Metadata.Command)
+}

--- a/api/pkg/types/org_audit_log.go
+++ b/api/pkg/types/org_audit_log.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type OrgAuditEventType string
+
+const (
+	OrgAuditEventMCPCall       OrgAuditEventType = "mcp_call"
+	OrgAuditEventSSHConnection OrgAuditEventType = "ssh_connection"
+	OrgAuditEventSSHCommand    OrgAuditEventType = "ssh_command"
+)
+
+type OrgAuditStatus string
+
+const (
+	OrgAuditStatusAttempted OrgAuditStatus = "attempted"
+	OrgAuditStatusSucceeded OrgAuditStatus = "succeeded"
+	OrgAuditStatusFailed    OrgAuditStatus = "failed"
+)
+
+type OrgAuditActorType string
+
+const (
+	OrgAuditActorBot  OrgAuditActorType = "bot"
+	OrgAuditActorUser OrgAuditActorType = "user"
+)
+
+type OrgAuditMetadata struct {
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	AssetRef      string          `json:"asset_ref,omitempty"`
+	Command       string          `json:"command,omitempty"`
+	CommandID     string          `json:"command_id,omitempty"`
+	Error         string          `json:"error,omitempty"`
+	RemoteAddress string          `json:"remote_address,omitempty"`
+	LocalAddress  string          `json:"local_address,omitempty"`
+	SSHUser       string          `json:"ssh_user,omitempty"`
+	ClientVersion string          `json:"client_version,omitempty"`
+	DurationMS    int64           `json:"duration_ms,omitempty"`
+}
+
+// OrgAuditLog is an append-only audit trail entry for actions performed
+// within a Helix organization.
+type OrgAuditLog struct {
+	ID             string            `json:"id" gorm:"primaryKey;size:255"`
+	OrganizationID string            `json:"organization_id" gorm:"size:255;index;not null"`
+	ProjectID      string            `json:"project_id,omitempty" gorm:"size:255;index"`
+	UserID         string            `json:"user_id,omitempty" gorm:"size:255;index"`
+	ActorID        string            `json:"actor_id" gorm:"size:255;index;not null"`
+	ActorType      OrgAuditActorType `json:"actor_type" gorm:"size:50;index;not null"`
+	AssetID        string            `json:"asset_id,omitempty" gorm:"size:255;index"`
+	EventType      OrgAuditEventType `json:"event_type" gorm:"size:50;index;not null"`
+	Action         string            `json:"action" gorm:"size:255;index;not null"`
+	Status         OrgAuditStatus    `json:"status" gorm:"size:50;index;not null"`
+	Metadata       OrgAuditMetadata  `json:"metadata,omitempty" gorm:"type:jsonb;serializer:json"`
+	CreatedAt      time.Time         `json:"created_at" gorm:"index"`
+}
+
+type OrgAuditLogFilters struct {
+	OrganizationID string            `json:"organization_id"`
+	ProjectID      string            `json:"project_id,omitempty"`
+	UserID         string            `json:"user_id,omitempty"`
+	ActorID        string            `json:"actor_id,omitempty"`
+	AssetID        string            `json:"asset_id,omitempty"`
+	EventType      OrgAuditEventType `json:"event_type,omitempty"`
+	Action         string            `json:"action,omitempty"`
+	Status         OrgAuditStatus    `json:"status,omitempty"`
+	StartDate      *time.Time        `json:"start_date,omitempty"`
+	EndDate        *time.Time        `json:"end_date,omitempty"`
+	Search         string            `json:"search,omitempty"`
+	Limit          int               `json:"limit,omitempty"`
+	Offset         int               `json:"offset,omitempty"`
+}
+
+type OrgAuditLogResponse struct {
+	Logs   []*OrgAuditLog `json:"logs"`
+	Total  int64          `json:"total"`
+	Limit  int            `json:"limit"`
+	Offset int            `json:"offset"`
+}

--- a/design/2026-08-02-org-asset-audit-logs.md
+++ b/design/2026-08-02-org-asset-audit-logs.md
@@ -1,0 +1,14 @@
+# Helix org asset audit logs
+
+Helix org actions are recorded in the append-only `org_audit_logs` table. Records are tenant-scoped by `organization_id` and may also carry `project_id`, authenticated `user_id`, Bot actor, and asset identifiers.
+
+Initial event coverage:
+
+- every Helix org MCP tool invocation, including failed invocations;
+- authenticated asset SSH proxy connections and trusted-certificate rejections;
+- SSH `exec` requests intercepted by the asset proxy;
+- direct asset command and SFTP connection paths used by org MCP tools.
+
+MCP arguments are stored after recursively redacting credential, password, private-key, secret, token, and authorization fields. Tool results are not stored because results such as `mint_credential` contain live credentials. SSH commands are stored verbatim because command accountability is the purpose of the audit event; callers must treat audit-log access as sensitive.
+
+SSH command status is `attempted` after the upstream server accepts the `exec` request. This does not claim that the remote process exited successfully. Connection and MCP statuses represent their completed outcomes.


### PR DESCRIPTION
## Summary

- add append-only org audit log types, GORM migration, indexed filters, and Postgres persistence
- record org MCP calls with actor/project/asset attribution, redacted arguments, status, errors, and duration
- record direct and proxied asset SSH connections plus intercepted exec commands

## Security

- redact password, token, secret, credential, authorization, and private-key MCP fields recursively
- do not persist MCP tool results because credential tools return live secrets
- persist SSH commands verbatim because command accountability is the audit requirement

## Tests

- go test ./pkg/org/...
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- go test -run TestOrgAuditLogServiceRecord ./pkg/services
- Postgres integration: TestPostgresStoreSuite/TestPostgresStore_OrgAuditLogs against localhost:5432
- verified the migrated org_audit_logs schema and indexes in the local Helix Postgres container