### PR TITLE
feat(org): add sandbox management and native SSH access

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -849,8 +849,8 @@ type WebServer struct {
 	URL                  string `envconfig:"SERVER_URL" description:"The URL the api server is listening on."`
 	Host                 string `envconfig:"SERVER_HOST" default:"0.0.0.0" description:"The host to bind the api server to."`
 	Port                 int    `envconfig:"SERVER_PORT" default:"80" description:""`
-	AssetSSHProxyListen  string `envconfig:"ASSET_SSH_PROXY_LISTEN" default:":2224" description:"Address for the Helix asset SSH proxy to listen on."`
-	AssetSSHProxyAddress string `envconfig:"ASSET_SSH_PROXY_ADDRESS" description:"Public host:port for agents to reach the Helix asset SSH proxy."`
+	AssetSSHProxyListen  string `envconfig:"ASSET_SSH_PROXY_LISTEN" default:":2224" description:"Address for the Helix managed-resource SSH proxy to listen on."`
+	AssetSSHProxyAddress string `envconfig:"ASSET_SSH_PROXY_ADDRESS" description:"Public host:port for agents to reach the Helix asset and sandbox SSH proxy."`
 	// Can either be a URL to frontend (for dev proxy) or a path to static files (for prod)
 	// Default is dev proxy; Dockerfile sets FRONTEND_URL=/www for production
 	FrontendURL string `envconfig:"FRONTEND_URL" default:"http://frontend:8081" description:"URL to proxy to or filesystem path to serve from"`

--- a/api/pkg/hydra/sandbox_handlers.go
+++ b/api/pkg/hydra/sandbox_handlers.go
@@ -286,7 +286,8 @@ func (s *Server) handleSandboxTerminal(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 
 	cmd := []string{"/bin/bash"}
-	if shell := r.URL.Query().Get("shell"); shell != "" {
+	shell := r.URL.Query().Get("shell")
+	if shell != "" {
 		// A shell value containing whitespace is treated as a /bin/sh -c
 		// expression so callers can pass multi-arg commands like
 		// "tmux new-session -A -s foo". A bare value like "/bin/zsh" is
@@ -308,16 +309,19 @@ func (s *Server) handleSandboxTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := dockerClient.ContainerExecCreate(r.Context(), dc.ContainerID, cfg)
 	if err != nil {
-		// Try /bin/sh as fallback.
+		conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"failed to create exec"}`))
+		return
+	}
+	attach, err := dockerClient.ContainerExecAttach(r.Context(), created.ID, dockertypes.ExecStartCheck{Tty: true})
+	if err != nil && shell == "" {
+		// Minimal/custom images may not include bash. The attach/start call is
+		// where Docker reports a missing executable, so retry the full exec with sh.
 		cfg.Cmd = []string{"/bin/sh"}
 		created, err = dockerClient.ContainerExecCreate(r.Context(), dc.ContainerID, cfg)
-		if err != nil {
-			conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"failed to create exec"}`))
-			return
+		if err == nil {
+			attach, err = dockerClient.ContainerExecAttach(r.Context(), created.ID, dockertypes.ExecStartCheck{Tty: true})
 		}
 	}
-
-	attach, err := dockerClient.ContainerExecAttach(r.Context(), created.ID, dockertypes.ExecStartCheck{Tty: true})
 	if err != nil {
 		conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"failed to attach exec"}`))
 		return
@@ -361,6 +365,14 @@ func (s *Server) handleSandboxTerminal(w http.ResponseWriter, r *http.Request) {
 	if _, err := stdcopyOrTty(&wsWriter, attach.Reader, true); err != nil && err != io.EOF {
 		log.Debug().Err(err).Msg("terminal stream ended")
 	}
+	inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
+	defer cancel()
+	inspect, err := dockerClient.ContainerExecInspect(inspectCtx, created.ID)
+	if err != nil {
+		_ = conn.WriteJSON(map[string]interface{}{"type": "exit", "code": 255})
+		return
+	}
+	_ = conn.WriteJSON(map[string]interface{}{"type": "exit", "code": inspect.ExitCode})
 }
 
 // wsBinaryWriter writes bytes as websocket binary frames.

--- a/api/pkg/org/application/sandboxes/sandboxes.go
+++ b/api/pkg/org/application/sandboxes/sandboxes.go
@@ -1,0 +1,94 @@
+// Package sandboxes exposes org-scoped standalone sandbox management to MCP
+// tools without coupling the org application layer to Helix's sandbox
+// controller.
+package sandboxes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+type MemberVerifier interface {
+	GetBot(ctx context.Context, orgID string, id orgchart.NodeID) (orgchart.Node, error)
+}
+
+type Service struct {
+	port    runtime.Sandboxes
+	members MemberVerifier
+}
+
+func New(port runtime.Sandboxes, members MemberVerifier) *Service {
+	return &Service{port: port, members: members}
+}
+
+func (s *Service) callerIdentity(ctx context.Context, caller tool.Caller) (string, orgchart.NodeID, error) {
+	if caller == nil {
+		return "", "", errors.New("caller missing on invocation")
+	}
+	orgID := caller.OrganizationID()
+	if orgID == "" {
+		return "", "", errors.New("caller has no organization id")
+	}
+	botID := orgchart.NodeID(caller.ID())
+	if botID == "" {
+		return "", "", errors.New("caller has no bot id")
+	}
+	if s.members != nil {
+		if _, err := s.members.GetBot(ctx, orgID, botID); err != nil {
+			return "", "", fmt.Errorf("caller bot %s is not a member of org %s: %w", botID, orgID, err)
+		}
+	}
+	return orgID, botID, nil
+}
+
+func (s *Service) ListRuntimes(ctx context.Context, caller tool.Caller) (runtime.SandboxRuntimeCatalog, error) {
+	if _, _, err := s.callerIdentity(ctx, caller); err != nil {
+		return runtime.SandboxRuntimeCatalog{}, err
+	}
+	return s.port.ListRuntimes(ctx)
+}
+
+func (s *Service) List(ctx context.Context, caller tool.Caller, projectID string) ([]runtime.SandboxView, error) {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return nil, err
+	}
+	return s.port.List(ctx, orgID, projectID)
+}
+
+func (s *Service) Get(ctx context.Context, caller tool.Caller, sandboxID string) (runtime.SandboxView, error) {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	return s.port.Get(ctx, orgID, sandboxID)
+}
+
+func (s *Service) Create(ctx context.Context, caller tool.Caller, in runtime.CreateSandboxInput) (runtime.SandboxView, error) {
+	orgID, botID, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	return s.port.Create(ctx, orgID, botID, in)
+}
+
+func (s *Service) Update(ctx context.Context, caller tool.Caller, sandboxID string, in runtime.UpdateSandboxInput) (runtime.SandboxView, error) {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	return s.port.Update(ctx, orgID, sandboxID, in)
+}
+
+func (s *Service) Delete(ctx context.Context, caller tool.Caller, sandboxID string) error {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return err
+	}
+	return s.port.Delete(ctx, orgID, sandboxID)
+}

--- a/api/pkg/org/application/sandboxes/sandboxes.go
+++ b/api/pkg/org/application/sandboxes/sandboxes.go
@@ -92,3 +92,26 @@ func (s *Service) Delete(ctx context.Context, caller tool.Caller, sandboxID stri
 	}
 	return s.port.Delete(ctx, orgID, sandboxID)
 }
+
+// AuthorizeSSH revalidates a certificate's org, agent, and sandbox scope at
+// connection time. This means removing the Bot or deleting/moving the sandbox
+// revokes an already-minted certificate immediately.
+func (s *Service) AuthorizeSSH(ctx context.Context, orgID, agentID, sandboxID string) (runtime.SandboxView, error) {
+	if orgID == "" || agentID == "" || sandboxID == "" {
+		return runtime.SandboxView{}, errors.New("sandbox SSH scope is incomplete")
+	}
+	if s.members == nil {
+		return runtime.SandboxView{}, errors.New("sandbox SSH member verification is not configured")
+	}
+	if _, err := s.members.GetBot(ctx, orgID, orgchart.NodeID(agentID)); err != nil {
+		return runtime.SandboxView{}, fmt.Errorf("authorize sandbox SSH agent: %w", err)
+	}
+	return s.port.Get(ctx, orgID, sandboxID)
+}
+
+func (s *Service) OpenSSHTerminal(ctx context.Context, orgID, agentID, sandboxID, shell string) (runtime.SandboxTerminal, error) {
+	if _, err := s.AuthorizeSSH(ctx, orgID, agentID, sandboxID); err != nil {
+		return nil, err
+	}
+	return s.port.OpenTerminal(ctx, orgID, sandboxID, shell)
+}

--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -60,7 +60,10 @@ After the key is installed, call ` + "`get_asset_health`" + `. Both ` + "`tcp_re
 Your tools are helix MCP tools (` + "`mcp__helix__…`" + `). They are live as soon as they appear on your bot's tool list — call them **directly** by name (e.g. ` + "`mcp__helix__list_bot_repositories`" + `). Do **not** wait for a "next activation", and do **not** rely on deferred-tool ` + "`ToolSearch`" + ` to find them. If ` + "`tools/list`" + ` / your tool list shows a name, invoke it now.
 
 ## Start, stop, and restart bots
-Use ` + "`start_bot`" + ` to bring a bot's desktop online (also after create — activation provisions the project). Use ` + "`stop_bot`" + ` to shut the desktop down without losing the transcript. Use ` + "`restart_bot`" + ` when you need a brand-new session (e.g. after changing tools or repo attachments).`
+Use ` + "`start_bot`" + ` to bring a bot's desktop online (also after create — activation provisions the project). Use ` + "`stop_bot`" + ` to shut the desktop down without losing the transcript. Use ` + "`restart_bot`" + ` when you need a brand-new session (e.g. after changing tools or repo attachments).
+
+## Manage standalone sandboxes
+Standalone sandboxes are the organization containers shown on the Sandboxes page; they are separate from Bot desktops. Use ` + "`list_sandbox_runtimes`" + ` to discover the configured runtimes, ` + "`create_sandbox`" + ` to provision one, and poll ` + "`get_sandbox`" + ` until it is running or failed. Use ` + "`list_sandboxes`" + ` for inventory, ` + "`update_sandbox`" + ` for its name, expiry, or tags, and ` + "`delete_sandbox`" + ` to tear it down.`
 
 // Default returns the built-in instructions for a seeded node, and
 // whether one exists. Nodes an operator created themselves have no

--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -63,7 +63,7 @@ Your tools are helix MCP tools (` + "`mcp__helix__…`" + `). They are live as s
 Use ` + "`start_bot`" + ` to bring a bot's desktop online (also after create — activation provisions the project). Use ` + "`stop_bot`" + ` to shut the desktop down without losing the transcript. Use ` + "`restart_bot`" + ` when you need a brand-new session (e.g. after changing tools or repo attachments).
 
 ## Manage standalone sandboxes
-Standalone sandboxes are the organization containers shown on the Sandboxes page; they are separate from Bot desktops. Use ` + "`list_sandbox_runtimes`" + ` to discover the configured runtimes, ` + "`create_sandbox`" + ` to provision one, and poll ` + "`get_sandbox`" + ` until it is running or failed. Use ` + "`list_sandboxes`" + ` for inventory, ` + "`update_sandbox`" + ` for its name, expiry, or tags, and ` + "`delete_sandbox`" + ` to tear it down.`
+Standalone sandboxes are the organization containers shown on the Sandboxes page; they are separate from Bot desktops. Use ` + "`list_sandbox_runtimes`" + ` to discover the configured runtimes, ` + "`create_sandbox`" + ` to provision one, and poll ` + "`get_sandbox`" + ` until it is running or failed. Once running, call ` + "`sandbox_ssh_access`" + ` and execute its setup command to work in the container with native SSH; no sandbox SSH server or exposed port is required. Use ` + "`list_sandboxes`" + ` for inventory, ` + "`update_sandbox`" + ` for its name, expiry, or tags, and ` + "`delete_sandbox`" + ` to tear it down.`
 
 // Default returns the built-in instructions for a seeded node, and
 // whether one exists. Nodes an operator created themselves have no

--- a/api/pkg/org/infrastructure/assetssh/proxy.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy.go
@@ -23,9 +23,13 @@ import (
 )
 
 const (
-	certOrgID   = "helix.org_id"
-	certAgentID = "helix.agent_id"
-	certAssetID = "helix.asset_id"
+	certOrgID         = "helix.org_id"
+	certAgentID       = "helix.agent_id"
+	certAssetID       = "helix.asset_id"
+	certSandboxID     = "helix.sandbox_id"
+	certTargetKind    = "helix.target_kind"
+	targetKindAsset   = "asset"
+	targetKindSandbox = "sandbox"
 )
 
 type ProxyIdentity struct {
@@ -74,7 +78,7 @@ func (i *Issuer) Mint(ctx context.Context, orgID, agentID, assetRef string) (Pro
 		ValidAfter:      uint64(now.Add(-time.Minute).Unix()),
 		ValidBefore:     uint64(expiresAt.Unix()),
 		Permissions: ssh.Permissions{Extensions: map[string]string{
-			certOrgID: orgID, certAgentID: agentID, certAssetID: a.ID,
+			certOrgID: orgID, certAgentID: agentID, certAssetID: a.ID, certTargetKind: targetKindAsset,
 		}},
 	}
 	if err := cert.SignCert(rand.Reader, i.ca); err != nil {
@@ -93,11 +97,12 @@ func (i *Issuer) Mint(ctx context.Context, orgID, agentID, assetRef string) (Pro
 }
 
 type Proxy struct {
-	assets   Assets
-	client   *Client
-	config   *ssh.ServerConfig
-	audit    orgaudit.Recorder
-	projects orgaudit.ProjectResolver
+	assets    Assets
+	sandboxes SandboxAccess
+	client    *Client
+	config    *ssh.ServerConfig
+	audit     orgaudit.Recorder
+	projects  orgaudit.ProjectResolver
 }
 
 func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, error) {
@@ -126,6 +131,28 @@ func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, erro
 		}
 		orgID := cert.Extensions[certOrgID]
 		agentID := cert.Extensions[certAgentID]
+		if cert.Extensions[certTargetKind] == targetKindSandbox || cert.Extensions[certSandboxID] != "" {
+			sandboxID := cert.Extensions[certSandboxID]
+			if orgID == "" || agentID == "" || sandboxID == "" {
+				return nil, errors.New("Helix sandbox proxy certificate is missing scope")
+			}
+			if p.sandboxes == nil {
+				return nil, errors.New("Helix sandbox SSH proxy is not configured")
+			}
+			if _, err := p.sandboxes.AuthorizeSSH(context.Background(), orgID, agentID, sandboxID); err != nil {
+				authErr := fmt.Errorf("authorize sandbox proxy: %w", err)
+				p.recordRejectedConnection(meta, orgID, agentID, "", "sandbox:"+sandboxID, authErr)
+				return nil, authErr
+			}
+			if meta.User() != sandboxSSHUser {
+				authErr := fmt.Errorf("SSH username must be %q for sandbox access", sandboxSSHUser)
+				p.recordRejectedConnection(meta, orgID, agentID, "", "sandbox:"+sandboxID, authErr)
+				return nil, authErr
+			}
+			return &ssh.Permissions{Extensions: map[string]string{
+				certOrgID: orgID, certAgentID: agentID, certSandboxID: sandboxID, certTargetKind: targetKindSandbox,
+			}}, nil
+		}
 		assetID := cert.Extensions[certAssetID]
 		if orgID == "" || agentID == "" || assetID == "" {
 			return nil, errors.New("Helix asset proxy certificate is missing scope")
@@ -133,12 +160,12 @@ func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, erro
 		a, err := assets.AuthorizeRef(context.Background(), orgID, agentID, assetID)
 		if err != nil {
 			authErr := fmt.Errorf("authorize asset proxy: %w", err)
-			p.recordRejectedConnection(meta, orgID, agentID, assetID, authErr)
+			p.recordRejectedConnection(meta, orgID, agentID, assetID, "", authErr)
 			return nil, authErr
 		}
 		if meta.User() != a.Name {
 			authErr := errors.New("SSH username must match the linked asset name")
-			p.recordRejectedConnection(meta, orgID, agentID, assetID, authErr)
+			p.recordRejectedConnection(meta, orgID, agentID, assetID, "", authErr)
 			return nil, authErr
 		}
 		return &ssh.Permissions{Extensions: map[string]string{
@@ -147,6 +174,11 @@ func NewProxy(assets Assets, client *Client, encryptionKey []byte) (*Proxy, erro
 	}}
 	p.config.AddHostKey(host)
 	return p, nil
+}
+
+func (p *Proxy) WithSandboxes(sandboxes SandboxAccess) *Proxy {
+	p.sandboxes = sandboxes
+	return p
 }
 
 func (p *Proxy) WithAudit(recorder orgaudit.Recorder, projects orgaudit.ProjectResolver) *Proxy {
@@ -183,24 +215,30 @@ func (p *Proxy) serve(ctx context.Context, listener net.Listener) error {
 
 func (p *Proxy) handle(ctx context.Context, raw net.Conn) {
 	defer raw.Close()
+	connectionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	conn, channels, requests, err := ssh.NewServerConn(raw, p.config)
 	if err != nil {
 		return
 	}
 	defer conn.Close()
-	p.recordConnection(ctx, conn, orgaudit.StatusSucceeded, nil)
+	p.recordConnection(connectionCtx, conn, orgaudit.StatusSucceeded, nil)
 	go ssh.DiscardRequests(requests)
 	for newChannel := range channels {
 		if newChannel.ChannelType() != "session" {
 			_ = newChannel.Reject(ssh.UnknownChannelType, "only SSH session channels are supported")
 			continue
 		}
-		go p.proxySession(ctx, conn, newChannel)
+		go p.proxySession(connectionCtx, conn, newChannel)
 	}
 }
 
 func (p *Proxy) proxySession(ctx context.Context, conn *ssh.ServerConn, incoming ssh.NewChannel) {
 	permissions := conn.Permissions.Extensions
+	if permissions[certTargetKind] == targetKindSandbox || permissions[certSandboxID] != "" {
+		p.proxySandboxSession(ctx, conn, incoming)
+		return
+	}
 	upstream, err := p.client.DialAuthorized(ctx, permissions[certOrgID], permissions[certAgentID], permissions[certAssetID])
 	if err != nil {
 		_ = incoming.Reject(ssh.ConnectionFailed, err.Error())
@@ -290,12 +328,16 @@ func (p *Proxy) recordConnection(ctx context.Context, conn *ssh.ServerConn, stat
 	if connectionErr != nil {
 		metadata.Error = connectionErr.Error()
 	}
+	assetID := permissions[certAssetID]
+	if permissions[certSandboxID] != "" {
+		metadata.AssetRef = "sandbox:" + permissions[certSandboxID]
+	}
 	p.recordAudit(ctx, orgaudit.Entry{
 		OrganizationID: permissions[certOrgID],
 		ProjectID:      p.projectID(ctx, permissions[certOrgID], permissions[certAgentID]),
 		ActorID:        permissions[certAgentID],
 		ActorType:      orgaudit.ActorBot,
-		AssetID:        permissions[certAssetID],
+		AssetID:        assetID,
 		EventType:      orgaudit.EventSSHConnection,
 		Action:         "connect",
 		Status:         status,
@@ -303,7 +345,7 @@ func (p *Proxy) recordConnection(ctx context.Context, conn *ssh.ServerConn, stat
 	})
 }
 
-func (p *Proxy) recordRejectedConnection(meta ssh.ConnMetadata, orgID, agentID, assetID string, connectionErr error) {
+func (p *Proxy) recordRejectedConnection(meta ssh.ConnMetadata, orgID, agentID, assetID, resourceRef string, connectionErr error) {
 	p.recordAudit(context.Background(), orgaudit.Entry{
 		OrganizationID: orgID,
 		ProjectID:      p.projectID(context.Background(), orgID, agentID),
@@ -314,6 +356,7 @@ func (p *Proxy) recordRejectedConnection(meta ssh.ConnMetadata, orgID, agentID, 
 		Action:         "connect",
 		Status:         orgaudit.StatusFailed,
 		Metadata: orgaudit.Metadata{
+			AssetRef:      resourceRef,
 			RemoteAddress: meta.RemoteAddr().String(),
 			LocalAddress:  meta.LocalAddr().String(),
 			SSHUser:       meta.User(),
@@ -367,7 +410,7 @@ func deterministicSigner(key []byte, purpose string) (ssh.Signer, error) {
 func ParseProxyAddress(value string) (host string, port int, err error) {
 	host, rawPort, err := net.SplitHostPort(value)
 	if err != nil {
-		return "", 0, fmt.Errorf("asset SSH proxy address must be host:port: %w", err)
+		return "", 0, fmt.Errorf("SSH proxy address must be host:port: %w", err)
 	}
 	port, err = strconv.Atoi(rawPort)
 	if err != nil || port < 1 || port > 65535 {

--- a/api/pkg/org/infrastructure/assetssh/proxy_test.go
+++ b/api/pkg/org/infrastructure/assetssh/proxy_test.go
@@ -3,18 +3,22 @@ package assetssh
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/ssh"
 
 	helixcrypto "github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/org/domain/asset"
 	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 )
 
 type recordingAudit struct {
@@ -320,6 +324,173 @@ func TestProxyForwardsAuthorizedAgentSessionAndRejectsRevokedLink(t *testing.T) 
 	if revokedClient, err := ssh.Dial("tcp", listener.Addr().String(), config); err == nil {
 		_ = revokedClient.Close()
 		t.Fatal("revoked agent link still opened the SSH proxy")
+	}
+	cancel()
+	select {
+	case err := <-proxyDone:
+		if err != nil {
+			t.Fatalf("proxy shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxy did not stop after context cancellation")
+	}
+}
+
+type sandboxTerminalFrame struct {
+	messageType int
+	data        []byte
+}
+
+type proxySandboxTerminal struct {
+	reads  chan sandboxTerminalFrame
+	writes chan sandboxTerminalFrame
+}
+
+func (t *proxySandboxTerminal) ReadMessage() (int, []byte, error) {
+	frame, ok := <-t.reads
+	if !ok {
+		return 0, nil, io.EOF
+	}
+	return frame.messageType, frame.data, nil
+}
+func (t *proxySandboxTerminal) WriteMessage(messageType int, data []byte) error {
+	t.writes <- sandboxTerminalFrame{messageType: messageType, data: append([]byte(nil), data...)}
+	return nil
+}
+func (*proxySandboxTerminal) Close() error { return nil }
+
+type proxySandboxes struct {
+	mu      sync.RWMutex
+	allowed bool
+	opened  chan string
+	writes  chan sandboxTerminalFrame
+}
+
+func (s *proxySandboxes) AuthorizeSSH(_ context.Context, orgID, agentID, sandboxID string) (runtime.SandboxView, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.allowed || orgID != "org-1" || agentID != "agent-1" || sandboxID != "sbx-1" {
+		return runtime.SandboxView{}, errors.New("sandbox access denied")
+	}
+	return runtime.SandboxView{ID: sandboxID, OrganizationID: orgID, Status: "running"}, nil
+}
+func (s *proxySandboxes) OpenSSHTerminal(_ context.Context, orgID, agentID, sandboxID, shell string) (runtime.SandboxTerminal, error) {
+	if _, err := s.AuthorizeSSH(context.Background(), orgID, agentID, sandboxID); err != nil {
+		return nil, err
+	}
+	s.opened <- shell
+	reads := make(chan sandboxTerminalFrame, 2)
+	reads <- sandboxTerminalFrame{messageType: websocket.BinaryMessage, data: []byte("sandbox-ok")}
+	reads <- sandboxTerminalFrame{messageType: websocket.TextMessage, data: []byte(`{"type":"exit","code":0}`)}
+	return &proxySandboxTerminal{reads: reads, writes: s.writes}, nil
+}
+func (s *proxySandboxes) setAllowed(value bool) {
+	s.mu.Lock()
+	s.allowed = value
+	s.mu.Unlock()
+}
+
+func TestProxyBridgesNativeSSHToAuthorizedSandboxTerminal(t *testing.T) {
+	assets := &proxyAssets{allowed: true, value: asset.Asset{
+		ID: "unused", OrganizationID: "org-1", Name: "unused", Kind: asset.KindServer,
+	}}
+	client, err := New(assets, func(string) ([]byte, error) { return nil, nil }, func() string { return "cmd" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandboxes := &proxySandboxes{
+		allowed: true,
+		opened:  make(chan string, 1),
+		writes:  make(chan sandboxTerminalFrame, 4),
+	}
+	key := []byte("01234567890123456789012345678901")
+	issuer, err := NewSandboxIssuer(sandboxes, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := issuer.Mint(context.Background(), "org-1", "agent-1", "sbx-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateSigner, err := ssh.ParsePrivateKey([]byte(identity.PrivateKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificateKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(identity.Certificate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, ok := certificateKey.(*ssh.Certificate)
+	if !ok {
+		t.Fatal("minted sandbox identity is not an SSH certificate")
+	}
+	certificateSigner, err := ssh.NewCertSigner(certificate, privateSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy, err := NewProxy(assets, client, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy.WithSandboxes(sandboxes)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proxyDone := make(chan error, 1)
+	go func() { proxyDone <- proxy.serve(ctx, listener) }()
+
+	config := &ssh.ClientConfig{
+		User: "sandbox", Auth: []ssh.AuthMethod{ssh.PublicKeys(certificateSigner)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), Timeout: 5 * time.Second,
+	}
+	proxyClient, err := ssh.Dial("tcp", listener.Addr().String(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := proxyClient.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.RequestPty("xterm-256color", 24, 80, ssh.TerminalModes{}); err != nil {
+		t.Fatal(err)
+	}
+	output, err := session.CombinedOutput("printf 'sandbox-ok'")
+	if err != nil {
+		t.Fatalf("sandbox SSH command failed: %v", err)
+	}
+	if string(output) != "sandbox-ok" {
+		t.Fatalf("sandbox SSH output = %q", output)
+	}
+	select {
+	case shell := <-sandboxes.opened:
+		if shell != "exec /bin/sh -c "+shellQuote("printf 'sandbox-ok'") {
+			t.Fatalf("sandbox terminal shell = %q", shell)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("sandbox terminal was not opened")
+	}
+	select {
+	case frame := <-sandboxes.writes:
+		var resize struct {
+			Type string `json:"type"`
+			Cols uint32 `json:"cols"`
+			Rows uint32 `json:"rows"`
+		}
+		if frame.messageType != websocket.TextMessage || json.Unmarshal(frame.data, &resize) != nil || resize.Type != "resize" || resize.Cols != 80 || resize.Rows != 24 {
+			t.Fatalf("sandbox resize frame = type %d data %s", frame.messageType, frame.data)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("sandbox terminal did not receive PTY dimensions")
+	}
+	_ = proxyClient.Close()
+
+	sandboxes.setAllowed(false)
+	if revokedClient, err := ssh.Dial("tcp", listener.Addr().String(), config); err == nil {
+		_ = revokedClient.Close()
+		t.Fatal("revoked sandbox certificate still opened the SSH proxy")
 	}
 	cancel()
 	select {

--- a/api/pkg/org/infrastructure/assetssh/sandboxes.go
+++ b/api/pkg/org/infrastructure/assetssh/sandboxes.go
@@ -1,0 +1,268 @@
+package assetssh
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/ssh"
+
+	orgaudit "github.com/helixml/helix/api/pkg/org/domain/audit"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+const sandboxSSHUser = "sandbox"
+
+type SandboxAccess interface {
+	AuthorizeSSH(ctx context.Context, orgID, agentID, sandboxID string) (runtime.SandboxView, error)
+	OpenSSHTerminal(ctx context.Context, orgID, agentID, sandboxID, shell string) (runtime.SandboxTerminal, error)
+}
+
+type SandboxProxyIdentity struct {
+	SandboxID   string    `json:"sandbox_id"`
+	PrivateKey  string    `json:"private_key"`
+	Certificate string    `json:"certificate"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+type SandboxIssuer struct {
+	sandboxes SandboxAccess
+	ca        ssh.Signer
+	now       func() time.Time
+}
+
+func NewSandboxIssuer(sandboxes SandboxAccess, encryptionKey []byte) (*SandboxIssuer, error) {
+	if sandboxes == nil || len(encryptionKey) == 0 {
+		return nil, errors.New("sandbox SSH issuer requires sandbox access and an encryption key")
+	}
+	ca, err := deterministicSigner(encryptionKey, "helix-asset-ssh-ca")
+	if err != nil {
+		return nil, err
+	}
+	return &SandboxIssuer{sandboxes: sandboxes, ca: ca, now: func() time.Time { return time.Now().UTC() }}, nil
+}
+
+func (i *SandboxIssuer) Mint(ctx context.Context, orgID, agentID, sandboxID string) (SandboxProxyIdentity, error) {
+	value, err := i.sandboxes.AuthorizeSSH(ctx, orgID, agentID, sandboxID)
+	if err != nil {
+		return SandboxProxyIdentity{}, err
+	}
+	if value.Status != "running" {
+		return SandboxProxyIdentity{}, fmt.Errorf("sandbox %s is not running (status=%s)", value.ID, value.Status)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return SandboxProxyIdentity{}, fmt.Errorf("generate sandbox proxy key: %w", err)
+	}
+	sshPublicKey, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		return SandboxProxyIdentity{}, fmt.Errorf("encode sandbox proxy public key: %w", err)
+	}
+	now := i.now()
+	expiresAt := now.Add(time.Hour)
+	cert := &ssh.Certificate{
+		Key: sshPublicKey, CertType: ssh.UserCert, KeyId: agentID,
+		ValidPrincipals: []string{sandboxSSHUser},
+		ValidAfter:      uint64(now.Add(-time.Minute).Unix()),
+		ValidBefore:     uint64(expiresAt.Unix()),
+		Permissions: ssh.Permissions{Extensions: map[string]string{
+			certOrgID: orgID, certAgentID: agentID, certTargetKind: targetKindSandbox, certSandboxID: value.ID,
+		}},
+	}
+	if err := cert.SignCert(rand.Reader, i.ca); err != nil {
+		return SandboxProxyIdentity{}, fmt.Errorf("sign sandbox proxy certificate: %w", err)
+	}
+	privateDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return SandboxProxyIdentity{}, fmt.Errorf("marshal sandbox proxy private key: %w", err)
+	}
+	return SandboxProxyIdentity{
+		SandboxID:   value.ID,
+		PrivateKey:  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})),
+		Certificate: strings.TrimSpace(string(ssh.MarshalAuthorizedKey(cert))),
+		ExpiresAt:   expiresAt,
+	}, nil
+}
+
+func (p *Proxy) proxySandboxSession(ctx context.Context, conn *ssh.ServerConn, incoming ssh.NewChannel) {
+	channel, requests, err := incoming.Accept()
+	if err != nil {
+		return
+	}
+	defer channel.Close()
+
+	var cols, rows uint32
+	for request := range requests {
+		switch request.Type {
+		case "pty-req":
+			var req struct {
+				Term                      string
+				Columns, Rows             uint32
+				WidthPixels, HeightPixels uint32
+				Modes                     string
+			}
+			if err := ssh.Unmarshal(request.Payload, &req); err != nil {
+				replySSHRequest(request, false)
+				continue
+			}
+			cols, rows = req.Columns, req.Rows
+			replySSHRequest(request, true)
+		case "shell", "exec":
+			command := ""
+			shell := ""
+			if request.Type == "exec" {
+				command, err = decodeExecRequest(request.Payload)
+				if err != nil {
+					replySSHRequest(request, false)
+					return
+				}
+				shell = "exec /bin/sh -c " + shellQuote(command)
+			}
+			permissions := conn.Permissions.Extensions
+			terminal, openErr := p.sandboxes.OpenSSHTerminal(ctx, permissions[certOrgID], permissions[certAgentID], permissions[certSandboxID], shell)
+			if openErr != nil {
+				replySSHRequest(request, false)
+				_, _ = channel.Stderr().Write([]byte(openErr.Error() + "\n"))
+				return
+			}
+			replySSHRequest(request, true)
+			if command != "" {
+				p.recordSandboxCommand(ctx, permissions, command)
+			}
+			p.bridgeSandboxTerminal(channel, requests, terminal, cols, rows)
+			return
+		default:
+			replySSHRequest(request, false)
+		}
+	}
+}
+
+func (p *Proxy) bridgeSandboxTerminal(channel ssh.Channel, requests <-chan *ssh.Request, terminal runtime.SandboxTerminal, cols, rows uint32) {
+	defer terminal.Close()
+	writes := &lockedTerminalWriter{terminal: terminal}
+	if cols > 0 && rows > 0 {
+		_ = writes.resize(cols, rows)
+	}
+	go func() {
+		buffer := make([]byte, 32*1024)
+		for {
+			n, err := channel.Read(buffer)
+			if n > 0 {
+				if writeErr := writes.writeBinary(buffer[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	go func() {
+		for request := range requests {
+			if request.Type != "window-change" {
+				replySSHRequest(request, false)
+				continue
+			}
+			var req struct{ Columns, Rows, WidthPixels, HeightPixels uint32 }
+			if err := ssh.Unmarshal(request.Payload, &req); err != nil {
+				replySSHRequest(request, false)
+				continue
+			}
+			err := writes.resize(req.Columns, req.Rows)
+			replySSHRequest(request, err == nil)
+		}
+	}()
+
+	exitCode := uint32(255)
+	for {
+		messageType, data, err := terminal.ReadMessage()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				_, _ = channel.Stderr().Write([]byte(err.Error() + "\n"))
+			}
+			break
+		}
+		if messageType == websocket.BinaryMessage {
+			if _, err := channel.Write(data); err != nil {
+				return
+			}
+			continue
+		}
+		if messageType != websocket.TextMessage {
+			continue
+		}
+		var control struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		}
+		if err := json.Unmarshal(data, &control); err != nil {
+			continue
+		}
+		switch control.Type {
+		case "error":
+			exitCode = 1
+			_, _ = channel.Stderr().Write([]byte(control.Message + "\n"))
+		case "exit":
+			if control.Code >= 0 {
+				exitCode = uint32(control.Code)
+			}
+			_, _ = channel.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{Status: exitCode}))
+			return
+		}
+	}
+	_, _ = channel.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{Status: exitCode}))
+}
+
+type lockedTerminalWriter struct {
+	mu       sync.Mutex
+	terminal runtime.SandboxTerminal
+}
+
+func (w *lockedTerminalWriter) writeBinary(data []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.terminal.WriteMessage(websocket.BinaryMessage, data)
+}
+
+func (w *lockedTerminalWriter) resize(cols, rows uint32) error {
+	data, err := json.Marshal(map[string]any{"type": "resize", "cols": cols, "rows": rows})
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.terminal.WriteMessage(websocket.TextMessage, data)
+}
+
+func replySSHRequest(request *ssh.Request, ok bool) {
+	if request.WantReply {
+		_ = request.Reply(ok, nil)
+	}
+}
+
+func (p *Proxy) recordSandboxCommand(ctx context.Context, permissions map[string]string, command string) {
+	p.recordAudit(ctx, orgaudit.Entry{
+		OrganizationID: permissions[certOrgID],
+		ProjectID:      p.projectID(ctx, permissions[certOrgID], permissions[certAgentID]),
+		ActorID:        permissions[certAgentID],
+		ActorType:      orgaudit.ActorBot,
+		EventType:      orgaudit.EventSSHCommand,
+		Action:         "exec",
+		Status:         orgaudit.StatusAttempted,
+		Metadata: orgaudit.Metadata{
+			AssetRef: "sandbox:" + permissions[certSandboxID],
+			Command:  command,
+		},
+	})
+}

--- a/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
@@ -1,0 +1,218 @@
+package helix
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type SandboxController interface {
+	RuntimeNames() []string
+	DefaultRuntimeName() string
+	List(ctx context.Context, orgID, projectID string) ([]*types.Sandbox, error)
+	Get(ctx context.Context, id string) (*types.Sandbox, error)
+	Create(ctx context.Context, orgID, owner string, req *types.CreateSandboxRequest) (*types.Sandbox, error)
+	Update(ctx context.Context, id string, req *types.UpdateSandboxRequest) (*types.Sandbox, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type SandboxProjectStore interface {
+	GetProject(ctx context.Context, id string) (*types.Project, error)
+}
+
+type Sandboxes struct {
+	orgStore *orgstore.Store
+	control  SandboxController
+	projects SandboxProjectStore
+}
+
+func NewSandboxes(orgStore *orgstore.Store, control SandboxController, projects SandboxProjectStore) (*Sandboxes, error) {
+	if orgStore == nil {
+		return nil, errors.New("helix.NewSandboxes: org store is nil")
+	}
+	if control == nil {
+		return nil, errors.New("helix.NewSandboxes: controller is nil")
+	}
+	if projects == nil {
+		return nil, errors.New("helix.NewSandboxes: project store is nil")
+	}
+	return &Sandboxes{orgStore: orgStore, control: control, projects: projects}, nil
+}
+
+var _ runtime.Sandboxes = (*Sandboxes)(nil)
+
+func (s *Sandboxes) ListRuntimes(_ context.Context) (runtime.SandboxRuntimeCatalog, error) {
+	names := append([]string(nil), s.control.RuntimeNames()...)
+	sort.Strings(names)
+	return runtime.SandboxRuntimeCatalog{
+		Runtimes:       names,
+		DefaultRuntime: s.control.DefaultRuntimeName(),
+	}, nil
+}
+
+func (s *Sandboxes) List(ctx context.Context, orgID, projectID string) ([]runtime.SandboxView, error) {
+	if orgID == "" {
+		return nil, errors.New("orgID is required")
+	}
+	values, err := s.control.List(ctx, orgID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list sandboxes: %w", err)
+	}
+	views := make([]runtime.SandboxView, 0, len(values))
+	for _, value := range values {
+		view, err := sandboxView(value)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (s *Sandboxes) Get(ctx context.Context, orgID, sandboxID string) (runtime.SandboxView, error) {
+	value, err := s.ownedSandbox(ctx, orgID, sandboxID)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	return sandboxView(value)
+}
+
+func (s *Sandboxes) Create(ctx context.Context, orgID string, botID orgchart.NodeID, in runtime.CreateSandboxInput) (runtime.SandboxView, error) {
+	if orgID == "" {
+		return runtime.SandboxView{}, errors.New("orgID is required")
+	}
+	if botID == "" {
+		return runtime.SandboxView{}, errors.New("botID is required")
+	}
+	if in.ProjectID != "" {
+		project, err := s.projects.GetProject(ctx, in.ProjectID)
+		if err != nil {
+			return runtime.SandboxView{}, fmt.Errorf("get project: %w", err)
+		}
+		if project.OrganizationID != orgID {
+			return runtime.SandboxView{}, fmt.Errorf("project %s does not belong to this organization", in.ProjectID)
+		}
+	}
+	owner, err := s.ownerID(ctx, orgID, botID)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	value, err := s.control.Create(ctx, orgID, owner, &types.CreateSandboxRequest{
+		Name:           in.Name,
+		Runtime:        types.SandboxRuntime(in.Runtime),
+		Image:          in.Image,
+		Env:            in.Env,
+		Tags:           in.Tags,
+		TimeoutSeconds: in.TimeoutSeconds,
+		VCPUs:          in.VCPUs,
+		MemoryMB:       in.MemoryMB,
+		DisplayWidth:   in.DisplayWidth,
+		DisplayHeight:  in.DisplayHeight,
+		DisplayFPS:     in.DisplayFPS,
+		ProjectID:      in.ProjectID,
+		Persistent:     in.Persistent,
+	})
+	if err != nil {
+		return runtime.SandboxView{}, fmt.Errorf("create sandbox: %w", err)
+	}
+	return sandboxView(value)
+}
+
+func (s *Sandboxes) Update(ctx context.Context, orgID, sandboxID string, in runtime.UpdateSandboxInput) (runtime.SandboxView, error) {
+	value, err := s.ownedSandbox(ctx, orgID, sandboxID)
+	if err != nil {
+		return runtime.SandboxView{}, err
+	}
+	updated, err := s.control.Update(ctx, value.ID, &types.UpdateSandboxRequest{
+		Name:           in.Name,
+		TimeoutSeconds: in.TimeoutSeconds,
+		Tags:           in.Tags,
+	})
+	if err != nil {
+		return runtime.SandboxView{}, fmt.Errorf("update sandbox: %w", err)
+	}
+	return sandboxView(updated)
+}
+
+func (s *Sandboxes) Delete(ctx context.Context, orgID, sandboxID string) error {
+	value, err := s.ownedSandbox(ctx, orgID, sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := s.control.Delete(ctx, value.ID); err != nil {
+		return fmt.Errorf("delete sandbox: %w", err)
+	}
+	return nil
+}
+
+func (s *Sandboxes) ownedSandbox(ctx context.Context, orgID, sandboxID string) (*types.Sandbox, error) {
+	if orgID == "" {
+		return nil, errors.New("orgID is required")
+	}
+	if strings.TrimSpace(sandboxID) == "" {
+		return nil, errors.New("sandbox_id is required")
+	}
+	value, err := s.control.Get(ctx, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("get sandbox: %w", err)
+	}
+	if value.OrganizationID != orgID {
+		return nil, fmt.Errorf("sandbox %s does not belong to this organization", sandboxID)
+	}
+	return value, nil
+}
+
+func (s *Sandboxes) ownerID(ctx context.Context, orgID string, botID orgchart.NodeID) (string, error) {
+	if userID := strings.TrimSpace(UserIDFromContext(ctx)); userID != "" {
+		return userID, nil
+	}
+	state, err := LoadState(ctx, s.orgStore, orgID, botID)
+	if err != nil {
+		return "", fmt.Errorf("resolve sandbox owner: %w", err)
+	}
+	if strings.TrimSpace(state.HiringUserID) == "" {
+		return "", fmt.Errorf("bot %s has no hiring user; restart it from Helix before creating a sandbox", botID)
+	}
+	return state.HiringUserID, nil
+}
+
+func sandboxView(value *types.Sandbox) (runtime.SandboxView, error) {
+	if value == nil {
+		return runtime.SandboxView{}, errors.New("sandbox is nil")
+	}
+	var tags map[string]string
+	if len(value.Tags) > 0 {
+		if err := json.Unmarshal(value.Tags, &tags); err != nil {
+			return runtime.SandboxView{}, fmt.Errorf("decode sandbox %s tags: %w", value.ID, err)
+		}
+	}
+	return runtime.SandboxView{
+		ID:             value.ID,
+		Name:           value.Name,
+		OrganizationID: value.OrganizationID,
+		ProjectID:      value.ProjectID,
+		Owner:          value.Owner,
+		Runtime:        string(value.Runtime),
+		Image:          value.Image,
+		Status:         string(value.Status),
+		StatusMessage:  value.StatusMessage,
+		VCPUs:          value.VCPUs,
+		MemoryMB:       value.MemoryMB,
+		Persistent:     value.Persistent,
+		Tags:           tags,
+		TimeoutSeconds: value.TimeoutSeconds,
+		CreatedAt:      value.CreatedAt,
+		UpdatedAt:      value.UpdatedAt,
+		StartedAt:      value.StartedAt,
+		StoppedAt:      value.StoppedAt,
+		ExpiresAt:      value.ExpiresAt,
+	}, nil
+}

--- a/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
@@ -22,6 +23,7 @@ type SandboxController interface {
 	Create(ctx context.Context, orgID, owner string, req *types.CreateSandboxRequest) (*types.Sandbox, error)
 	Update(ctx context.Context, id string, req *types.UpdateSandboxRequest) (*types.Sandbox, error)
 	Delete(ctx context.Context, id string) error
+	HydraClient(sandbox *types.Sandbox) (*hydra.RevDialClient, error)
 }
 
 type SandboxProjectStore interface {
@@ -151,6 +153,25 @@ func (s *Sandboxes) Delete(ctx context.Context, orgID, sandboxID string) error {
 		return fmt.Errorf("delete sandbox: %w", err)
 	}
 	return nil
+}
+
+func (s *Sandboxes) OpenTerminal(ctx context.Context, orgID, sandboxID, shell string) (runtime.SandboxTerminal, error) {
+	value, err := s.ownedSandbox(ctx, orgID, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if value.Status != types.SandboxStatusRunning {
+		return nil, fmt.Errorf("sandbox %s is not running (status=%s)", sandboxID, value.Status)
+	}
+	client, err := s.control.HydraClient(value)
+	if err != nil {
+		return nil, fmt.Errorf("connect to sandbox host: %w", err)
+	}
+	terminal, err := client.OpenSandboxTerminal(ctx, value.ID, shell)
+	if err != nil {
+		return nil, fmt.Errorf("open sandbox terminal: %w", err)
+	}
+	return terminal, nil
 }
 
 func (s *Sandboxes) ownedSandbox(ctx context.Context, orgID, sandboxID string) (*types.Sandbox, error) {

--- a/api/pkg/org/infrastructure/runtime/helix/sandboxes_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sandboxes_test.go
@@ -1,0 +1,143 @@
+package helix
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/datatypes"
+)
+
+type fakeSandboxController struct {
+	sandboxes map[string]*types.Sandbox
+	created   *types.CreateSandboxRequest
+	createOrg string
+	owner     string
+	updated   *types.UpdateSandboxRequest
+	deleted   string
+}
+
+func (f *fakeSandboxController) RuntimeNames() []string     { return []string{"node22", "ubuntu-desktop"} }
+func (f *fakeSandboxController) DefaultRuntimeName() string { return "node22" }
+func (f *fakeSandboxController) List(_ context.Context, orgID, projectID string) ([]*types.Sandbox, error) {
+	var out []*types.Sandbox
+	for _, value := range f.sandboxes {
+		if value.OrganizationID == orgID && (projectID == "" || value.ProjectID == projectID) {
+			out = append(out, value)
+		}
+	}
+	return out, nil
+}
+func (f *fakeSandboxController) Get(_ context.Context, id string) (*types.Sandbox, error) {
+	value := f.sandboxes[id]
+	if value == nil {
+		return nil, errors.New("not found")
+	}
+	return value, nil
+}
+func (f *fakeSandboxController) Create(_ context.Context, orgID, owner string, req *types.CreateSandboxRequest) (*types.Sandbox, error) {
+	f.createOrg, f.owner, f.created = orgID, owner, req
+	value := &types.Sandbox{
+		ID: "sbx_new", OrganizationID: orgID, Owner: owner, Name: req.Name,
+		Runtime: types.SandboxRuntime(req.Runtime), Status: types.SandboxStatusPending,
+		Env: datatypes.JSON([]byte(`{"TOKEN":"secret"}`)), Tags: datatypes.JSON([]byte(`{"team":"ops"}`)),
+	}
+	f.sandboxes[value.ID] = value
+	return value, nil
+}
+func (f *fakeSandboxController) Update(_ context.Context, id string, req *types.UpdateSandboxRequest) (*types.Sandbox, error) {
+	f.updated = req
+	value := f.sandboxes[id]
+	if value == nil {
+		return nil, errors.New("not found")
+	}
+	if req.Name != nil {
+		value.Name = *req.Name
+	}
+	return value, nil
+}
+func (f *fakeSandboxController) Delete(_ context.Context, id string) error {
+	f.deleted = id
+	delete(f.sandboxes, id)
+	return nil
+}
+
+type fakeSandboxProjects map[string]*types.Project
+
+func (f fakeSandboxProjects) GetProject(_ context.Context, id string) (*types.Project, error) {
+	project := f[id]
+	if project == nil {
+		return nil, errors.New("not found")
+	}
+	return project, nil
+}
+
+func TestSandboxesCRUDUsesAuthenticatedOwnerAndOrgScope(t *testing.T) {
+	t.Parallel()
+	orgStore := orggorm.GetOrgTestDB(t)
+	control := &fakeSandboxController{sandboxes: map[string]*types.Sandbox{
+		"sbx_owned": {ID: "sbx_owned", OrganizationID: "org-a", Owner: "user-a", Runtime: "node22", Status: types.SandboxStatusRunning},
+		"sbx_other": {ID: "sbx_other", OrganizationID: "org-b", Owner: "user-b", Runtime: "node22", Status: types.SandboxStatusRunning},
+	}}
+	port, err := NewSandboxes(orgStore, control, fakeSandboxProjects{
+		"prj-a": {ID: "prj-a", OrganizationID: "org-a"},
+		"prj-b": {ID: "prj-b", OrganizationID: "org-b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := WithUserID(context.Background(), "user-authenticated")
+	created, err := port.Create(ctx, "org-a", "chief-of-staff", runtime.CreateSandboxInput{
+		Name: "ops", Runtime: "node22", ProjectID: "prj-a", Env: map[string]string{"TOKEN": "secret"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if control.createOrg != "org-a" || control.owner != "user-authenticated" {
+		t.Fatalf("create attribution = org %q owner %q", control.createOrg, control.owner)
+	}
+	if created.Tags["team"] != "ops" {
+		t.Fatalf("created tags = %+v", created.Tags)
+	}
+
+	name := "renamed"
+	updated, err := port.Update(ctx, "org-a", created.ID, runtime.UpdateSandboxInput{Name: &name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != name || control.updated == nil {
+		t.Fatalf("updated = %+v", updated)
+	}
+	if err := port.Delete(ctx, "org-a", created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if control.deleted != created.ID {
+		t.Fatalf("deleted = %q, want %q", control.deleted, created.ID)
+	}
+
+	if _, err := port.Get(ctx, "org-a", "sbx_other"); err == nil {
+		t.Fatal("cross-org sandbox get succeeded")
+	}
+	if _, err := port.Create(ctx, "org-a", "chief-of-staff", runtime.CreateSandboxInput{ProjectID: "prj-b"}); err == nil {
+		t.Fatal("cross-org project association succeeded")
+	}
+}
+
+func TestSandboxesRuntimeCatalogSorted(t *testing.T) {
+	t.Parallel()
+	port, err := NewSandboxes(orggorm.GetOrgTestDB(t), &fakeSandboxController{sandboxes: map[string]*types.Sandbox{}}, fakeSandboxProjects{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := port.ListRuntimes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Runtimes) != 2 || catalog.Runtimes[0] != "node22" || catalog.DefaultRuntime != "node22" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/sandboxes_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sandboxes_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/hydra"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 	"github.com/helixml/helix/api/pkg/types"
@@ -63,6 +64,9 @@ func (f *fakeSandboxController) Delete(_ context.Context, id string) error {
 	f.deleted = id
 	delete(f.sandboxes, id)
 	return nil
+}
+func (f *fakeSandboxController) HydraClient(*types.Sandbox) (*hydra.RevDialClient, error) {
+	return nil, errors.New("terminal not configured in CRUD test")
 }
 
 type fakeSandboxProjects map[string]*types.Project

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
@@ -383,6 +384,94 @@ func (NoopProjects) Get(_ context.Context, _, _ string) (ProjectView, error) {
 // ErrProjectsUnsupported is what the noop impl returns. Tools translate it
 // into a friendly MCP error.
 var ErrProjectsUnsupported = errors.New("project access not wired on this runtime")
+
+// Sandboxes is the port the org MCP sandbox tools use to manage standalone
+// Sandboxes API containers in the caller's organization. Implementations must
+// scope every row by orgID and derive the human owner for Create from the
+// authenticated caller/runtime state rather than accepting it as tool input.
+type Sandboxes interface {
+	ListRuntimes(ctx context.Context) (SandboxRuntimeCatalog, error)
+	List(ctx context.Context, orgID, projectID string) ([]SandboxView, error)
+	Get(ctx context.Context, orgID, sandboxID string) (SandboxView, error)
+	Create(ctx context.Context, orgID string, botID orgchart.NodeID, in CreateSandboxInput) (SandboxView, error)
+	Update(ctx context.Context, orgID, sandboxID string, in UpdateSandboxInput) (SandboxView, error)
+	Delete(ctx context.Context, orgID, sandboxID string) error
+}
+
+type SandboxRuntimeCatalog struct {
+	Runtimes       []string `json:"runtimes"`
+	DefaultRuntime string   `json:"default_runtime"`
+}
+
+type CreateSandboxInput struct {
+	Name           string            `json:"name,omitempty"`
+	Runtime        string            `json:"runtime,omitempty"`
+	Image          string            `json:"image,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	VCPUs          int               `json:"vcpus,omitempty"`
+	MemoryMB       int               `json:"memory_mb,omitempty"`
+	DisplayWidth   int               `json:"display_width,omitempty"`
+	DisplayHeight  int               `json:"display_height,omitempty"`
+	DisplayFPS     int               `json:"display_fps,omitempty"`
+	ProjectID      string            `json:"project_id,omitempty"`
+	Persistent     bool              `json:"persistent,omitempty"`
+}
+
+type UpdateSandboxInput struct {
+	Name           *string            `json:"name,omitempty"`
+	TimeoutSeconds *int               `json:"timeout_seconds,omitempty"`
+	Tags           *map[string]string `json:"tags,omitempty"`
+}
+
+// SandboxView intentionally excludes environment variables: list/get tool
+// results are fed back into an LLM transcript, so echoing sandbox secrets by
+// default would turn routine inventory into credential disclosure.
+type SandboxView struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name,omitempty"`
+	OrganizationID string            `json:"organization_id"`
+	ProjectID      string            `json:"project_id,omitempty"`
+	Owner          string            `json:"owner"`
+	Runtime        string            `json:"runtime"`
+	Image          string            `json:"image,omitempty"`
+	Status         string            `json:"status"`
+	StatusMessage  string            `json:"status_message,omitempty"`
+	VCPUs          int               `json:"vcpus"`
+	MemoryMB       int               `json:"memory_mb"`
+	Persistent     bool              `json:"persistent"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+	StartedAt      *time.Time        `json:"started_at,omitempty"`
+	StoppedAt      *time.Time        `json:"stopped_at,omitempty"`
+	ExpiresAt      *time.Time        `json:"expires_at,omitempty"`
+}
+
+type NoopSandboxes struct{}
+
+func (NoopSandboxes) ListRuntimes(_ context.Context) (SandboxRuntimeCatalog, error) {
+	return SandboxRuntimeCatalog{}, ErrSandboxesUnsupported
+}
+func (NoopSandboxes) List(_ context.Context, _, _ string) ([]SandboxView, error) {
+	return nil, ErrSandboxesUnsupported
+}
+func (NoopSandboxes) Get(_ context.Context, _, _ string) (SandboxView, error) {
+	return SandboxView{}, ErrSandboxesUnsupported
+}
+func (NoopSandboxes) Create(_ context.Context, _ string, _ orgchart.NodeID, _ CreateSandboxInput) (SandboxView, error) {
+	return SandboxView{}, ErrSandboxesUnsupported
+}
+func (NoopSandboxes) Update(_ context.Context, _, _ string, _ UpdateSandboxInput) (SandboxView, error) {
+	return SandboxView{}, ErrSandboxesUnsupported
+}
+func (NoopSandboxes) Delete(_ context.Context, _, _ string) error {
+	return ErrSandboxesUnsupported
+}
+
+var ErrSandboxesUnsupported = errors.New("sandbox access not wired on this runtime")
 
 // Repositories is the port the org MCP repository tools use to list the
 // Helix git repositories in the caller's org and attach/detach them on a

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -396,6 +396,16 @@ type Sandboxes interface {
 	Create(ctx context.Context, orgID string, botID orgchart.NodeID, in CreateSandboxInput) (SandboxView, error)
 	Update(ctx context.Context, orgID, sandboxID string, in UpdateSandboxInput) (SandboxView, error)
 	Delete(ctx context.Context, orgID, sandboxID string) error
+	OpenTerminal(ctx context.Context, orgID, sandboxID, shell string) (SandboxTerminal, error)
+}
+
+// SandboxTerminal is the message-oriented interactive terminal transport used
+// by the native SSH proxy. Implementations preserve binary stdin/stdout frames
+// and JSON text control frames (resize, error, exit) from the sandbox runtime.
+type SandboxTerminal interface {
+	ReadMessage() (messageType int, data []byte, err error)
+	WriteMessage(messageType int, data []byte) error
+	Close() error
 }
 
 type SandboxRuntimeCatalog struct {
@@ -469,6 +479,9 @@ func (NoopSandboxes) Update(_ context.Context, _, _ string, _ UpdateSandboxInput
 }
 func (NoopSandboxes) Delete(_ context.Context, _, _ string) error {
 	return ErrSandboxesUnsupported
+}
+func (NoopSandboxes) OpenTerminal(_ context.Context, _, _, _ string) (SandboxTerminal, error) {
+	return nil, ErrSandboxesUnsupported
 }
 
 var ErrSandboxesUnsupported = errors.New("sandbox access not wired on this runtime")

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -16,6 +16,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
 	"github.com/helixml/helix/api/pkg/org/application/reconcile"
+	orgsandboxes "github.com/helixml/helix/api/pkg/org/application/sandboxes"
 	"github.com/helixml/helix/api/pkg/org/application/spectasks"
 	"github.com/helixml/helix/api/pkg/org/application/subscriptions"
 	"github.com/helixml/helix/api/pkg/org/application/topics"
@@ -112,6 +113,9 @@ type Deps struct {
 	// project-discovery tools (list_projects/get_project), scoped to the
 	// caller's org.
 	Projects *projects.Service
+	// Sandboxes is the front-of-house application service backing standalone
+	// sandbox discovery and CRUD, scoped to the caller's org.
+	Sandboxes *orgsandboxes.Service
 	// Repositories backs list_repositories / list_bot_repositories /
 	// attach_repository / detach_repository — org git repos attached to
 	// Bot projects so sandboxes can clone the code.
@@ -163,6 +167,9 @@ type Config struct {
 	// nil → Build defaults to runtime.NoopProjects{} so the tools return a
 	// clear "not wired" error instead of nil-derefing.
 	Projects runtime.Projects
+	// Sandboxes is the runtime port for standalone org sandbox management.
+	// nil → Build defaults to runtime.NoopSandboxes{}.
+	Sandboxes runtime.Sandboxes
 	// ProjectAccess resolves the caller Bot's own runtime project so project
 	// discovery can combine it with the explicit per-Bot allowlist.
 	ProjectAccess projects.OwnProjectResolver
@@ -217,12 +224,25 @@ func (c Config) Build() Deps {
 		ProjectConfig:        c.ProjectConfig,
 		SpecTasks:            c.specTasksService(),
 		Projects:             c.projectsService(),
+		Sandboxes:            c.sandboxesService(),
 		Repositories:         c.repositoriesPort(),
 		CredentialProviders:  c.CredentialProviders,
 		RecordCredential:     c.RecordCredential,
 		Hub:                  c.Hub,
 		HumanDelivery:        c.HumanDelivery,
 	}
+}
+
+func (c Config) sandboxesService() *orgsandboxes.Service {
+	port := c.Sandboxes
+	if port == nil {
+		port = runtime.NoopSandboxes{}
+	}
+	var members orgsandboxes.MemberVerifier
+	if c.Queries != nil {
+		members = c.Queries
+	}
+	return orgsandboxes.New(port, members)
 }
 
 // processorsService returns the pre-built Processors service when the
@@ -361,6 +381,7 @@ func DefaultDeps(s *store.Store) Config {
 		ProjectConfig:       runtime.NoopProjectConfig{},
 		SpecTasks:           runtime.NoopSpecTasks{},
 		Projects:            runtime.NoopProjects{},
+		Sandboxes:           runtime.NoopSandboxes{},
 		Repositories:        runtime.NoopRepositories{},
 		CredentialProviders: map[string]credential.Provider{},
 	}
@@ -452,6 +473,14 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		// per-Role (not in BaseReadTools).
 		NewListProjects(deps),
 		NewGetProject(deps),
+		// Standalone org sandboxes — discovery and CRUD. Chief of Staff gets
+		// these through OwnerBotTools; other Bots may receive them explicitly.
+		NewListSandboxRuntimes(deps),
+		NewListSandboxes(deps),
+		NewGetSandbox(deps),
+		NewCreateSandbox(deps),
+		NewUpdateSandbox(deps),
+		NewDeleteSandbox(deps),
 		// Git repositories — list org repos and attach/detach them on Bot
 		// projects so sandboxes clone the code. OwnerBotTools grants these
 		// to Chief of Staff by default.

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -93,6 +93,7 @@ type Deps struct {
 	Assets               *assets.Service
 	AssetSSH             ServerAssetRuntime
 	AssetSSHIssuer       AssetSSHIdentityIssuer
+	SandboxSSHIssuer     SandboxSSHIdentityIssuer
 	AssetSSHProxyAddress string
 	AssetHealth          func(ctx context.Context, orgID, assetRef string) assetssh.Health
 
@@ -194,6 +195,7 @@ type Config struct {
 	Assets               *assets.Service
 	AssetSSH             ServerAssetRuntime
 	AssetSSHIssuer       AssetSSHIdentityIssuer
+	SandboxSSHIssuer     SandboxSSHIdentityIssuer
 	AssetSSHProxyAddress string
 	AssetHealth          func(ctx context.Context, orgID, assetRef string) assetssh.Health
 	Publishing           *publishing.Publishing
@@ -216,6 +218,7 @@ func (c Config) Build() Deps {
 		Assets:               c.Assets,
 		AssetSSH:             c.AssetSSH,
 		AssetSSHIssuer:       c.AssetSSHIssuer,
+		SandboxSSHIssuer:     c.SandboxSSHIssuer,
 		AssetSSHProxyAddress: c.AssetSSHProxyAddress,
 		AssetHealth:          c.AssetHealth,
 		Workspace:            c.Workspace,
@@ -481,6 +484,7 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		NewCreateSandbox(deps),
 		NewUpdateSandbox(deps),
 		NewDeleteSandbox(deps),
+		NewSandboxSSHAccess(deps),
 		// Git repositories — list org repos and attach/detach them on Bot
 		// projects so sandboxes clone the code. OwnerBotTools grants these
 		// to Chief of Staff by default.

--- a/api/pkg/org/interfaces/mcptools/defaults.go
+++ b/api/pkg/org/interfaces/mcptools/defaults.go
@@ -100,6 +100,13 @@ func OwnerBotTools() []tool.Name {
 		StartBotName,
 		StopBotName,
 		RestartBotName,
+		// Standalone Sandboxes API lifecycle for the organization.
+		ListSandboxRuntimesName,
+		ListSandboxesName,
+		GetSandboxName,
+		CreateSandboxName,
+		UpdateSandboxName,
+		DeleteSandboxName,
 	}
 	// Org assets: create/configure inventory and grant/revoke Bot access.
 	ownerMutations = append(ownerMutations, AssetManagementTools...)

--- a/api/pkg/org/interfaces/mcptools/defaults.go
+++ b/api/pkg/org/interfaces/mcptools/defaults.go
@@ -107,6 +107,7 @@ func OwnerBotTools() []tool.Name {
 		CreateSandboxName,
 		UpdateSandboxName,
 		DeleteSandboxName,
+		SandboxSSHAccessName,
 	}
 	// Org assets: create/configure inventory and grant/revoke Bot access.
 	ownerMutations = append(ownerMutations, AssetManagementTools...)

--- a/api/pkg/org/interfaces/mcptools/sandboxes.go
+++ b/api/pkg/org/interfaces/mcptools/sandboxes.go
@@ -1,0 +1,226 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+const (
+	ListSandboxRuntimesName tool.Name = "list_sandbox_runtimes"
+	ListSandboxesName       tool.Name = "list_sandboxes"
+	GetSandboxName          tool.Name = "get_sandbox"
+	CreateSandboxName       tool.Name = "create_sandbox"
+	UpdateSandboxName       tool.Name = "update_sandbox"
+	DeleteSandboxName       tool.Name = "delete_sandbox"
+)
+
+type sandboxTool struct{ deps Deps }
+
+type emptySandboxArgs struct{}
+
+var emptySandboxSchema = mustSchema[emptySandboxArgs]()
+
+type ListSandboxRuntimes struct{ sandboxTool }
+
+func NewListSandboxRuntimes(deps Deps) *ListSandboxRuntimes {
+	return &ListSandboxRuntimes{sandboxTool{deps: deps}}
+}
+func (t *ListSandboxRuntimes) Name() tool.Name                 { return ListSandboxRuntimesName }
+func (t *ListSandboxRuntimes) InputSchema() *jsonschema.Schema { return emptySandboxSchema }
+func (t *ListSandboxRuntimes) Description() string {
+	return "List the standalone sandbox runtimes configured on this Helix server and identify the default runtime. Call before create_sandbox when runtime requirements matter."
+}
+func (t *ListSandboxRuntimes) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	value, err := t.deps.Sandboxes.ListRuntimes(ctx, inv.Caller)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+type listSandboxesArgs struct {
+	ProjectID string `json:"project_id,omitempty"`
+}
+
+var listSandboxesSchema = mustSchema[listSandboxesArgs]()
+
+type ListSandboxes struct{ sandboxTool }
+
+func NewListSandboxes(deps Deps) *ListSandboxes {
+	return &ListSandboxes{sandboxTool{deps: deps}}
+}
+func (t *ListSandboxes) Name() tool.Name                 { return ListSandboxesName }
+func (t *ListSandboxes) InputSchema() *jsonschema.Schema { return listSandboxesSchema }
+func (t *ListSandboxes) Description() string {
+	return "List standalone sandboxes in your organization, optionally filtered by project_id. Returns lifecycle status, runtime, resources, tags, and expiry; environment variables are intentionally omitted."
+}
+func (t *ListSandboxes) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args listSandboxesArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	values, err := t.deps.Sandboxes.List(ctx, inv.Caller, args.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(values)
+}
+
+type sandboxIDArgs struct {
+	SandboxID string `json:"sandbox_id"`
+}
+
+var sandboxIDSchema = mustSchema[sandboxIDArgs]()
+
+func parseSandboxID(raw json.RawMessage) (sandboxIDArgs, error) {
+	var args sandboxIDArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return sandboxIDArgs{}, fmt.Errorf("parse args: %w", err)
+	}
+	if args.SandboxID == "" {
+		return sandboxIDArgs{}, errors.New("sandbox_id is required")
+	}
+	return args, nil
+}
+
+type GetSandbox struct{ sandboxTool }
+
+func NewGetSandbox(deps Deps) *GetSandbox             { return &GetSandbox{sandboxTool{deps: deps}} }
+func (t *GetSandbox) Name() tool.Name                 { return GetSandboxName }
+func (t *GetSandbox) InputSchema() *jsonschema.Schema { return sandboxIDSchema }
+func (t *GetSandbox) Description() string {
+	return "Get one standalone sandbox in your organization by sandbox_id. Environment variables are intentionally omitted from the result."
+}
+func (t *GetSandbox) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	args, err := parseSandboxID(inv.Args)
+	if err != nil {
+		return nil, err
+	}
+	value, err := t.deps.Sandboxes.Get(ctx, inv.Caller, args.SandboxID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+type createSandboxArgs struct {
+	Name           string            `json:"name,omitempty"`
+	Runtime        string            `json:"runtime,omitempty"`
+	Image          string            `json:"image,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	VCPUs          int               `json:"vcpus,omitempty"`
+	MemoryMB       int               `json:"memory_mb,omitempty"`
+	DisplayWidth   int               `json:"display_width,omitempty"`
+	DisplayHeight  int               `json:"display_height,omitempty"`
+	DisplayFPS     int               `json:"display_fps,omitempty"`
+	ProjectID      string            `json:"project_id,omitempty"`
+	Persistent     bool              `json:"persistent,omitempty"`
+}
+
+var createSandboxSchema = mustSchema[createSandboxArgs]()
+
+type CreateSandbox struct{ sandboxTool }
+
+func NewCreateSandbox(deps Deps) *CreateSandbox          { return &CreateSandbox{sandboxTool{deps: deps}} }
+func (t *CreateSandbox) Name() tool.Name                 { return CreateSandboxName }
+func (t *CreateSandbox) InputSchema() *jsonschema.Schema { return createSandboxSchema }
+func (t *CreateSandbox) Description() string {
+	return "Create a standalone sandbox in your organization. Omit runtime and image to use the server default; otherwise call list_sandbox_runtimes first. image works only when custom images are enabled. timeout_seconds=0 uses the one-hour default and a negative value means no expiry. The returned pending sandbox provisions asynchronously; poll get_sandbox until running or failed."
+}
+func (t *CreateSandbox) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args createSandboxArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	value, err := t.deps.Sandboxes.Create(ctx, inv.Caller, runtime.CreateSandboxInput{
+		Name:           args.Name,
+		Runtime:        args.Runtime,
+		Image:          args.Image,
+		Env:            args.Env,
+		Tags:           args.Tags,
+		TimeoutSeconds: args.TimeoutSeconds,
+		VCPUs:          args.VCPUs,
+		MemoryMB:       args.MemoryMB,
+		DisplayWidth:   args.DisplayWidth,
+		DisplayHeight:  args.DisplayHeight,
+		DisplayFPS:     args.DisplayFPS,
+		ProjectID:      args.ProjectID,
+		Persistent:     args.Persistent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+type updateSandboxArgs struct {
+	SandboxID      string             `json:"sandbox_id"`
+	Name           *string            `json:"name,omitempty"`
+	TimeoutSeconds *int               `json:"timeout_seconds,omitempty"`
+	Tags           *map[string]string `json:"tags,omitempty"`
+}
+
+var updateSandboxSchema = mustSchema[updateSandboxArgs]()
+
+type UpdateSandbox struct{ sandboxTool }
+
+func NewUpdateSandbox(deps Deps) *UpdateSandbox          { return &UpdateSandbox{sandboxTool{deps: deps}} }
+func (t *UpdateSandbox) Name() tool.Name                 { return UpdateSandboxName }
+func (t *UpdateSandbox) InputSchema() *jsonschema.Schema { return updateSandboxSchema }
+func (t *UpdateSandbox) Description() string {
+	return "Update a standalone sandbox's name, positive timeout_seconds, or tags. Omitted fields are unchanged."
+}
+func (t *UpdateSandbox) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args updateSandboxArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	if args.SandboxID == "" {
+		return nil, errors.New("sandbox_id is required")
+	}
+	if args.Name == nil && args.TimeoutSeconds == nil && args.Tags == nil {
+		return nil, errors.New("at least one of name, timeout_seconds, or tags is required")
+	}
+	if args.TimeoutSeconds != nil && *args.TimeoutSeconds <= 0 {
+		return nil, errors.New("timeout_seconds must be positive when updating a sandbox")
+	}
+	value, err := t.deps.Sandboxes.Update(ctx, inv.Caller, args.SandboxID, runtime.UpdateSandboxInput{
+		Name:           args.Name,
+		TimeoutSeconds: args.TimeoutSeconds,
+		Tags:           args.Tags,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+type DeleteSandbox struct{ sandboxTool }
+
+func NewDeleteSandbox(deps Deps) *DeleteSandbox          { return &DeleteSandbox{sandboxTool{deps: deps}} }
+func (t *DeleteSandbox) Name() tool.Name                 { return DeleteSandboxName }
+func (t *DeleteSandbox) InputSchema() *jsonschema.Schema { return sandboxIDSchema }
+func (t *DeleteSandbox) Description() string {
+	return "Delete a standalone sandbox in your organization and tear down its container. This is irreversible."
+}
+func (t *DeleteSandbox) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	args, err := parseSandboxID(inv.Args)
+	if err != nil {
+		return nil, err
+	}
+	if err := t.deps.Sandboxes.Delete(ctx, inv.Caller, args.SandboxID); err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		DeletedSandboxID string `json:"deleted_sandbox_id"`
+	}{DeletedSandboxID: args.SandboxID})
+}

--- a/api/pkg/org/interfaces/mcptools/sandboxes.go
+++ b/api/pkg/org/interfaces/mcptools/sandboxes.go
@@ -2,6 +2,7 @@ package mcptools
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/assetssh"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 )
 
@@ -19,7 +21,12 @@ const (
 	CreateSandboxName       tool.Name = "create_sandbox"
 	UpdateSandboxName       tool.Name = "update_sandbox"
 	DeleteSandboxName       tool.Name = "delete_sandbox"
+	SandboxSSHAccessName    tool.Name = "sandbox_ssh_access"
 )
+
+type SandboxSSHIdentityIssuer interface {
+	Mint(ctx context.Context, orgID, agentID, sandboxID string) (assetssh.SandboxProxyIdentity, error)
+}
 
 type sandboxTool struct{ deps Deps }
 
@@ -211,6 +218,53 @@ func (t *DeleteSandbox) Name() tool.Name                 { return DeleteSandboxN
 func (t *DeleteSandbox) InputSchema() *jsonschema.Schema { return sandboxIDSchema }
 func (t *DeleteSandbox) Description() string {
 	return "Delete a standalone sandbox in your organization and tear down its container. This is irreversible."
+}
+
+type SandboxSSHAccess struct{ sandboxTool }
+
+func NewSandboxSSHAccess(deps Deps) *SandboxSSHAccess {
+	return &SandboxSSHAccess{sandboxTool{deps: deps}}
+}
+func (t *SandboxSSHAccess) Name() tool.Name                 { return SandboxSSHAccessName }
+func (t *SandboxSSHAccess) InputSchema() *jsonschema.Schema { return sandboxIDSchema }
+func (t *SandboxSSHAccess) Description() string {
+	return "Mint a one-hour SSH certificate for this agent to a running standalone sandbox and return the exact setup command. The connection uses Helix's audited proxy and native ssh; the sandbox does not need sshd or an exposed port."
+}
+func (t *SandboxSSHAccess) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	args, err := parseSandboxID(inv.Args)
+	if err != nil {
+		return nil, err
+	}
+	if inv.Caller == nil || inv.Caller.OrganizationID() == "" || inv.Caller.ID() == "" {
+		return nil, errors.New("sandbox SSH caller scope is missing")
+	}
+	if t.deps.SandboxSSHIssuer == nil || t.deps.AssetSSHProxyAddress == "" {
+		return nil, errors.New("sandbox SSH proxy is not configured")
+	}
+	identity, err := t.deps.SandboxSSHIssuer.Mint(ctx, inv.Caller.OrganizationID(), inv.Caller.ID(), args.SandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("mint sandbox SSH access: %w", err)
+	}
+	host, port, err := assetssh.ParseProxyAddress(t.deps.AssetSSHProxyAddress)
+	if err != nil {
+		return nil, err
+	}
+	identityPath := "$HOME/.ssh/helix-sandbox-" + identity.SandboxID
+	usage := fmt.Sprintf(
+		"install -d -m 700 \"$HOME/.ssh\" && printf '%%s' '%s' | base64 -d > \"%s\" && printf '%%s' '%s' | base64 -d > \"%s-cert.pub\" && chmod 600 \"%s\" \"%s-cert.pub\"; ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -i \"%s\" -p %d sandbox@%s",
+		base64.StdEncoding.EncodeToString([]byte(identity.PrivateKey)), identityPath,
+		base64.StdEncoding.EncodeToString([]byte(identity.Certificate+"\n")), identityPath,
+		identityPath, identityPath, identityPath, port, host,
+	)
+	return json.Marshal(map[string]any{
+		"sandbox_id":  identity.SandboxID,
+		"proxy_host":  host,
+		"proxy_port":  port,
+		"private_key": identity.PrivateKey,
+		"certificate": identity.Certificate,
+		"expires_at":  identity.ExpiresAt,
+		"usage":       usage,
+	})
 }
 func (t *DeleteSandbox) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseSandboxID(inv.Args)

--- a/api/pkg/org/interfaces/mcptools/sandboxes_test.go
+++ b/api/pkg/org/interfaces/mcptools/sandboxes_test.go
@@ -3,11 +3,14 @@ package mcptools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	orgsandboxes "github.com/helixml/helix/api/pkg/org/application/sandboxes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/assetssh"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 )
@@ -21,6 +24,44 @@ type fakeSandboxesPort struct {
 	created runtime.CreateSandboxInput
 	updated runtime.UpdateSandboxInput
 	deleted string
+}
+
+type fakeSandboxSSHIssuer struct{}
+
+func (fakeSandboxSSHIssuer) Mint(context.Context, string, string, string) (assetssh.SandboxProxyIdentity, error) {
+	return assetssh.SandboxProxyIdentity{
+		SandboxID: "sbx_1", PrivateKey: "private", Certificate: "certificate", ExpiresAt: time.Unix(100, 0).UTC(),
+	}, nil
+}
+
+func TestSandboxSSHAccessReturnsNativeCommand(t *testing.T) {
+	t.Parallel()
+	toolDeps := Deps{
+		SandboxSSHIssuer:     fakeSandboxSSHIssuer{},
+		AssetSSHProxyAddress: "api.internal:2224",
+	}
+	result, err := NewSandboxSSHAccess(toolDeps).Invoke(context.Background(), tool.Invocation{
+		Caller: sandboxCaller{id: "chief-of-staff", orgID: "org-a"},
+		Args:   json.RawMessage(`{"sandbox_id":"sbx_1"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output struct {
+		SandboxID string `json:"sandbox_id"`
+		ProxyHost string `json:"proxy_host"`
+		ProxyPort int    `json:"proxy_port"`
+		Usage     string `json:"usage"`
+	}
+	if err := json.Unmarshal(result, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.SandboxID != "sbx_1" || output.ProxyHost != "api.internal" || output.ProxyPort != 2224 {
+		t.Fatalf("SSH access output = %+v", output)
+	}
+	if !strings.Contains(output.Usage, "ssh -o IdentitiesOnly=yes") || !strings.Contains(output.Usage, "sandbox@api.internal") {
+		t.Fatalf("usage is not a native SSH command: %s", output.Usage)
+	}
 }
 
 func (f *fakeSandboxesPort) ListRuntimes(context.Context) (runtime.SandboxRuntimeCatalog, error) {
@@ -43,6 +84,9 @@ func (f *fakeSandboxesPort) Update(_ context.Context, orgID, sandboxID string, i
 func (f *fakeSandboxesPort) Delete(_ context.Context, _ string, sandboxID string) error {
 	f.deleted = sandboxID
 	return nil
+}
+func (f *fakeSandboxesPort) OpenTerminal(context.Context, string, string, string) (runtime.SandboxTerminal, error) {
+	return nil, runtime.ErrSandboxesUnsupported
 }
 
 func TestSandboxToolsCRUD(t *testing.T) {
@@ -121,6 +165,7 @@ func TestSandboxToolsRegisteredAndGrantedToChiefOfStaff(t *testing.T) {
 		CreateSandboxName,
 		UpdateSandboxName,
 		DeleteSandboxName,
+		SandboxSSHAccessName,
 	}
 
 	store := orggorm.GetOrgTestDB(t)

--- a/api/pkg/org/interfaces/mcptools/sandboxes_test.go
+++ b/api/pkg/org/interfaces/mcptools/sandboxes_test.go
@@ -1,0 +1,152 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	orgsandboxes "github.com/helixml/helix/api/pkg/org/application/sandboxes"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+type sandboxCaller struct{ id, orgID string }
+
+func (c sandboxCaller) ID() string             { return c.id }
+func (c sandboxCaller) OrganizationID() string { return c.orgID }
+
+type fakeSandboxesPort struct {
+	created runtime.CreateSandboxInput
+	updated runtime.UpdateSandboxInput
+	deleted string
+}
+
+func (f *fakeSandboxesPort) ListRuntimes(context.Context) (runtime.SandboxRuntimeCatalog, error) {
+	return runtime.SandboxRuntimeCatalog{Runtimes: []string{"node22"}, DefaultRuntime: "node22"}, nil
+}
+func (f *fakeSandboxesPort) List(context.Context, string, string) ([]runtime.SandboxView, error) {
+	return []runtime.SandboxView{{ID: "sbx_1", OrganizationID: "org-a", Owner: "user-a", Runtime: "node22", Status: "running"}}, nil
+}
+func (f *fakeSandboxesPort) Get(context.Context, string, string) (runtime.SandboxView, error) {
+	return runtime.SandboxView{ID: "sbx_1", OrganizationID: "org-a", Owner: "user-a", Runtime: "node22", Status: "running"}, nil
+}
+func (f *fakeSandboxesPort) Create(_ context.Context, orgID string, _ orgchart.NodeID, in runtime.CreateSandboxInput) (runtime.SandboxView, error) {
+	f.created = in
+	return runtime.SandboxView{ID: "sbx_new", OrganizationID: orgID, Owner: "user-a", Runtime: in.Runtime, Status: "pending"}, nil
+}
+func (f *fakeSandboxesPort) Update(_ context.Context, orgID, sandboxID string, in runtime.UpdateSandboxInput) (runtime.SandboxView, error) {
+	f.updated = in
+	return runtime.SandboxView{ID: sandboxID, OrganizationID: orgID, Owner: "user-a", Runtime: "node22", Status: "running", Name: *in.Name}, nil
+}
+func (f *fakeSandboxesPort) Delete(_ context.Context, _ string, sandboxID string) error {
+	f.deleted = sandboxID
+	return nil
+}
+
+func TestSandboxToolsCRUD(t *testing.T) {
+	t.Parallel()
+	port := &fakeSandboxesPort{}
+	deps := Deps{Sandboxes: orgsandboxes.New(port, nil)}
+	caller := sandboxCaller{id: "chief-of-staff", orgID: "org-a"}
+
+	created, err := NewCreateSandbox(deps).Invoke(context.Background(), tool.Invocation{
+		Caller: caller,
+		Args:   json.RawMessage(`{"name":"ops","runtime":"node22","env":{"TOKEN":"secret"},"tags":{"team":"ops"}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port.created.Name != "ops" || port.created.Env["TOKEN"] != "secret" {
+		t.Fatalf("create input = %+v", port.created)
+	}
+	if string(created) == "" || containsJSONValue(created, "secret") {
+		t.Fatalf("create result leaked environment value: %s", created)
+	}
+
+	name := "renamed"
+	updated, err := NewUpdateSandbox(deps).Invoke(context.Background(), tool.Invocation{
+		Caller: caller,
+		Args:   json.RawMessage(`{"sandbox_id":"sbx_new","name":"renamed"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port.updated.Name == nil || *port.updated.Name != name || len(updated) == 0 {
+		t.Fatalf("update input = %+v result = %s", port.updated, updated)
+	}
+	zero := 0
+	zeroArgs, err := json.Marshal(updateSandboxArgs{SandboxID: "sbx_new", TimeoutSeconds: &zero})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewUpdateSandbox(deps).Invoke(context.Background(), tool.Invocation{Caller: caller, Args: zeroArgs}); err == nil {
+		t.Fatal("zero timeout update succeeded")
+	}
+
+	deleted, err := NewDeleteSandbox(deps).Invoke(context.Background(), tool.Invocation{
+		Caller: caller,
+		Args:   json.RawMessage(`{"sandbox_id":"sbx_new"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port.deleted != "sbx_new" || string(deleted) != `{"deleted_sandbox_id":"sbx_new"}` {
+		t.Fatalf("delete = %q, result = %s", port.deleted, deleted)
+	}
+}
+
+func containsJSONValue(raw json.RawMessage, value string) bool {
+	var decoded struct {
+		Env map[string]string `json:"env"`
+	}
+	if json.Unmarshal(raw, &decoded) != nil {
+		return true
+	}
+	for _, got := range decoded.Env {
+		if got == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSandboxToolsRegisteredAndGrantedToChiefOfStaff(t *testing.T) {
+	t.Parallel()
+	names := []tool.Name{
+		ListSandboxRuntimesName,
+		ListSandboxesName,
+		GetSandboxName,
+		CreateSandboxName,
+		UpdateSandboxName,
+		DeleteSandboxName,
+	}
+
+	store := orggorm.GetOrgTestDB(t)
+	registry := NewRegistry()
+	config := DefaultDeps(store)
+	injectTestPublishing(&config)
+	if err := RegisterBuiltins(registry, config.Build()); err != nil {
+		t.Fatal(err)
+	}
+	owner := make(map[tool.Name]bool)
+	for _, name := range OwnerBotTools() {
+		owner[name] = true
+	}
+	base := make(map[tool.Name]bool)
+	for _, name := range BaseReadTools {
+		base[name] = true
+	}
+	for _, name := range names {
+		if _, err := registry.Get(name); err != nil {
+			t.Errorf("tool %q not registered: %v", name, err)
+		}
+		if !owner[name] {
+			t.Errorf("OwnerBotTools missing %q", name)
+		}
+		if base[name] {
+			t.Errorf("sandbox tool %q must not be universal", name)
+		}
+	}
+}

--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -200,6 +200,12 @@ func (c *Controller) waitProvisions() {
 // expose a discovery endpoint and validate requests synchronously.
 func (c *Controller) Runtimes() *RuntimeRegistry { return c.runtimes }
 
+// RuntimeNames and DefaultRuntimeName expose the discovery slice needed by
+// non-HTTP adapters without leaking RuntimeRegistry through their interfaces.
+func (c *Controller) RuntimeNames() []string { return c.runtimes.Names() }
+
+func (c *Controller) DefaultRuntimeName() string { return c.runtimes.DefaultRuntimeName() }
+
 // Get returns a sandbox by id. Soft-deleted rows are not returned.
 func (c *Controller) Get(ctx context.Context, id string) (*types.Sandbox, error) {
 	return c.store.GetSandbox(ctx, id)

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -31,6 +31,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
+	orgsandboxes "github.com/helixml/helix/api/pkg/org/application/sandboxes"
 	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
 	"github.com/helixml/helix/api/pkg/org/application/subscriptions"
 	"github.com/helixml/helix/api/pkg/org/application/topics"
@@ -569,6 +570,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		return nil, fmt.Errorf("init sandboxes: %w", err)
 	}
 	deps.Sandboxes = sandboxesPort
+	sandboxAccess := orgsandboxes.New(sandboxesPort, deps.Queries)
 
 	// Repositories backs list_repositories / attach_repository /
 	// detach_repository — org git repos attached to Bot projects so
@@ -959,6 +961,11 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	if err != nil {
 		return nil, fmt.Errorf("init asset SSH proxy: %w", err)
 	}
+	sandboxSSHIssuer, err := assetssh.NewSandboxIssuer(sandboxAccess, encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("init sandbox SSH certificate issuer: %w", err)
+	}
+	assetSSHProxy.WithSandboxes(sandboxAccess)
 	orgAudit := services.NewOrgAuditLogService(helixStore)
 	auditProjects := func(ctx context.Context, orgID, actorID string) (string, error) {
 		state, err := runtimehelix.LoadState(ctx, st, orgID, orgchart.NodeID(actorID))
@@ -972,6 +979,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	deps.Assets = assetsSvc
 	deps.AssetSSH = assetSSH
 	deps.AssetSSHIssuer = assetSSHIssuer
+	deps.SandboxSSHIssuer = sandboxSSHIssuer
 	deps.AssetSSHProxyAddress = cfg.APIServer.Cfg.WebServer.AssetSSHProxyAddress
 	deps.AssetHealth = assetSSH.Health
 

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -560,6 +560,16 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	}
 	deps.Projects = projectsPort
 
+	// Sandboxes backs the Chief of Staff's standalone sandbox discovery and
+	// CRUD tools. It delegates to the same controller as the REST/UI surface,
+	// while the adapter derives the human owner and hard-scopes every row to
+	// the caller's organization.
+	sandboxesPort, err := runtimehelix.NewSandboxes(st, cfg.APIServer.sandboxController, helixStore)
+	if err != nil {
+		return nil, fmt.Errorf("init sandboxes: %w", err)
+	}
+	deps.Sandboxes = sandboxesPort
+
 	// Repositories backs list_repositories / attach_repository /
 	// detach_repository — org git repos attached to Bot projects so
 	// sandboxes can clone the code. Chief of Staff gets these by default.

--- a/frontend/src/components/helix-org/ToolPickerDialog.test.tsx
+++ b/frontend/src/components/helix-org/ToolPickerDialog.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ToolPickerDialog, { groupToolCatalogue, toolCapabilityGroupKey } from './ToolPickerDialog'
+
+const catalogue = [
+  { name: 'create_bot', description: 'Create an agent.' },
+  { name: 'publish', description: 'Publish an event.' },
+  { name: 'list_sandboxes', description: 'List standalone sandboxes.' },
+  { name: 'create_sandbox', description: 'Create a standalone sandbox.' },
+  { name: 'server_run_command', description: 'Run a command on a server.' },
+  { name: 'future_capability', description: 'A newly registered capability.' },
+]
+
+const openSection = (name: string) => {
+  const summary = screen.getByText(name).closest('[role="button"]')
+  expect(summary).toBeTruthy()
+  fireEvent.click(summary!)
+}
+
+describe('ToolPickerDialog', () => {
+  it('groups known tools and leaves new tools discoverable in Other tools', () => {
+    expect(toolCapabilityGroupKey('create_bot')).toBe('agents')
+    expect(toolCapabilityGroupKey('create_sandbox')).toBe('sandboxes')
+    expect(toolCapabilityGroupKey('server_run_command')).toBe('infrastructure')
+    expect(toolCapabilityGroupKey('future_capability')).toBe('other')
+
+    const groups = groupToolCatalogue(catalogue)
+    expect(groups.find((group) => group.key === 'sandboxes')?.tools.map((tool) => tool.name)).toEqual([
+      'create_sandbox',
+      'list_sandboxes',
+    ])
+    expect(groups.find((group) => group.key === 'other')?.tools[0].name).toBe('future_capability')
+  })
+
+  it('edits a draft selection and applies it without saving on each click', () => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ToolPickerDialog
+        open
+        tools={catalogue}
+        selectedTools={['list_sandboxes']}
+        onApply={onApply}
+        onClose={onClose}
+      />,
+    )
+
+    expect(screen.getByText('Create and administer standalone organization containers independently from agent desktops.')).toBeTruthy()
+    expect(screen.queryByRole('checkbox', { name: 'Enable list_sandboxes' })).not.toBeInTheDocument()
+    openSection('Sandbox environments')
+    expect(screen.getByRole('checkbox', { name: 'Enable list_sandboxes' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Enable create_sandbox' })).not.toBeChecked()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Enable create_sandbox' }))
+    expect(onApply).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Apply selection' }))
+
+    expect(onApply).toHaveBeenCalledWith(['create_sandbox', 'list_sandboxes'])
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('can enable or disable a complete section', () => {
+    const onApply = vi.fn()
+    render(
+      <ToolPickerDialog
+        open
+        tools={catalogue}
+        selectedTools={[]}
+        onApply={onApply}
+        onClose={vi.fn()}
+      />,
+    )
+
+    openSection('Sandbox environments')
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Toggle all Sandbox environments tools' }))
+    expect(screen.getByRole('checkbox', { name: 'Enable create_sandbox' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Enable list_sandboxes' })).toBeChecked()
+    fireEvent.click(screen.getByRole('button', { name: 'Apply selection' }))
+    expect(onApply).toHaveBeenCalledWith(['create_sandbox', 'list_sandboxes'])
+  })
+})

--- a/frontend/src/components/helix-org/ToolPickerDialog.tsx
+++ b/frontend/src/components/helix-org/ToolPickerDialog.tsx
@@ -227,9 +227,15 @@ const ToolPickerDialog: FC<ToolPickerDialogProps> = ({
       onClose={onClose}
       maxWidth="md"
       fullWidth
-      PaperProps={{ sx: { bgcolor: 'background.paper' } }}
+      PaperProps={{
+        sx: {
+          bgcolor: 'background.paper',
+          height: '80vh',
+          maxHeight: 'calc(100% - 32px)',
+        },
+      }}
     >
-      <DialogTitle component="div" sx={{ pb: 1 }}>
+      <DialogTitle component="div" sx={{ pb: 1, flexShrink: 0 }}>
         <Typography variant="h6">Agent tools</Typography>
         <Typography variant="body2" color="text.secondary">
           Choose the MCP capabilities this agent can call. Section checkboxes enable or disable an entire capability area.
@@ -238,8 +244,28 @@ const ToolPickerDialog: FC<ToolPickerDialogProps> = ({
           Applying a selection updates this form; use Save agent to persist the configuration.
         </Typography>
       </DialogTitle>
-      <DialogContent dividers sx={{ p: 2 }}>
-        <Stack spacing={2}>
+      <DialogContent
+        dividers
+        sx={{
+          p: 0,
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          sx={{
+            p: 2,
+            flexShrink: 0,
+            bgcolor: 'background.paper',
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            position: 'sticky',
+            top: 0,
+            zIndex: 1,
+          }}
+        >
           <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'center' }}>
             <TextField
               value={search}
@@ -264,124 +290,128 @@ const ToolPickerDialog: FC<ToolPickerDialogProps> = ({
               </Button>
             </Stack>
           </Stack>
+        </Box>
 
-          {visibleGroups.length === 0 ? (
-            <Box sx={{ py: 6, textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                No tools match “{search}”.
-              </Typography>
-            </Box>
-          ) : visibleGroups.map((visibleGroup) => {
-            const fullGroup = groupedTools.find((group) => group.key === visibleGroup.key) ?? visibleGroup
-            const groupNames = fullGroup.tools.map((tool) => tool.name ?? '').filter(Boolean)
-            const enabledCount = groupNames.filter((name) => selected.has(name)).length
-            const allEnabled = enabledCount === groupNames.length
-            const someEnabled = enabledCount > 0 && !allEnabled
-            return (
-              <Accordion
-                key={visibleGroup.key}
-                disableGutters
-                elevation={0}
-                sx={{
-                  border: '1px solid',
-                  borderColor: 'divider',
-                  borderRadius: '8px !important',
-                  bgcolor: 'transparent',
-                  '&:before': { display: 'none' },
-                }}
-              >
-                <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 1.5 }}>
-                  <Checkbox
-                    checked={allEnabled}
-                    indeterminate={someEnabled}
-                    onClick={(event) => event.stopPropagation()}
-                    onFocus={(event) => event.stopPropagation()}
-                    onChange={() => toggleGroup(fullGroup)}
-                    inputProps={{ 'aria-label': `Toggle all ${fullGroup.title} tools` }}
-                    sx={{ alignSelf: 'flex-start', mt: -0.25, mr: 0.75 }}
-                  />
-                  <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Typography variant="subtitle2" sx={{ fontSize: '0.8rem' }}>{fullGroup.title}</Typography>
-                      <Chip
-                        label={`${enabledCount}/${groupNames.length}`}
-                        size="small"
-                        sx={{ height: 20, fontSize: '0.65rem' }}
-                      />
-                    </Stack>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ display: 'block', mt: 0.25, fontSize: '0.68rem' }}
-                    >
-                      {fullGroup.description}
-                    </Typography>
-                  </Box>
-                </AccordionSummary>
-                <AccordionDetails sx={{ pt: 0, px: 1.5, pb: 1.5 }}>
-                  <Box sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
-                    {visibleGroup.tools.map((tool) => {
-                      const name = tool.name ?? ''
-                      const enabled = selected.has(name)
-                      return (
-                        <Box
-                          component="label"
-                          key={name}
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1.5,
-                            py: 1.25,
-                            px: 0.5,
-                            borderBottom: '1px solid',
-                            borderColor: 'divider',
-                            bgcolor: 'transparent',
-                            cursor: 'pointer',
-                            '&:last-child': { borderBottom: 0 },
-                          }}
-                        >
-                          <Box sx={{ minWidth: 0, flex: 1 }}>
-                            <Typography
-                              variant="body2"
-                              sx={{ fontFamily: 'monospace', fontSize: '0.75rem', fontWeight: 600, wordBreak: 'break-word' }}
-                            >
-                              {name}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              title={tool.description || undefined}
-                              sx={{
-                                display: '-webkit-box',
-                                mt: 0.25,
-                                fontSize: '0.68rem',
-                                lineHeight: 1.4,
-                                overflow: 'hidden',
-                                WebkitBoxOrient: 'vertical',
-                                WebkitLineClamp: 2,
-                              }}
-                            >
-                              {tool.description || 'No description is available for this tool.'}
-                            </Typography>
+        <Box sx={{ minHeight: 0, flex: 1, overflowY: 'auto', p: 2 }}>
+          <Stack spacing={2}>
+            {visibleGroups.length === 0 ? (
+              <Box sx={{ py: 6, textAlign: 'center' }}>
+                <Typography variant="body2" color="text.secondary">
+                  No tools match “{search}”.
+                </Typography>
+              </Box>
+            ) : visibleGroups.map((visibleGroup) => {
+              const fullGroup = groupedTools.find((group) => group.key === visibleGroup.key) ?? visibleGroup
+              const groupNames = fullGroup.tools.map((tool) => tool.name ?? '').filter(Boolean)
+              const enabledCount = groupNames.filter((name) => selected.has(name)).length
+              const allEnabled = enabledCount === groupNames.length
+              const someEnabled = enabledCount > 0 && !allEnabled
+              return (
+                <Accordion
+                  key={visibleGroup.key}
+                  disableGutters
+                  elevation={0}
+                  sx={{
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: '8px !important',
+                    bgcolor: 'transparent',
+                    '&:before': { display: 'none' },
+                  }}
+                >
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 1.5 }}>
+                    <Checkbox
+                      checked={allEnabled}
+                      indeterminate={someEnabled}
+                      onClick={(event) => event.stopPropagation()}
+                      onFocus={(event) => event.stopPropagation()}
+                      onChange={() => toggleGroup(fullGroup)}
+                      inputProps={{ 'aria-label': `Toggle all ${fullGroup.title} tools` }}
+                      sx={{ alignSelf: 'flex-start', mt: -0.25, mr: 0.75 }}
+                    />
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography variant="subtitle2" sx={{ fontSize: '0.8rem' }}>{fullGroup.title}</Typography>
+                        <Chip
+                          label={`${enabledCount}/${groupNames.length}`}
+                          size="small"
+                          sx={{ height: 20, fontSize: '0.65rem' }}
+                        />
+                      </Stack>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: 'block', mt: 0.25, fontSize: '0.68rem' }}
+                      >
+                        {fullGroup.description}
+                      </Typography>
+                    </Box>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ pt: 0, px: 1.5, pb: 1.5 }}>
+                    <Box sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
+                      {visibleGroup.tools.map((tool) => {
+                        const name = tool.name ?? ''
+                        const enabled = selected.has(name)
+                        return (
+                          <Box
+                            component="label"
+                            key={name}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1.5,
+                              py: 1.25,
+                              px: 0.5,
+                              borderBottom: '1px solid',
+                              borderColor: 'divider',
+                              bgcolor: 'transparent',
+                              cursor: 'pointer',
+                              '&:last-child': { borderBottom: 0 },
+                            }}
+                          >
+                            <Box sx={{ minWidth: 0, flex: 1 }}>
+                              <Typography
+                                variant="body2"
+                                sx={{ fontFamily: 'monospace', fontSize: '0.75rem', fontWeight: 600, wordBreak: 'break-word' }}
+                              >
+                                {name}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                title={tool.description || undefined}
+                                sx={{
+                                  display: '-webkit-box',
+                                  mt: 0.25,
+                                  fontSize: '0.68rem',
+                                  lineHeight: 1.4,
+                                  overflow: 'hidden',
+                                  WebkitBoxOrient: 'vertical',
+                                  WebkitLineClamp: 2,
+                                }}
+                              >
+                                {tool.description || 'No description is available for this tool.'}
+                              </Typography>
+                            </Box>
+                            <Checkbox
+                              checked={enabled}
+                              onChange={() => toggleTool(name)}
+                              inputProps={{ 'aria-label': `Enable ${name}` }}
+                              size="small"
+                              sx={{ flexShrink: 0 }}
+                            />
                           </Box>
-                          <Checkbox
-                            checked={enabled}
-                            onChange={() => toggleTool(name)}
-                            inputProps={{ 'aria-label': `Enable ${name}` }}
-                            size="small"
-                            sx={{ flexShrink: 0 }}
-                          />
-                        </Box>
-                      )
-                    })}
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
-            )
-          })}
-        </Stack>
+                        )
+                      })}
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              )
+            })}
+          </Stack>
+        </Box>
       </DialogContent>
-      <DialogActions sx={{ px: 2, py: 1.5 }}>
+      <DialogActions sx={{ px: 2, py: 1.5, flexShrink: 0 }}>
         <Typography variant="body2" color="text.secondary" sx={{ mr: 'auto' }}>
           {draftTools.length} of {tools.length} enabled
         </Typography>

--- a/frontend/src/components/helix-org/ToolPickerDialog.tsx
+++ b/frontend/src/components/helix-org/ToolPickerDialog.tsx
@@ -1,0 +1,397 @@
+import { FC, useEffect, useMemo, useState } from 'react'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Chip from '@mui/material/Chip'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import SearchIcon from '@mui/icons-material/Search'
+
+import { ToolDTO } from '../../services/helixOrgService'
+
+export type ToolCapabilityGroupKey =
+  | 'coordination'
+  | 'agents'
+  | 'topics'
+  | 'delivery'
+  | 'sandboxes'
+  | 'infrastructure'
+  | 'credentials'
+  | 'other'
+
+export interface ToolCapabilityGroup {
+  key: ToolCapabilityGroupKey
+  title: string
+  description: string
+}
+
+export const TOOL_CAPABILITY_GROUPS: ToolCapabilityGroup[] = [
+  {
+    key: 'coordination',
+    title: 'Coordination & awareness',
+    description: 'Understand the organization, inspect agent activity, and communicate with people or reporting-line peers.',
+  },
+  {
+    key: 'agents',
+    title: 'Agent administration',
+    description: 'Create and configure agents, control their desktops, and change the capabilities available to them.',
+  },
+  {
+    key: 'topics',
+    title: 'Topics & automation',
+    description: 'Publish and route events, manage subscriptions, and build processors that transform topic traffic.',
+  },
+  {
+    key: 'delivery',
+    title: 'Projects & delivery',
+    description: 'Discover projects and repositories, attach code to agents, and manage specification-driven work.',
+  },
+  {
+    key: 'sandboxes',
+    title: 'Sandbox environments',
+    description: 'Create and administer standalone organization containers independently from agent desktops.',
+  },
+  {
+    key: 'infrastructure',
+    title: 'Infrastructure & servers',
+    description: 'Manage organization assets and operate linked servers through commands, files, health checks, and SSH.',
+  },
+  {
+    key: 'credentials',
+    title: 'Credentials & secrets',
+    description: 'Read project secrets and mint short-lived credentials for approved external providers.',
+  },
+  {
+    key: 'other',
+    title: 'Other tools',
+    description: 'Registered or legacy capabilities that do not yet belong to one of the standard groups.',
+  },
+]
+
+const COORDINATION_TOOLS = new Set([
+  'managers',
+  'reports',
+  'list_bots',
+  'get_bot',
+  'bot_log',
+  'read_events',
+  'dm',
+  'ask_human',
+  'set_human_contact',
+])
+
+const AGENT_TOOLS = new Set([
+  'create_bot',
+  'set_bot_content',
+  'delete_bot',
+  'attach_tool',
+  'detach_tool',
+  'start_bot',
+  'stop_bot',
+  'restart_bot',
+  'get_bot_project',
+  'configure_bot_project',
+])
+
+const TOPIC_TOOLS = new Set([
+  'list_topics',
+  'get_topic',
+  'list_topic_events',
+  'create_topic',
+  'topic_members',
+  'subscribe',
+  'unsubscribe',
+  'publish',
+  'list_processors',
+  'get_processor',
+  'create_processor',
+  'update_processor',
+  'delete_processor',
+])
+
+export const toolCapabilityGroupKey = (name: string): ToolCapabilityGroupKey => {
+  if (name.includes('sandbox')) return 'sandboxes'
+  if (name.startsWith('server_') || name.includes('asset')) return 'infrastructure'
+  if (COORDINATION_TOOLS.has(name)) return 'coordination'
+  if (AGENT_TOOLS.has(name)) return 'agents'
+  if (TOPIC_TOOLS.has(name)) return 'topics'
+  if (name.includes('spectask') || name.includes('project') || name.includes('repository')) return 'delivery'
+  if (name === 'mint_credential' || name === 'list_secrets') return 'credentials'
+  return 'other'
+}
+
+export interface GroupedToolCatalogueEntry extends ToolCapabilityGroup {
+  tools: ToolDTO[]
+}
+
+export const groupToolCatalogue = (tools: ToolDTO[]): GroupedToolCatalogueEntry[] => {
+  const byGroup = new Map<ToolCapabilityGroupKey, ToolDTO[]>()
+  for (const tool of tools) {
+    const name = tool.name?.trim()
+    if (!name) continue
+    const normalizedTool = { ...tool, name }
+    const key = toolCapabilityGroupKey(name)
+    const current = byGroup.get(key) ?? []
+    current.push(normalizedTool)
+    byGroup.set(key, current)
+  }
+  return TOOL_CAPABILITY_GROUPS
+    .map((group) => ({
+      ...group,
+      tools: (byGroup.get(group.key) ?? []).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '')),
+    }))
+    .filter((group) => group.tools.length > 0)
+}
+
+interface ToolPickerDialogProps {
+  open: boolean
+  tools: ToolDTO[]
+  selectedTools: string[]
+  onClose: () => void
+  onApply: (tools: string[]) => void
+}
+
+const normalizedSelection = (names: string[]) => Array.from(new Set(names)).sort()
+
+const ToolPickerDialog: FC<ToolPickerDialogProps> = ({
+  open,
+  tools,
+  selectedTools,
+  onClose,
+  onApply,
+}) => {
+  const [draftTools, setDraftTools] = useState<string[]>([])
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setDraftTools(normalizedSelection(selectedTools))
+    setSearch('')
+  }, [open, selectedTools])
+
+  const groupedTools = useMemo(() => groupToolCatalogue(tools), [tools])
+  const selected = useMemo(() => new Set(draftTools), [draftTools])
+  const searchValue = search.trim().toLowerCase()
+  const visibleGroups = useMemo(() => {
+    if (!searchValue) return groupedTools
+    return groupedTools
+      .map((group) => ({
+        ...group,
+        tools: group.tools.filter((tool) =>
+          `${tool.name ?? ''} ${tool.description ?? ''}`.toLowerCase().includes(searchValue),
+        ),
+      }))
+      .filter((group) => group.tools.length > 0)
+  }, [groupedTools, searchValue])
+
+  const toggleTool = (name: string) => {
+    setDraftTools((current) => {
+      const next = new Set(current)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return normalizedSelection(Array.from(next))
+    })
+  }
+
+  const toggleGroup = (group: GroupedToolCatalogueEntry) => {
+    const names = group.tools.map((tool) => tool.name ?? '').filter(Boolean)
+    const allEnabled = names.every((name) => selected.has(name))
+    setDraftTools((current) => {
+      const next = new Set(current)
+      for (const name of names) {
+        if (allEnabled) next.delete(name)
+        else next.add(name)
+      }
+      return normalizedSelection(Array.from(next))
+    })
+  }
+
+  const handleApply = () => {
+    onApply(normalizedSelection(draftTools))
+    onClose()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{ sx: { bgcolor: 'background.paper' } }}
+    >
+      <DialogTitle component="div" sx={{ pb: 1 }}>
+        <Typography variant="h6">Agent tools</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Choose the MCP capabilities this agent can call. Section checkboxes enable or disable an entire capability area.
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          Applying a selection updates this form; use Save agent to persist the configuration.
+        </Typography>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'center' }}>
+            <TextField
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search tools"
+              size="small"
+              fullWidth
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+              <Button size="small" onClick={() => setDraftTools(normalizedSelection(tools.map((tool) => tool.name ?? '').filter(Boolean)))}>
+                Enable all
+              </Button>
+              <Button size="small" onClick={() => setDraftTools([])} disabled={draftTools.length === 0}>
+                Clear all
+              </Button>
+            </Stack>
+          </Stack>
+
+          {visibleGroups.length === 0 ? (
+            <Box sx={{ py: 6, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                No tools match “{search}”.
+              </Typography>
+            </Box>
+          ) : visibleGroups.map((visibleGroup) => {
+            const fullGroup = groupedTools.find((group) => group.key === visibleGroup.key) ?? visibleGroup
+            const groupNames = fullGroup.tools.map((tool) => tool.name ?? '').filter(Boolean)
+            const enabledCount = groupNames.filter((name) => selected.has(name)).length
+            const allEnabled = enabledCount === groupNames.length
+            const someEnabled = enabledCount > 0 && !allEnabled
+            return (
+              <Accordion
+                key={visibleGroup.key}
+                disableGutters
+                elevation={0}
+                sx={{
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: '8px !important',
+                  bgcolor: 'transparent',
+                  '&:before': { display: 'none' },
+                }}
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 1.5 }}>
+                  <Checkbox
+                    checked={allEnabled}
+                    indeterminate={someEnabled}
+                    onClick={(event) => event.stopPropagation()}
+                    onFocus={(event) => event.stopPropagation()}
+                    onChange={() => toggleGroup(fullGroup)}
+                    inputProps={{ 'aria-label': `Toggle all ${fullGroup.title} tools` }}
+                    sx={{ alignSelf: 'flex-start', mt: -0.25, mr: 0.75 }}
+                  />
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography variant="subtitle2" sx={{ fontSize: '0.8rem' }}>{fullGroup.title}</Typography>
+                      <Chip
+                        label={`${enabledCount}/${groupNames.length}`}
+                        size="small"
+                        sx={{ height: 20, fontSize: '0.65rem' }}
+                      />
+                    </Stack>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 0.25, fontSize: '0.68rem' }}
+                    >
+                      {fullGroup.description}
+                    </Typography>
+                  </Box>
+                </AccordionSummary>
+                <AccordionDetails sx={{ pt: 0, px: 1.5, pb: 1.5 }}>
+                  <Box sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
+                    {visibleGroup.tools.map((tool) => {
+                      const name = tool.name ?? ''
+                      const enabled = selected.has(name)
+                      return (
+                        <Box
+                          component="label"
+                          key={name}
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1.5,
+                            py: 1.25,
+                            px: 0.5,
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
+                            bgcolor: 'transparent',
+                            cursor: 'pointer',
+                            '&:last-child': { borderBottom: 0 },
+                          }}
+                        >
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Typography
+                              variant="body2"
+                              sx={{ fontFamily: 'monospace', fontSize: '0.75rem', fontWeight: 600, wordBreak: 'break-word' }}
+                            >
+                              {name}
+                            </Typography>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              title={tool.description || undefined}
+                              sx={{
+                                display: '-webkit-box',
+                                mt: 0.25,
+                                fontSize: '0.68rem',
+                                lineHeight: 1.4,
+                                overflow: 'hidden',
+                                WebkitBoxOrient: 'vertical',
+                                WebkitLineClamp: 2,
+                              }}
+                            >
+                              {tool.description || 'No description is available for this tool.'}
+                            </Typography>
+                          </Box>
+                          <Checkbox
+                            checked={enabled}
+                            onChange={() => toggleTool(name)}
+                            inputProps={{ 'aria-label': `Enable ${name}` }}
+                            size="small"
+                            sx={{ flexShrink: 0 }}
+                          />
+                        </Box>
+                      )
+                    })}
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            )
+          })}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 2, py: 1.5 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mr: 'auto' }}>
+          {draftTools.length} of {tools.length} enabled
+        </Typography>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" color="secondary" onClick={handleApply}>
+          Apply selection
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ToolPickerDialog

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -4,8 +4,8 @@
 // A Bot is the merge of the former Role and Worker: its markdown
 // `content` is its identity/prompt, its `tools` list is its MCP tool
 // surface, it carries topic subscriptions, and it reports to other bots
-// (parent_ids). Content + tools are edited here via Monaco + a tools
-// multi-select and saved in one step through useUpdateBot (there is no
+// (parent_ids). Content + tools are edited here via Monaco + a grouped tools
+// dialog and saved in one step through useUpdateBot (there is no
 // separate identity field). Subscriptions are managed in the panel below.
 //
 // This page deliberately carries NO inline transcript or desktop viewer —
@@ -43,6 +43,7 @@ import Typography from '@mui/material/Typography'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
@@ -55,6 +56,7 @@ import Tooltip from '@mui/material/Tooltip'
 
 import HelixOrgShell from '../components/helix-org/HelixOrgShell'
 import AgentConfigForm, { AgentConfigValue } from '../components/helix-org/BotRuntimeForm'
+import ToolPickerDialog from '../components/helix-org/ToolPickerDialog'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import MonacoEditor from '../components/widgets/MonacoEditor'
@@ -108,6 +110,7 @@ const HelixOrgBotDetail: FC = () => {
   const { data: toolCatalogue } = useListHelixOrgTools()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [confirmingResetInstructions, setConfirmingResetInstructions] = useState(false)
+  const [editingTools, setEditingTools] = useState(false)
   const [agentMenuEl, setAgentMenuEl] = useState<null | HTMLElement>(null)
   // The bot owns one durable exploratory session. Runtime edits must switch
   // that session through the canonical lifecycle instead of leaving it bound
@@ -592,63 +595,48 @@ const HelixOrgBotDetail: FC = () => {
                 </Box>
 
                 <Box>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Tools</Typography>
-                  <Autocomplete
-                    multiple
-                    disableCloseOnSelect
-                    options={toolOptions}
-                    value={toolOptions.filter((o) => tools.includes(o.name))}
-                    onChange={(_e, value) => setTools(value.map((v) => v.name))}
-                    getOptionLabel={(o) => o.name}
-                    isOptionEqualToValue={(a, b) => a.name === b.name}
-                    renderOption={(props, option, { selected }) => {
-                      // Pass key explicitly rather than via the props
-                      // spread — React 18.3 warns when a spread object
-                      // carries a key.
-                      const { key, ...liProps } = props as typeof props & { key?: Key }
-                      return (
-                        <li key={key ?? option.name} {...liProps}>
-                          <Checkbox
-                            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-                            checkedIcon={<CheckBoxIcon fontSize="small" />}
-                            style={{ marginRight: 8 }}
-                            checked={selected}
-                          />
-                          <Box sx={{ minWidth: 0 }}>
-                            <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                              {option.name}
-                            </Typography>
-                            {option.description && (
-                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                                {option.description}
-                              </Typography>
-                            )}
-                          </Box>
-                        </li>
-                      )
-                    }}
-                    renderTags={(value, getTagProps) =>
-                      value.map((option, index) => {
-                        const { key, ...tagProps } = getTagProps({ index })
-                        return (
-                          <Chip
-                            key={key ?? option.name}
-                            {...tagProps}
-                            label={option.name}
-                            size="small"
-                            sx={{ fontFamily: 'monospace' }}
-                          />
-                        )
-                      })
-                    }
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        placeholder={tools.length === 0 ? 'Pick the tools this agent can call' : ''}
-                        helperText="MCP tools this agent can call. Empty = no tools (the agent can still receive owner-chat)."
-                      />
-                    )}
-                  />
+                  <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Stack spacing={1.5}>
+                      <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+                        <Box>
+                          <Typography variant="subtitle2">Tools</Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {tools.length} MCP {tools.length === 1 ? 'capability' : 'capabilities'} enabled
+                          </Typography>
+                        </Box>
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          startIcon={<EditOutlinedIcon />}
+                          onClick={() => setEditingTools(true)}
+                        >
+                          Edit tools
+                        </Button>
+                      </Stack>
+                      {tools.length > 0 ? (
+                        <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+                          {[...tools].sort().slice(0, 8).map((toolName) => (
+                            <Chip
+                              key={toolName}
+                              label={toolName}
+                              size="small"
+                              sx={{ fontFamily: 'monospace' }}
+                            />
+                          ))}
+                          {tools.length > 8 && (
+                            <Chip label={`+${tools.length - 8} more`} size="small" variant="outlined" />
+                          )}
+                        </Stack>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          No tools selected. The agent can still receive owner chat, but cannot call Helix Org MCP capabilities.
+                        </Typography>
+                      )}
+                      <Typography variant="caption" color="text.secondary">
+                        Changes made in the tool picker are saved with the rest of this agent configuration.
+                      </Typography>
+                    </Stack>
+                  </Paper>
                 </Box>
 
                 <Box>
@@ -840,6 +828,14 @@ const HelixOrgBotDetail: FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <ToolPickerDialog
+        open={editingTools}
+        tools={toolOptions}
+        selectedTools={tools}
+        onClose={() => setEditingTools(false)}
+        onApply={setTools}
+      />
 
       {confirmingDelete && botId && (
         <DeleteConfirmWindow


### PR DESCRIPTION
## What changed

- expose org-scoped standalone sandbox runtime discovery, list, get, create, update, and delete operations as Helix Org MCP tools
- grant those tools to the Chief of Staff by default and document the workflow in its seed instructions
- replace the agent tool multi-select with a grouped, searchable capability dialog with collapsed sections, compact single-row tools, and the Helix secondary-blue action style
- add `sandbox_ssh_access`, which mints a one-hour agent- and sandbox-scoped SSH certificate
- route native SSH sessions and commands through the existing audited SSH proxy and Hydra terminal channel, without requiring `sshd` or an exposed sandbox port
- revalidate org membership and sandbox ownership on every connection so deletion or access removal revokes an already-minted certificate
- support interactive PTYs, window resizing, command execution, and command exit-status propagation

## Why

Organization agents need to manage and work inside the same standalone sandboxes available from the Helix UI. Operators also need a clearer way to understand and configure an agent's growing MCP capability surface.

## Validation

- `go test ./pkg/org/application/sandboxes ./pkg/org/infrastructure/runtime/helix ./pkg/org/infrastructure/assetssh ./pkg/org/interfaces/mcptools ./pkg/org/domain/seedprompts ./pkg/config`
- `go test ./pkg/hydra -run '^$'`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `./stack build-sandbox`
- `yarn test ToolPickerDialog.test.tsx --run`
- `yarn tsc`
- `yarn build`
- live browser verification on the local Chief of Staff agent page
- live MCP call to `sandbox_ssh_access` for a real running sandbox
- native SSH from the Chief of Staff desktop container to that sandbox through `api:2224`; verified stdout, container hostname, and non-zero exit-status propagation
- verified successful MCP, SSH connection, and SSH command audit entries, then deleted the test sandbox

## Test note

The full `go test ./pkg/hydra` run still has two existing disk-pressure test failures (`TestPoolFreeBytes_EmptyPoolName` and `TestPoolFreeBytes_ZFSUnavailable`) outside this diff. The changed Hydra package compiles, the sandbox image rebuild completed, and the modified terminal path passed the live end-to-end SSH test above.
