### PR TITLE
fix(frontend): compact chat activity controls

### DIFF
--- a/frontend/src/components/helix-org/ChartTopicVisibilityMenu.tsx
+++ b/frontend/src/components/helix-org/ChartTopicVisibilityMenu.tsx
@@ -1,111 +1,22 @@
-import { FC, useState } from 'react'
-import Button from '@mui/material/Button'
-import Checkbox from '@mui/material/Checkbox'
-import Divider from '@mui/material/Divider'
-import ListItemText from '@mui/material/ListItemText'
-import Menu from '@mui/material/Menu'
-import MenuItem from '@mui/material/MenuItem'
+import { FC } from 'react'
 import FilterListIcon from '@mui/icons-material/FilterList'
 
 import { ChartTopicFilter, CHART_TOPIC_FILTERS } from './chartTopicVisibility'
-
-export const chartToolbarButtonSizeSx = {
-  minWidth: 0,
-  height: 30,
-  px: 1,
-  fontSize: '0.72rem',
-  '& .MuiButton-startIcon': { mr: 0.5 },
-}
-
-export const chartToolbarButtonSx = {
-  ...chartToolbarButtonSizeSx,
-  color: 'text.secondary',
-  borderColor: 'divider',
-  backgroundColor: 'background.paper',
-  '&:hover': {
-    color: 'text.primary',
-    borderColor: 'text.disabled',
-    backgroundColor: 'action.hover',
-  },
-}
+import ChartVisibilityMenu from './ChartVisibilityMenu'
 
 const ChartTopicVisibilityMenu: FC<{
   selected: ChartTopicFilter[]
   onChange: (selected: ChartTopicFilter[]) => void
 }> = ({ selected, onChange }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const allSelected = selected.length === CHART_TOPIC_FILTERS.length
-  const someSelected = selected.length > 0 && !allSelected
-
-  const toggleFilter = (filter: ChartTopicFilter) => {
-    if (selected.includes(filter)) {
-      onChange(selected.filter((candidate) => candidate !== filter))
-      return
-    }
-    onChange(CHART_TOPIC_FILTERS
-      .map((candidate) => candidate.id)
-      .filter((candidate) => candidate === filter || selected.includes(candidate)))
-  }
-
   return (
-    <>
-      <Button
-        size="small"
-        variant="outlined"
-        startIcon={<FilterListIcon />}
-        onClick={(event) => setAnchorEl(event.currentTarget)}
-        aria-label="Choose topic types shown on chart"
-        aria-haspopup="menu"
-        aria-expanded={Boolean(anchorEl)}
-        sx={chartToolbarButtonSx}
-      >
-        Topics {selected.length}/{CHART_TOPIC_FILTERS.length}
-      </Button>
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={() => setAnchorEl(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-        MenuListProps={{ dense: true, sx: { py: 0.5 } }}
-        PaperProps={{ sx: { minWidth: 200 } }}
-      >
-        <MenuItem
-          dense
-          onClick={() => onChange(allSelected ? [] : CHART_TOPIC_FILTERS.map((filter) => filter.id))}
-          sx={{ minHeight: 32, px: 1 }}
-        >
-          <Checkbox
-            size="small"
-            checked={allSelected}
-            indeterminate={someSelected}
-            sx={{
-              p: 0.5,
-              mr: 0.5,
-              color: 'text.disabled',
-              '&.Mui-checked, &.MuiCheckbox-indeterminate': { color: 'text.secondary' },
-            }}
-          />
-          <ListItemText primary="All topic types" primaryTypographyProps={{ fontSize: '0.8rem', fontWeight: 600 }} />
-        </MenuItem>
-        <Divider sx={{ my: 0.5 }} />
-        {CHART_TOPIC_FILTERS.map((filter) => (
-          <MenuItem key={filter.id} dense onClick={() => toggleFilter(filter.id)} sx={{ minHeight: 32, px: 1 }}>
-            <Checkbox
-              size="small"
-              checked={selected.includes(filter.id)}
-              sx={{
-                p: 0.5,
-                mr: 0.5,
-                color: 'text.disabled',
-                '&.Mui-checked': { color: 'text.secondary' },
-              }}
-            />
-            <ListItemText primary={filter.label} primaryTypographyProps={{ fontSize: '0.8rem' }} />
-          </MenuItem>
-        ))}
-      </Menu>
-    </>
+    <ChartVisibilityMenu
+      label="Topics"
+      icon={<FilterListIcon />}
+      options={CHART_TOPIC_FILTERS}
+      selected={selected}
+      onChange={(filters) => onChange(filters as ChartTopicFilter[])}
+      allLabel="All topic types"
+    />
   )
 }
 

--- a/frontend/src/components/helix-org/ChartVisibilityMenu.tsx
+++ b/frontend/src/components/helix-org/ChartVisibilityMenu.tsx
@@ -1,0 +1,167 @@
+import { FC, ReactElement, useMemo, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Divider from '@mui/material/Divider'
+import InputAdornment from '@mui/material/InputAdornment'
+import ListItemText from '@mui/material/ListItemText'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import TextField from '@mui/material/TextField'
+import SearchIcon from '@mui/icons-material/Search'
+
+import { matchesAllTokens } from '../../utils/searchUtils'
+
+export const chartToolbarButtonSizeSx = {
+  minWidth: 0,
+  height: 30,
+  px: 1,
+  fontSize: '0.72rem',
+  '& .MuiButton-startIcon': { mr: 0.5 },
+}
+
+export const chartToolbarButtonSx = {
+  ...chartToolbarButtonSizeSx,
+  color: 'text.secondary',
+  borderColor: 'divider',
+  backgroundColor: 'background.paper',
+  '&:hover': {
+    color: 'text.primary',
+    borderColor: 'text.disabled',
+    backgroundColor: 'action.hover',
+  },
+}
+
+export type ChartVisibilityOption = {
+  id: string
+  label: string
+}
+
+const checkboxSx = {
+  p: 0.5,
+  mr: 0.5,
+  color: 'text.disabled',
+  '&.Mui-checked, &.MuiCheckbox-indeterminate': { color: 'text.secondary' },
+}
+
+const ChartVisibilityMenu: FC<{
+  label: string
+  icon: ReactElement
+  options: readonly ChartVisibilityOption[]
+  selected: string[]
+  onChange: (selected: string[]) => void
+  allLabel?: string
+}> = ({ label, icon, options, selected, onChange, allLabel = `All ${label.toLowerCase()}` }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [query, setQuery] = useState('')
+  const selectedSet = useMemo(() => new Set(selected), [selected])
+  const filteredOptions = useMemo(
+    () => options.filter((option) => matchesAllTokens(query, option.label, option.id)),
+    [options, query],
+  )
+  const selectedResultCount = filteredOptions.filter((option) => selectedSet.has(option.id)).length
+  const allResultsSelected = filteredOptions.length > 0 && selectedResultCount === filteredOptions.length
+  const someResultsSelected = selectedResultCount > 0 && !allResultsSelected
+
+  const close = () => {
+    setAnchorEl(null)
+    setQuery('')
+  }
+
+  const toggleOption = (id: string) => {
+    const next = new Set(selected)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    onChange(options.map((option) => option.id).filter((optionID) => next.has(optionID)))
+  }
+
+  const toggleFilteredOptions = () => {
+    const next = new Set(selected)
+    filteredOptions.forEach((option) => {
+      if (allResultsSelected) next.delete(option.id)
+      else next.add(option.id)
+    })
+    onChange(options.map((option) => option.id).filter((optionID) => next.has(optionID)))
+  }
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={icon}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        aria-label={`Choose ${label.toLowerCase()} shown on chart`}
+        aria-haspopup="menu"
+        aria-expanded={Boolean(anchorEl)}
+        sx={chartToolbarButtonSx}
+      >
+        {label} {selected.length}/{options.length}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        MenuListProps={{ dense: true, sx: { py: 0.5 } }}
+        PaperProps={{ sx: { width: 240, maxHeight: 380 } }}
+      >
+        <Box sx={{ px: 1, pt: 0.5, pb: 0.75 }}>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => event.stopPropagation()}
+            placeholder={`Search ${label.toLowerCase()}`}
+            inputProps={{ 'aria-label': `Search ${label.toLowerCase()}` }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: 16 }} />
+                </InputAdornment>
+              ),
+              sx: { height: 32, fontSize: '0.8rem' },
+            }}
+          />
+        </Box>
+        <MenuItem
+          dense
+          disabled={filteredOptions.length === 0}
+          onClick={toggleFilteredOptions}
+          sx={{ minHeight: 32, px: 1 }}
+        >
+          <Checkbox
+            size="small"
+            checked={allResultsSelected}
+            indeterminate={someResultsSelected}
+            sx={checkboxSx}
+          />
+          <ListItemText
+            primary={query.trim() ? 'All search results' : allLabel}
+            primaryTypographyProps={{ fontSize: '0.8rem', fontWeight: 600 }}
+          />
+        </MenuItem>
+        <Divider sx={{ my: 0.5 }} />
+        {filteredOptions.map((option) => (
+          <MenuItem key={option.id} dense onClick={() => toggleOption(option.id)} sx={{ minHeight: 32, px: 1 }}>
+            <Checkbox size="small" checked={selectedSet.has(option.id)} sx={checkboxSx} />
+            <ListItemText
+              primary={option.label || option.id}
+              primaryTypographyProps={{ fontSize: '0.8rem', noWrap: true }}
+            />
+          </MenuItem>
+        ))}
+        {filteredOptions.length === 0 && (
+          <Box sx={{ px: 1.5, py: 1, color: 'text.secondary', fontSize: '0.78rem' }}>
+            No matches
+          </Box>
+        )}
+      </Menu>
+    </>
+  )
+}
+
+export default ChartVisibilityMenu

--- a/frontend/src/components/helix-org/chartEntityVisibility.test.ts
+++ b/frontend/src/components/helix-org/chartEntityVisibility.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  loadHiddenChartEntityIDs,
+  saveHiddenChartEntityIDs,
+} from './chartEntityVisibility'
+
+describe('chartEntityVisibility', () => {
+  const userID = 'usr_test'
+  const orgID = 'org_test'
+
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('round-trips hidden entities and scopes them by user and org', () => {
+    saveHiddenChartEntityIDs(userID, orgID, {
+      agents: ['bot_one'],
+      processors: ['processor_one'],
+      assets: ['asset_one'],
+    })
+
+    expect(loadHiddenChartEntityIDs(userID, orgID)).toEqual({
+      agents: ['bot_one'],
+      processors: ['processor_one'],
+      assets: ['asset_one'],
+    })
+    expect(loadHiddenChartEntityIDs('other_user', orgID)).toBeNull()
+    expect(loadHiddenChartEntityIDs(userID, 'other_org')).toBeNull()
+  })
+
+  it('rejects incomplete and invalid settings', () => {
+    const key = `helix.orgChart.entityVisibility.${userID}.${orgID}`
+    window.localStorage.setItem(key, JSON.stringify({ agents: [], processors: [] }))
+    expect(loadHiddenChartEntityIDs(userID, orgID)).toBeNull()
+    window.localStorage.setItem(key, 'not-json')
+    expect(loadHiddenChartEntityIDs(userID, orgID)).toBeNull()
+  })
+})

--- a/frontend/src/components/helix-org/chartEntityVisibility.ts
+++ b/frontend/src/components/helix-org/chartEntityVisibility.ts
@@ -1,0 +1,50 @@
+export type ChartEntityKind = 'agents' | 'processors' | 'assets'
+
+export type HiddenChartEntityIDs = Record<ChartEntityKind, string[]>
+
+export const EMPTY_HIDDEN_CHART_ENTITY_IDS: HiddenChartEntityIDs = {
+  agents: [],
+  processors: [],
+  assets: [],
+}
+
+const storageKey = (userID: string, orgID: string): string =>
+  `helix.orgChart.entityVisibility.${userID}.${orgID}`
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+export const loadHiddenChartEntityIDs = (
+  userID: string,
+  orgID: string,
+): HiddenChartEntityIDs | null => {
+  if (!userID || !orgID) return null
+  try {
+    const raw = window.localStorage.getItem(storageKey(userID, orgID))
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const value = parsed as Partial<HiddenChartEntityIDs>
+    if (!isStringArray(value.agents) || !isStringArray(value.processors) || !isStringArray(value.assets)) return null
+    return {
+      agents: [...new Set(value.agents)],
+      processors: [...new Set(value.processors)],
+      assets: [...new Set(value.assets)],
+    }
+  } catch {
+    return null
+  }
+}
+
+export const saveHiddenChartEntityIDs = (
+  userID: string,
+  orgID: string,
+  hiddenIDs: HiddenChartEntityIDs,
+): void => {
+  if (!userID || !orgID) return
+  try {
+    window.localStorage.setItem(storageKey(userID, orgID), JSON.stringify(hiddenIDs))
+  } catch {
+    // The chart remains usable when storage is unavailable.
+  }
+}

--- a/frontend/src/components/session/ActivitySummary.test.tsx
+++ b/frontend/src/components/session/ActivitySummary.test.tsx
@@ -43,7 +43,7 @@ describe("ActivitySummary", () => {
   it("shows the live working label and activity indicator", () => {
     renderSummary(true);
 
-    expect(screen.getByText("Working… 2m 5s")).toBeInTheDocument();
+    expect(screen.getByText("Working for 2m 5s")).toBeInTheDocument();
     expect(screen.getByTestId("streaming-indicator")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/session/ActivitySummary.test.tsx
+++ b/frontend/src/components/session/ActivitySummary.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { describe, expect, it } from "vitest";
+
+import ActivitySummary, { formatActivityDuration } from "./ActivitySummary";
+
+const renderSummary = (isStreaming = false) =>
+  render(
+    <ThemeProvider theme={createTheme({ palette: { mode: "dark" } })}>
+      <ActivitySummary
+        durationMs={125000}
+        hasActivity
+        isStreaming={isStreaming}
+        startedAt={Date.now() - 125000}
+      >
+        <div>all activity</div>
+      </ActivitySummary>
+    </ThemeProvider>,
+  );
+
+describe("ActivitySummary", () => {
+  it("formats elapsed durations compactly", () => {
+    expect(formatActivityDuration(0)).toBe("0s");
+    expect(formatActivityDuration(65000)).toBe("1m 5s");
+  });
+
+  it("keeps activity collapsed while leaving the completion summary visible", () => {
+    renderSummary();
+
+    expect(screen.getByText("Worked for 2m 5s")).toBeInTheDocument();
+    expect(screen.queryByText("all activity")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show work log" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show work log" }));
+
+    expect(screen.getByText("all activity")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide work log" })).toBeInTheDocument();
+  });
+
+  it("shows the live working label and activity indicator", () => {
+    renderSummary(true);
+
+    expect(screen.getByText("Working… 2m 5s")).toBeInTheDocument();
+    expect(screen.getByTestId("streaming-indicator")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/session/ActivitySummary.test.tsx
+++ b/frontend/src/components/session/ActivitySummary.test.tsx
@@ -31,10 +31,13 @@ describe("ActivitySummary", () => {
     expect(screen.queryByText("all activity")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show work log" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Show work log" }));
+    fireEvent.click(screen.getByText("Worked for 2m 5s"));
 
     expect(screen.getByText("all activity")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Hide work log" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide work log" }));
+    expect(screen.queryByText("all activity")).not.toBeInTheDocument();
   });
 
   it("shows the live working label and activity indicator", () => {

--- a/frontend/src/components/session/ActivitySummary.tsx
+++ b/frontend/src/components/session/ActivitySummary.tsx
@@ -66,15 +66,29 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
     setExpanded((value) => !value);
   };
 
+  const handleHeaderKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!hasActivity || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    toggleExpanded();
+  };
+
   return (
     <Box sx={{ my: 0.75 }}>
       <Box
+        onClick={hasActivity ? toggleExpanded : undefined}
+        onKeyDown={handleHeaderKeyDown}
+        role={hasActivity ? "button" : undefined}
+        tabIndex={hasActivity ? 0 : undefined}
         sx={{
           display: "flex",
           alignItems: "center",
           gap: 0.5,
           minHeight: 24,
+          cursor: hasActivity ? "pointer" : "default",
           color: textColor,
+          "&:focus-visible": hasActivity
+            ? { outline: "1px solid currentColor", outlineOffset: 2 }
+            : undefined,
         }}
       >
         {isStreaming && <StreamingIndicator />}
@@ -94,7 +108,10 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
         {hasActivity && (
           <IconButton
             size="small"
-            onClick={toggleExpanded}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleExpanded();
+            }}
             aria-expanded={expanded}
             aria-label={expanded ? "Hide work log" : "Show work log"}
             sx={{

--- a/frontend/src/components/session/ActivitySummary.tsx
+++ b/frontend/src/components/session/ActivitySummary.tsx
@@ -82,7 +82,7 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
         sx={{
           display: "flex",
           alignItems: "center",
-          gap: 0.5,
+          gap: 1,
           minHeight: 24,
           cursor: hasActivity ? "pointer" : "default",
           color: textColor,
@@ -102,7 +102,7 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
           }}
         >
           {isStreaming
-            ? `Working… ${formatActivityDuration(elapsedMs)}`
+            ? `Working for ${formatActivityDuration(elapsedMs)}`
             : `Worked for ${formatActivityDuration(elapsedMs)}`}
         </Typography>
         {hasActivity && (

--- a/frontend/src/components/session/ActivitySummary.tsx
+++ b/frontend/src/components/session/ActivitySummary.tsx
@@ -1,0 +1,120 @@
+import React, { FC, ReactNode, useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import StreamingIndicator from "./StreamingIndicator";
+import { preserveDisclosureExpansion } from "./disclosureScroll";
+
+export const formatActivityDuration = (durationMs: number) => {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+};
+
+interface ActivitySummaryProps {
+  children?: ReactNode;
+  durationMs?: number;
+  hasActivity: boolean;
+  isStreaming: boolean;
+  startedAt?: number;
+}
+
+/**
+ * Keeps reasoning and tool activity behind one response-level disclosure.
+ * The final assistant prose is rendered outside this component and remains
+ * visible when the activity is collapsed.
+ */
+const ActivitySummary: FC<ActivitySummaryProps> = ({
+  children,
+  durationMs = 0,
+  hasActivity,
+  isStreaming,
+  startedAt,
+}) => {
+  const theme = useTheme();
+  const [expanded, setExpanded] = useState(false);
+  const [elapsedMs, setElapsedMs] = useState(durationMs);
+  const lastElapsedMsRef = useRef(durationMs);
+  const textColor =
+    theme.palette.mode === "dark" ? "rgba(255,255,255,0.55)" : "text.secondary";
+
+  useEffect(() => {
+    if (!isStreaming) {
+      const completedDuration = durationMs || lastElapsedMsRef.current;
+      setElapsedMs(completedDuration);
+      lastElapsedMsRef.current = completedDuration;
+      return;
+    }
+
+    const started = startedAt || Date.now();
+    const updateElapsed = () => {
+      const nextElapsed = Math.max(0, Date.now() - started);
+      setElapsedMs(nextElapsed);
+      lastElapsedMsRef.current = nextElapsed;
+    };
+    updateElapsed();
+    const interval = window.setInterval(updateElapsed, 1000);
+    return () => window.clearInterval(interval);
+  }, [durationMs, isStreaming, startedAt]);
+
+  const toggleExpanded = (event: React.MouseEvent<HTMLElement>) => {
+    if (!expanded) preserveDisclosureExpansion(event.currentTarget);
+    setExpanded((value) => !value);
+  };
+
+  return (
+    <Box sx={{ my: 0.75 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          minHeight: 24,
+          color: textColor,
+        }}
+      >
+        {isStreaming && <StreamingIndicator />}
+        <Typography
+          variant="body2"
+          sx={{
+            flex: 1,
+            fontSize: "0.76rem",
+            color: "inherit",
+            fontFamily: "monospace",
+          }}
+        >
+          {isStreaming
+            ? `Working… ${formatActivityDuration(elapsedMs)}`
+            : `Worked for ${formatActivityDuration(elapsedMs)}`}
+        </Typography>
+        {hasActivity && (
+          <IconButton
+            size="small"
+            onClick={toggleExpanded}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Hide work log" : "Show work log"}
+            sx={{
+              p: 0,
+              color: "inherit",
+              "&:hover": { backgroundColor: "transparent" },
+            }}
+          >
+            {expanded ? (
+              <ChevronUp size={15} strokeWidth={1.8} />
+            ) : (
+              <ChevronDown size={15} strokeWidth={1.8} />
+            )}
+          </IconButton>
+        )}
+      </Box>
+      {expanded ? children : null}
+    </Box>
+  );
+};
+
+export default ActivitySummary;

--- a/frontend/src/components/session/ActivitySummary.tsx
+++ b/frontend/src/components/session/ActivitySummary.tsx
@@ -6,7 +6,6 @@ import { useTheme } from "@mui/material/styles";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
 import StreamingIndicator from "./StreamingIndicator";
-import { preserveDisclosureExpansion } from "./disclosureScroll";
 
 export const formatActivityDuration = (durationMs: number) => {
   const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
@@ -63,8 +62,7 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
     return () => window.clearInterval(interval);
   }, [durationMs, isStreaming, startedAt]);
 
-  const toggleExpanded = (event: React.MouseEvent<HTMLElement>) => {
-    if (!expanded) preserveDisclosureExpansion(event.currentTarget);
+  const toggleExpanded = () => {
     setExpanded((value) => !value);
   };
 
@@ -74,6 +72,7 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
         sx={{
           display: "flex",
           alignItems: "center",
+          gap: 0.5,
           minHeight: 24,
           color: textColor,
         }}

--- a/frontend/src/components/session/CollapsibleSystemPrefix.tsx
+++ b/frontend/src/components/session/CollapsibleSystemPrefix.tsx
@@ -1,13 +1,14 @@
 import React, { FC, useState } from "react";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { preserveDisclosureExpansion } from "./disclosureScroll";
 
 const USER_REQUEST_SPLIT =
   /^([\s\S]*?)\n\n\*\*(User Request|Original Request[^*]*?):\*\*\n?([\s\S]*)$/;
@@ -57,11 +58,13 @@ export function splitSystemPrefix(message: string): SplitResult {
 interface CollapsibleSystemPrefixProps {
   prefix: string;
   label?: string;
+  tone?: "neutral" | "success";
 }
 
 export const CollapsibleSystemPrefix: FC<CollapsibleSystemPrefixProps> = ({
   prefix,
   label = "Planning Instructions",
+  tone = "neutral",
 }) => {
   const [expanded, setExpanded] = useState(false);
   const theme = useTheme();
@@ -70,86 +73,121 @@ export const CollapsibleSystemPrefix: FC<CollapsibleSystemPrefixProps> = ({
   return (
     <Box
       sx={{
-        mb: 1,
-        borderLeft: `3px solid ${isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.12)"}`,
-        borderRadius: "4px",
-        overflow: "hidden",
+        mb: 0.75,
         alignSelf: "stretch",
         maxWidth: "100%",
+        fontFamily: "inherit",
       }}
     >
       <Box
-        onClick={() => setExpanded(!expanded)}
+        component="button"
+        type="button"
+        aria-expanded={expanded}
+        onClick={(event) => {
+          if (!expanded) preserveDisclosureExpansion(event.currentTarget);
+          setExpanded(!expanded);
+        }}
         sx={{
           display: "flex",
           alignItems: "center",
           gap: 0.75,
-          px: 1.5,
-          py: 0.75,
+          width: "100%",
+          px: 0.25,
+          py: 0.5,
+          border: 0,
           cursor: "pointer",
-          backgroundColor: isDark
-            ? "rgba(255,255,255,0.04)"
-            : "rgba(0,0,0,0.03)",
+          color: "text.secondary",
+          font: "inherit",
+          textAlign: "left",
+          backgroundColor: "transparent",
           "&:hover": {
-            backgroundColor: isDark
-              ? "rgba(255,255,255,0.08)"
-              : "rgba(0,0,0,0.06)",
+            color: "text.primary",
+            backgroundColor: "transparent",
           },
-          transition: "background-color 0.15s ease",
+          "&:focus-visible": {
+            outline: `1px solid ${theme.palette.primary.main}`,
+            outlineOffset: 2,
+            borderRadius: 0.5,
+          },
+          transition: "color 0.15s ease",
           userSelect: "none",
         }}
       >
-        <InfoOutlinedIcon
-          sx={{
-            fontSize: 16,
-            color: isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)",
-          }}
-        />
+        {tone === "success" ? (
+          <CheckCircleOutlineIcon
+            sx={{ fontSize: 15, color: "success.main", flexShrink: 0 }}
+          />
+        ) : (
+          <InfoOutlinedIcon sx={{ fontSize: 15, flexShrink: 0 }} />
+        )}
         <Typography
           variant="body2"
           sx={{
             flex: 1,
-            fontSize: "0.82rem",
-            fontStyle: "italic",
-            color: isDark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+            fontSize: "0.8rem",
+            lineHeight: 1.4,
+            fontWeight: 500,
+            fontFamily: "inherit",
+            color: "inherit",
           }}
         >
           {label}
         </Typography>
-        <IconButton size="small" sx={{ p: 0, ml: 0.5 }} aria-label="toggle">
-          {expanded ? (
-            <ExpandLessIcon sx={{ fontSize: 18 }} />
-          ) : (
-            <ExpandMoreIcon sx={{ fontSize: 18 }} />
-          )}
-        </IconButton>
+        {expanded ? (
+          <ExpandLessIcon sx={{ fontSize: 16, flexShrink: 0 }} />
+        ) : (
+          <ExpandMoreIcon sx={{ fontSize: 16, flexShrink: 0 }} />
+        )}
       </Box>
 
       {expanded && (
         <Box
           sx={{
-            px: 1.5,
-            py: 1,
-            fontSize: "0.85rem",
-            color: isDark ? "rgba(255,255,255,0.75)" : "rgba(0,0,0,0.7)",
-            backgroundColor: isDark
-              ? "rgba(255,255,255,0.02)"
-              : "rgba(0,0,0,0.015)",
-            borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)"}`,
-            maxHeight: "400px",
+            ml: 0.9,
+            pl: 2,
+            pr: 0.5,
+            pt: 0.25,
+            pb: 0.75,
+            borderLeft: `1px solid ${isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)"}`,
+            fontSize: "0.8rem",
+            lineHeight: 1.55,
+            fontFamily: "inherit",
+            color: "text.secondary",
+            backgroundColor: "transparent",
+            maxHeight: "320px",
             overflow: "auto",
+            "& > :first-of-type": { mt: 0 },
+            "& > :last-child": { mb: 0 },
+            "& h1, & h2, & h3": {
+              mt: 1.25,
+              mb: 0.5,
+              fontSize: "0.72rem",
+              lineHeight: 1.4,
+              fontWeight: 600,
+              fontFamily: "inherit",
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "text.primary",
+            },
             "& p": { my: 0.5 },
+            "& ul, & ol": { my: 0.5, pl: 2.5 },
+            "& li": { mb: 0.25, pl: 0.25 },
+            "& hr": {
+              my: 1.25,
+              border: 0,
+              borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"}`,
+            },
             "& pre": {
               backgroundColor: isDark
                 ? "rgba(255,255,255,0.06)"
                 : "rgba(0,0,0,0.05)",
               p: 1,
-              borderRadius: "4px",
+              borderRadius: 1,
               overflow: "auto",
             },
             "& code": {
               fontFamily: "monospace",
-              fontSize: "0.8rem",
+              fontSize: "0.76rem",
             },
           }}
         >

--- a/frontend/src/components/session/CollapsibleToolCall.test.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.test.tsx
@@ -2,9 +2,21 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import { describe, expect, it } from 'vitest'
 
-import { CollapsibleToolCall } from './CollapsibleToolCall'
+import { CollapsibleToolCall, getToolCallPresentation } from './CollapsibleToolCall'
 
 describe('CollapsibleToolCall', () => {
+  it('presents shell calls as a compact command row', () => {
+    const presentation = getToolCallPresentation(
+      'Bash',
+      '| | |\n|---|---|\n| Command | `git status --short` |\n| Exit | 0 |',
+    )
+
+    expect(presentation).toEqual({
+      label: 'Ran command',
+      preview: 'Bash: git status --short',
+    })
+  })
+
   it('marks disclosure growth so the chat keeps the header in place', () => {
     const { container } = render(
       <div data-session-scroll-container>

--- a/frontend/src/components/session/CollapsibleToolCall.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.tsx
@@ -1,14 +1,16 @@
-import React, { FC, useState, useMemo } from "react";
+import React, { FC, useState } from "react";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import BuildIcon from "@mui/icons-material/Build";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  CircleAlert,
+  LoaderCircle,
+  Wrench,
+} from "lucide-react";
 import { preserveDisclosureExpansion } from "./disclosureScroll";
 
 /**
@@ -110,13 +112,13 @@ export function parseToolCallBlocks(text: string): MessageSegment[] {
 const statusIcon = (status: string) => {
   const lower = status.toLowerCase();
   if (lower === "completed") {
-    return <CheckCircleOutlineIcon sx={{ fontSize: 16, color: "success.main" }} />;
+    return <CheckCircle2 size={15} strokeWidth={1.8} color="#66bb6a" aria-hidden="true" />;
   }
   if (lower === "failed" || lower === "rejected" || lower === "canceled") {
-    return <ErrorOutlineIcon sx={{ fontSize: 16, color: "error.main" }} />;
+    return <CircleAlert size={15} strokeWidth={1.8} color="#ef5350" aria-hidden="true" />;
   }
   // Pending, InProgress, etc.
-  return <HourglassEmptyIcon sx={{ fontSize: 16, color: "warning.main" }} />;
+  return <LoaderCircle size={15} strokeWidth={1.8} color="#ffb74d" aria-hidden="true" />;
 };
 
 interface CollapsibleToolCallProps {
@@ -125,6 +127,8 @@ interface CollapsibleToolCallProps {
   body: string;
   /** If true, render expanded by default (e.g. during streaming) */
   defaultExpanded?: boolean;
+  /** Use the tighter row sizing needed inside a Work Log. */
+  dense?: boolean;
 }
 
 export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
@@ -132,6 +136,7 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
   status,
   body,
   defaultExpanded = false,
+  dense = false,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const theme = useTheme();
@@ -140,10 +145,7 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
   return (
     <Box
       sx={{
-        my: 1,
-        borderLeft: `3px solid ${isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.12)"}`,
-        borderRadius: "4px",
-        overflow: "hidden",
+        my: dense ? 0.25 : 0.75,
       }}
     >
       {/* Collapsed header — always visible */}
@@ -156,45 +158,39 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
           display: "flex",
           alignItems: "center",
           gap: 0.75,
-          px: 1.5,
-          py: 0.75,
+          px: 0,
+          py: dense ? 0.25 : 0.5,
           cursor: "pointer",
-          backgroundColor: isDark
-            ? "rgba(255,255,255,0.04)"
-            : "rgba(0,0,0,0.03)",
+          backgroundColor: "transparent",
           "&:hover": {
-            backgroundColor: isDark
-              ? "rgba(255,255,255,0.08)"
-              : "rgba(0,0,0,0.06)",
+            backgroundColor: "transparent",
           },
-          transition: "background-color 0.15s ease",
           userSelect: "none",
         }}
       >
-        <BuildIcon
-          sx={{
-            fontSize: 16,
-            color: isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)",
-          }}
+        <Wrench
+          size={15}
+          strokeWidth={1.8}
+          color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
+          aria-hidden="true"
         />
         <Typography
           variant="body2"
           sx={{
             flex: 1,
-            fontSize: "0.82rem",
-            color: isDark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.6)",
+            fontSize: dense ? "0.76rem" : "0.82rem",
+            color: isDark ? "rgba(255,255,255,0.65)" : "text.secondary",
             fontFamily: "monospace",
           }}
         >
           {toolName}
         </Typography>
         {statusIcon(status)}
-        <IconButton size="small" sx={{ p: 0, ml: 0.5 }}>
-          {expanded ? (
-            <ExpandLessIcon sx={{ fontSize: 18 }} />
-          ) : (
-            <ExpandMoreIcon sx={{ fontSize: 18 }} />
-          )}
+        <IconButton
+          size="small"
+          sx={{ p: 0, ml: 0.5, "&:hover": { backgroundColor: "transparent" } }}
+        >
+          {expanded ? <ChevronUp size={15} strokeWidth={1.8} /> : <ChevronDown size={15} strokeWidth={1.8} />}
         </IconButton>
       </Box>
 
@@ -202,17 +198,15 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
       {expanded && body && (
         <Box
           sx={{
-            px: 1.5,
+            pl: dense ? 2.5 : 2.75,
+            pr: 0,
             py: 1,
             fontSize: "0.8rem",
             fontFamily: "monospace",
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
-            color: isDark ? "rgba(255,255,255,0.6)" : "rgba(0,0,0,0.55)",
-            backgroundColor: isDark
-              ? "rgba(255,255,255,0.02)"
-              : "rgba(0,0,0,0.015)",
-            borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)"}`,
+            color: isDark ? "rgba(255,255,255,0.55)" : "text.secondary",
+            backgroundColor: "transparent",
             maxHeight: "300px",
             overflow: "auto",
           }}

--- a/frontend/src/components/session/CollapsibleToolCall.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.tsx
@@ -9,7 +9,7 @@ import {
   ChevronUp,
   CircleAlert,
   LoaderCircle,
-  Wrench,
+  Terminal,
 } from "lucide-react";
 import { preserveDisclosureExpansion } from "./disclosureScroll";
 
@@ -121,6 +121,41 @@ const statusIcon = (status: string) => {
   return <LoaderCircle size={15} strokeWidth={1.8} color="#ffb74d" aria-hidden="true" />;
 };
 
+const commandToolPattern = /^(bash|sh|zsh|shell|terminal|command)(?::\s*(.*))?$/i;
+
+const extractCommand = (body: string) => {
+  const tableCommand = body.match(/\|\s*Command\s*\|\s*`([^`]+)`\s*\|/i);
+  if (tableCommand?.[1]) return tableCommand[1].trim();
+
+  const fieldCommand = body.match(/(?:^|\n)Command:\s*(.+)$/im);
+  if (fieldCommand?.[1]) return fieldCommand[1].trim();
+
+  const firstLine = body
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line && !line.startsWith("```") && !line.startsWith("|"));
+  return firstLine || "";
+};
+
+export const getToolCallPresentation = (toolName: string, body: string) => {
+  const toolMatch = toolName.match(commandToolPattern);
+  const bodyCommand = extractCommand(body);
+  const isCommand = Boolean(toolMatch || body.match(/\|\s*Command\s*\|/i));
+
+  if (!isCommand) {
+    return { label: toolName, preview: "" };
+  }
+
+  const namedCommand = toolMatch?.[2]?.trim();
+  const preview = namedCommand
+    ? toolName.trim()
+    : bodyCommand
+      ? `${toolName.trim()}: ${bodyCommand}`
+      : toolName.trim();
+
+  return { label: "Ran command", preview };
+};
+
 interface CollapsibleToolCallProps {
   toolName: string;
   status: string;
@@ -141,6 +176,7 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
   const [expanded, setExpanded] = useState(defaultExpanded);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+  const presentation = getToolCallPresentation(toolName, body);
 
   return (
     <Box
@@ -168,23 +204,57 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
           userSelect: "none",
         }}
       >
-        <Wrench
+        <Terminal
           size={15}
           strokeWidth={1.8}
           color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
           aria-hidden="true"
         />
-        <Typography
-          variant="body2"
+        <Box
           sx={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 0.75,
+            minWidth: 0,
             flex: 1,
-            fontSize: dense ? "0.76rem" : "0.82rem",
-            color: isDark ? "rgba(255,255,255,0.65)" : "text.secondary",
-            fontFamily: "monospace",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
           }}
         >
-          {toolName}
-        </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              flexShrink: 0,
+              fontSize: dense ? "0.76rem" : "0.82rem",
+              color: presentation.preview
+                ? isDark
+                  ? "#f5f5f5"
+                  : "text.primary"
+                : isDark
+                  ? "rgba(255,255,255,0.65)"
+                  : "text.secondary",
+              fontWeight: presentation.preview ? 600 : 400,
+              fontFamily: "monospace",
+            }}
+          >
+            {presentation.label}
+          </Typography>
+          {presentation.preview && (
+            <Typography
+              variant="body2"
+              sx={{
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                fontSize: dense ? "0.72rem" : "0.78rem",
+                color: isDark ? "rgba(255,255,255,0.42)" : "text.secondary",
+                fontFamily: "monospace",
+              }}
+            >
+              {presentation.preview}
+            </Typography>
+          )}
+        </Box>
         {statusIcon(status)}
         <IconButton
           size="small"

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -819,7 +819,23 @@ const EmbeddedSessionView = forwardRef<
             zIndex: 3,
             textTransform: "none",
             borderRadius: 999,
-            boxShadow: 3,
+            px: 1.5,
+            py: 0.65,
+            minHeight: 32,
+            fontWeight: 600,
+            backgroundColor: lightTheme.isDark ? "#000000" : "#ffffff",
+            color: lightTheme.isDark ? "#ffffff" : "#111111",
+            border: `1px solid ${lightTheme.isDark ? "rgba(255,255,255,0.72)" : "rgba(0,0,0,0.62)"}`,
+            boxShadow: lightTheme.isDark
+              ? "0 2px 10px rgba(0,0,0,0.45)"
+              : "0 2px 10px rgba(0,0,0,0.18)",
+            "&:hover": {
+              backgroundColor: lightTheme.isDark ? "#111111" : "#f3f3f3",
+              borderColor: lightTheme.isDark ? "#ffffff" : "#000000",
+              boxShadow: lightTheme.isDark
+                ? "0 3px 12px rgba(0,0,0,0.55)"
+                : "0 3px 12px rgba(0,0,0,0.24)",
+            },
           }}
         >
           Jump to latest

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -478,7 +478,7 @@ export const Interaction: FC<InteractionProps> = ({
         >
           <InteractionContainer
             buttons={headerButtons}
-            background={true}
+            background={false}
             align="left"
             border={false}
             isAssistant={true}

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -347,9 +347,10 @@ export const Interaction: FC<InteractionProps> = ({
           {systemPrefix && !isEditing && (
             <CollapsibleSystemPrefix
               prefix={systemPrefix}
+              tone={systemPrefixKind === "approval" ? "success" : "neutral"}
               label={
                 systemPrefixKind === "approval"
-                  ? "Spec Approved — Implementation Instructions"
+                  ? "Spec approved · Implementation instructions"
                   : systemPrefixLabel?.startsWith("Original Request")
                     ? "Planning Instructions (cloned task)"
                     : "Planning Instructions"

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -478,7 +478,7 @@ export const Interaction: FC<InteractionProps> = ({
         >
           <InteractionContainer
             buttons={headerButtons}
-            background={false}
+            background={true}
             align="left"
             border={false}
             isAssistant={true}

--- a/frontend/src/components/session/InteractionContainer.tsx
+++ b/frontend/src/components/session/InteractionContainer.tsx
@@ -29,8 +29,12 @@ export const InteractionContainer: FC<{
       sx={{
         px: 2,
         py: 0.5,
-        borderRadius: 4,
-        backgroundColor: background ? theme.palette.background.default : 'transparent',
+        borderRadius: isAssistant ? 0 : 4,
+        backgroundColor: background
+          ? isAssistant && theme.palette.mode === 'dark'
+            ? '#0d0d0d'
+            : theme.palette.background.default
+          : 'transparent',
         border: border ? '1px solid #33373a' : 'none',
         // User messages: fit content but don't exceed container width
         // Assistant messages: take full width

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -10,7 +10,7 @@ import Row from "../widgets/Row";
 import Cell from "../widgets/Cell";
 import Markdown from "./Markdown";
 import StreamingIndicator from "./StreamingIndicator";
-import { CollapsibleToolCall } from "./CollapsibleToolCall";
+import WorkLog from "./WorkLog";
 
 /**
  * A structured response entry from the Go API.
@@ -73,10 +73,6 @@ const ImagePreview = styled("img")({
  * field), renders each entry with the correct component in the correct order.
  * Otherwise falls back to regex parsing of the flat text (for old interactions).
  */
-// Maximum entries to render initially. Older entries are collapsed behind a button
-// to prevent the browser from choking on 500+ Markdown/tool-call components.
-const VISIBLE_ENTRIES_LIMIT = 50;
-
 export const MessageWithToolCalls: FC<{
   text: string;
   responseEntries?: ResponseEntry[];
@@ -96,41 +92,37 @@ export const MessageWithToolCalls: FC<{
   onFilterDocument,
   compactThinking = false,
 }) => {
-  const [showAll, setShowAll] = useState(false);
-
   // Structured path: use response_entries from the Go API (preserves type + order)
   if (responseEntries && responseEntries.length > 0) {
-    const hiddenCount = showAll ? 0 : Math.max(0, responseEntries.length - VISIBLE_ENTRIES_LIMIT);
-    const visibleEntries = showAll
-      ? responseEntries
-      : responseEntries.slice(hiddenCount);
+    const toolCallEntries = responseEntries
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => entry.type === "tool_call");
+    const lastToolCallIndex = toolCallEntries[toolCallEntries.length - 1]?.index;
+    const lastResponseEntryIndex = responseEntries.length - 1;
 
     return (
       <>
-        {hiddenCount > 0 && (
-          <Button
-            size="small"
-            onClick={() => setShowAll(true)}
-            sx={{ mb: 1, textTransform: "none" }}
-          >
-            Show {hiddenCount} earlier entries
-          </Button>
-        )}
-        {visibleEntries.map((entry, vi) => {
-          const i = showAll ? vi : vi + hiddenCount;
+        {responseEntries.map((entry, i) => {
           if (entry.type === "tool_call") {
-            const isLast = i === responseEntries.length - 1;
-            const toolName = entry.tool_name || "Tool Call";
-            const status = entry.tool_status || (isLast && isStreaming ? "Running" : "Completed");
-            const body = entry.content || "";
+            if (i !== lastToolCallIndex) return null;
+
             return (
-              <React.Fragment key={`tc-${i}`}>
-                <CollapsibleToolCall
-                  toolName={toolName}
-                  status={status}
-                  body={body}
+              <React.Fragment key="work-log">
+                <WorkLog
+                  entries={toolCallEntries.map(({ entry: toolEntry, index }) => ({
+                    id: `${toolEntry.message_id || "tool-call"}-${index}`,
+                    toolName: toolEntry.tool_name || "Tool Call",
+                    status:
+                      toolEntry.tool_status ||
+                      (index === lastResponseEntryIndex && isStreaming
+                        ? "Running"
+                        : "Completed"),
+                    body: toolEntry.content || "",
+                  }))}
                 />
-                {isLast && showBlinker && isStreaming && <StreamingIndicator />}
+                {i === lastResponseEntryIndex && showBlinker && isStreaming && (
+                  <StreamingIndicator />
+                )}
               </React.Fragment>
             );
           }
@@ -372,7 +364,7 @@ export const InteractionInference: FC<{
                 <Box
                   sx={{
                     position: "relative",
-                    "&:hover .action-buttons": {
+                    "&:hover .action-buttons, &:focus-within .action-buttons": {
                       opacity: 1,
                     },
                   }}
@@ -395,10 +387,10 @@ export const InteractionInference: FC<{
                         alignItems: "center",
                         mt: 1,
                         gap: 1,
-                        opacity: isLastInteraction ? 1 : 0,
+                        opacity: 0,
                         transition: "opacity 0.2s ease-in-out",
                         position: "relative",
-                        "&:hover": {
+                        "&:hover, &:focus-within": {
                           opacity: 1,
                         },
                       }}

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -9,8 +9,9 @@ import ClickLink from "../widgets/ClickLink";
 import Row from "../widgets/Row";
 import Cell from "../widgets/Cell";
 import Markdown from "./Markdown";
-import StreamingIndicator from "./StreamingIndicator";
 import WorkLog from "./WorkLog";
+import ActivitySummary from "./ActivitySummary";
+import { getInteractionDurationMs } from "./interactionDuration";
 
 /**
  * A structured response entry from the Go API.
@@ -82,6 +83,9 @@ export const MessageWithToolCalls: FC<{
   isStreaming: boolean;
   onFilterDocument?: (docId: string) => void;
   compactThinking?: boolean;
+  durationMs?: number;
+  activityStartedAt?: number;
+  showActivitySummary?: boolean;
 }> = ({
   text,
   responseEntries,
@@ -91,7 +95,26 @@ export const MessageWithToolCalls: FC<{
   isStreaming,
   onFilterDocument,
   compactThinking = false,
+  durationMs = 0,
+  activityStartedAt,
+  showActivitySummary = true,
 }) => {
+  const hasThinking = (content: string) => /<(?:think|thinking)>/i.test(content);
+
+  if (!showActivitySummary) {
+    return (
+      <Markdown
+        text={text}
+        session={session}
+        getFileURL={getFileURL}
+        showBlinker={showBlinker}
+        isStreaming={isStreaming}
+        onFilterDocument={onFilterDocument}
+        compactThinking={compactThinking}
+      />
+    );
+  }
+
   // Structured path: use response_entries from the Go API (preserves type + order)
   if (responseEntries && responseEntries.length > 0) {
     const toolCallEntries = responseEntries
@@ -99,62 +122,156 @@ export const MessageWithToolCalls: FC<{
       .filter(({ entry }) => entry.type === "tool_call");
     const lastToolCallIndex = toolCallEntries[toolCallEntries.length - 1]?.index;
     const lastResponseEntryIndex = responseEntries.length - 1;
+    const hasActivity = responseEntries.some(
+      (entry) => entry.type === "tool_call" || hasThinking(entry.content),
+    );
+    const workLogEntries = toolCallEntries.map(({ entry: toolEntry, index }) => ({
+      id: `${toolEntry.message_id || "tool-call"}-${index}`,
+      toolName: toolEntry.tool_name || "Tool Call",
+      status:
+        toolEntry.tool_status ||
+        (index === lastResponseEntryIndex && isStreaming ? "Running" : "Completed"),
+      body: toolEntry.content || "",
+    }));
 
-    return (
+    const activity = responseEntries.map((entry, i) => {
+      if (entry.type === "tool_call") {
+        if (i !== lastToolCallIndex) return null;
+        return <WorkLog key="work-log" entries={workLogEntries} showAll />;
+      }
+      if (!hasThinking(entry.content)) return null;
+      return (
+        <Markdown
+          key={`thought-${i}`}
+          text={entry.content}
+          session={session}
+          getFileURL={getFileURL}
+          showBlinker={false}
+          isStreaming={false}
+          onFilterDocument={onFilterDocument}
+          compactThinking={compactThinking}
+          renderThinkingWidget
+          renderContent={false}
+        />
+      );
+    });
+    const latestThought = [...responseEntries]
+      .map((entry, index) => ({ entry, index }))
+      .reverse()
+      .find(({ entry }) => entry.type === "text" && hasThinking(entry.content));
+    const streamingPreview = workLogEntries.length > 0 ? (
+      <WorkLog entries={workLogEntries} />
+    ) : latestThought ? (
+      <Markdown
+        text={latestThought.entry.content}
+        session={session}
+        getFileURL={getFileURL}
+        showBlinker={false}
+        isStreaming={false}
+        onFilterDocument={onFilterDocument}
+        compactThinking={compactThinking}
+        renderThinkingWidget
+        renderContent={false}
+      />
+    ) : null;
+
+    const finalContent = responseEntries.map((entry, i) => {
+      if (entry.type === "tool_call") return null;
+      return (
+        <Markdown
+          key={`md-${i}`}
+          text={entry.content}
+          session={session}
+          getFileURL={getFileURL}
+          showBlinker={false}
+          isStreaming={isStreaming && i === responseEntries.length - 1}
+          onFilterDocument={onFilterDocument}
+          compactThinking={compactThinking}
+          renderThinkingWidget={false}
+        />
+      );
+    });
+
+    return isStreaming ? (
       <>
-        {responseEntries.map((entry, i) => {
-          if (entry.type === "tool_call") {
-            if (i !== lastToolCallIndex) return null;
-
-            return (
-              <React.Fragment key="work-log">
-                <WorkLog
-                  entries={toolCallEntries.map(({ entry: toolEntry, index }) => ({
-                    id: `${toolEntry.message_id || "tool-call"}-${index}`,
-                    toolName: toolEntry.tool_name || "Tool Call",
-                    status:
-                      toolEntry.tool_status ||
-                      (index === lastResponseEntryIndex && isStreaming
-                        ? "Running"
-                        : "Completed"),
-                    body: toolEntry.content || "",
-                  }))}
-                />
-                {i === lastResponseEntryIndex && showBlinker && isStreaming && (
-                  <StreamingIndicator />
-                )}
-              </React.Fragment>
-            );
-          }
-          // text entry
-          return (
-            <Markdown
-              key={`md-${i}`}
-              text={entry.content}
-              session={session}
-              getFileURL={getFileURL}
-              showBlinker={showBlinker && i === responseEntries.length - 1}
-              isStreaming={isStreaming && i === responseEntries.length - 1}
-              onFilterDocument={onFilterDocument}
-              compactThinking={compactThinking}
-            />
-          );
-        })}
+        {streamingPreview}
+        {finalContent}
+        <ActivitySummary
+          durationMs={durationMs}
+          hasActivity={hasActivity}
+          isStreaming
+          startedAt={activityStartedAt}
+        >
+          {activity}
+        </ActivitySummary>
+      </>
+    ) : (
+      <>
+        <ActivitySummary
+          durationMs={durationMs}
+          hasActivity={hasActivity}
+          isStreaming={false}
+          startedAt={activityStartedAt}
+        >
+          {activity}
+        </ActivitySummary>
+        {finalContent}
       </>
     );
   }
 
   // Plain markdown for text-only interactions
-  return (
+  const plainHasThinking = hasThinking(text);
+  const finalContent = (
     <Markdown
       text={text}
       session={session}
       getFileURL={getFileURL}
-      showBlinker={showBlinker}
+      showBlinker={false}
       isStreaming={isStreaming}
       onFilterDocument={onFilterDocument}
       compactThinking={compactThinking}
+      renderThinkingWidget={false}
     />
+  );
+  const activityContent = plainHasThinking ? (
+    <Markdown
+      text={text}
+      session={session}
+      getFileURL={getFileURL}
+      showBlinker={false}
+      isStreaming={false}
+      onFilterDocument={onFilterDocument}
+      compactThinking={compactThinking}
+      renderThinkingWidget
+      renderContent={false}
+    />
+  ) : null;
+
+  return isStreaming ? (
+    <>
+      {finalContent}
+      <ActivitySummary
+        durationMs={durationMs}
+        hasActivity={plainHasThinking}
+        isStreaming
+        startedAt={activityStartedAt}
+      >
+        {activityContent}
+      </ActivitySummary>
+    </>
+  ) : (
+    <>
+      <ActivitySummary
+        durationMs={durationMs}
+        hasActivity={plainHasThinking}
+        isStreaming={false}
+        startedAt={activityStartedAt}
+      >
+        {activityContent}
+      </ActivitySummary>
+      {finalContent}
+    </>
   );
 };
 
@@ -376,6 +493,8 @@ export const InteractionInference: FC<{
                     getFileURL={getFileURL}
                     showBlinker={false}
                     isStreaming={false}
+                    durationMs={getInteractionDurationMs(interaction)}
+                    showActivitySummary={isFromAssistant}
                     onFilterDocument={onFilterDocument}
                   />
                   {isFromAssistant && onRegenerate && (

--- a/frontend/src/components/session/InteractionLiveStream.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.tsx
@@ -9,8 +9,6 @@ import React, {
 
 // Throttle interval for scroll updates during streaming (ms)
 const SCROLL_THROTTLE_MS = 200;
-import Box from "@mui/material/Box";
-import { useTheme } from "@mui/material/styles";
 import useLiveInteraction from "../../hooks/useLiveInteraction";
 import { MessageWithToolCalls } from "./InteractionInference";
 import { TypesServerConfigForFrontend } from "../../api/api";
@@ -19,6 +17,7 @@ import {
   TypesSession,
 } from "../../api/api";
 import ToolStepsWidget from "./ToolStepsWidget";
+import ActivitySummary from "./ActivitySummary";
 
 export const InteractionLiveStream: FC<{
   session_id: string;
@@ -39,13 +38,19 @@ export const InteractionLiveStream: FC<{
   onMessageUpdate,
   onFilterDocument,
 }) => {
-  const { message, responseEntries, stepInfos, isComplete } = useLiveInteraction(
+  const { message, responseEntries, durationMs, stepInfos, isComplete } = useLiveInteraction(
     session_id,
     interaction,
   );
 
   // Track if we're still in streaming mode or completed
   const [isActivelyStreaming, setIsActivelyStreaming] = useState(true);
+  const activityStartedAtRef = useRef(Date.now());
+  const effectiveDurationMs =
+    durationMs ||
+    (!isActivelyStreaming
+      ? Math.max(0, Date.now() - activityStartedAtRef.current)
+      : 0);
 
   const useClientURL = useCallback(
     (url: string) => {
@@ -75,6 +80,7 @@ export const InteractionLiveStream: FC<{
   // Reset streaming state when interaction ID changes
   useEffect(() => {
     setIsActivelyStreaming(true);
+    activityStartedAtRef.current = Date.now();
   }, [interaction?.id]);
 
   // Detect completion from the server (WebSocket)
@@ -136,7 +142,13 @@ export const InteractionLiveStream: FC<{
       )}
 
       {/* Show thinking indicator when waiting and no content yet */}
-      {interaction.state === "waiting" && !hasContent && <ThinkingBox />}
+      {interaction.state === "waiting" && !hasContent && (
+        <ActivitySummary
+          hasActivity={false}
+          isStreaming
+          startedAt={activityStartedAtRef.current}
+        />
+      )}
 
       {hasContent && (
         <div>
@@ -147,52 +159,13 @@ export const InteractionLiveStream: FC<{
             getFileURL={useClientURL}
             showBlinker={true}
             isStreaming={isActivelyStreaming}
+            durationMs={effectiveDurationMs}
+            activityStartedAt={activityStartedAtRef.current}
             onFilterDocument={onFilterDocument}
           />
         </div>
       )}
     </>
-  );
-};
-
-const ThinkingBox: FC = () => {
-  const theme = useTheme();
-
-  return (
-    <Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "16px",
-        margin: "8px 0",
-        gap: "4px",
-        "@keyframes bounce": {
-          "0%, 80%, 100%": {
-            transform: "scale(0.8)",
-            opacity: 0.5,
-          },
-          "40%": {
-            transform: "scale(1)",
-            opacity: 1,
-          },
-        },
-      }}
-    >
-      {[0, 0.2, 0.4].map((delay) => (
-        <Box
-          key={delay}
-          sx={{
-            width: "8px",
-            height: "8px",
-            borderRadius: "50%",
-            backgroundColor: theme.palette.mode === "light" ? "#666" : "#999",
-            animation: "bounce 1.4s ease-in-out infinite",
-            animationDelay: `${delay}s`,
-          }}
-        />
-      ))}
-    </Box>
   );
 };
 

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -763,6 +763,8 @@ export interface InteractionMarkdownProps {
   isStreaming: boolean;
   onFilterDocument?: (docId: string) => void;
   compactThinking?: boolean;
+  renderThinkingWidget?: boolean;
+  renderContent?: boolean;
 }
 
 // Add this new component for the code block with copy button
@@ -865,6 +867,8 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
   isStreaming = false,
   onFilterDocument,
   compactThinking = false,
+  renderThinkingWidget = true,
+  renderContent = true,
 }) => {
   const theme = useTheme();
   const [processedContent, setProcessedContent] = useState<string>("");
@@ -1115,7 +1119,7 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
           display: "flow-root",
         }}
       >
-        {thinkingWidgetContent && (
+        {renderThinkingWidget && thinkingWidgetContent && (
           <ThinkingWidget
             text={thinkingWidgetContent}
             isStreaming={isStreaming}
@@ -1132,7 +1136,9 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
               ragResults={session?.config?.session_rag_results || []}
             />
           )}
-        <MemoizedMarkdownRenderer processedContent={processedContent} />
+        {renderContent && (
+          <MemoizedMarkdownRenderer processedContent={processedContent} />
+        )}
         {showBlinker && isStreaming && <StreamingIndicator />}
       </Box>
     </>

--- a/frontend/src/components/session/StreamingIndicator.tsx
+++ b/frontend/src/components/session/StreamingIndicator.tsx
@@ -102,6 +102,7 @@ const StreamingIndicator: FC<StreamingIndicatorProps> = ({ className }) => {
   return (
     <Box
       className={className}
+      data-testid="streaming-indicator"
       sx={{
         display: "flex",
         alignItems: "center",

--- a/frontend/src/components/session/ThinkingWidget.test.tsx
+++ b/frontend/src/components/session/ThinkingWidget.test.tsx
@@ -6,7 +6,7 @@ import ThinkingWidget from './ThinkingWidget'
 
 const renderWidget = (isStreaming = false) => render(
   <ThemeProvider theme={createTheme()}>
-    <ThinkingWidget text="Inspect the current subscription state" isStreaming={isStreaming} />
+    <ThinkingWidget text={"Inspect the current\nsubscription state"} isStreaming={isStreaming} />
   </ThemeProvider>,
 )
 
@@ -15,7 +15,7 @@ describe('ThinkingWidget', () => {
     const { container } = render(
       <div data-session-scroll-container>
         <ThemeProvider theme={createTheme()}>
-          <ThinkingWidget text="Inspect the current subscription state" isStreaming={false} />
+          <ThinkingWidget text={"Inspect the current\nsubscription state"} isStreaming={false} />
         </ThemeProvider>
       </div>,
     )
@@ -25,9 +25,22 @@ describe('ThinkingWidget', () => {
 
     fireEvent.click(screen.getByText('Thoughts'))
 
-    expect(container.firstElementChild).toHaveAttribute('data-preserve-disclosure-expansion', 'true')
+    expect(container.querySelector('[data-session-scroll-container]'))
+      .toHaveAttribute('data-preserve-disclosure-expansion', 'true')
     expect(screen.getByText('Inspect the current subscription state')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Collapse thoughts' })).toBeInTheDocument()
+  })
+
+  it('shows single-line thoughts inline without a second disclosure', () => {
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <ThinkingWidget text="Check the current branch" isStreaming={false} />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByText('Thoughts')).toBeInTheDocument()
+    expect(screen.getByText('Check the current branch')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Expand thoughts' })).not.toBeInTheDocument()
   })
 
   it('shows an active thinking status while streaming', () => {

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -25,6 +25,7 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
   const [expanded, setExpanded] = useState(false)
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
+  const isMultiline = text.trim().includes('\n')
   const startedAt = useRef(
     typeof startTime === 'number'
       ? startTime
@@ -51,17 +52,17 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
       }}
     >
       <Box
-        onClick={(event) => {
+        onClick={isMultiline ? (event) => {
           if (!expanded) preserveDisclosureExpansion(event.currentTarget)
           setExpanded((value) => !value)
-        }}
+        } : undefined}
         sx={{
           display: 'flex',
           alignItems: 'center',
           gap: 0.75,
           px: 0,
           py: 0.5,
-          cursor: 'pointer',
+          cursor: isMultiline ? 'pointer' : 'default',
           backgroundColor: 'transparent',
           '&:hover': {
             backgroundColor: 'transparent',
@@ -72,18 +73,42 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
         <Lightbulb size={15} strokeWidth={1.8} color={iconColor} aria-hidden="true" />
         <Typography
           variant="body2"
-          sx={{ flex: 1, fontSize: '0.76rem', color: textColor, fontFamily: 'monospace' }}
+          sx={{
+            flex: isMultiline ? 1 : '0 0 auto',
+            fontSize: '0.76rem',
+            color: textColor,
+            fontFamily: 'monospace',
+          }}
         >
           {isStreaming ? `Thinking ${formatDuration(elapsed)}` : 'Thoughts'}
         </Typography>
+        {!isStreaming && !isMultiline && (
+          <Typography
+            variant="body2"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              fontSize: '0.76rem',
+              color: isDark ? 'rgba(255,255,255,0.5)' : 'text.secondary',
+              fontFamily: 'monospace',
+            }}
+          >
+            {text.trim()}
+          </Typography>
+        )}
         {isStreaming && <CircularProgress size={16} thickness={4} color="warning" />}
-        <IconButton
-          size="small"
-          aria-label={expanded ? 'Collapse thoughts' : 'Expand thoughts'}
-          sx={{ p: 0, ml: 0.5, '&:hover': { backgroundColor: 'transparent' } }}
-        >
-          {expanded ? <ChevronUp size={15} strokeWidth={1.8} /> : <ChevronDown size={15} strokeWidth={1.8} />}
-        </IconButton>
+        {isMultiline && (
+          <IconButton
+            size="small"
+            aria-label={expanded ? 'Collapse thoughts' : 'Expand thoughts'}
+            sx={{ p: 0, ml: 0.5, '&:hover': { backgroundColor: 'transparent' } }}
+          >
+            {expanded ? <ChevronUp size={15} strokeWidth={1.8} /> : <ChevronDown size={15} strokeWidth={1.8} />}
+          </IconButton>
+        )}
       </Box>
 
       {expanded && text && (

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -4,9 +4,7 @@ import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/material/styles'
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined'
+import { ChevronDown, ChevronUp, Lightbulb } from 'lucide-react'
 import { preserveDisclosureExpansion } from './disclosureScroll'
 
 interface ThinkingWidgetProps {
@@ -43,17 +41,13 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
     return () => window.clearInterval(interval)
   }, [isStreaming])
 
-  const borderColor = isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)'
   const iconColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.45)'
-  const textColor = isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)'
+  const textColor = isDark ? 'rgba(255,255,255,0.65)' : 'text.secondary'
 
   return (
     <Box
       sx={{
-        my: 1,
-        borderLeft: `3px solid ${borderColor}`,
-        borderRadius: '4px',
-        overflow: 'hidden',
+        my: 0.75,
       }}
     >
       <Box
@@ -65,21 +59,20 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
           display: 'flex',
           alignItems: 'center',
           gap: 0.75,
-          px: 1.5,
-          py: 0.75,
+          px: 0,
+          py: 0.5,
           cursor: 'pointer',
-          backgroundColor: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+          backgroundColor: 'transparent',
           '&:hover': {
-            backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+            backgroundColor: 'transparent',
           },
-          transition: 'background-color 0.15s ease',
           userSelect: 'none',
         }}
       >
-        <LightbulbOutlinedIcon sx={{ fontSize: 16, color: iconColor }} />
+        <Lightbulb size={15} strokeWidth={1.8} color={iconColor} aria-hidden="true" />
         <Typography
           variant="body2"
-          sx={{ flex: 1, fontSize: '0.82rem', color: textColor, fontFamily: 'monospace' }}
+          sx={{ flex: 1, fontSize: '0.76rem', color: textColor, fontFamily: 'monospace' }}
         >
           {isStreaming ? `Thinking ${formatDuration(elapsed)}` : 'Thoughts'}
         </Typography>
@@ -87,26 +80,24 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
         <IconButton
           size="small"
           aria-label={expanded ? 'Collapse thoughts' : 'Expand thoughts'}
-          sx={{ p: 0, ml: 0.5 }}
+          sx={{ p: 0, ml: 0.5, '&:hover': { backgroundColor: 'transparent' } }}
         >
-          {expanded
-            ? <ExpandLessIcon sx={{ fontSize: 18 }} />
-            : <ExpandMoreIcon sx={{ fontSize: 18 }} />}
+          {expanded ? <ChevronUp size={15} strokeWidth={1.8} /> : <ChevronDown size={15} strokeWidth={1.8} />}
         </IconButton>
       </Box>
 
       {expanded && text && (
         <Box
           sx={{
-            px: 1.5,
+            pl: 2.5,
+            pr: 0,
             py: 1,
             fontSize: '0.8rem',
             fontFamily: 'monospace',
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-word',
-            color: isDark ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.55)',
-            backgroundColor: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
-            borderTop: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+            color: isDark ? 'rgba(255,255,255,0.55)' : 'text.secondary',
+            backgroundColor: 'transparent',
             maxHeight: '300px',
             overflow: 'auto',
           }}

--- a/frontend/src/components/session/WorkLog.test.tsx
+++ b/frontend/src/components/session/WorkLog.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { describe, expect, it } from "vitest";
+
+import { WorkLog } from "./WorkLog";
+
+const entries = [
+  { id: "1", toolName: "first command", status: "Completed", body: "first output" },
+  { id: "2", toolName: "second command", status: "Completed", body: "second output" },
+  { id: "3", toolName: "latest command", status: "Running", body: "latest output" },
+];
+
+const renderWorkLog = () =>
+  render(
+    <ThemeProvider theme={createTheme({ palette: { mode: "dark" } })}>
+      <WorkLog entries={entries} />
+    </ThemeProvider>,
+  );
+
+describe("WorkLog", () => {
+  it("shows only the latest entry until previous entries are requested", () => {
+    renderWorkLog();
+
+    expect(screen.getByText("latest command")).toBeInTheDocument();
+    expect(screen.queryByText("first command")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /\+2 previous log entries/ })).toBeInTheDocument();
+  });
+
+  it("reveals the full log and can collapse it again", () => {
+    renderWorkLog();
+
+    fireEvent.click(screen.getByRole("button", { name: /\+2 previous log entries/ }));
+
+    expect(screen.getByText("Work Log")).toBeInTheDocument();
+    expect(screen.getByText("first command")).toBeInTheDocument();
+    expect(screen.getByText("second command")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Show fewer log entries/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show fewer log entries/ }));
+
+    expect(screen.queryByText("first command")).not.toBeInTheDocument();
+    expect(screen.getByText("latest command")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -45,6 +45,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
             color: isDark ? "rgba(255,255,255,0.5)" : "text.secondary",
             fontWeight: 600,
             letterSpacing: "0.01em",
+            fontFamily: "monospace",
           }}
         >
           Work Log
@@ -86,7 +87,8 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
               minHeight: 24,
               px: 0.5,
               color: isDark ? "rgba(255,255,255,0.65)" : "text.secondary",
-              fontSize: "0.72rem",
+              fontSize: "0.76rem",
+              fontFamily: "monospace",
               textTransform: "none",
               "&:hover": { backgroundColor: "transparent" },
             }}
@@ -110,7 +112,12 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
       >
         <Typography
           variant="caption"
-          sx={{ flex: 1, fontWeight: 600, letterSpacing: "0.01em" }}
+          sx={{
+            flex: 1,
+            fontWeight: 600,
+            letterSpacing: "0.01em",
+            fontFamily: "monospace",
+          }}
         >
           Work Log
         </Typography>
@@ -123,7 +130,8 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
             minHeight: 24,
             px: 0.5,
             color: "inherit",
-            fontSize: "0.72rem",
+            fontSize: "0.76rem",
+            fontFamily: "monospace",
             textTransform: "none",
             "&:hover": { backgroundColor: "transparent" },
           }}

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -1,0 +1,118 @@
+import React, { FC, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useTheme } from "@mui/material/styles";
+
+import { CollapsibleToolCall } from "./CollapsibleToolCall";
+import { preserveDisclosureExpansion } from "./disclosureScroll";
+
+export interface WorkLogEntry {
+  id: string;
+  toolName: string;
+  status: string;
+  body: string;
+}
+
+interface WorkLogProps {
+  entries: WorkLogEntry[];
+}
+
+/**
+ * Keeps a long sequence of agent activity out of the main response flow.
+ * The current entry remains visible; older entries are available on demand.
+ */
+export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
+  const [expanded, setExpanded] = useState(false);
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const latestEntry = entries[entries.length - 1];
+  const previousCount = Math.max(0, entries.length - 1);
+
+  if (!latestEntry) return null;
+
+  const toggleExpanded = (event: React.MouseEvent<HTMLElement>) => {
+    if (!expanded) preserveDisclosureExpansion(event.currentTarget);
+    setExpanded((value) => !value);
+  };
+
+  if (!expanded) {
+    return (
+      <Box sx={{ my: 1 }}>
+        <CollapsibleToolCall
+          toolName={latestEntry.toolName}
+          status={latestEntry.status}
+          body={latestEntry.body}
+          dense
+        />
+        {previousCount > 0 && (
+          <Button
+            size="small"
+            onClick={toggleExpanded}
+            aria-expanded={false}
+            endIcon={<ExpandMoreIcon sx={{ fontSize: 16 }} />}
+            sx={{
+              minHeight: 24,
+              px: 0.5,
+              color: isDark ? "rgba(255,255,255,0.65)" : "text.secondary",
+              fontSize: "0.72rem",
+              textTransform: "none",
+              "&:hover": { backgroundColor: "transparent" },
+            }}
+          >
+            +{previousCount} previous log {previousCount === 1 ? "entry" : "entries"}
+          </Button>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ my: 1 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          minHeight: 28,
+          color: isDark ? "rgba(255,255,255,0.7)" : "text.secondary",
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{ flex: 1, fontWeight: 600, letterSpacing: "0.01em" }}
+        >
+          Work Log
+        </Typography>
+        <Button
+          size="small"
+          onClick={toggleExpanded}
+          aria-expanded={true}
+          endIcon={<ExpandLessIcon sx={{ fontSize: 16 }} />}
+          sx={{
+            minHeight: 24,
+            px: 0.5,
+            color: "inherit",
+            fontSize: "0.72rem",
+            textTransform: "none",
+            "&:hover": { backgroundColor: "transparent" },
+          }}
+        >
+          Show fewer log entries
+        </Button>
+      </Box>
+      {entries.map((entry) => (
+        <CollapsibleToolCall
+          key={entry.id}
+          toolName={entry.toolName}
+          status={entry.status}
+          body={entry.body}
+          dense
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default WorkLog;

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -18,13 +18,14 @@ export interface WorkLogEntry {
 
 interface WorkLogProps {
   entries: WorkLogEntry[];
+  showAll?: boolean;
 }
 
 /**
  * Keeps a long sequence of agent activity out of the main response flow.
  * The current entry remains visible; older entries are available on demand.
  */
-export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
+export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
   const [expanded, setExpanded] = useState(false);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
@@ -32,6 +33,34 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
   const previousCount = Math.max(0, entries.length - 1);
 
   if (!latestEntry) return null;
+
+  if (showAll) {
+    return (
+      <Box sx={{ my: 1 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            display: "block",
+            mb: 0.25,
+            color: isDark ? "rgba(255,255,255,0.5)" : "text.secondary",
+            fontWeight: 600,
+            letterSpacing: "0.01em",
+          }}
+        >
+          Work Log
+        </Typography>
+        {entries.map((entry) => (
+          <CollapsibleToolCall
+            key={entry.id}
+            toolName={entry.toolName}
+            status={entry.status}
+            body={entry.body}
+            dense
+          />
+        ))}
+      </Box>
+    );
+  }
 
   const toggleExpanded = (event: React.MouseEvent<HTMLElement>) => {
     if (!expanded) preserveDisclosureExpansion(event.currentTarget);

--- a/frontend/src/components/session/interactionDuration.test.ts
+++ b/frontend/src/components/session/interactionDuration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getInteractionDurationMs } from "./interactionDuration";
+
+describe("getInteractionDurationMs", () => {
+  it("prefers the server measured duration", () => {
+    expect(
+      getInteractionDurationMs({
+        duration_ms: 2500,
+        created: "2026-08-03T00:00:00.000Z",
+        completed: "2026-08-03T00:01:00.000Z",
+      }),
+    ).toBe(2500);
+  });
+
+  it("falls back to interaction timestamps", () => {
+    expect(
+      getInteractionDurationMs({
+        duration_ms: 0,
+        created: "2026-08-03T00:00:00.000Z",
+        completed: "2026-08-03T00:00:02.500Z",
+      }),
+    ).toBe(2500);
+  });
+});

--- a/frontend/src/components/session/interactionDuration.ts
+++ b/frontend/src/components/session/interactionDuration.ts
@@ -1,0 +1,18 @@
+import { TypesInteraction } from "../../api/api";
+
+/** Prefer the server's measured duration, with a timestamp fallback for older rows. */
+export const getInteractionDurationMs = (
+  interaction?: Pick<TypesInteraction, "duration_ms" | "created" | "completed"> | null,
+) => {
+  if (interaction?.duration_ms && interaction.duration_ms > 0) {
+    return interaction.duration_ms;
+  }
+
+  if (!interaction?.created || !interaction.completed) return 0;
+
+  const createdAt = Date.parse(interaction.created);
+  const completedAt = Date.parse(interaction.completed);
+  if (!Number.isFinite(createdAt) || !Number.isFinite(completedAt)) return 0;
+
+  return Math.max(0, completedAt - createdAt);
+};

--- a/frontend/src/hooks/useLiveInteraction.ts
+++ b/frontend/src/hooks/useLiveInteraction.ts
@@ -2,10 +2,12 @@ import { useState, useEffect, useRef } from "react";
 import { useStreaming } from "../contexts/streaming";
 import { TypesInteraction, TypesInteractionState } from "../api/api";
 import { ResponseEntry } from "../components/session/InteractionInference";
+import { getInteractionDurationMs } from "../components/session/interactionDuration";
 
 interface LiveInteractionResult {
   message: string;
   responseEntries: ResponseEntry[] | undefined;
+  durationMs: number | undefined;
   status: string;
   isComplete: boolean;
   stepInfos: any[];
@@ -146,6 +148,7 @@ const useLiveInteraction = (
     // This prevents blank screen when streaming context clears during completion
     message,
     responseEntries,
+    durationMs: getInteractionDurationMs(interaction),
     status: interaction?.state || "",
     isComplete:
       interaction?.state === TypesInteractionState.InteractionStateComplete,

--- a/frontend/src/pages/HelixOrgChart.assets.test.tsx
+++ b/frontend/src/pages/HelixOrgChart.assets.test.tsx
@@ -1,14 +1,15 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { AssetAuthType, AssetKind } from '../api/api'
 import type { AssetDTO } from '../services/helixOrgService'
-import { AssetNode, assetLinkFromConnection, buildGraph } from './HelixOrgChart'
+import { AssetNode, assetLinkFromConnection, BotNode, buildGraph } from './HelixOrgChart'
 
 const handlers = {
   onSelectBot: vi.fn(),
   onOpenBotDetails: vi.fn(),
+  onViewProject: vi.fn(),
   onNewBot: vi.fn(),
   onDeleteBot: vi.fn(),
   onStartBot: vi.fn(),
@@ -94,5 +95,33 @@ describe('HelixOrgChart server assets', () => {
     }
     expect(screen.getByRole('status')).toHaveAccessibleName('Network or SSH unavailable')
     expect(screen.getByText('1 allowed agent')).toBeInTheDocument()
+  })
+})
+
+describe('HelixOrgChart agent actions', () => {
+  it('opens the agent project from the node menu', () => {
+    render(
+      <ReactFlowProvider>
+        <BotNode {...({
+          id: 'bot:chief-of-staff',
+          data: {
+            botId: 'chief-of-staff',
+            botName: 'Chief of Staff',
+            agentStatus: 'running',
+            agentRuntime: 'zed_external',
+            agentModel: 'test',
+            projectId: 'project-1',
+            taskStats: { backlog: 0, inProgress: 0, done: 0 },
+            selected: false,
+            ...handlers,
+          },
+        } as any)} />
+      </ReactFlowProvider>,
+    )
+
+    fireEvent.contextMenu(screen.getByText('Chief of Staff'))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'View project' }))
+
+    expect(handlers.onViewProject).toHaveBeenCalledWith('project-1')
   })
 })

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -19,6 +19,7 @@ import AddIcon from '@mui/icons-material/Add'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined'
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined'
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
@@ -72,7 +73,15 @@ import {
   loadChartTopicVisibility,
   saveChartTopicVisibility,
 } from '../components/helix-org/chartTopicVisibility'
-import ChartTopicVisibilityMenu, { chartToolbarButtonSizeSx } from '../components/helix-org/ChartTopicVisibilityMenu'
+import ChartTopicVisibilityMenu from '../components/helix-org/ChartTopicVisibilityMenu'
+import ChartVisibilityMenu, { chartToolbarButtonSizeSx } from '../components/helix-org/ChartVisibilityMenu'
+import {
+  ChartEntityKind,
+  EMPTY_HIDDEN_CHART_ENTITY_IDS,
+  HiddenChartEntityIDs,
+  loadHiddenChartEntityIDs,
+  saveHiddenChartEntityIDs,
+} from '../components/helix-org/chartEntityVisibility'
 import {
   CHAT_BOT_FOCUS_EVENT,
   ChatBotFocusDetail,
@@ -198,6 +207,7 @@ type FlatBot = {
   agentStatus: 'running' | 'stopped'
   agentRuntime: string
   agentModel: string
+  projectId?: string
   taskStats: BotTaskStats
 }
 
@@ -210,6 +220,7 @@ type BotNodeData = {
   agentStatus: 'running' | 'stopped'
   agentRuntime: string
   agentModel: string
+  projectId: string
   taskStats: BotTaskStats
   /** True when the left chat rail is focused on this bot. */
   selected: boolean
@@ -217,6 +228,7 @@ type BotNodeData = {
   onSelectBot: (botId: string) => void
   /** Open the bot detail page from the menu or a card double-click. */
   onOpenBotDetails: (botId: string) => void
+  onViewProject: (projectId: string) => void
   onNewBot: (parentBotId: string) => void
   onDeleteBot: (botId: string) => void
   onStartBot: (botId: string) => void
@@ -510,7 +522,7 @@ export const AssetNode: FC<NodeProps<Node<AssetNodeData>>> = ({ data }) => {
   )
 }
 
-const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
+export const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
   const lightTheme = useLightTheme()
   const muted = lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)'
   const idleBorder = lightTheme.isLight ? 'rgba(0,0,0,0.14)' : 'rgba(255,255,255,0.18)'
@@ -634,6 +646,16 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
             >
               <OpenInNewIcon sx={{ mr: 1, fontSize: 20 }} />
               Details
+            </MenuItem>
+            <MenuItem
+              disabled={!data.projectId}
+              onClick={() => {
+                closeMenu()
+                data.onViewProject(data.projectId)
+              }}
+            >
+              <FolderOpenOutlinedIcon sx={{ mr: 1, fontSize: 20 }} />
+              View project
             </MenuItem>
             {online ? (
               <>
@@ -957,6 +979,7 @@ export const buildGraph = (
   handlers: {
     onSelectBot: (botId: string) => void
     onOpenBotDetails: (botId: string) => void
+    onViewProject: (projectId: string) => void
     onNewBot: (parentBotId: string) => void
     onDeleteBot: (botId: string) => void
     onStartBot: (botId: string) => void
@@ -1039,10 +1062,12 @@ export const buildGraph = (
         agentStatus: b.agentStatus,
         agentRuntime: b.agentRuntime,
         agentModel: b.agentModel,
+        projectId: b.projectId ?? '',
         taskStats: b.taskStats,
         selected: selectedBotId !== '' && selectedBotId === b.id,
         onSelectBot: handlers.onSelectBot,
         onOpenBotDetails: handlers.onOpenBotDetails,
+        onViewProject: handlers.onViewProject,
         onNewBot: handlers.onNewBot,
         onDeleteBot: handlers.onDeleteBot,
         onStartBot: handlers.onStartBot,
@@ -1721,6 +1746,7 @@ const ChartCanvas: FC<{
   handlers: {
     onSelectBot: (botId: string) => void
     onOpenBotDetails: (botId: string) => void
+    onViewProject: (projectId: string) => void
     onNewBot: (parentBotId: string) => void
     onDeleteBot: (botId: string) => void
     onStartBot: (botId: string) => void
@@ -2253,6 +2279,15 @@ const HelixOrgChart: FC = () => {
     return stats
   }, [tasksByBotId])
 
+  const projectIDByBotID = useMemo(() => {
+    const projectIDs = new Map<string, string>()
+    botDetails.forEach((detail, index) => {
+      const botID = botIds[index]
+      if (botID && detail?.project_id) projectIDs.set(botID, detail.project_id)
+    })
+    return projectIDs
+  }, [botDetails, botIds])
+
   const flat = useMemo<FlatBot[]>(
     () => (botsData ?? [])
       // People (kind=human) are managed in the People tab, not on the agent
@@ -2265,9 +2300,10 @@ const HelixOrgChart: FC = () => {
         agentStatus: b.agent_status === 'running' ? 'running' as const : 'stopped' as const,
         agentRuntime: b.agent_runtime ?? '',
         agentModel: b.agent_model ?? '',
+        projectId: projectIDByBotID.get(b.id ?? '') ?? '',
         taskStats: taskStatsByBotId.get(b.id ?? '') ?? { backlog: 0, inProgress: 0, done: 0 },
       })),
-    [taskStatsByBotId, botsData],
+    [botsData, projectIDByBotID, taskStatsByBotId],
   )
 
   // People (kind=human) — shown in the docked PeoplePanel on the chart, not
@@ -2325,19 +2361,92 @@ const HelixOrgChart: FC = () => {
     [topics, processorConsumerCounts],
   )
 
-  const topicVisibilityScopeRef = useRef('')
-  const [visibleTopicFilters, setVisibleTopicFilters] = useState<ChartTopicFilter[]>(() => [...DEFAULT_CHART_TOPIC_FILTERS])
+  const agentOptions = useMemo(
+    () => flat
+      .map((agent) => ({ id: agent.id, label: agent.name || agent.id }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [flat],
+  )
+  const processorOptions = useMemo(
+    () => (processorsData ?? [])
+      .filter((processor) => !!processor.id)
+      .map((processor) => ({ id: processor.id, label: processor.name || processor.id }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [processorsData],
+  )
+  const assetOptions = useMemo(
+    () => assetsData
+      .filter((asset) => !!asset.id)
+      .map((asset) => ({ id: asset.id ?? '', label: asset.name || asset.id || '' }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [assetsData],
+  )
+
+  const visibilityScope = userID && orgID ? `${userID}:${orgID}` : ''
+  const entityVisibilityScopeRef = useRef(visibilityScope)
+  const [hiddenEntityIDs, setHiddenEntityIDs] = useState<HiddenChartEntityIDs>(() => (
+    visibilityScope
+      ? loadHiddenChartEntityIDs(userID, orgID) ?? { ...EMPTY_HIDDEN_CHART_ENTITY_IDS }
+      : { ...EMPTY_HIDDEN_CHART_ENTITY_IDS }
+  ))
   useEffect(() => {
-    const scope = userID && orgID ? `${userID}:${orgID}` : ''
-    if (!scope) {
+    if (!visibilityScope) {
+      entityVisibilityScopeRef.current = ''
+      setHiddenEntityIDs({ ...EMPTY_HIDDEN_CHART_ENTITY_IDS })
+      return
+    }
+    if (visibilityScope === entityVisibilityScopeRef.current) return
+    entityVisibilityScopeRef.current = visibilityScope
+    setHiddenEntityIDs(loadHiddenChartEntityIDs(userID, orgID) ?? { ...EMPTY_HIDDEN_CHART_ENTITY_IDS })
+  }, [userID, orgID, visibilityScope])
+
+  const selectedAgentIDs = useMemo(() => {
+    const hidden = new Set(hiddenEntityIDs.agents)
+    return agentOptions.map((option) => option.id).filter((id) => !hidden.has(id))
+  }, [agentOptions, hiddenEntityIDs.agents])
+  const selectedProcessorIDs = useMemo(() => {
+    const hidden = new Set(hiddenEntityIDs.processors)
+    return processorOptions.map((option) => option.id).filter((id) => !hidden.has(id))
+  }, [processorOptions, hiddenEntityIDs.processors])
+  const selectedAssetIDs = useMemo(() => {
+    const hidden = new Set(hiddenEntityIDs.assets)
+    return assetOptions.map((option) => option.id).filter((id) => !hidden.has(id))
+  }, [assetOptions, hiddenEntityIDs.assets])
+
+  const updateEntityVisibility = (
+    kind: ChartEntityKind,
+    options: readonly { id: string }[],
+    selectedIDs: string[],
+  ) => {
+    const selected = new Set(selectedIDs)
+    const next = {
+      ...hiddenEntityIDs,
+      [kind]: options.map((option) => option.id).filter((id) => !selected.has(id)),
+    }
+    setHiddenEntityIDs(next)
+    saveHiddenChartEntityIDs(userID, orgID, next)
+  }
+
+  const topicVisibilityScopeRef = useRef(visibilityScope)
+  const [visibleTopicFilters, setVisibleTopicFilters] = useState<ChartTopicFilter[]>(() => (
+    visibilityScope
+      ? loadChartTopicVisibility(userID, orgID) ?? [...DEFAULT_CHART_TOPIC_FILTERS]
+      : [...DEFAULT_CHART_TOPIC_FILTERS]
+  ))
+  useEffect(() => {
+    if (!visibilityScope) {
       topicVisibilityScopeRef.current = ''
       setVisibleTopicFilters([...DEFAULT_CHART_TOPIC_FILTERS])
       return
     }
-    if (scope === topicVisibilityScopeRef.current) return
-    topicVisibilityScopeRef.current = scope
+    if (visibilityScope === topicVisibilityScopeRef.current) return
+    topicVisibilityScopeRef.current = visibilityScope
     setVisibleTopicFilters(loadChartTopicVisibility(userID, orgID) ?? [...DEFAULT_CHART_TOPIC_FILTERS])
-  }, [userID, orgID])
+  }, [userID, orgID, visibilityScope])
+
+  const visibilityReady = visibilityScope !== ''
+    && entityVisibilityScopeRef.current === visibilityScope
+    && topicVisibilityScopeRef.current === visibilityScope
 
   const onTopicFiltersChange = useCallback((filters: ChartTopicFilter[]) => {
     setVisibleTopicFilters(filters)
@@ -2346,10 +2455,12 @@ const HelixOrgChart: FC = () => {
 
   const visibleTopicIds = useMemo(() => {
     const selected = new Set(visibleTopicFilters)
+    const visibleProcessors = new Set(selectedProcessorIDs)
     return new Set(topics
       .filter((topic) => selected.has(chartTopicFilterFor(topic)))
+      .filter((topic) => !topic.ownedByProcessor || visibleProcessors.has(topic.ownedByProcessor))
       .map((topic) => topic.id))
-  }, [topics, visibleTopicFilters])
+  }, [topics, visibleTopicFilters, selectedProcessorIDs])
 
   // Retained-message counts only run for cards currently shown on the chart.
   const visibleTopicIdList = useMemo(() => Array.from(visibleTopicIds), [visibleTopicIds])
@@ -2370,6 +2481,22 @@ const HelixOrgChart: FC = () => {
       })),
     })),
     [processorsData],
+  )
+
+  const visibleAgentIDs = useMemo(() => new Set(selectedAgentIDs), [selectedAgentIDs])
+  const visibleProcessorIDs = useMemo(() => new Set(selectedProcessorIDs), [selectedProcessorIDs])
+  const visibleAssetIDs = useMemo(() => new Set(selectedAssetIDs), [selectedAssetIDs])
+  const visibleFlat = useMemo(
+    () => flat.filter((agent) => visibleAgentIDs.has(agent.id)),
+    [flat, visibleAgentIDs],
+  )
+  const visibleProcessorSummaries = useMemo(
+    () => processorSummaries.filter((processor) => visibleProcessorIDs.has(processor.id)),
+    [processorSummaries, visibleProcessorIDs],
+  )
+  const visibleAssets = useMemo(
+    () => assetsData.filter((asset) => visibleAssetIDs.has(asset.id ?? '')),
+    [assetsData, visibleAssetIDs],
   )
 
   const [selection, setSelection] = useState<Selection>({ kind: 'none' })
@@ -2462,6 +2589,13 @@ const HelixOrgChart: FC = () => {
     },
     [router, orgSlug],
   )
+  const onViewProject = useCallback(
+    (projectId: string) => {
+      if (!orgSlug || !projectId) return
+      router.navigate('org_project-specs', { org_id: orgSlug, id: projectId })
+    },
+    [router, orgSlug],
+  )
   const onSelectPerson = useCallback(
     (botId: string) => {
       if (!orgSlug) return
@@ -2517,10 +2651,10 @@ const HelixOrgChart: FC = () => {
   const onDeleteAsset = useCallback((assetId: string) => setConfirmDelete({ kind: 'asset', id: assetId }), [])
   const handlers = useMemo(
     () => ({
-      onSelectBot, onOpenBotDetails, onNewBot, onDeleteBot, onStartBot, onStopBot, onRestartBot,
+      onSelectBot, onOpenBotDetails, onViewProject, onNewBot, onDeleteBot, onStartBot, onStopBot, onRestartBot,
       onSelectTopic, onDeleteTopic, onSelectProcessor, onDeleteProcessor, onSelectAsset, onDeleteAsset,
     }),
-    [onSelectBot, onOpenBotDetails, onNewBot, onDeleteBot, onStartBot, onStopBot, onRestartBot, onSelectTopic, onDeleteTopic, onSelectProcessor, onDeleteProcessor, onSelectAsset, onDeleteAsset],
+    [onSelectBot, onOpenBotDetails, onViewProject, onNewBot, onDeleteBot, onStartBot, onStopBot, onRestartBot, onSelectTopic, onDeleteTopic, onSelectProcessor, onDeleteProcessor, onSelectAsset, onDeleteAsset],
   )
 
   const onAddParent = useCallback(
@@ -2735,8 +2869,29 @@ const HelixOrgChart: FC = () => {
             overflow: 'hidden',
           }}
         >
-          <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
+          {visibilityReady && <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
             <ChartTopicVisibilityMenu selected={visibleTopicFilters} onChange={onTopicFiltersChange} />
+            <ChartVisibilityMenu
+              label="Agents"
+              icon={<SmartToyOutlinedIcon />}
+              options={agentOptions}
+              selected={selectedAgentIDs}
+              onChange={(selected) => updateEntityVisibility('agents', agentOptions, selected)}
+            />
+            <ChartVisibilityMenu
+              label="Processors"
+              icon={<TransformIcon />}
+              options={processorOptions}
+              selected={selectedProcessorIDs}
+              onChange={(selected) => updateEntityVisibility('processors', processorOptions, selected)}
+            />
+            <ChartVisibilityMenu
+              label="Assets"
+              icon={<DnsOutlinedIcon />}
+              options={assetOptions}
+              selected={selectedAssetIDs}
+              onChange={(selected) => updateEntityVisibility('assets', assetOptions, selected)}
+            />
             <Button
               size="small"
               variant="contained"
@@ -2769,9 +2924,9 @@ const HelixOrgChart: FC = () => {
                 <ListItemText>Asset</ListItemText>
               </MenuItem>
             </Menu>
-          </Stack>
+          </Stack>}
 
-          {isLoading || assetsLoading ? (
+          {!visibilityReady || isLoading || assetsLoading ? (
             <Box sx={{ p: 4 }}><LoadingSpinner /></Box>
           ) : flat.length === 0 && assetsData.length === 0 ? (
             <Box
@@ -2789,7 +2944,7 @@ const HelixOrgChart: FC = () => {
           ) : (
             <ReactFlowProvider>
               <ChartCanvas
-                flat={flat}
+                flat={visibleFlat}
                 handlers={handlers}
                 onAddParent={onAddParent}
                 onRemoveParent={onRemoveParent}
@@ -2802,8 +2957,8 @@ const HelixOrgChart: FC = () => {
                 onCanvasContextMenu={openCtxMenu}
                 topics={topicsWithConsumerCounts}
                 messageCounts={messageCounts}
-                processors={processorSummaries}
-                assets={assetsData}
+                processors={visibleProcessorSummaries}
+                assets={visibleAssets}
                 assetHealth={assetHealth}
                 savedPositions={savedPositions}
                 visibleTopicIds={visibleTopicIds}


### PR DESCRIPTION
## Summary

- Collapse tool-call activity into a compact Work Log showing the latest call by default.
- Make tool calls and Thoughts borderless, transparent, and visually quieter.
- Use Lucide icons for activity, status, and disclosure controls.
- Show response actions such as copy, regenerate, export, and thumbs feedback only on hover or keyboard focus.

## Why

Org-chart and spec-task chats can accumulate many tool calls and thought blocks, which currently dominate the conversation. This keeps the active work visible while preserving access to the complete history.

## Validation

- `yarn test ThinkingWidget.test.tsx WorkLog.test.tsx CollapsibleToolCall.test.tsx`
- `yarn tsc --noEmit`
- `yarn build`
