### PR TITLE
fix(api): record ACP turns even when the agent reports no usage

### DIFF
--- a/api/pkg/server/external_agent_usage.go
+++ b/api/pkg/server/external_agent_usage.go
@@ -9,6 +9,7 @@ import (
 	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	openailogger "github.com/helixml/helix/api/pkg/openai/logger"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
 )
 
 type acpTurnUsage struct {
@@ -27,11 +28,8 @@ func (s *HelixAPIServer) recordACPUsage(
 ) error {
 	var usage acpTurnUsage
 	usageKnown := false
-	rawUsage, hasUsage := syncMsg.Data["usage"]
+	rawUsage := syncMsg.Data["usage"]
 	agentName, _ := syncMsg.Data["agent_name"].(string)
-	if !hasUsage && agentName == "" {
-		return nil
-	}
 	if rawUsage != nil {
 		encoded, err := json.Marshal(rawUsage)
 		if err != nil {
@@ -56,6 +54,17 @@ func (s *HelixAPIServer) recordACPUsage(
 	}
 
 	provider, model := acpUsageProviderAndModel(assistant)
+	if !usageKnown {
+		// The turn still gets a metric row (request counts stay accurate), but
+		// token totals will read zero. The usual cause is a Zed build predating
+		// the `usage` field on message_completed — see sandbox-versions.txt.
+		log.Warn().
+			Str("session_id", session.ID).
+			Str("interaction_id", interaction.ID).
+			Str("agent_name", agentName).
+			Str("code_agent_runtime", string(assistant.CodeAgentRuntime)).
+			Msg("ACP turn completed without usage data; recording metric with usage_known=false")
+	}
 	durationMs := interaction.DurationMs
 	if durationMs == 0 && !interaction.Created.IsZero() && !interaction.Completed.IsZero() {
 		durationMs = int(interaction.Completed.Sub(interaction.Created).Milliseconds())

--- a/api/pkg/server/external_agent_usage_test.go
+++ b/api/pkg/server/external_agent_usage_test.go
@@ -96,6 +96,49 @@ func (s *WebSocketSyncSuite) TestRecordACPUsage_RecordsUnknownUsageAsActivity() 
 	require.NoError(s.T(), err)
 }
 
+// Zed's message_completed carries neither `usage` nor `agent_name` when the
+// binary predates the ACP turn-usage change. The turn must still be recorded so
+// request counts and activity remain visible.
+func (s *WebSocketSyncSuite) TestRecordACPUsage_RecordsTurnWithoutUsageOrAgentName() {
+	app := &types.App{ID: "app_123", Config: types.AppConfig{Helix: types.AppHelixConfig{
+		Assistants: []types.AssistantConfig{{
+			AgentType:               types.AgentTypeZedExternal,
+			CodeAgentRuntime:        types.CodeAgentRuntimeCodexCLI,
+			CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+			Model:                   "gpt-5.6-sol",
+		}},
+	}}}
+	s.store.EXPECT().GetApp(gomock.Any(), "app_123").Return(app, nil)
+	s.store.EXPECT().CreateUsageMetric(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, metric *types.UsageMetric) (*types.UsageMetric, error) {
+			assert.Equal(s.T(), types.UsageMetricSourceACP, metric.Source)
+			assert.Equal(s.T(), "ses_123:int_123", metric.SourceID)
+			assert.False(s.T(), metric.UsageKnown)
+			assert.Zero(s.T(), metric.TotalTokens)
+			assert.Equal(s.T(), "prj_123", metric.ProjectID)
+			assert.Equal(s.T(), "task_123", metric.SpecTaskID)
+			return metric, nil
+		},
+	)
+
+	err := s.server.recordACPUsage(
+		context.Background(),
+		&types.Session{
+			ID:        "ses_123",
+			ParentApp: "app_123",
+			ProjectID: "prj_123",
+			Metadata:  types.SessionMetadata{SpecTaskID: "task_123"},
+		},
+		&types.Interaction{ID: "int_123"},
+		&types.SyncMessage{Data: map[string]interface{}{
+			"acp_thread_id": "019fc6c4-33b7-7671-bfc0-0358c7d225ba",
+			"message_id":    "0",
+			"request_id":    "req_123",
+		}},
+	)
+	require.NoError(s.T(), err)
+}
+
 func (s *WebSocketSyncSuite) TestRecordACPUsage_SkipsAPIKeyAgent() {
 	app := &types.App{ID: "app_123", Config: types.AppConfig{Helix: types.AppHelixConfig{
 		Assistants: []types.AssistantConfig{{


### PR DESCRIPTION
## Problem

Project token-usage charts read **0 tokens / 0 requests** for spec-task and org-bot work that demonstrably ran (e.g. `prj_01kz1sn1zzry9ff7fezp5dm6xf`, which planned + implemented a task and opened a PR on 2026-08-03).

`recordACPUsage` bails at its first guard when `message_completed` carries neither `usage` nor `agent_name`:

```go
rawUsage, hasUsage := syncMsg.Data["usage"]
agentName, _ := syncMsg.Data["agent_name"].(string)
if !hasUsage && agentName == "" {
    return nil
}
```

Zed only populates those two fields on builds that include `helixml/zed@4268a5a558` ("feat(external-sync): report ACP turn usage"). Against a Zed binary without it, every ACP turn hit the early return: **no `usage_metrics` row, no request count, and no log line** — the feature failed completely silently for two days before anyone noticed.

Confirmed on a live instance: of all `message_completed` events in the API log, `0` contained a `usage` key, and the deployed Zed binary contained `0` occurrences of `cached_write_tokens`.

## Fix

Always write the metric row for subscription ACP turns, with `usage_known=false` when token data is absent, and emit a warning naming the session/interaction/runtime so a non-reporting agent is diagnosable instead of invisible.

Request counts and per-project activity stay accurate regardless of what the agent reports; token totals fill in once the agent reports them.

## Tests

Every existing test supplied `agent_name`, so none covered the payload Zed actually sends. Added `TestRecordACPUsage_RecordsTurnWithoutUsageOrAgentName` using a real captured `message_completed` payload (`acp_thread_id` / `message_id` / `request_id` only).

```
$ go test -run "TestWebSocketSyncSuite/TestRecordACPUsage" ./pkg/server/ -count=1
ok  	github.com/helixml/helix/api/pkg/server	0.021s
```

## Note

No Zed-side change is required — `sandbox-versions.txt` already pins `ZED_COMMIT=473a1c7cc`, which is `helixml/zed` main HEAD and does contain the usage feature. This PR hardens the Helix side so a stale or non-reporting agent degrades to "requests visible, tokens unknown" rather than silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)