### PR TITLE
feat(org): make Helix Org generally available

### DIFF
--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -50,29 +50,6 @@ func requireAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(f)
 }
 
-// requireFeature returns middleware that gates access on the given
-// alpha-feature flag. The flag must be present in the authenticated
-// user's AlphaFeatures slice; missing returns 403. This is the
-// server-side gate — frontend toggles are cosmetic only.
-func requireFeature(name string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			user := getRequestUser(r)
-			if !hasUser(user) {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-			for _, f := range user.AlphaFeatures {
-				if f == name {
-					next.ServeHTTP(w, r)
-					return
-				}
-			}
-			http.Error(w, "Forbidden", http.StatusForbidden)
-		})
-	}
-}
-
 func requireRunner(next http.Handler) http.Handler {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		user := getRequestUser(r)

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -39314,7 +39314,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "alpha_features": {
-                    "description": "AlphaFeatures lists the feature flags this user has been granted\naccess to. Server-enforced via requireFeature middleware — the\nfrontend uses it only to decide whether to render the entry\npoint. Granted per-user via SQL (no deploy).",
+                    "description": "AlphaFeatures lists feature flags granted to this user.\nGranted per-user via SQL (no deploy).",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -133,8 +133,7 @@ type helixOrgHandlers struct {
 }
 
 // initHelixOrgHandler builds the in-process helix-org HTTP handler;
-// mounted at /api/v1/orgs/{org}/, gated per-user by the `helix-org`
-// alpha feature flag.
+// mounted at /api/v1/orgs/{org}/.
 //
 // Storage: the org-graph rows land in the same Postgres database
 // helix uses for its primary state — no separate connection pool,
@@ -303,8 +302,7 @@ func buildOrgServices(st *helixorgstore.Store, deps *mcptools.Config, bc *wakebu
 // callbacks on the insecure router, the org-scoped Slack endpoints and
 // the /orgs/{org}/ catch-all on the auth router, the org MCP backend,
 // plus the long-lived stream-cron and Socket Mode goroutines. Every
-// org-shaped route + lifecycle hook lives here. Org-graph access is gated
-// per-user by the `helix-org` alpha feature.
+// org-shaped route + lifecycle hook lives here.
 func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRouter, authRouter *mux.Router) error {
 	orgHandlers, err := initHelixOrgHandler(helixOrgConfig{
 		LocalFSPath:          s.Cfg.FileStore.LocalFSPath,
@@ -426,13 +424,10 @@ func (s *HelixAPIServer) registerHelixOrgAuthenticatedRoutes(authRouter *mux.Rou
 	authRouter.Handle("/orgs/{org}/github/app-installation", identityOnly).Methods(http.MethodGet)
 	authRouter.Handle("/orgs/{org}/github/app-manifest", identityOnly).Methods(http.MethodPost)
 
-	// All remaining per-tenant org-graph routes require the alpha feature
-	// and bootstrap the graph before dispatch.
+	// All remaining per-tenant org-graph routes bootstrap the graph before dispatch.
 	authRouter.PathPrefix("/orgs/{org}/").Handler(
-		requireFeature(helixorg.AlphaFeature)(
-			s.withHelixOrgScope(orgHandlers.scope,
-				stripOrgScopedPrefix(orgHandlers.api),
-			),
+		s.withHelixOrgScope(orgHandlers.scope,
+			stripOrgScopedPrefix(orgHandlers.api),
 		),
 	)
 }
@@ -1426,7 +1421,7 @@ func workerRuntimeSupportsSubscription(runtime string) bool {
 // API key configured. HelixOrgURL points at our embedded MCP gateway
 // so the Zed sandbox can reach helix-org without external tunneling;
 // the service api_key is forwarded as the MCP Authorization header
-// so the gateway's alpha-feature check passes.
+// so the gateway can authenticate the request.
 //
 // BearerForUser resolves the hiring user's id (persisted on the
 // Worker's runtime state by hire_worker) to a current api_key at

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -35,7 +35,7 @@ func (s *bootstrapHelixStore) GetOrganization(_ context.Context, _ *helixstore.G
 }
 
 func (s *bootstrapHelixStore) GetUser(_ context.Context, _ *helixstore.GetUserQuery) (*types.User, error) {
-	return &types.User{ID: "user-owner", AlphaFeatures: []string{"helix-org"}}, nil
+	return &types.User{ID: "user-owner"}, nil
 }
 
 func (s *bootstrapHelixStore) CreateAPIKey(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) {
@@ -187,11 +187,33 @@ func TestHelixOrgSettingsRoutesDoNotRequireFeature(t *testing.T) {
 	}
 }
 
-func TestHelixOrgChartRouteStillRequiresFeature(t *testing.T) {
-	handler, _ := newHelixOrgRouteTestHandler(t)
+func TestHelixOrgChartRouteDoesNotRequireFeature(t *testing.T) {
+	handler, scope := newHelixOrgRouteTestHandler(t)
+	scope.bootstrapped["org_acme"] = true
 	rec := helixOrgRouteRequest(handler, http.MethodGet, "/api/v1/orgs/acme/chart/positions")
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func TestHelixOrgMCPBackendDoesNotRequireFeature(t *testing.T) {
+	scope := &helixOrgScope{bootstrapped: map[string]bool{"org_acme": true}}
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if orgID := helixorgserver.OrgIDFromContext(r.Context()); orgID != "org_acme" {
+			t.Errorf("org ID context = %q, want org_acme", orgID)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := &HelixAPIServer{Store: &helixOrgRouteTestStore{}}
+	backend := NewHelixOrgMCPBackend(server, &helixOrgHandlers{api: downstream, scope: scope})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/acme", nil)
+	req = mux.SetURLVars(req, map[string]string{"path": "acme"})
+	rec := httptest.NewRecorder()
+
+	backend.ServeHTTP(rec, req, &types.User{ID: "user-1"})
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
 	}
 }
 

--- a/api/pkg/server/helixorg/apikeys.go
+++ b/api/pkg/server/helixorg/apikeys.go
@@ -72,26 +72,6 @@ func (k *HelixAPIKeys) Service(ctx context.Context, orgID string) (string, error
 		return "", fmt.Errorf("organization owner %s not found", org.Owner)
 	}
 
-	// Grant the alpha-feature flag to the service owner so the MCP
-	// gateway accepts requests authenticated by this key. Without it,
-	// per-Worker MCP calls from Zed sandboxes 403 — the backend's
-	// requireFeature check applies to every authenticated caller,
-	// including service identities. Idempotent.
-	hasFlag := false
-	for _, f := range owner.AlphaFeatures {
-		if f == AlphaFeature {
-			hasFlag = true
-			break
-		}
-	}
-	if !hasFlag {
-		owner.AlphaFeatures = append(owner.AlphaFeatures, AlphaFeature)
-		if _, err := k.store.UpdateUser(ctx, owner); err != nil {
-			return "", fmt.Errorf("grant alpha flag to service owner: %w", err)
-		}
-		log.Info().Str("owner_email", owner.Email).Msg("helix-org granted alpha flag to service owner")
-	}
-
 	keyStr, err := system.GenerateAPIKey()
 	if err != nil {
 		return "", fmt.Errorf("generate api key: %w", err)
@@ -100,7 +80,7 @@ func (k *HelixAPIKeys) Service(ctx context.Context, orgID string) (string, error
 		Owner:     owner.ID,
 		OwnerType: types.OwnerTypeUser,
 		Key:       keyStr,
-		Name:      "helix-org alpha (auto-provisioned)",
+		Name:      "helix-org service (auto-provisioned)",
 		Type:      types.APIkeytypeAPI,
 	}); err != nil {
 		return "", fmt.Errorf("create api key: %w", err)
@@ -140,7 +120,7 @@ func (k *HelixAPIKeys) User(ctx context.Context, userID string) (string, error) 
 		Owner:     userID,
 		OwnerType: types.OwnerTypeUser,
 		Key:       keyStr,
-		Name:      "helix-org alpha (per-user)",
+		Name:      "helix-org (per-user)",
 		Type:      types.APIkeytypeAPI,
 	}); err != nil {
 		return "", fmt.Errorf("create api key: %w", err)

--- a/api/pkg/server/helixorg/apikeys_test.go
+++ b/api/pkg/server/helixorg/apikeys_test.go
@@ -54,7 +54,7 @@ func TestAPIKeys_User_MintsWhenNone(t *testing.T) {
 	st.EXPECT().ListAPIKeys(gomock.Any(), gomock.Any()).Return([]*types.ApiKey{}, nil)
 	st.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, k *types.ApiKey) (*types.ApiKey, error) {
-			if k.Owner != "usr-2" || k.Type != types.APIkeytypeAPI {
+			if k.Owner != "usr-2" || k.Type != types.APIkeytypeAPI || k.Name != "helix-org (per-user)" {
 				t.Errorf("unexpected key: %+v", k)
 			}
 			return k, nil
@@ -77,25 +77,17 @@ func TestAPIKeys_Service_MintsForOrganizationOwner(t *testing.T) {
 	defer ctrl.Finish()
 	st := store.NewMockStore(ctrl)
 
-	owner := &types.User{ID: "usr-owner", Email: "owner@test"}
+	owner := &types.User{ID: "usr-owner", Email: "owner@test", AlphaFeatures: []string{"other-feature"}}
 	st.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-test"}).
 		Return(&types.Organization{ID: "org-test", Owner: owner.ID}, nil)
 	st.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: owner.ID}).Return(owner, nil)
-	st.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, u *types.User) (*types.User, error) {
-			var granted bool
-			for _, f := range u.AlphaFeatures {
-				if f == AlphaFeature {
-					granted = true
-				}
-			}
-			if !granted {
-				t.Errorf("alpha flag not granted: %+v", u.AlphaFeatures)
-			}
-			return u, nil
-		})
 	st.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, k *types.ApiKey) (*types.ApiKey, error) { return k, nil })
+		func(_ context.Context, k *types.ApiKey) (*types.ApiKey, error) {
+			if k.Name != "helix-org service (auto-provisioned)" {
+				t.Errorf("unexpected key name: %q", k.Name)
+			}
+			return k, nil
+		})
 
 	reg := newTestConfigs(t)
 	k := NewHelixAPIKeys(st, reg)
@@ -105,6 +97,9 @@ func TestAPIKeys_Service_MintsForOrganizationOwner(t *testing.T) {
 	}
 	if got == "" {
 		t.Fatal("expected a minted service key")
+	}
+	if len(owner.AlphaFeatures) != 1 || owner.AlphaFeatures[0] != "other-feature" {
+		t.Fatalf("owner alpha features mutated: %+v", owner.AlphaFeatures)
 	}
 	// Cached in config for next time.
 	if v, _ := reg.GetString(context.Background(), "org-test", "helix.api_key"); v != got {

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -4,12 +4,6 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 )
 
-// AlphaFeature is the alpha-feature flag that gates the embedded
-// helix-org surface. Granted per-user via:
-//
-//	UPDATE users SET alpha_features = array_append(alpha_features, 'helix-org')
-const AlphaFeature = "helix-org"
-
 // RegisterConfigSpecs declares the operational-config keys the
 // embedded helix-org honours. agent.default is the user-facing default
 // copied into newly provisioned Bot apps. The worker.* keys remain readable

--- a/api/pkg/server/mcp_backend_helix_org.go
+++ b/api/pkg/server/mcp_backend_helix_org.go
@@ -8,20 +8,19 @@ import (
 	"github.com/rs/zerolog/log"
 
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
-	"github.com/helixml/helix/api/pkg/server/helixorg"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
 // HelixOrgMCPBackend exposes the embedded helix-org MCP server through
 // the Helix MCP gateway. The gateway sits behind Helix's standard auth
 // chain, so by the time we get a request here the user has already
-// been authenticated by api_key; we only need to enforce the alpha
-// feature flag and forward to the in-process helix-org handler.
+// been authenticated by api_key; we enforce org membership and forward
+// to the in-process helix-org handler.
 //
 // The backend honours a Worker ID embedded in the suffix path:
 // `/api/v1/mcp/helix-org/workers/<id>/mcp` routes to /workers/<id>/mcp
 // in helix-org. Callers that don't specify a Worker default to
-// `w-owner` (the single alpha owner). The Spawner uses this to scope
+// `w-owner`. The Spawner uses this to scope
 // each Worker activation to its own MCP path so subscribe/publish
 // land on the activating Worker, not the owner.
 type HelixOrgMCPBackend struct {
@@ -43,18 +42,8 @@ func NewHelixOrgMCPBackend(apiServer *HelixAPIServer, orgHandlers *helixOrgHandl
 }
 
 // ServeHTTP implements MCPBackend. The MCP gateway has already
-// authenticated the request; we add the alpha-feature gate here so a
-// user without the flag can't attach this MCP to an agent and call
-// org tools, even though their api_key would otherwise satisfy the
-// gateway. Defence in depth — the picker is alpha-gated already, but
-// agents can be shared.
+// authenticated the request; this backend additionally enforces org membership.
 func (b *HelixOrgMCPBackend) ServeHTTP(w http.ResponseWriter, r *http.Request, user *types.User) {
-	if !hasAlphaFeature(user, helixorg.AlphaFeature) {
-		log.Warn().Str("user_id", user.ID).Msg("helix-org MCP: user lacks alpha feature flag")
-		http.Error(w, "forbidden: helix-org alpha not enabled for this user", http.StatusForbidden)
-		return
-	}
-
 	// Parse the org segment + worker ID from the suffix path the gateway
 	// captured. Accept forms:
 	//   {org}/workers/<id>/mcp     (preferred — explicit)
@@ -102,18 +91,4 @@ func (b *HelixOrgMCPBackend) ServeHTTP(w http.ResponseWriter, r *http.Request, u
 		Msg("helix-org MCP: forwarding to in-process handler")
 
 	b.orgHandler.ServeHTTP(w, rewritten)
-}
-
-// hasAlphaFeature reports whether the user has been granted name in
-// their AlphaFeatures slice. nil-safe.
-func hasAlphaFeature(user *types.User, name string) bool {
-	if user == nil {
-		return false
-	}
-	for _, f := range user.AlphaFeatures {
-		if strings.EqualFold(f, name) {
-			return true
-		}
-	}
-	return false
 }

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -892,10 +892,8 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	adminRouter := authRouter.MatcherFunc(matchAllRoutes).Subrouter()
 	adminRouter.Use(requireAdmin)
 
-	// helix-org: register the helix-org HTTP surface, gated per-user by
-	// the `helix-org` alpha feature. See
-	// design/2026-05-17-helix-org-saas-alpha.md. All of its routing +
-	// lifecycle wiring lives in registerHelixOrgRoutes (helix_org.go). It
+	// helix-org: register the helix-org HTTP surface. All of its routing +
+	// lifecycle wiring lives in registerHelixOrgRoutes (helix_org.go).
 	// Route registration does not depend on a deployment-wide service user.
 	if err := apiServer.registerHelixOrgRoutes(ctx, insecureRouter, authRouter); err != nil {
 		return nil, err

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -39310,7 +39310,7 @@
                     "type": "boolean"
                 },
                 "alpha_features": {
-                    "description": "AlphaFeatures lists the feature flags this user has been granted\naccess to. Server-enforced via requireFeature middleware — the\nfrontend uses it only to decide whether to render the entry\npoint. Granted per-user via SQL (no deploy).",
+                    "description": "AlphaFeatures lists feature flags granted to this user.\nGranted per-user via SQL (no deploy).",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -12074,10 +12074,8 @@ definitions:
         type: boolean
       alpha_features:
         description: |-
-          AlphaFeatures lists the feature flags this user has been granted
-          access to. Server-enforced via requireFeature middleware — the
-          frontend uses it only to decide whether to render the entry
-          point. Granted per-user via SQL (no deploy).
+          AlphaFeatures lists feature flags granted to this user.
+          Granted per-user via SQL (no deploy).
         items:
           type: string
         type: array

--- a/api/pkg/types/authz.go
+++ b/api/pkg/types/authz.go
@@ -277,10 +277,8 @@ type User struct {
 	// Updated (throttled) from auth middleware so the column isn't hammered on every request.
 	LastSeenAt *time.Time `json:"last_seen_at,omitempty"`
 
-	// AlphaFeatures lists the feature flags this user has been granted
-	// access to. Server-enforced via requireFeature middleware — the
-	// frontend uses it only to decide whether to render the entry
-	// point. Granted per-user via SQL (no deploy).
+	// AlphaFeatures lists feature flags granted to this user.
+	// Granted per-user via SQL (no deploy).
 	AlphaFeatures pq.StringArray `gorm:"type:text[];default:'{}'" json:"alpha_features"`
 }
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7562,10 +7562,8 @@ export interface TypesUser {
   /** if the ID of the user is contained in the env setting */
   admin?: boolean;
   /**
-   * AlphaFeatures lists the feature flags this user has been granted
-   * access to. Server-enforced via requireFeature middleware — the
-   * frontend uses it only to decide whether to render the entry
-   * point. Granted per-user via SQL (no deploy).
+   * AlphaFeatures lists feature flags granted to this user.
+   * Granted per-user via SQL (no deploy).
    */
   alpha_features?: string[];
   /** if the token is associated with an app */

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -10,7 +10,6 @@ import Divider from '@mui/material/Divider'
 import Typography from '@mui/material/Typography'
 
 import { TypesOrganization } from '../../api/api'
-import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
@@ -38,11 +37,9 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   onClose,
   onSubmit,
 }) => {
-  const account = useAccount()
   const api = useApi()
   const router = useRouter()
   const snackbar = useSnackbar()
-  const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
 
   const [slug, setSlug] = useState('')
   const [name, setName] = useState('')
@@ -151,7 +148,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
 
       // New org + operator picked a default agent config: persist it against
       // the real created slug (the backend may have suffixed it for uniqueness).
-      if (!org && agentDefaultsDirty && helixOrgEnabled && created && created.name) {
+      if (!org && agentDefaultsDirty && created && created.name) {
         try {
           await persistAgentDefaults(created.name)
         } catch (e) {
@@ -163,11 +160,10 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
       // backend on org create — see api/pkg/server/org_graph_seed.go. The
       // frontend no longer creates it.
 
-      // Land the operator on the freshly created org: the org chart when
-      // helix-org is enabled, otherwise projects.
+      // Land the operator on the freshly created org chart.
       if (!org && created && created.name) {
         localStorage.setItem(SELECTED_ORG_STORAGE_KEY, created.name)
-        router.navigate(orgLandingRoute(account.user), { org_id: created.name })
+        router.navigate(orgLandingRoute(), { org_id: created.name })
       }
 
       onClose()
@@ -214,9 +210,8 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
             helperText={errors.slug || "Unique identifier for the organization (no spaces allowed)"}
           />
 
-          {/* Default Agent Configuration - only when creating, and only for helix-org
-              alpha users. Optional: leave untouched to configure later. */}
-          {!org && helixOrgEnabled && (
+          {/* Default Agent Configuration - only when creating. */}
+          {!org && (
             <Box sx={{ mt: 3 }}>
               <Divider sx={{ mb: 2 }} />
               <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>

--- a/frontend/src/components/orgs/HelixOrgSidebar.tsx
+++ b/frontend/src/components/orgs/HelixOrgSidebar.tsx
@@ -8,7 +8,7 @@ import useAccount from '../../hooks/useAccount'
 import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 
 // HelixOrgSidebar is the secondary navigation column for the
-// helix-org alpha. Sits between the primary org-menu rail and the
+// helix-org surface. Sits between the primary org-menu rail and the
 // page body. Today: chart + agents + topics + assets.
 const HelixOrgSidebar: FC = () => {
   const router = useRouter()

--- a/frontend/src/components/orgs/OrgsTable.tsx
+++ b/frontend/src/components/orgs/OrgsTable.tsx
@@ -29,7 +29,6 @@ import {
 } from '../../api/api'
 
 import useRouter from '../../hooks/useRouter'
-import useAccount from '../../hooks/useAccount'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
 import { orgLandingRoute } from '../../utils/organizations'
 
@@ -146,7 +145,6 @@ const OrgCard: FC<{
   onMenuOpen: (event: React.MouseEvent<HTMLElement>, org: TypesOrganization) => void
 }> = ({ org, userID, onMenuOpen }) => {
   const router = useRouter()
-  const account = useAccount()
   const membership = computeMembershipState(org, userID)
   const isOwner = membership.kind === 'owner'
   const isNonMember = membership.kind === 'admin-view'
@@ -185,7 +183,7 @@ const OrgCard: FC<{
         }}
         onClick={() => {
           localStorage.setItem(SELECTED_ORG_STORAGE_KEY, org.name || '')
-          router.navigate(orgLandingRoute(account.user), { org_id: org.name })
+          router.navigate(orgLandingRoute(), { org_id: org.name })
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2, gap: 1 }}>
@@ -315,11 +313,9 @@ const OrgsTable: FC<{
 
       {loading ? (
         <Grid container spacing={{ xs: 2, sm: 3 }}>
-          {[0, 1, 2].map((i) => (
-            <Grid item xs={12} sm={6} lg={4} key={i}>
-              <Skeleton variant="rectangular" height={160} sx={{ borderRadius: 1 }} />
-            </Grid>
-          ))}
+          <Grid item xs={12} sm={6} lg={4}>
+            <Skeleton variant="rectangular" height={160} sx={{ borderRadius: 1 }} />
+          </Grid>
         </Grid>
       ) : data.length === 0 ? (
         <Box sx={{ textAlign: 'center', py: 8 }}>

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -281,7 +281,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     if (!firstAccessibleOrg) return
     const firstOrgSlug = firstAccessibleOrg.name
     localStorage.setItem(SELECTED_ORG_STORAGE_KEY, firstOrgSlug)
-    const useRouteName = router.name.startsWith('org_') ? router.name : orgLandingRoute(account.user)
+    const useRouteName = router.name.startsWith('org_') ? router.name : orgLandingRoute()
     const useParams = Object.assign({}, router.params, { org_id: firstOrgSlug })
     router.navigate(useRouteName, useParams)
   }, [listOrgs, account.user])
@@ -289,7 +289,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
   // Handle org select, also remember the last org user has been in
   const handleOrgSelect = (orgSlug: string) => {
     localStorage.setItem(SELECTED_ORG_STORAGE_KEY, orgSlug)
-    router.navigate(orgLandingRoute(account.user), { org_id: orgSlug })
+    router.navigate(orgLandingRoute(), { org_id: orgSlug })
     setDialogOpen(false)
   }
 
@@ -382,27 +382,22 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     postNavigateTo()
   }
 
-  const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
-
   // Navigation buttons configuration
   const navigationButtons = useMemo(() => {
     const baseButtons = [
-      // Helix Org overview. Alpha-gated: only rendered for users granted
-      // the 'helix-org' alpha_features flag. Leads the rail as the primary
-      // org-level surface.
-      ...(helixOrgEnabled ? [{
-        icon: <Network size={NAV_BUTTON_SIZE} />,
-        tooltip: "View org chart",
-        isActive: router.name.startsWith('helix_org'),
-        onClick: handleHelixOrgClick,
-        label: "Org Chart",
-      }] : []),
       {
         icon: <Kanban size={NAV_BUTTON_SIZE} />,
         tooltip: "View projects",
         isActive: isActive(['spec-tasks', 'projects', 'project']),
         onClick: handleProjectsClick,
         label: "Projects",
+      },
+      {
+        icon: <Network size={NAV_BUTTON_SIZE} />,
+        tooltip: "View org chart",
+        isActive: router.name.startsWith('helix_org'),
+        onClick: handleHelixOrgClick,
+        label: "Org Chart",
       },
       {
         icon: <Bot size={NAV_BUTTON_SIZE} />,
@@ -476,7 +471,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     }
 
     return baseButtons
-  }, [isActive, currentOrgSlug, helixOrgEnabled, router.name])
+  }, [isActive, currentOrgSlug, router.name])
 
   const isAccountSettingsActive = settingsDialog.activeDialog === 'account'
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -562,7 +562,7 @@ const routes: IApplicationRoute[] = [
   },
   render: () => <AdminRunnerLogsPage />,
 }, {
-  // helix-org alpha - Other resources (bots and topics) are
+  // Other resources (bots and topics) are
   // operated via MCP tools / API; the overview is the visual entry
   // point.
   // drawer: false - secondary context sidebar is unused; Chart/Bots/Topics

--- a/frontend/src/utils/organizations.ts
+++ b/frontend/src/utils/organizations.ts
@@ -1,14 +1,7 @@
 import { TypesOrganization, TypesOrganizationRole, TypesOrganizationMembership } from '../api/api'
 
-// True when the user has the helix-org alpha feature (the Org Chart surface).
-export function isHelixOrgEnabled(user?: { alpha_features?: string[] } | null): boolean {
-  return user?.alpha_features?.includes('helix-org') ?? false
-}
-
-// Route to land on after creating or selecting an org: the org chart when
-// helix-org is enabled, otherwise projects.
-export function orgLandingRoute(user?: { alpha_features?: string[] } | null): string {
-  return isHelixOrgEnabled(user) ? 'helix_org_chart' : 'org_projects'
+export function orgLandingRoute(): string {
+  return 'helix_org_chart'
 }
 
 /**
@@ -59,4 +52,4 @@ export function isUserMemberOfOrganization(
 ): boolean {
   // User is a member if they have any membership role
   return getUserMembership(organization, userId) !== undefined
-} 
+}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -12074,10 +12074,8 @@ definitions:
         type: boolean
       alpha_features:
         description: |-
-          AlphaFeatures lists the feature flags this user has been granted
-          access to. Server-enforced via requireFeature middleware — the
-          frontend uses it only to decide whether to render the entry
-          point. Granted per-user via SQL (no deploy).
+          AlphaFeatures lists feature flags granted to this user.
+          Granted per-user via SQL (no deploy).
         items:
           type: string
         type: array

--- a/openapi.json
+++ b/openapi.json
@@ -43877,7 +43877,7 @@
                         "type": "boolean"
                     },
                     "alpha_features": {
-                        "description": "AlphaFeatures lists the feature flags this user has been granted\naccess to. Server-enforced via requireFeature middleware — the\nfrontend uses it only to decide whether to render the entry\npoint. Granted per-user via SQL (no deploy).",
+                        "description": "AlphaFeatures lists feature flags granted to this user.\nGranted per-user via SQL (no deploy).",
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -39310,7 +39310,7 @@
                     "type": "boolean"
                 },
                 "alpha_features": {
-                    "description": "AlphaFeatures lists the feature flags this user has been granted\naccess to. Server-enforced via requireFeature middleware — the\nfrontend uses it only to decide whether to render the entry\npoint. Granted per-user via SQL (no deploy).",
+                    "description": "AlphaFeatures lists feature flags granted to this user.\nGranted per-user via SQL (no deploy).",
                     "type": "array",
                     "items": {
                         "type": "string"


### PR DESCRIPTION
## Summary

- replace the fixed three-card organization loading state with one placeholder
- make Org Chart available without the helix-org alpha feature and order the sidebar as Projects, Org Chart, Agents, Chat, Tasks, Sandbox, Settings
- remove the HTTP and MCP alpha gates while retaining organization membership authorization
- stop mutating organization owners alpha features during service-key provisioning
- regenerate OpenAPI artifacts

## Verification

- `go build ./pkg/server ./pkg/store ./pkg/types/`
- `go test ./pkg/server/helixorg -run "^TestAPIKeys_" -count=1`
- `go test ./pkg/server -run "^TestHelixOrg(ChartRouteDoesNotRequireFeature|MCPBackendDoesNotRequireFeature|SettingsRoutesDoNotRequireFeature|SettingsRoutesDoNotBootstrap)$" -count=1`
- `cd frontend && yarn build`
- standalone Playwright with a non-admin account and empty alpha features confirmed the requested sidebar order
- standalone Playwright confirmed one loading placeholder transitions to one organization card

## Not tested

- full live Org Chart against the patched API because the active localhost API belongs to another worktree