### PR TITLE
feat(agents): unify org chart and standard agent editing

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -1043,6 +1043,9 @@ func (s *HelixAPIServer) getAgent(_ http.ResponseWriter, r *http.Request) (*type
 	if err != nil {
 		return nil, system.NewHTTPError403(err.Error())
 	}
+	if httpErr := s.markHelixOrgAgents(r.Context(), app.OrganizationID, []*types.Agent{app}); httpErr != nil {
+		return nil, httpErr
+	}
 
 	return app, nil
 }
@@ -1173,6 +1176,9 @@ func (s *HelixAPIServer) updateAgent(_ http.ResponseWriter, r *http.Request) (*t
 	err = s.ensureTriggerConfigurations(r.Context(), updated)
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
+	}
+	if httpErr := s.markHelixOrgAgents(r.Context(), updated.OrganizationID, []*types.Agent{updated}); httpErr != nil {
+		return nil, httpErr
 	}
 
 	return updated, nil

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -105,6 +105,56 @@ func TestUpdateAppRejectsMismatchedBodyID(t *testing.T) {
 	require.Contains(t, httpErr.Message, "does not match URL")
 }
 
+func TestUpdateAppResponseMarksLinkedOrgAgent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	orgStore := orgmemory.New()
+
+	node, err := orgchart.NewNode("b-linked", "# Linked", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.NoError(t, orgStore.Nodes.Create(context.Background(), node.WithAgentID("app-linked")))
+
+	existing := &types.App{
+		ID:             "app-linked",
+		Owner:          "user-test",
+		OrganizationID: "org-test",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Name:       "Linked",
+			Assistants: []types.AssistantConfig{{Name: "Linked"}},
+		}},
+	}
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID:         existing.Owner,
+		OrganizationID: existing.OrganizationID,
+		Role:           types.OrganizationRoleMember,
+	}, nil)
+	helixStore.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, updated *types.App) (*types.App, error) {
+		return updated, nil
+	})
+	helixStore.EXPECT().ListKnowledge(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListTriggerConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	server := &HelixAPIServer{
+		Store: helixStore,
+		helixOrg: &helixOrgHandlers{
+			store: orgStore,
+		},
+	}
+	body, err := json.Marshal(existing)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/apps/"+existing.ID, bytes.NewReader(body))
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
+
+	updated, httpErr := server.updateAgent(nil, req)
+
+	require.Nil(t, httpErr)
+	require.NotNil(t, updated)
+	assert.True(t, updated.IsHelixOrgAgent)
+}
+
 func Test_markHelixOrgAgents_UsesNodesRepository(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	orgStore := orgmemory.New()

--- a/frontend/src/components/app/AgentInfoPanel.tsx
+++ b/frontend/src/components/app/AgentInfoPanel.tsx
@@ -1,0 +1,103 @@
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import Link from '@mui/material/Link'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+import { BotDTO, useHelixOrgBot } from '../../services/helixOrgService'
+import useAccount from '../../hooks/useAccount'
+import { CODE_AGENT_RUNTIME_DISPLAY_NAMES, CodeAgentRuntime, getModelDisplayName } from '../../contexts/apps'
+import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAppFlatState } from '../../types'
+import { formatDate } from '../../utils/format'
+
+const timestamp = (value?: string | Date) => {
+  if (!value) return '-'
+  return formatDate(value instanceof Date ? value.toISOString() : value) || '-'
+}
+
+const AgentInfoPanel: FC<{
+  app: IApp
+  settings: IAppFlatState
+  orgAgent?: BotDTO
+}> = ({ app, settings, orgAgent }) => {
+  const account = useAccount()
+  const { data: detail } = useHelixOrgBot(orgAgent?.id, { enabled: !!orgAgent?.id })
+  const node = detail?.bot ?? orgAgent
+  const runtime = node?.code_agent_runtime ?? node?.agent_runtime ?? settings.code_agent_runtime
+  const runtimeName = runtime
+    ? CODE_AGENT_RUNTIME_DISPLAY_NAMES[runtime as CodeAgentRuntime] ?? runtime
+    : settings.default_agent_type === AGENT_TYPE_ZED_EXTERNAL ? 'Zed Agent' : 'Helix Agent'
+  const model = node?.model ?? node?.agent_model ?? settings.model ?? settings.generation_model ?? settings.reasoning_model
+  const projectID = detail?.project_id
+  const status = node?.agent_status
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="caption" color="text.secondary">Agent ID</Typography>
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+              {node?.id ?? app.id}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">Created</Typography>
+            <Typography variant="body2">{timestamp(node?.created_at ?? app.created)}</Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">Updated</Typography>
+            <Typography variant="body2">{timestamp(node?.updated_at ?? app.updated)}</Typography>
+          </Box>
+          {orgAgent && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">Status</Typography>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                {status && (
+                  <Box
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor: status === 'running' ? 'success.main' : 'text.disabled',
+                    }}
+                  />
+                )}
+                <Typography variant="body2">
+                  {status === 'running' ? 'Running' : status ? 'Stopped' : '-'}
+                </Typography>
+              </Stack>
+            </Box>
+          )}
+          {orgAgent && projectID && (
+            <Box>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Project</Typography>
+              <Link
+                component="button"
+                variant="body2"
+                underline="hover"
+                onClick={() => account.orgNavigate('project-specs', { id: projectID })}
+                sx={{ fontFamily: 'monospace', textAlign: 'left', wordBreak: 'break-all' }}
+              >
+                {projectID}
+              </Link>
+            </Box>
+          )}
+          <Divider />
+          <Box>
+            <Typography variant="caption" color="text.secondary">Runtime</Typography>
+            <Typography variant="body2">{runtimeName}</Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">Model</Typography>
+            <Typography variant="body2" title={model}>{model ? getModelDisplayName(model) : '-'}</Typography>
+          </Box>
+        </Stack>
+      </Paper>
+    </Box>
+  )
+}
+
+export default AgentInfoPanel

--- a/frontend/src/components/app/AgentInfoPanel.tsx
+++ b/frontend/src/components/app/AgentInfoPanel.tsx
@@ -1,15 +1,11 @@
 import { FC } from 'react'
 import Box from '@mui/material/Box'
-import Divider from '@mui/material/Divider'
-import Link from '@mui/material/Link'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 
-import { BotDTO, useHelixOrgBot } from '../../services/helixOrgService'
-import useAccount from '../../hooks/useAccount'
-import { CODE_AGENT_RUNTIME_DISPLAY_NAMES, CodeAgentRuntime, getModelDisplayName } from '../../contexts/apps'
-import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAppFlatState } from '../../types'
+import { BotDTO } from '../../services/helixOrgService'
+import { IApp } from '../../types'
 import { formatDate } from '../../utils/format'
 
 const timestamp = (value?: string | Date) => {
@@ -19,19 +15,9 @@ const timestamp = (value?: string | Date) => {
 
 const AgentInfoPanel: FC<{
   app: IApp
-  settings: IAppFlatState
   orgAgent?: BotDTO
-}> = ({ app, settings, orgAgent }) => {
-  const account = useAccount()
-  const { data: detail } = useHelixOrgBot(orgAgent?.id, { enabled: !!orgAgent?.id })
-  const node = detail?.bot ?? orgAgent
-  const runtime = node?.code_agent_runtime ?? node?.agent_runtime ?? settings.code_agent_runtime
-  const runtimeName = runtime
-    ? CODE_AGENT_RUNTIME_DISPLAY_NAMES[runtime as CodeAgentRuntime] ?? runtime
-    : settings.default_agent_type === AGENT_TYPE_ZED_EXTERNAL ? 'Zed Agent' : 'Helix Agent'
-  const model = node?.model ?? node?.agent_model ?? settings.model ?? settings.generation_model ?? settings.reasoning_model
-  const projectID = detail?.project_id
-  const status = node?.agent_status
+}> = ({ app, orgAgent }) => {
+  const status = orgAgent?.agent_status
 
   return (
     <Box sx={{ p: 2 }}>
@@ -40,16 +26,16 @@ const AgentInfoPanel: FC<{
           <Box>
             <Typography variant="caption" color="text.secondary">Agent ID</Typography>
             <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-              {node?.id ?? app.id}
+              {orgAgent?.id ?? app.id}
             </Typography>
           </Box>
           <Box>
             <Typography variant="caption" color="text.secondary">Created</Typography>
-            <Typography variant="body2">{timestamp(node?.created_at ?? app.created)}</Typography>
+            <Typography variant="body2">{timestamp(orgAgent?.created_at ?? app.created)}</Typography>
           </Box>
           <Box>
             <Typography variant="caption" color="text.secondary">Updated</Typography>
-            <Typography variant="body2">{timestamp(node?.updated_at ?? app.updated)}</Typography>
+            <Typography variant="body2">{timestamp(orgAgent?.updated_at ?? app.updated)}</Typography>
           </Box>
           {orgAgent && (
             <Box>
@@ -71,29 +57,6 @@ const AgentInfoPanel: FC<{
               </Stack>
             </Box>
           )}
-          {orgAgent && projectID && (
-            <Box>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Project</Typography>
-              <Link
-                component="button"
-                variant="body2"
-                underline="hover"
-                onClick={() => account.orgNavigate('project-specs', { id: projectID })}
-                sx={{ fontFamily: 'monospace', textAlign: 'left', wordBreak: 'break-all' }}
-              >
-                {projectID}
-              </Link>
-            </Box>
-          )}
-          <Divider />
-          <Box>
-            <Typography variant="caption" color="text.secondary">Runtime</Typography>
-            <Typography variant="body2">{runtimeName}</Typography>
-          </Box>
-          <Box>
-            <Typography variant="caption" color="text.secondary">Model</Typography>
-            <Typography variant="body2" title={model}>{model ? getModelDisplayName(model) : '-'}</Typography>
-          </Box>
         </Stack>
       </Paper>
     </Box>

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -20,7 +20,6 @@ import Alert from '@mui/material/Alert'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import Menu from '@mui/material/Menu'
-import { styled } from '@mui/material/styles'
 
 import { useQuery } from '@tanstack/react-query'
 
@@ -53,6 +52,7 @@ import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
 import { useCodexSubscriptions } from '../../services/codexSubscriptionsService'
 import useRouter from '../../hooks/useRouter'
 import { useGetOrgByName } from '../../services/orgService'
+import MonacoEditor from '../widgets/MonacoEditor'
 
 // Recommended models configuration
 const RECOMMENDED_MODELS = {
@@ -176,35 +176,6 @@ const BarsIcon = ({ effort }: { effort: string }) => {
     </Box>
   )
 }
-
-// Add styled resizable textarea component
-const ResizableTextarea = styled('textarea')(({ theme }) => ({
-  width: '100%',
-  minHeight: '200px', // Increased from 120px to 200px
-  padding: '16.5px 14px',
-  fontSize: '1rem',
-  fontFamily: 'inherit',
-  lineHeight: '1.4375em',
-  border: `1px solid ${theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'}`,
-  borderRadius: '4px',
-  backgroundColor: 'transparent',
-  color: theme.palette.text.primary,
-  resize: 'vertical',
-  outline: 'none',
-  transition: theme.transitions.create(['border-color', 'box-shadow']),
-  '&:focus': {
-    borderColor: theme.palette.primary.main,
-    boxShadow: `0 0 0 2px ${theme.palette.primary.main}20`,
-  },
-  '&:disabled': {
-    backgroundColor: theme.palette.action.disabledBackground,
-    color: theme.palette.action.disabled,
-    cursor: 'not-allowed',
-  },
-  '&::placeholder': {
-    color: theme.palette.text.disabled,
-  },
-}));
 
 const AppSettings: FC<AppSettingsProps> = ({
   id,
@@ -620,21 +591,30 @@ const AppSettings: FC<AppSettingsProps> = ({
 
         </Typography>
         <Box sx={{ mb: 3, mt: 1 }}>
-          <ResizableTextarea
+          <MonacoEditor
             value={system_prompt}
-            onChange={(e) => {
-              setSystemPrompt(e.target.value)
-              debouncedUpdate('system_prompt', e.target.value)
+            onChange={(value: string) => {
+              setSystemPrompt(value)
+              debouncedUpdate('system_prompt', value)
             }}
-            disabled={readOnly}
-            placeholder="What does this agent do? How does it behave? What should it avoid doing?"
-            style={{
-              minHeight: '200px',
-              resize: 'vertical'
+            onSave={() => {
+              debouncedUpdate.cancel()
+              void onUpdate({ system_prompt })
+            }}
+            language="markdown"
+            readOnly={readOnly}
+            minHeight={240}
+            maxHeight={600}
+            autoHeight
+            theme="helix-dark"
+            options={{
+              overviewRulerLanes: 0,
+              overviewRulerBorder: false,
+              hideCursorInOverviewRuler: true,
             }}
           />
           <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-            What does this agent do? How does it behave? What should it avoid doing?
+            Markdown supported. Cmd/Ctrl+S saves immediately.
           </Typography>
         </Box>
 

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -14,11 +14,14 @@ import Typography from '@mui/material/Typography'
 import Stack from '@mui/material/Stack'
 import Link from '@mui/material/Link'
 import Button from '@mui/material/Button'
+import Collapse from '@mui/material/Collapse'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import Alert from '@mui/material/Alert'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Menu from '@mui/material/Menu'
 
 import { useQuery } from '@tanstack/react-query'
@@ -204,6 +207,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   }, [showAdvanced])
 
   // State for form fields
+  const [name, setName] = useState(app.name || '')
   const [system_prompt, setSystemPrompt] = useState(app.system_prompt || '')
   const [global, setGlobal] = useState(app.global || false)
   const [model, setModel] = useState(app.model || '')
@@ -338,6 +342,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   useEffect(() => {
     // Only initialize values if not already initialized
     if (!isInitialized.current) {
+      setName(app.name || '')
       setSystemPrompt(app.system_prompt || DEFAULT_SYSTEM_PROMPT)
       setGlobal(app.global || false)
       setModel(app.model || '')
@@ -583,6 +588,21 @@ const AppSettings: FC<AppSettingsProps> = ({
         <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
           Configuration
         </Typography>
+        <TextField
+          id="app-name"
+          name="app-name"
+          label="Agent name"
+          value={name}
+          error={showErrors && !name}
+          helperText="Use a name that makes this agent easy to identify."
+          disabled={readOnly}
+          onChange={(event) => setName(event.target.value)}
+          onBlur={() => {
+            if (name !== app.name) void onUpdate({ name })
+          }}
+          fullWidth
+          sx={{ mb: 3 }}
+        />
         <Stack direction="row" alignItems="center">
           <Typography gutterBottom>System Instructions</Typography>
           <ResetLink field="system_prompt" value={system_prompt} onClick={() => handleReset('system_prompt')} />
@@ -1149,7 +1169,19 @@ const AppSettings: FC<AppSettingsProps> = ({
         {/* Multi-Turn Agent Configuration */}
         {default_agent_type === AGENT_TYPE_HELIX_AGENT && (
           <Box sx={{ mt: 2 }}>
-            <Typography variant="subtitle1" sx={{ mb: 2 }}>Multi-Turn Agent Configuration</Typography>
+            <Button
+              variant="text"
+              onClick={() => setShowAdvanced((value) => !value)}
+              endIcon={showAdvanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              aria-expanded={showAdvanced}
+              aria-controls="advanced-model-settings"
+              sx={{ px: 0, textTransform: 'none' }}
+            >
+              Advanced model settings
+            </Button>
+            <Collapse in={showAdvanced}>
+              <Box id="advanced-model-settings" sx={{ mt: 2 }}>
+                <Typography variant="subtitle1" sx={{ mb: 2 }}>Multi-Turn Agent Configuration</Typography>
 
             <Box sx={{ mb: 3 }}>
               <Typography gutterBottom>Main Reasoning Model (tool calling)</Typography>
@@ -1456,6 +1488,8 @@ const AppSettings: FC<AppSettingsProps> = ({
                 inputProps={{ min: 1 }}
               />
             </Box>
+              </Box>
+            </Collapse>
           </Box>
         )}
       </Box>

--- a/frontend/src/components/app/AppSidebar.tsx
+++ b/frontend/src/components/app/AppSidebar.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react'
 
 import {
   Settings,
-  Palette,
   Webhook,
   LibraryBig,
   Lightbulb,
@@ -18,12 +17,13 @@ import {
 
 import useRouter from '../../hooks/useRouter'
 import useApp from '../../hooks/useApp'
+import { isHelixOrgChartAgent } from '../../utils/apps'
 import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 
 const AppSidebar: FC = () => {
   const router = useRouter()
   const { tab, app_id } = router.params
-  const currentTab = tab || 'appearance'
+  const currentTab = tab === 'appearance' ? 'settings' : tab || 'settings'
   
   // Get app data and user access information
   const appTools = useApp(app_id)
@@ -38,15 +38,8 @@ const AppSidebar: FC = () => {
       title: 'Agent Configuration',
       items: [
         {
-          id: 'appearance',
-          label: 'Appearance',
-          icon: <Palette size={20} /> ,
-          isActive: currentTab === 'appearance',
-          onClick: () => handleNavigationClick('appearance')
-        },
-        {
           id: 'settings',
-          label: 'Settings',
+          label: 'Instructions & Runtime',
           icon: <Settings size={20} />,
           isActive: currentTab === 'settings',
           onClick: () => handleNavigationClick('settings')
@@ -72,7 +65,7 @@ const AppSidebar: FC = () => {
         },
         {
           id: 'skills',
-          label: 'MCPs & APIs',
+          label: app && isHelixOrgChartAgent(app) ? 'Org Tools & APIs' : 'Tools',
           icon: <Lightbulb size={20} />,
           isActive: currentTab === 'skills',
           onClick: () => handleNavigationClick('skills')
@@ -159,4 +152,4 @@ const AppSidebar: FC = () => {
   )
 }
 
-export default AppSidebar 
+export default AppSidebar

--- a/frontend/src/components/app/AppearanceSettings.tsx
+++ b/frontend/src/components/app/AppearanceSettings.tsx
@@ -7,15 +7,12 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
 import Avatar from '@mui/material/Avatar'
 import Grid from '@mui/material/Grid'
-import Card from '@mui/material/Card'
-import CardContent from '@mui/material/CardContent'
 import { IAppFlatState } from '../../types'
 import { useUpdateAppAvatar, useDeleteAppAvatar } from '../../services/appService'
 import { getFlatStateAvatarUrl } from '../../utils/app'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import useApps from '../../hooks/useApps'
-import useLightTheme from '../../hooks/useLightTheme'
 
 interface AppearanceSettingsProps {
   app: IAppFlatState
@@ -29,11 +26,8 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
   app,
   onUpdate,
   readOnly = false,
-  showErrors = true,
   id,
 }) => {
-  const [name, setName] = useState(app.name || '')
-  const [description, setDescription] = useState(app.description || '')
   const [conversationStarters, setConversationStarters] = useState<string[]>(app.conversation_starters || [])
   const [newStarter, setNewStarter] = useState('')
   const [avatarUpdateKey, setAvatarUpdateKey] = useState(0)
@@ -43,28 +37,6 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
   const deleteAvatarMutation = useDeleteAppAvatar(id)
 
   const apps = useApps()
-  const lightTheme = useLightTheme()
-
-  const handleBlur = (field: 'name' | 'description') => {
-    const currentValue = {
-      name,
-      description,
-    }[field]
-    
-    const originalValue = (app[field] || '') as string
-    
-    if (currentValue !== originalValue) {
-      const updatedApp: IAppFlatState = {
-        ...app,
-        name,
-        description,
-        conversation_starters: conversationStarters
-      }
-      
-      onUpdate(updatedApp)
-    }
-  }
-
   const handleConversationStarterBlur = () => {
     if (newStarter.trim()) {
       const updatedStarters = [...conversationStarters, newStarter.trim()]
@@ -159,49 +131,8 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
 
   return (
     <Box sx={{ mt: 2, mr: 2 }}>
-      {/* Basic Information Card */}
-      {/* <Card sx={{ mb: 3, backgroundColor: lightTheme.panelColor }}>
-        <CardContent> */}
           <Grid container spacing={3}>
-            {/* Left column - Name and Description */}
-            <Grid item xs={12} md={6}>
-              <Box sx={{ mb: 3 }}>
-                <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
-                  Agent name
-                </Typography>
-                <TextField
-                  sx={{ mb: 2 }}
-                  id="app-name"
-                  name="app-name"
-                  error={showErrors && !name}
-                  value={name}
-                  disabled={readOnly}
-                  onChange={(e) => setName(e.target.value)}
-                  onBlur={() => handleBlur('name')}
-                  fullWidth              
-                  helperText="Name your app"
-                />
-                <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
-                  Description
-                </Typography>
-                <TextField
-                  sx={{ mb: 2 }}
-                  id="app-description"
-                  name="app-description"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  onBlur={() => handleBlur('description')}
-                  disabled={readOnly}
-                  fullWidth
-                  rows={2}
-                  label="Description"
-                  helperText="Enter a short description of what this agent does, e.g. 'Tax filing assistant'"
-                />
-              </Box>
-            </Grid>
-
-            {/* Right column - Avatar */}
-            <Grid item xs={12} md={6}>
+            <Grid item xs={12}>
               <Box
                 sx={{
                   display: 'flex',
@@ -224,7 +155,6 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
                 >              
                   <Avatar
                     src={`${getFlatStateAvatarUrl(app, id)}${getFlatStateAvatarUrl(app, id).includes('?') ? '&' : '?'}t=${avatarUpdateKey}`}
-                    // src={`/api/v1/agents/${id}/avatar?t=${avatarUpdateKey}`}
                     sx={{
                       width: 200,
                       height: 200,
@@ -278,12 +208,7 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
               </Box>
             </Grid>
           </Grid>
-        {/* </CardContent>
-      </Card> */}
 
-      {/* Conversation Starters Card */}
-      {/* <Card sx={{ backgroundColor: lightTheme.panelColor, boxShadow: 'none' }}>
-        <CardContent> */}
           <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
             Conversation Starters
           </Typography>
@@ -340,10 +265,8 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
               </IconButton>
             </Box>
           </Box>
-        {/* </CardContent>
-      </Card> */}
     </Box>
   )
 }
 
-export default AppearanceSettings 
+export default AppearanceSettings

--- a/frontend/src/components/app/OrgAgentSettings.tsx
+++ b/frontend/src/components/app/OrgAgentSettings.tsx
@@ -1,0 +1,264 @@
+import { FC, Key, useState } from 'react'
+import Autocomplete from '@mui/material/Autocomplete'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Chip from '@mui/material/Chip'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import CheckBoxIcon from '@mui/icons-material/CheckBox'
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+
+import ToolPickerDialog from '../helix-org/ToolPickerDialog'
+import useSnackbar from '../../hooks/useSnackbar'
+import { useListProjects } from '../../services/projectService'
+import {
+  ToolDTO,
+  useHelixOrgBot,
+  useListBotSubscriptions,
+  useListHelixOrgBots,
+  useListHelixOrgTopics,
+  useListHelixOrgTools,
+  useSubscribeBot,
+  useUnsubscribeBot,
+  useUpdateBot,
+} from '../../services/helixOrgService'
+
+const OrgAgentSettings: FC<{
+  agentID: string
+  section: 'runtime' | 'tools' | 'access' | 'subscriptions'
+  readOnly: boolean
+}> = ({ agentID, section, readOnly }) => {
+  const snackbar = useSnackbar()
+  const { data: agents = [] } = useListHelixOrgBots()
+  const linkedAgent = agents.find((agent) => (agent.agent_id ?? agent.agent_app_id) === agentID)
+  const { data: detail } = useHelixOrgBot(linkedAgent?.id, { enabled: !!linkedAgent?.id })
+  const updateAgent = useUpdateBot()
+  const { data: projects = [] } = useListProjects(linkedAgent?.organization_id, { enabled: section === 'access' && !!linkedAgent?.organization_id })
+  const { data: catalogue = [] } = useListHelixOrgTools({ enabled: section === 'tools' && !!linkedAgent })
+  const { data: topicsData, isLoading: topicsLoading } = useListHelixOrgTopics({ enabled: section === 'subscriptions' && !!linkedAgent })
+  const { data: subscriptionsData, isLoading: subscriptionsLoading } = useListBotSubscriptions(linkedAgent?.id, { enabled: section === 'subscriptions' && !!linkedAgent })
+  const subscribe = useSubscribeBot(linkedAgent?.id)
+  const unsubscribe = useUnsubscribeBot(linkedAgent?.id)
+  const [editingTools, setEditingTools] = useState(false)
+
+  const agent = detail?.bot ?? linkedAgent
+  const projectID = detail?.project_id
+  const projectIDs = Array.from(new Set([...(agent?.project_ids ?? []), ...(projectID ? [projectID] : [])]))
+  const knownTools = new Set(catalogue.map((tool) => tool.name))
+  const toolOptions: ToolDTO[] = [
+    ...catalogue,
+    ...(agent?.tools ?? [])
+      .filter((name) => !knownTools.has(name))
+      .map((name) => ({ name, description: '(not in current catalogue)' })),
+  ]
+
+  if (!agent?.id) return null
+
+  const update = async (patch: { tools?: string[]; project_ids?: string[]; preserve_context?: boolean }) => {
+    try {
+      await updateAgent.mutateAsync({ id: agent.id ?? '', ...patch })
+      snackbar.success('Org agent updated')
+    } catch (error: any) {
+      snackbar.error(error?.response?.data?.error ?? error?.message ?? 'update failed')
+    }
+  }
+
+  if (section === 'runtime') {
+    return (
+      <Paper variant="outlined" sx={{ p: 2, m: 3, mb: 0 }}>
+        <FormControlLabel
+          control={(
+            <Switch
+              checked={agent.preserve_context ?? false}
+              onChange={(_event, checked) => void update({ preserve_context: checked })}
+              disabled={readOnly || updateAgent.isPending}
+            />
+          )}
+          label="Preserve context across triggers"
+        />
+        <Typography variant="body2" color="text.secondary">
+          Keep this org agent's conversation context between triggered runs.
+        </Typography>
+      </Paper>
+    )
+  }
+
+  if (section === 'tools') {
+    const tools = agent.tools ?? []
+    return (
+      <Paper variant="outlined" sx={{ p: 2, m: 3, mb: 0 }}>
+        <Stack spacing={1.5}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+            <Box>
+              <Typography variant="subtitle1">Org tools</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Helix organization capabilities available to this org agent.
+              </Typography>
+            </Box>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<EditOutlinedIcon />}
+              onClick={() => setEditingTools(true)}
+              disabled={readOnly || updateAgent.isPending}
+            >
+              Edit tools
+            </Button>
+          </Stack>
+          <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+            {[...tools].sort().map((tool) => (
+              <Chip key={tool} label={tool} size="small" sx={{ fontFamily: 'monospace' }} />
+            ))}
+            {tools.length === 0 && (
+              <Typography variant="body2" color="text.secondary">No org tools selected.</Typography>
+            )}
+          </Stack>
+        </Stack>
+        <ToolPickerDialog
+          open={editingTools}
+          tools={toolOptions}
+          selectedTools={tools}
+          onClose={() => setEditingTools(false)}
+          onApply={(selectedTools) => {
+            setEditingTools(false)
+            void update({ tools: selectedTools })
+          }}
+        />
+      </Paper>
+    )
+  }
+
+  if (section === 'subscriptions') {
+    const topics = topicsData?.topics ?? []
+    const subscribedIDs = new Set((subscriptionsData?.subscriptions ?? []).map((subscription) => subscription.topic_id))
+    const subscribedTopics = topics.filter((topic) => subscribedIDs.has(topic.id))
+    const updating = subscribe.isPending || unsubscribe.isPending
+
+    return (
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h6" sx={{ mb: 0.5 }}>Topic subscriptions</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Topics that trigger this org agent.
+        </Typography>
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          disabled={readOnly || updating}
+          loading={topicsLoading || subscriptionsLoading}
+          options={topics}
+          value={subscribedTopics}
+          onChange={async (_event, value) => {
+            const nextIDs = new Set(value.map((topic) => topic.id))
+            const toAdd = value.filter((topic) => !subscribedIDs.has(topic.id))
+            const toRemove = (subscriptionsData?.subscriptions ?? []).filter((subscription) => !nextIDs.has(subscription.topic_id))
+            try {
+              for (const topic of toAdd) await subscribe.mutateAsync(topic.id)
+              for (const subscription of toRemove) await unsubscribe.mutateAsync(subscription.topic_id)
+              if (toAdd.length || toRemove.length) snackbar.success('Topic subscriptions updated')
+            } catch (error: any) {
+              snackbar.error(error?.response?.data?.error ?? error?.message ?? 'subscription update failed')
+            }
+          }}
+          getOptionLabel={(topic) => topic.id}
+          isOptionEqualToValue={(a, b) => a.id === b.id}
+          renderOption={(props, option, { selected }) => {
+            const { key, ...liProps } = props as typeof props & { key?: Key }
+            return (
+              <li key={key ?? option.id} {...liProps}>
+                <Checkbox
+                  icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                  checkedIcon={<CheckBoxIcon fontSize="small" />}
+                  sx={{ mr: 1 }}
+                  checked={selected}
+                />
+                <Box>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{option.id}</Typography>
+                  {option.description && (
+                    <Typography variant="caption" color="text.secondary">{option.description}</Typography>
+                  )}
+                </Box>
+              </li>
+            )
+          }}
+          renderTags={(value, getTagProps) => value.map((option, index) => {
+            const { key, ...tagProps } = getTagProps({ index })
+            return (
+              <Chip
+                key={key ?? option.id}
+                {...tagProps}
+                label={option.id}
+                size="small"
+                sx={{ fontFamily: 'monospace' }}
+              />
+            )
+          })}
+          renderInput={(params) => <TextField {...params} label="Topics" placeholder="Select topics" />}
+        />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Typography variant="h6" sx={{ mb: 0.5 }}>Project access</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Projects this org agent can use through its organization tools.
+      </Typography>
+      <Autocomplete
+        multiple
+        disableCloseOnSelect
+        disabled={readOnly || updateAgent.isPending}
+        options={projects}
+        value={projects.filter((project) => !!project.id && projectIDs.includes(project.id))}
+        onChange={(_event, value) => {
+          const selected = value.map((project) => project.id).filter((id): id is string => !!id)
+          void update({ project_ids: Array.from(new Set([...(projectID ? [projectID] : []), ...selected])) })
+        }}
+        getOptionDisabled={(project) => project.id === projectID}
+        getOptionLabel={(project) => project.name || project.id || 'Unnamed project'}
+        isOptionEqualToValue={(a, b) => a.id === b.id}
+        renderOption={(props, option, { selected }) => {
+          const { key, ...liProps } = props as typeof props & { key?: Key }
+          return (
+            <li key={key ?? option.id} {...liProps}>
+              <Checkbox
+                icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                checkedIcon={<CheckBoxIcon fontSize="small" />}
+                sx={{ mr: 1 }}
+                checked={selected}
+              />
+              <Box>
+                <Typography variant="body2">{option.name || option.id}</Typography>
+                {option.id === projectID && (
+                  <Typography variant="caption" color="text.secondary">Own project</Typography>
+                )}
+              </Box>
+            </li>
+          )
+        }}
+        renderTags={(value, getTagProps) => value.map((option, index) => {
+          const { key, onDelete, ...tagProps } = getTagProps({ index })
+          const ownProject = option.id === projectID
+          return (
+            <Chip
+              key={key ?? option.id}
+              {...tagProps}
+              onDelete={ownProject ? undefined : onDelete}
+              label={`${option.name || option.id}${ownProject ? ' (own)' : ''}`}
+              size="small"
+            />
+          )
+        })}
+        renderInput={(params) => <TextField {...params} placeholder="Select projects" />}
+      />
+    </Box>
+  )
+}
+
+export default OrgAgentSettings

--- a/frontend/src/components/apps/AppsTable.tsx
+++ b/frontend/src/components/apps/AppsTable.tsx
@@ -29,7 +29,8 @@ import {
 } from '../../api/api'
 
 import {  
-  getAppName,  
+  getAppName,
+  isHelixOrgChartAgent,
 } from '../../utils/apps'
 
 import {
@@ -238,7 +239,7 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
             </Cell>
             <Cell grow>
               <Box>
-                <Typography variant="body1">                
+                <Typography variant="body1" component="div" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <a
                     style={{
                       textDecoration: 'none',
@@ -249,11 +250,14 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
                     onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
                       e.preventDefault()
                       e.stopPropagation()
-                      account.orgNavigate('new', { app_id: app.id, resource_type: 'apps' })
+                      onEdit(app)
                     }}
                   >
                     { getAppName(app) }
                   </a>
+                  {isHelixOrgChartAgent(app) && (
+                    <Chip label="Org Chart" size="small" color="primary" variant="outlined" />
+                  )}
                 </Typography>
                 {description && (
                   <Typography
@@ -436,7 +440,7 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
       }, 
       {
         name: 'skills',
-        title: 'MCPs & APIs',
+        title: 'Tools',
       },
       {
         name: 'triggers',

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -212,8 +212,9 @@ const HelixOrgChatPanel: FC = () => {
 
   const handleOpenSettings = () => {
     closeMenu()
-    if (!orgId || !selectedBotId) return
-    router.navigate('helix_org_bot_detail', { org_id: orgId, bot_id: selectedBotId })
+    const agentID = botDetail?.agent_id ?? botDetail?.agent_app_id
+    if (!orgId || !agentID) return
+    router.navigate('org_agent', { org_id: orgId, app_id: agentID })
   }
 
   // Selecting in the dropdown also broadcasts so other surfaces stay in sync.

--- a/frontend/src/components/helix-org/HelixOrgTopNav.tsx
+++ b/frontend/src/components/helix-org/HelixOrgTopNav.tsx
@@ -32,9 +32,9 @@ const ITEMS: NavItem[] = [
   {
     id: 'agents',
     label: 'Agents',
-    route: 'helix_org_bots',
+    route: 'org_agents',
     icon: <Bot size={16} />,
-    isActive: (n) => n === 'helix_org_bots' || n === 'helix_org_bot_detail' || n === 'helix_org_human_detail',
+    isActive: (n) => n === 'org_agents' || n === 'org_agent',
   },
   {
     id: 'topics',

--- a/frontend/src/components/system/Sidebar.tsx
+++ b/frontend/src/components/system/Sidebar.tsx
@@ -25,6 +25,7 @@ import useApp from '../../hooks/useApp'
 import { useCreateFilestoreFolder, useUploadFilestoreFiles, useFilestoreConfig } from '../../services/filestoreService'
 import DarkDialog from '../dialog/DarkDialog'
 import useSnackbar from '../../hooks/useSnackbar'
+import { isHelixOrgChartAgent } from '../../utils/apps'
 
 import SlideMenuContainer from './SlideMenuContainer'
 import SidebarContextHeader from './SidebarContextHeader'
@@ -262,7 +263,9 @@ const SidebarContentInner: React.FC<{
           }}
         >
           {
-            showTopLinks && (router.name === 'org_chat' || router.name === 'org_session' || router.name === 'org_qa-results' || router.name === 'org_agent' || router.name === 'org_new') && (
+            showTopLinks &&
+            (router.name !== 'org_agent' || (!!appTools.app && !isHelixOrgChartAgent(appTools.app))) &&
+            (router.name === 'org_chat' || router.name === 'org_session' || router.name === 'org_qa-results' || router.name === 'org_agent' || router.name === 'org_new') && (
               <List disablePadding>
 
                 {/* New resource creation button */}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -339,7 +339,6 @@ const App: FC = () => {
                         <Grid item xs={12} md={4}>
                           <AgentInfoPanel
                             app={appTools.app}
-                            settings={appTools.flatApp}
                             orgAgent={linkedOrgAgent}
                           />
                         </Grid>

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,7 +1,11 @@
 import React, { FC, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
+import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined'
 
 import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/material/styles'
@@ -9,6 +13,7 @@ import { useTheme } from '@mui/material/styles'
 
 import APIKeysSection from '../components/app/APIKeysSection'
 import AppSettings from '../components/app/AppSettings'
+import AgentInfoPanel from '../components/app/AgentInfoPanel'
 import AppearanceSettings from '../components/app/AppearanceSettings'
 import AccessManagement from '../components/app/AccessManagement'
 import CodeExamples from '../components/app/CodeExamples'
@@ -32,8 +37,12 @@ import EvaluationTab from '../components/app/EvaluationTab'
 import IdeIntegrationSection from '../components/app/IdeIntegrationSection'
 import useLightTheme from '../hooks/useLightTheme'
 import Skills from '../components/app/Skills'
+import OrgAgentSettings from '../components/app/OrgAgentSettings'
 import MemoriesManagement from '../components/app/MemoriesManagement'
+import HelixOrgTopNav from '../components/helix-org/HelixOrgTopNav'
+import { useActivateBot, useListHelixOrgBots } from '../services/helixOrgService'
 import { AGENT_TYPE_ZED_EXTERNAL } from '../types'
+import { isHelixOrgChartAgent } from '../utils/apps'
 
 const App: FC = () => {
   const account = useAccount()  
@@ -41,11 +50,15 @@ const App: FC = () => {
   const snackbar = useSnackbar()
   const themeConfig = useThemeConfig()
   const theme = useTheme()
-  const {
-    params,
-  } = useRouter()
+  const router = useRouter()
+  const { params } = router
 
   const appTools = useApp(params.app_id)
+  const { data: orgAgents = [] } = useListHelixOrgBots()
+  const linkedOrgAgent = orgAgents.find(
+    (agent) => (agent.agent_id ?? agent.agent_app_id) === params.app_id,
+  )
+  const activateOrgAgent = useActivateBot()
   // Get user access information from appTools
   const { userAccess } = appTools
 
@@ -58,7 +71,13 @@ const App: FC = () => {
   const [isSearchMode, setIsSearchMode] = useState(() => searchParams.get('isSearchMode') === 'true');
   
   // Get tab from URL params instead of local state
-  const tabValue = params.tab || 'appearance';
+  const tabValue = params.tab === 'appearance' ? 'settings' : params.tab || 'settings';
+
+  useEffect(() => {
+    if (params.tab === 'appearance') {
+      router.mergeParams({ tab: 'settings' })
+    }
+  }, [params.tab])
 
   useEffect(() => {
     const checkAccess = async () => {
@@ -84,6 +103,27 @@ const App: FC = () => {
 
   const isReadOnly = appTools.isReadOnly || !appTools.isSafeToSave
 
+  const openChat = async () => {
+    if (!linkedOrgAgent?.id) {
+      account.orgNavigate('new', { app_id: appTools.id, resource_type: 'apps' })
+      return
+    }
+    if (!params.org_id) return
+    try {
+      const result = await activateOrgAgent.mutateAsync(linkedOrgAgent.id)
+      let sessionID = result.session_id
+      if (!sessionID) {
+        if (!result.project_id) throw new Error('failed to open agent chat')
+        const response = await api.getApiClient().v1ProjectsExploratorySessionCreate(result.project_id)
+        sessionID = response.data?.id
+      }
+      if (!sessionID) throw new Error('failed to open agent chat')
+      router.navigate('org_session', { org_id: params.org_id, session_id: sessionID })
+    } catch (error: any) {
+      snackbar.error(error?.response?.data?.error ?? error?.message ?? 'failed to open agent chat')
+    }
+  }
+
   return (
     <Page
       showDrawerButton={false}
@@ -97,6 +137,23 @@ const App: FC = () => {
           title: appTools.flatApp?.name || 'Agent',
         }
       ]}
+      topbarContent={(
+        <>
+          <HelixOrgTopNav />
+          {isHelixOrgChartAgent(appTools.app) && (
+            <Chip label="Org Chart" size="small" color="primary" variant="outlined" />
+          )}
+          <Button
+            variant="contained"
+            color="secondary"
+            startIcon={activateOrgAgent.isPending ? <CircularProgress size={16} /> : <ChatOutlinedIcon />}
+            onClick={() => void openChat()}
+            disabled={activateOrgAgent.isPending}
+          >
+            Open chat
+          </Button>
+        </>
+      )}
     >
       <Container
         maxWidth="xl"
@@ -211,32 +268,15 @@ const App: FC = () => {
                     </Grid>
                   ) : (
                     <>
-                      <Grid item xs={12} md={appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL && tabValue !== 'apikeys' ? 12 : 6} sx={{
-                        ...(( appTools.flatApp?.default_agent_type !== AGENT_TYPE_ZED_EXTERNAL || tabValue === 'apikeys') && { borderRight: '1px solid #303047' }),
-                        overflow: 'auto',
+                      <Grid item xs={12} md={tabValue === 'settings' ? 8 : appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL && tabValue !== 'apikeys' ? 12 : 6} sx={{
+                        ...((tabValue === 'settings' || appTools.flatApp?.default_agent_type !== AGENT_TYPE_ZED_EXTERNAL || tabValue === 'apikeys') && { borderRight: { xs: 'none', md: '1px solid #303047' } }),
                         pb: 8,
-                        minHeight: 'calc(100vh - 120px)',
-                        ...lightTheme.scrollbar
+                        minHeight: 'calc(100vh - 120px)'
                       }}>
                         <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
                           {appTools.flatApp && (
-                            <Box sx={{ display: tabValue === 'appearance' ? 'block' : 'none', height: '100%', overflow: 'auto' }}>
-                              <AppearanceSettings
-                                app={appTools.flatApp}
-                                onUpdate={appTools.saveFlatApp}
-                                readOnly={isReadOnly}
-                                showErrors={appTools.showErrors}
-                                id={appTools.id}
-                              />
-                            </Box>
-                          )}
-
-                          {appTools.flatApp && (
                             <Box sx={{
                               display: tabValue === 'settings' ? 'block' : 'none',
-                              height: 'calc(100vh - 200px)',
-                              overflow: 'auto',
-                              ...lightTheme.scrollbar,
                               pb: 4
                             }}>
                               <AppSettings
@@ -246,6 +286,21 @@ const App: FC = () => {
                                 readOnly={isReadOnly}
                                 showErrors={appTools.showErrors}
                                 isAdmin={account.admin}
+                              />
+                              {isHelixOrgChartAgent(appTools.app) && (
+                                <>
+                                  <OrgAgentSettings agentID={appTools.id} section="runtime" readOnly={isReadOnly} />
+                                  <OrgAgentSettings agentID={appTools.id} section="access" readOnly={isReadOnly} />
+                                  <OrgAgentSettings agentID={appTools.id} section="subscriptions" readOnly={isReadOnly} />
+                                  <OrgAgentSettings agentID={appTools.id} section="tools" readOnly={isReadOnly} />
+                                </>
+                              )}
+                              <AppearanceSettings
+                                app={appTools.flatApp}
+                                onUpdate={appTools.saveFlatApp}
+                                readOnly={isReadOnly}
+                                showErrors={appTools.showErrors}
+                                id={appTools.id}
                               />
                             </Box>
                           )}
@@ -280,7 +335,15 @@ const App: FC = () => {
                           </Box>
                         </Box>
                       </Grid>
-                      {tabValue === 'apikeys' ? (
+                      {tabValue === 'settings' && appTools.flatApp ? (
+                        <Grid item xs={12} md={4}>
+                          <AgentInfoPanel
+                            app={appTools.app}
+                            settings={appTools.flatApp}
+                            orgAgent={linkedOrgAgent}
+                          />
+                        </Grid>
+                      ) : tabValue === 'apikeys' ? (
                         <CodeExamples apiKey={account.appApiKeys[0]?.key || ''} />
                       ) : appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL ? null : (
                         <PreviewPanel

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -16,6 +16,7 @@ import useRouter from '../hooks/useRouter'
 import useCreateBlankAgent from '../hooks/useCreateBlankAgent'
 import useSubscriptionGate from '../hooks/useSubscriptionGate'
 import Paywall from '../components/subscription/Paywall'
+import HelixOrgTopNav from '../components/helix-org/HelixOrgTopNav'
 
 import {
   IApp,
@@ -30,7 +31,6 @@ const Apps: FC = () => {
 
   const {
     params,
-    navigate,
   } = useRouter()
 
   const [ deletingApp, setDeletingApp ] = useState<IApp>()
@@ -95,6 +95,7 @@ const Apps: FC = () => {
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <>
+          <HelixOrgTopNav />
           <Button
             id="secrets-button"
             variant="contained"

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -2582,13 +2582,12 @@ const HelixOrgChart: FC = () => {
     [orgSlug],
   )
   // Agent menu Details / card double-click → agent detail page.
-  const onOpenBotDetails = useCallback(
-    (botId: string) => {
-      if (!orgSlug) return
-      router.navigate('helix_org_bot_detail', { org_id: orgSlug, bot_id: botId })
-    },
-    [router, orgSlug],
-  )
+  const onOpenBotDetails = (botId: string) => {
+    const bot = botsData?.find((candidate) => candidate.id === botId)
+    const agentID = bot?.agent_id ?? bot?.agent_app_id
+    if (!orgSlug || !agentID) return
+    router.navigate('org_agent', { org_id: orgSlug, app_id: agentID })
+  }
   const onViewProject = useCallback(
     (projectId: string) => {
       if (!orgSlug || !projectId) return

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -48,8 +48,6 @@ import Waitlist from './pages/Waitlist'
 import Login from './pages/Login'
 import NotFound from './pages/NotFound'
 import HelixOrgChart from './pages/HelixOrgChart'
-import HelixOrgBots from './pages/HelixOrgBots'
-import HelixOrgBotDetail from './pages/HelixOrgBotDetail'
 import HelixOrgHumanDetail from './pages/HelixOrgHumanDetail'
 import HelixOrgTopics from './pages/HelixOrgTopics'
 import HelixOrgAssets from './pages/HelixOrgAssets'
@@ -57,6 +55,7 @@ import HelixOrgTopicDetail from './pages/HelixOrgTopicDetail'
 import HelixOrgProcessorDetail from './pages/HelixOrgProcessorDetail'
 import useRouter from './hooks/useRouter'
 import { recordNavRoute } from './lib/navHistory'
+import { useHelixOrgBot } from './services/helixOrgService'
 
 // extend the base router5 route to add metadata and self rendering
 export interface IApplicationRoute extends Route {
@@ -69,6 +68,30 @@ export const NOT_FOUND_ROUTE: IApplicationRoute = {
   path: '/notfound',
   meta: {},
   render: () => <NotFound />,
+}
+
+const HelixOrgAgentRedirect = () => {
+  const { navigateReplace, params } = useRouter()
+  const { data } = useHelixOrgBot(params.bot_id)
+
+  React.useEffect(() => {
+    const agentID = data?.agent_id ?? data?.agent_app_id
+    if (data?.bot?.kind === 'human') {
+      navigateReplace('helix_org_human_detail', { org_id: params.org_id, bot_id: params.bot_id })
+    } else if (agentID) {
+      navigateReplace('org_agent', { org_id: params.org_id, app_id: agentID })
+    }
+  }, [data?.agent_id, data?.agent_app_id, data?.bot?.kind, params.org_id, params.bot_id])
+
+  return null
+}
+
+const RouteRedirect = ({ route }: { route: string }) => {
+  const { navigateReplace, params } = useRouter()
+  React.useEffect(() => {
+    navigateReplace(route, params)
+  }, [])
+  return null
 }
 
 
@@ -302,13 +325,18 @@ const routes: IApplicationRoute[] = [
   ),
 }, {
   name: 'org_agent',
-  path: '/orgs/:org_id/agent/:app_id',
+  path: '/orgs/:org_id/agents/:app_id',
   meta: {
     drawer: true,
   },
   render: () => (
     <App />
   ),
+}, {
+  name: 'org_agent_legacy',
+  path: '/orgs/:org_id/agent/:app_id',
+  meta: { drawer: true },
+  render: () => <RouteRedirect route="org_agent" />,
 }, {
   // Backward compat: redirect /app/:app_id to /agent/:app_id
   name: 'org_app',
@@ -562,94 +590,96 @@ const routes: IApplicationRoute[] = [
   },
   render: () => <AdminRunnerLogsPage />,
 }, {
-  // Other resources (bots and topics) are
-  // operated via MCP tools / API; the overview is the visual entry
-  // point.
-  // drawer: false - secondary context sidebar is unused; Chart/Bots/Topics
-  // live in the AppBar (HelixOrgTopNav). The 64px org rail still shows.
+  // Backward-compatible redirects for the old /helix-org URLs.
   name: 'helix_org_root',
   path: '/orgs/:org_id/helix-org',
   meta: { drawer: false, title: 'Helix Org' },
-  render: () => {
-    const { navigateReplace, params } = useRouter()
-    React.useEffect(() => {
-      navigateReplace('helix_org_chart', { org_id: params.org_id })
-    }, [params.org_id])
-    return null
-  },
+  render: () => <RouteRedirect route="helix_org_chart" />,
 }, {
   name: 'helix_org_chart',
-  path: '/orgs/:org_id/helix-org/chart',
-  meta: { drawer: false, title: 'Helix Org · Chart' },
+  path: '/orgs/:org_id/chart',
+  meta: { drawer: false, title: 'Org Chart' },
   render: () => <HelixOrgChart />,
+}, {
+  name: 'helix_org_chart_legacy',
+  path: '/orgs/:org_id/helix-org/chart',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_chart" />,
 }, {
   name: 'helix_org_bots',
   path: '/orgs/:org_id/helix-org/agents',
-  meta: { drawer: false, title: 'Helix Org · Agents' },
-  render: () => <HelixOrgBots />,
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="org_agents" />,
 }, {
   name: 'helix_org_bot_detail',
   path: '/orgs/:org_id/helix-org/agents/:bot_id',
-  meta: { drawer: false, title: 'Helix Org · Agent' },
-  render: () => <HelixOrgBotDetail />,
+  meta: { drawer: false },
+  render: () => <HelixOrgAgentRedirect />,
 }, {
   name: 'helix_org_bots_legacy',
   path: '/orgs/:org_id/helix-org/bots',
-  meta: { drawer: false, title: 'Helix Org · Agents' },
-  render: () => {
-    const { navigateReplace, params } = useRouter()
-    React.useEffect(() => {
-      navigateReplace('helix_org_bots', { org_id: params.org_id })
-    }, [params.org_id])
-    return null
-  },
+  meta: { drawer: false, title: 'Helix Org - Agents' },
+  render: () => <RouteRedirect route="helix_org_bots" />,
 }, {
   name: 'helix_org_bot_detail_legacy',
   path: '/orgs/:org_id/helix-org/bots/:bot_id',
-  meta: { drawer: false, title: 'Helix Org · Agent' },
-  render: () => {
-    const { navigateReplace, params } = useRouter()
-    React.useEffect(() => {
-      navigateReplace('helix_org_bot_detail', { org_id: params.org_id, bot_id: params.bot_id })
-    }, [params.org_id, params.bot_id])
-    return null
-  },
+  meta: { drawer: false, title: 'Helix Org - Agent' },
+  render: () => <RouteRedirect route="helix_org_bot_detail" />,
 }, {
   name: 'helix_org_human_detail',
-  path: '/orgs/:org_id/helix-org/humans/:bot_id',
-  meta: { drawer: false, title: 'Helix Org · Person' },
+  path: '/orgs/:org_id/people/:bot_id',
+  meta: { drawer: false, title: 'Person' },
   render: () => <HelixOrgHumanDetail />,
+}, {
+  name: 'helix_org_human_detail_legacy',
+  path: '/orgs/:org_id/helix-org/humans/:bot_id',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_human_detail" />,
 }, {
   name: 'helix_org_settings',
   path: '/orgs/:org_id/helix-org/settings',
   meta: { drawer: false },
-  render: () => {
-    const { navigateReplace, params } = useRouter()
-    React.useEffect(() => {
-      navigateReplace('org_general', { org_id: params.org_id })
-    }, [params.org_id])
-    return null
-  },
+  render: () => <RouteRedirect route="org_general" />,
 }, {
   name: 'helix_org_topics',
-  path: '/orgs/:org_id/helix-org/topics',
-  meta: { drawer: false, title: 'Helix Org · Topics' },
+  path: '/orgs/:org_id/topics',
+  meta: { drawer: false, title: 'Topics' },
   render: () => <HelixOrgTopics />,
 }, {
+  name: 'helix_org_topics_legacy',
+  path: '/orgs/:org_id/helix-org/topics',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_topics" />,
+}, {
   name: 'helix_org_assets',
-  path: '/orgs/:org_id/helix-org/assets',
-  meta: { drawer: false, title: 'Helix Org · Assets' },
+  path: '/orgs/:org_id/assets',
+  meta: { drawer: false, title: 'Assets' },
   render: () => <HelixOrgAssets />,
 }, {
+  name: 'helix_org_assets_legacy',
+  path: '/orgs/:org_id/helix-org/assets',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_assets" />,
+}, {
   name: 'helix_org_processor_detail',
-  path: '/orgs/:org_id/helix-org/processors/:processor_id',
-  meta: { drawer: false, title: 'Helix Org · Processor' },
+  path: '/orgs/:org_id/processors/:processor_id',
+  meta: { drawer: false, title: 'Processor' },
   render: () => <HelixOrgProcessorDetail />,
 }, {
+  name: 'helix_org_processor_detail_legacy',
+  path: '/orgs/:org_id/helix-org/processors/:processor_id',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_processor_detail" />,
+}, {
   name: 'helix_org_topic_detail',
-  path: '/orgs/:org_id/helix-org/topics/:topic_id',
-  meta: { drawer: false, title: 'Helix Org · Topic' },
+  path: '/orgs/:org_id/topics/:topic_id',
+  meta: { drawer: false, title: 'Topic' },
   render: () => <HelixOrgTopicDetail />,
+}, {
+  name: 'helix_org_topic_detail_legacy',
+  path: '/orgs/:org_id/helix-org/topics/:topic_id',
+  meta: { drawer: false },
+  render: () => <RouteRedirect route="helix_org_topic_detail" />,
 }, NOT_FOUND_ROUTE]
 
 export const router = createRouter(routes, {

--- a/frontend/src/utils/apps.test.ts
+++ b/frontend/src/utils/apps.test.ts
@@ -42,6 +42,7 @@ describe('isSpecTaskSwitchableAgent', () => {
 
   it('drops an external agent that backs an org-chart Worker', () => {
     const app = makeApp({ agentType: AGENT_TYPE_ZED_EXTERNAL, isHelixOrgAgent: true })
+    expect(isHelixOrgChartAgent(null)).toBe(false)
     expect(isHelixOrgChartAgent(app)).toBe(true)
     expect(isSpecTaskSwitchableAgent(app)).toBe(false)
   })

--- a/frontend/src/utils/apps.ts
+++ b/frontend/src/utils/apps.ts
@@ -90,8 +90,8 @@ export const isExternalAgent = (app: IApp): boolean => {
 
 // True when this app backs a Helix org-chart Worker (flagged server-side).
 // These belong to the org chart, not to spec tasks.
-export const isHelixOrgChartAgent = (app: IApp): boolean => {
-  return app.is_helix_org_agent === true
+export const isHelixOrgChartAgent = (app: IApp | null | undefined): boolean => {
+  return app?.is_helix_org_agent === true
 }
 
 // Agents you can switch a spec task to: external agents that are not part of


### PR DESCRIPTION
## Summary

- flatten Org Chart routes and use the shared Agent list and editor
- add Org Chart badges, project access, topic subscriptions, tools, chat activation, and shared metadata
- restore Markdown instruction highlighting and remove nested settings scrolling
- simplify the initial Agent settings form with name first and advanced model settings collapsed
- suppress the generic New Chat shortcut for Org Chart agents

## Verification

- `cd frontend && yarn build`
- `cd frontend && yarn vitest run src/utils/apps.test.ts src/services/helixOrgService.test.ts`
- `cd api && go test ./pkg/server -run "TestUpdateAppResponseMarksLinkedOrgAgent|Test_markHelixOrgAgents" -count=1`
- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- standalone Playwright verification for ordinary and Org Chart agent list, edit, chat, loading, and autosave states