### PR TITLE
feat(ui): chat ux improvements

### DIFF
--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-github/v57/github"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 )
 
 // Client wraps the GitHub API client
@@ -169,21 +170,11 @@ func MintInstallationCredential(ctx context.Context, appID, installationID int64
 	return InstallationCredential{Token: tok, ExpiresAt: expiresAt}, nil
 }
 
-// ListRepositories lists all repositories accessible to the authenticated user
-// including personal repos, collaborator repos, and organization repos (both public and private).
-//
-// GitHub's GET /user/repos with affiliation=organization_member may not return
-// public org repos, so we supplement with per-org repo listing. We discover orgs
-// from two sources because each misses cases the other catches:
-//   - GET /user/orgs returns orgs the user is a *member* of, but not orgs where
-//     the user is only an outside collaborator on individual repos.
-//   - The owners of repos returned by /user/repos surface those collaborator orgs,
-//     but only if the user has access to at least one repo in them.
-//
-// Unioning both gives us every org we can plausibly enumerate public repos for.
+// ListRepositories lists repositories the authenticated user can access directly:
+// owned repositories, collaborator repositories, and organization repositories.
+// Public repositories outside those affiliations can still be linked by URL; walking
+// every repository in every organization makes this interactive endpoint unbounded.
 func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, error) {
-	// Step 1: Get user repos (personal, collaborator, org-member)
-	var allRepos []*github.Repository
 	opt := &github.RepositoryListOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 		Sort:        "updated",
@@ -191,80 +182,45 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 		Visibility:  "all",
 	}
 
-	for {
-		repos, resp, err := c.client.Repositories.List(ctx, "", opt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list repositories: %w", err)
-		}
-		allRepos = append(allRepos, repos...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
-	}
-
-	log.Info().Int("user_repos_count", len(allRepos)).Msg("Step 1: fetched user repos")
-
-	// Collect orgs from owners of org-owned repos in Step 1. This catches orgs
-	// where the user is an outside collaborator and so doesn't appear in /user/orgs.
-	orgsFromRepos := make(map[string]bool)
-	for _, repo := range allRepos {
-		owner := repo.GetOwner()
-		if owner == nil {
-			continue
-		}
-		if owner.GetType() == "Organization" {
-			orgsFromRepos[owner.GetLogin()] = true
-		}
-	}
-
-	// Step 2: List user's organizations (orgs the user is a member of).
-	// May fail if read:org scope is missing — in that case we still proceed
-	// using only the orgs derived from Step 1.
-	memberOrgs, err := c.listUserOrganizations(ctx)
+	firstPage, response, err := c.client.Repositories.List(ctx, "", opt)
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to list user organizations (needs read:org scope) — falling back to orgs derived from user repos")
+		return nil, fmt.Errorf("failed to list repositories: %w", err)
+	}
+	if response.NextPage == 0 {
+		return firstPage, nil
+	}
+	if response.LastPage < response.NextPage {
+		return nil, fmt.Errorf("GitHub repository pagination response omitted the last page")
 	}
 
-	allOrgs := make(map[string]bool, len(orgsFromRepos)+len(memberOrgs))
-	for org := range orgsFromRepos {
-		allOrgs[org] = true
+	pages := make([][]*github.Repository, response.LastPage)
+	pages[0] = firstPage
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(8)
+	for page := response.NextPage; page <= response.LastPage; page++ {
+		page := page
+		group.Go(func() error {
+			pageOptions := *opt
+			pageOptions.Page = page
+			repositories, _, err := c.client.Repositories.List(groupCtx, "", &pageOptions)
+			if err != nil {
+				return fmt.Errorf("failed to list repositories page %d: %w", page, err)
+			}
+			pages[page-1] = repositories
+			return nil
+		})
 	}
-	for _, org := range memberOrgs {
-		allOrgs[org.GetLogin()] = true
-	}
-
-	memberOrgNames := make([]string, len(memberOrgs))
-	for i, org := range memberOrgs {
-		memberOrgNames[i] = org.GetLogin()
-	}
-	collaboratorOnlyOrgs := make([]string, 0)
-	for org := range orgsFromRepos {
-		if _, isMember := lookupOrgInList(memberOrgs, org); !isMember {
-			collaboratorOnlyOrgs = append(collaboratorOnlyOrgs, org)
-		}
-	}
-	log.Info().
-		Strs("member_orgs", memberOrgNames).
-		Strs("collaborator_only_orgs", collaboratorOnlyOrgs).
-		Int("total_orgs_to_query", len(allOrgs)).
-		Msg("Step 2: assembled org list (members + collaborator-only)")
-
-	// Step 3: For each org, list all visible repos (includes public ones)
-	for orgLogin := range allOrgs {
-		orgRepos, err := c.listOrgRepositories(ctx, orgLogin)
-		if err != nil {
-			log.Warn().Err(err).Str("org", orgLogin).Msg("Step 3: failed to list org repos, skipping")
-			continue
-		}
-		log.Info().Str("org", orgLogin).Int("repo_count", len(orgRepos)).Msg("Step 3: fetched org repos")
-		allRepos = append(allRepos, orgRepos...)
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
-	// Step 4: Deduplicate by repo ID
-	deduped := deduplicateRepos(allRepos)
-	log.Info().Int("total_before_dedup", len(allRepos)).Int("total_after_dedup", len(deduped)).Msg("Step 4: deduplicated repos")
-	return deduped, nil
+	allRepos := make([]*github.Repository, 0, response.LastPage*opt.PerPage)
+	for _, page := range pages {
+		allRepos = append(allRepos, page...)
+	}
+
+	log.Info().Int("repository_count", len(allRepos)).Msg("Fetched repositories accessible to user")
+	return allRepos, nil
 }
 
 // HasWriteAccess returns true when the authenticated user can push to the repo.
@@ -277,74 +233,6 @@ func HasWriteAccess(repo *github.Repository) bool {
 		return true
 	}
 	return perms["admin"] || perms["maintain"] || perms["push"]
-}
-
-// lookupOrgInList returns the matching org and true if login appears in orgs.
-func lookupOrgInList(orgs []*github.Organization, login string) (*github.Organization, bool) {
-	for _, o := range orgs {
-		if o.GetLogin() == login {
-			return o, true
-		}
-	}
-	return nil, false
-}
-
-// listUserOrganizations returns all organizations the authenticated user belongs to.
-func (c *Client) listUserOrganizations(ctx context.Context) ([]*github.Organization, error) {
-	var allOrgs []*github.Organization
-	opt := &github.ListOptions{PerPage: 100}
-
-	for {
-		orgs, resp, err := c.client.Organizations.List(ctx, "", opt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list organizations: %w", err)
-		}
-		allOrgs = append(allOrgs, orgs...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
-	}
-
-	return allOrgs, nil
-}
-
-// listOrgRepositories returns all repositories in an organization visible to the authenticated user.
-func (c *Client) listOrgRepositories(ctx context.Context, orgLogin string) ([]*github.Repository, error) {
-	var allRepos []*github.Repository
-	opt := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
-		Sort:        "updated",
-		Type:        "all",
-	}
-
-	for {
-		repos, resp, err := c.client.Repositories.ListByOrg(ctx, orgLogin, opt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list org repositories for %s: %w", orgLogin, err)
-		}
-		allRepos = append(allRepos, repos...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
-	}
-
-	return allRepos, nil
-}
-
-// deduplicateRepos removes duplicate repositories by ID.
-func deduplicateRepos(repos []*github.Repository) []*github.Repository {
-	seen := make(map[int64]bool)
-	var result []*github.Repository
-	for _, repo := range repos {
-		id := repo.GetID()
-		if !seen[id] {
-			seen[id] = true
-			result = append(result, repo)
-		}
-	}
-	return result
 }
 
 // CreatePullRequest creates a new pull request

--- a/api/pkg/agent/skill/github/client_test.go
+++ b/api/pkg/agent/skill/github/client_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	githubapi "github.com/google/go-github/v57/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRepositoriesUsesUserRepositoryPagination(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		require.Equal(t, "/user/repos", r.URL.Path)
+		require.Equal(t, "owner,collaborator,organization_member", r.URL.Query().Get("affiliation"))
+
+		page := 1
+		if value := r.URL.Query().Get("page"); value != "" {
+			page, _ = strconv.Atoi(value)
+		}
+		if page == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/user/repos?page=2>; rel="next", <%s/user/repos?page=4>; rel="last"`, server.URL, server.URL))
+		}
+		_, err := fmt.Fprintf(w, `[{"id":%d,"name":"page-%d"}]`, page, page)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	apiClient := githubapi.NewClient(server.Client())
+	apiClient.BaseURL = baseURL
+
+	client := &Client{client: apiClient}
+	repositories, err := client.ListRepositories(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, repositories, 4)
+	for index, repository := range repositories {
+		require.Equal(t, int64(index+1), repository.GetID())
+	}
+	require.Equal(t, int32(4), requestCount.Load())
+}

--- a/api/pkg/server/spa/spa.go
+++ b/api/pkg/server/spa/spa.go
@@ -1,7 +1,9 @@
 package spa
 
 import (
+	"bufio"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -142,4 +144,12 @@ type statusRecorder struct {
 func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
 	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("response writer %T does not support hijacking", r.ResponseWriter)
+	}
+	return hijacker.Hijack()
 }

--- a/api/pkg/server/spa/spa_test.go
+++ b/api/pkg/server/spa/spa_test.go
@@ -1,0 +1,51 @@
+package spa
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type hijackableResponseWriter struct {
+	header http.Header
+	conn   net.Conn
+	rw     *bufio.ReadWriter
+}
+
+func (w *hijackableResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *hijackableResponseWriter) Write(body []byte) (int, error) {
+	return len(body), nil
+}
+
+func (w *hijackableResponseWriter) WriteHeader(_ int) {}
+
+func (w *hijackableResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.conn, w.rw, nil
+}
+
+func TestStatusRecorderPreservesHijacker(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		require.NoError(t, serverConn.Close())
+		require.NoError(t, clientConn.Close())
+	})
+
+	buffer := bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn))
+	underlying := &hijackableResponseWriter{
+		header: make(http.Header),
+		conn:   serverConn,
+		rw:     buffer,
+	}
+	recorder := &statusRecorder{ResponseWriter: underlying, status: http.StatusOK}
+
+	conn, rw, err := recorder.Hijack()
+	require.NoError(t, err)
+	require.Same(t, serverConn, conn)
+	require.Same(t, buffer, rw)
+}

--- a/design/2026-08-03-pdf-export-invalid-hook-call.md
+++ b/design/2026-08-03-pdf-export-invalid-hook-call.md
@@ -1,0 +1,31 @@
+# PDF export invalid hook call
+
+## Root cause
+
+`ToPDFImpl` is loaded with `React.lazy`, so Vite did not discover
+`@uiw/react-md-editor` or `@react-pdf/renderer` during its initial dependency
+optimization pass. Opening PDF export caused Vite to optimize both packages and
+invalidate the dependency cache. The already-rendered application and the new
+PDF chunk then referenced different cache generations, producing React's
+invalid-hook-call error.
+
+Vite attempted to reload the page after re-optimization, but the API frontend
+proxy wrapped its response writer in `statusRecorder`, which did not preserve
+`http.Hijacker`. The HMR WebSocket upgrade therefore failed before the reload
+could reach the browser.
+
+## Fix
+
+- Pre-optimize both lazy PDF dependencies and deduplicate React/React DOM.
+- Preserve `http.Hijacker` through `statusRecorder` so WebSocket upgrades work.
+
+## Verification
+
+- Opened Export to PDF in a live local org-chat session and waited for the PDF
+  preview iframe; no hook exceptions occurred.
+- Confirmed the proxied Vite HMR endpoint returns `101 Switching Protocols` and
+  a connected frame.
+- `go test ./api/pkg/server/spa -count=1`
+- `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`
+- `cd frontend && yarn build`
+- `cd frontend && yarn test src` (49 files, 298 tests passed; one skipped)

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -17,7 +17,7 @@ Adopt T3 Code's chat hierarchy for Helix's two agent-chat surfaces:
 - thumbnail-first image attachments in both the composer and sent message;
 - one durable attachment model shared by direct org-chat sends and queued spec-task sends.
 
-Do not restyle the whole Helix application. The font and dark palette should be scoped to the shared chat surface, with Helix cyan retained for focus and primary actions. Do not implement sent-image previews using only browser blob URLs or sandbox paths embedded in visible message text: neither is durable message data.
+Use bundled DM Sans as the application-wide UI font so root DOM, MUI components, portals, and chat render the same face. Keep the T3 dark palette scoped to the shared chat surface, with Helix cyan retained for focus and primary actions. Do not implement sent-image previews using only browser blob URLs or sandbox paths embedded in visible message text: neither is durable message data.
 
 ## Reference and method
 
@@ -173,7 +173,7 @@ Add chat-scoped semantic tokens rather than changing the global MUI palette.
 
 Light mode retains the existing Helix light palette in the first change. The new tokens must still define a legible light equivalent so the components do not contain mode checks.
 
-Bundle `@fontsource-variable/dm-sans` and `@fontsource/jetbrains-mono`. Apply DM Sans only below the shared chat root. Keep the rest of the application on its current typography until a separate global typography decision is made.
+Bundle `@fontsource-variable/dm-sans` and `@fontsource-variable/jetbrains-mono`. Apply DM Sans through the root MUI theme and `CssBaseline`; plain form controls inherit the root face, while deliberate monospace overrides remain intact.
 
 ### Shared component boundary
 

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -163,7 +163,7 @@ Add chat-scoped semantic tokens rather than changing the global MUI palette.
 |---|---|---|
 | `chat.canvas` | `#0a0a0a` | transcript and composer dock |
 | `chat.text` | `#f5f5f5` | user message text |
-| `chat.assistantText` | `rgba(245,245,245,0.80)` | assistant markdown |
+| `chat.assistantText` | `rgba(245,245,245,0.80)` | assistant markdown; the opacity is applied at the message container so nested Markdown inherits it consistently |
 | `chat.mutedText` | `#818181` | timestamps and secondary metadata |
 | `chat.userBubble` | `rgba(255,255,255,0.04)` | user bubble |
 | `chat.raised` | `rgba(255,255,255,0.03)` | composer surface |

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -131,7 +131,7 @@ Both requested surfaces share the transcript renderer and composer primitives bu
 | Area | Helix today | T3 direction |
 |---|---|---|
 | Sans font | IBM Plex declaration without a bundled font; practical fallback is Helvetica/Arial | Bundled DM Sans Variable |
-| Chat background | Helix `#121214` app background | scoped neutral-black canvas |
+| Chat background | T3 `neutral-950` (`#0a0a0a`) | exact scoped dark-mode canvas |
 | Transcript width | 700 px | 768 px |
 | User width | fit-content up to nearly the full 700 px | maximum 80% |
 | User bubble | 16 px radius, 1 px `#33373a` border, 16 px horizontal/4 px vertical padding | borderless 4% white surface, 12 px padding |

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -173,7 +173,7 @@ Add chat-scoped semantic tokens rather than changing the global MUI palette.
 
 Light mode retains the existing Helix light palette in the first change. The new tokens must still define a legible light equivalent so the components do not contain mode checks.
 
-Bundle `@fontsource-variable/dm-sans` and `@fontsource-variable/jetbrains-mono`. Apply DM Sans through the root MUI theme and `CssBaseline`; plain form controls inherit the root face, while deliberate monospace overrides remain intact.
+Bundle `@fontsource-variable/dm-sans` and `@fontsource-variable/jetbrains-mono`. Apply DM Sans through the root MUI theme and `CssBaseline`; plain form controls inherit the root face, while deliberate monospace overrides remain intact. Override MUI's forced grayscale font smoothing with the browser default (`auto`) to match T3's rendering rather than making DM Sans artificially thin on macOS/Chromium.
 
 ### Shared component boundary
 

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -161,7 +161,7 @@ Add chat-scoped semantic tokens rather than changing the global MUI palette.
 
 | Token | Dark value | Use |
 |---|---|---|
-| `chat.canvas` | `#0a0a0a` | transcript and composer dock |
+| `chat.canvas` | application `background.default` (`#0a0a0a` in dark mode) | transcript and composer dock; the literal is defined once as `DARK_APP_BACKGROUND` in `themeTokens.ts` |
 | `chat.text` | `#f5f5f5` | user message text |
 | `chat.assistantText` | `rgba(245,245,245,0.80)` | assistant markdown; the opacity is applied at the message container so nested Markdown inherits it consistently |
 | `chat.mutedText` | `#818181` | timestamps and secondary metadata |
@@ -308,6 +308,12 @@ Unbound draft attachments should be garbage-collected after a bounded interval. 
 
 ## Implementation plan
 
+### Transcript turn navigator
+
+The shared transcript includes a desktop-only turn navigator modeled on T3 Code's minimap. Each visible user turn gets an evenly spaced marker in the reserved left gutter. Hovering the rail expands the nearest marker and shows one line of user text plus up to three lines of the final assistant prose. Clicking, Enter, or Space smooth-scrolls to that turn and pauses auto-follow; Arrow keys and Home/End move between previews. Markers for turns intersecting the viewport use the foreground color.
+
+The navigator is absent on coarse pointers and when fewer than two turns exist. Its collapsed hit area stays inside the 36 px transcript gutter so it does not block message selection. The transcript root and every intervening flex item use `min-width: 0`; horizontal overflow is clipped at the transcript scroller so narrow split panes retain their 20 px right content margin.
+
 ### 1. Shared visual foundation
 
 - Add bundled DM Sans Variable and JetBrains Mono.
@@ -354,10 +360,11 @@ Unbound draft attachments should be garbage-collected after a bounded interval. 
 - Direct org sends and queued spec-task sends preserve the same attachment metadata and retry semantics.
 - No raw frontend request is added where a generated API client method can be used.
 - Existing light mode, system prefixes, tool calls, prompt queueing, interrupt mode, auto-scroll, and live streaming still work.
+- Desktop chats expose a keyboard-accessible turn navigator with T3-style hover previews and manual navigation pauses auto-follow.
 
 ## Explicit non-goals
 
 - Replacing the global Helix application theme or typography.
-- Copying T3's provider/model controls, minimap, prompt stash, or review-annotation system.
+- Copying T3's provider/model controls, prompt stash, or review-annotation system.
 - General document/PDF attachment cards in the first pass.
 - Sending authenticated preview URLs directly to the external agent. The agent receives server-built workspace paths; the UI receives authorized filestore previews.

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -1,0 +1,363 @@
+# T3 Code-inspired agent chat redesign
+
+**Status:** Visual/mechanics pass implemented on `feat/t3-chat-redesign`; durable attachment binding remains planned
+
+**Date:** 2026-08-03
+
+**Scope:** Helix org-chart agent chat and project spec-task chat
+
+## Summary
+
+Adopt T3 Code's chat hierarchy for Helix's two agent-chat surfaces:
+
+- a quiet near-black transcript canvas;
+- compact 14 px DM Sans message typography;
+- right-aligned, softly raised user messages;
+- unboxed assistant output;
+- thumbnail-first image attachments in both the composer and sent message;
+- one durable attachment model shared by direct org-chat sends and queued spec-task sends.
+
+Do not restyle the whole Helix application. The font and dark palette should be scoped to the shared chat surface, with Helix cyan retained for focus and primary actions. Do not implement sent-image previews using only browser blob URLs or sandbox paths embedded in visible message text: neither is durable message data.
+
+## Reference and method
+
+The catalogue is based on `pingdotgg/t3code` commit [`30c96228067bcd3a49e432ec898e52d4acb04297`](https://github.com/pingdotgg/t3code/commit/30c96228067bcd3a49e432ec898e52d4acb04297), dated 2026-08-02.
+
+Primary source files:
+
+- [`apps/web/src/index.css`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/apps/web/src/index.css)
+- [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/apps/web/src/components/chat/MessagesTimeline.tsx)
+- [`ChatComposer.tsx`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/apps/web/src/components/chat/ChatComposer.tsx)
+- [`ComposerPromptEditor.tsx`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/apps/web/src/components/ComposerPromptEditor.tsx)
+- [`ExpandedImageDialog.tsx`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/apps/web/src/components/chat/ExpandedImageDialog.tsx)
+- [`orchestration.ts`](https://github.com/pingdotgg/t3code/blob/30c96228067bcd3a49e432ec898e52d4acb04297/packages/contracts/src/orchestration.ts)
+
+The public hosted app had no connected environment, so a populated chat could not be inspected there. The visual measurements below are source-derived rather than estimates from a screenshot. The live dark shell did confirm the DM Sans stack and neutral dark theme.
+
+## T3 Code catalogue
+
+### Typography
+
+| Element | T3 Code value |
+|---|---|
+| UI and chat sans | `DM Sans Variable`, `DM Sans`, Apple/system fallbacks |
+| Monospace | `SF Mono`, `SFMono-Regular`, `JetBrains Mono`, Consolas, Liberation Mono, Menlo |
+| User and assistant text | 14 px (`text-sm`) |
+| Message line height | `1.625` (`leading-relaxed`), about 22.75 px at 14 px |
+| Composer text | 14 px from the `sm` breakpoint; 16 px on narrow screens to avoid mobile input zoom |
+| Timestamp and message actions | 12 px (`text-xs`) |
+| Compact work/tool metadata | 10–12 px; long raw output uses 11 px mono |
+
+T3 bundles DM Sans Variable and JetBrains Mono through Fontsource. Helix currently declares IBM Plex Sans but does not bundle it, so most clients fall through to Helvetica or Arial.
+
+### Dark palette
+
+T3 uses semantic translucent layers over a neutral-black base rather than many unrelated opaque grays.
+
+| Token/use | T3 Code value |
+|---|---|
+| Workspace background | Tailwind `neutral-950`, `oklch(14.5% 0 0)` |
+| Primary foreground | `neutral-100`, `oklch(97% 0 0)` |
+| Card | 3% white mixed into the background |
+| Popover | 6% white mixed into the background |
+| Accent, muted, secondary | 4% white alpha |
+| Border | 6% white alpha |
+| Input border/surface | 8% white alpha |
+| Muted foreground | approximately `#818181` in the current theme |
+| User bubble | `accent`: 4% white over the dark background |
+| Assistant body | primary foreground at 80% opacity |
+
+The composer is a rounded glass layer: 22 px outer radius, a subtly lifted dark surface, a 5% white outline, a 3% inset highlight, and no dark-mode drop shadow.
+
+### Transcript geometry
+
+| Element | T3 Code value |
+|---|---|
+| Timeline and composer maximum width | 48 rem / 768 px (`max-w-3xl`) |
+| Timeline horizontal inset | 12 px narrow, 20 px from `sm` |
+| Normal turn spacing | 16 px below the row |
+| User alignment | right |
+| User bubble maximum width | 80% of timeline |
+| User bubble chrome | 16 px radius, 12 px padding, no border |
+| Assistant chrome | no bubble; 4 px horizontal and 2 px vertical inset |
+| User metadata | right-aligned below bubble, hidden until hover/focus |
+
+Long user messages collapse when they exceed either 600 characters or eight lines. The collapsed body is at most 176 px high with a bottom fade and an explicit “Show full message” control.
+
+### Turn and interrupt mechanics
+
+T3 gives a newly submitted turn a viewport-sized end spacer. Scrolling to the end therefore places the new user message near the top of the transcript, with a clean response area below it. As the response exceeds that reserved area, normal tail-following resumes. Manual upward scrolling still disengages auto-scroll.
+
+During an active turn, the composer swaps in a prominent destructive stop control: a red circular button with a white square. It is absent while idle. The control cancels the current turn without clearing the composer or changing the active session, so the next normal send continues in the same thread.
+
+### Image attachment UX
+
+T3 treats images as message data, not as paths inserted into message text.
+
+Composer behavior:
+
+- accepts pasted and dropped image files;
+- validates image MIME types;
+- allows up to eight images per turn;
+- caps each transmitted image at 10 MiB;
+- downscales oversized images instead of immediately rejecting them, preserving at most a 2048 px longest edge during re-encoding;
+- shows each image as a 64 × 64 px, 8 px-radius, `object-cover` tile;
+- places remove and persistence-warning actions over the tile;
+- opens the same full-screen viewer used by sent messages when a tile is clicked.
+
+Sent-message behavior:
+
+- renders images before the user's text inside the bubble;
+- uses a two-column grid, 8 px gap, maximum width 420 px;
+- uses 8 px-radius tiles with a subtle border and dark background;
+- caps displayed image height at 220 px and uses `object-cover`;
+- retains an optimistic blob preview until the durable server preview URL is available, avoiding a visible flash;
+- opens a 75% black lightbox with Escape-to-close, click-outside close, arrow-key navigation, previous/next buttons, filename, and position (`2/4`).
+
+## Current Helix implementation
+
+Both requested surfaces share the transcript renderer and composer primitives but duplicate their wiring:
+
+- org chat: `frontend/src/components/helix-org/HelixOrgChatPanel.tsx`
+- spec-task desktop and mobile chat: `frontend/src/components/tasks/SpecTaskDetailContent.tsx`
+- shared transcript: `frontend/src/components/session/EmbeddedSessionView.tsx`
+- message row: `frontend/src/components/session/Interaction.tsx`
+- message bubble: `frontend/src/components/session/InteractionContainer.tsx`
+- image rendering: `frontend/src/components/session/InteractionInference.tsx`
+- composer: `frontend/src/components/common/RobustPromptInput.tsx`
+
+### Current visual differences
+
+| Area | Helix today | T3 direction |
+|---|---|---|
+| Sans font | IBM Plex declaration without a bundled font; practical fallback is Helvetica/Arial | Bundled DM Sans Variable |
+| Chat background | Helix `#121214` app background | scoped neutral-black canvas |
+| Transcript width | 700 px | 768 px |
+| User width | fit-content up to nearly the full 700 px | maximum 80% |
+| User bubble | 16 px radius, 1 px `#33373a` border, 16 px horizontal/4 px vertical padding | borderless 4% white surface, 12 px padding |
+| Assistant | unboxed, but shares old typography and spacing | unboxed with quieter 80% text |
+| Message text | 0.9 rem markdown, about 14.4 px | 14 px with consistent relaxed line height |
+| Sent images | vertically repeated 150 × 150 previews | compact two-column gallery in the user bubble |
+| Image viewer | image-only backdrop; no filename, navigation, close button, or keyboard handling | accessible gallery lightbox |
+| Composer preview | chip with a 20 × 20 icon-sized crop and filename | 64 × 64 visual tile tray |
+
+### Functional attachment gap
+
+`RobustPromptInput` supports an upload callback, paste, drag/drop, and attachment chips, but neither target surface passes `onFileUpload` or `onImagePaste`. Attachments are therefore disabled in both target composers.
+
+The spec-task page has a separate upload action that writes files to `~/work/incoming`; it does not associate the file with a chat message or render it in message history. Where `RobustPromptInput` uploads are enabled elsewhere, uploaded sandbox paths are prepended to the text. That is useful transport for a coding agent, but it is not sufficient UI state:
+
+- the path becomes visible message content;
+- a browser blob preview disappears after reload;
+- the sandbox file is not a durable, authorized preview source;
+- queued spec-task sends and direct org-chat sends take different code paths;
+- a retry must retain exactly the same attachment association.
+
+## Proposed Helix design
+
+### Visual tokens
+
+Add chat-scoped semantic tokens rather than changing the global MUI palette.
+
+| Token | Dark value | Use |
+|---|---|---|
+| `chat.canvas` | `#0a0a0a` | transcript and composer dock |
+| `chat.text` | `#f5f5f5` | user message text |
+| `chat.assistantText` | `rgba(245,245,245,0.80)` | assistant markdown |
+| `chat.mutedText` | `#818181` | timestamps and secondary metadata |
+| `chat.userBubble` | `rgba(255,255,255,0.04)` | user bubble |
+| `chat.raised` | `rgba(255,255,255,0.03)` | composer surface |
+| `chat.border` | `rgba(255,255,255,0.06)` | passive separators |
+| `chat.inputBorder` | `rgba(255,255,255,0.08)` | composer and attachment tiles |
+| `chat.focus` | Helix cyan `#00d5ff` | focus ring and primary chat actions |
+
+Light mode retains the existing Helix light palette in the first change. The new tokens must still define a legible light equivalent so the components do not contain mode checks.
+
+Bundle `@fontsource-variable/dm-sans` and `@fontsource/jetbrains-mono`. Apply DM Sans only below the shared chat root. Keep the rest of the application on its current typography until a separate global typography decision is made.
+
+### Shared component boundary
+
+Introduce one composed `AgentChat` component for both surfaces. Page-specific headers, thread selectors, and desktop/spec tabs remain outside it.
+
+```text
+HelixOrgChatPanel ─┐
+                   ├─ AgentChat
+SpecTaskDetail ────┘    ├─ EmbeddedSessionView
+                        │    └─ Interaction
+                        │         ├─ UserMessage
+                        │         │    └─ ChatImageGrid
+                        │         └─ AssistantMessage
+                        ├─ SessionPromptQueue (configured by queue mode)
+                        └─ RobustPromptInput
+                             └─ ChatAttachmentTray
+
+AgentChat root ── one ImageLightbox instance for composer and transcript images
+```
+
+Suggested `AgentChat` inputs:
+
+- `sessionId`
+- `projectId`
+- optional `specTaskId`
+- `placeholder`
+- `disabled`
+- `onWillSend`
+- `onCancel`
+- `isAgentBusy`
+- `showPromptQueue`
+- `enableInteractionDebugCopy`
+
+The component owns scroll-to-bottom coordination, upload integration, attachment lightbox state, and consistent composer padding. It does not own page navigation or session/thread selection.
+
+### Message presentation
+
+- Set transcript and composer content to a shared 768 px maximum width with 12 px mobile and 20 px desktop gutters.
+- Render user bubbles at `max-width: 80%`, 16 px radius, 12 px padding, no border.
+- Render assistant output full-width without a bubble; use 14 px/1.625 text at 80% foreground.
+- Prefer `interaction.display_message` for the visible user text. Keep transport-only sandbox paths in `prompt_message` so agents can read files without exposing those paths as the user's prose.
+- Move timestamp, copy, edit, and debug actions into a 12 px row below the user bubble. Reveal it on hover and `focus-within`; keep it reachable by keyboard and visible on touch layouts.
+- Add T3-style long-user-message disclosure using the 600-character/eight-line threshold and a 176 px faded collapsed state.
+- Preserve the current system-prefix, fork, activity, tool-call, and streaming components. Restyle their surfaces using chat tokens rather than removing them.
+
+### Turn mechanics
+
+- While the newest interaction is `waiting`, give that turn a minimum height of one transcript viewport minus the normal gutters.
+- Continue using the existing scroll-to-bottom operation: the minimum height makes the user message land at the viewport top without a second competing scroll algorithm.
+- Remove the reserved height when the interaction completes or is interrupted.
+- Respect the existing manual-scroll unlock. Do not force the viewport back to the active turn after the operator scrolls up.
+- Derive busy state inside `AgentChat` from the newest interaction so org chat and both spec-task layouts show the same red interrupt control.
+- After interrupting, keep the composer enabled and preserve session identity; the next send is the required lifecycle seam test.
+
+### Attachment presentation
+
+Composer:
+
+- Add a visible attachment button; keep paste and drag/drop.
+- Initial scope is images only. Do not advertise PDFs or arbitrary files in this tray until they have a designed sent-message representation.
+- Show 64 × 64 px tiles above the editor, wrapping with an 8 px gap.
+- Tile states: uploading progress, uploaded, failed with retry, and remove.
+- Clicking a tile opens the shared lightbox.
+- Allow eight images per message and 10 MiB per normalized image. Re-encode oversized images to a maximum 2048 px longest edge. Reject unreadable images and source files too large to decode safely.
+
+Sent user message:
+
+- Render image attachments before text in a two-column grid capped at 420 px.
+- Use 8 px gaps/radii, subtle token border, and 220 px maximum tile height.
+- Preserve the original filename for accessible labels and the lightbox caption.
+- For attachment-only messages, render the gallery without an empty text block.
+
+Lightbox:
+
+- one portal-backed dialog shared across the chat;
+- 75% black backdrop;
+- close button and click-outside close;
+- Escape, Left, and Right keys;
+- previous/next buttons only for multi-image messages;
+- contained image up to 86 vh × 92 vw;
+- filename and current/total count;
+- focus trap and focus restoration to the opening thumbnail.
+
+### Durable attachment model
+
+Use a generic session-chat attachment primitive; do not create separate org-chat and spec-task attachment implementations.
+
+Proposed typed record:
+
+```go
+type ChatAttachment struct {
+    ID             string
+    SessionID      string
+    OwnerID        string
+    PromptHistoryID string
+    InteractionID  string
+    Name           string
+    MIMEType       string
+    SizeBytes      int64
+    FilestorePath  string
+    SandboxPath    string
+    CreatedAt      time.Time
+}
+```
+
+The association IDs are empty while the attachment belongs to a draft. Binding attachments to a prompt must be transactional and idempotent. Exact GORM tags and cleanup fields belong in implementation, not in this UI catalogue.
+
+Data flow:
+
+1. Composer uploads an image through a generated-client `POST /api/v1/sessions/{session_id}/chat-attachments` endpoint.
+2. The server authorizes write access to the session, validates and normalizes the image, stores a durable preview in the Helix filestore, copies the agent-readable file into `~/work/incoming`, and returns typed metadata.
+3. The composer queues/sends visible text plus attachment IDs. Local draft state keeps IDs and preview URLs, not base64 payloads.
+4. The server binds the IDs to the `PromptHistoryEntry`. Add an `AttachmentIDs` JSONB field to both the sync and session-scoped queue paths.
+5. Queue dispatch builds transport text from `SandboxPath` plus the user's message, while storing the clean user text in `Interaction.DisplayMessage`.
+6. The created interaction receives structured attachment metadata in `PromptMessageContent` or a typed interaction attachment field. Store stable filestore keys, not expiring signed URLs and not base64 image bodies in Postgres.
+7. `EmbeddedSessionView` resolves authorized preview URLs and renders `ChatImageGrid` identically after polling, WebSocket updates, retry, and reload.
+
+For direct org-chat dispatch, extend the send request with attachment IDs and run the same server binding/interaction construction use case. For queued spec-task dispatch, `PromptHistoryEntry` carries those IDs until the message is claimed. Both paths must call the same attachment-binding and transport-text builder.
+
+Unbound draft attachments should be garbage-collected after a bounded interval. Removing a tile may delete an unbound attachment immediately; attachments bound to prompts/interactions remain immutable history.
+
+### Security and correctness constraints
+
+- Resolve and authorize the session before accepting, binding, or serving an attachment.
+- Attachment ownership and session ID must match the prompt and interaction.
+- Ignore client-supplied filestore or sandbox paths; the server owns both.
+- Sanitize filenames and generate collision-free storage names.
+- Validate decoded image content, not only MIME type or extension.
+- Do not expose container filesystem paths as preview URLs.
+- Retry and queue reordering must retain attachment IDs without re-uploading or duplicating files.
+- Deleting or clearing a draft must not delete an attachment already bound to an interaction.
+
+## Implementation plan
+
+### 1. Shared visual foundation
+
+- Add bundled DM Sans Variable and JetBrains Mono.
+- Add typed chat theme tokens and a scoped chat root.
+- Restyle `EmbeddedSessionView`, `InteractionContainer`, `InteractionInference`, and markdown typography.
+- Add `UserMessageBody` disclosure and hover/focus metadata treatment.
+- Extract `ImageLightbox`, initially replacing the current image-only overlay.
+
+### 2. Durable attachment primitive
+
+- Add `ChatAttachment`, AutoMigrate registration, store interface, and store tests.
+- Add upload/bind/read endpoints with Swagger annotations, then run `./stack update_openapi`.
+- Implement a frontend React Query service using the generated API client.
+- Extend prompt-history sync and direct session send types with attachment IDs.
+- Centralize interaction creation and agent transport-text construction so both queue paths behave identically.
+
+### 3. Shared composer and message gallery
+
+- Replace attachment chips with `ChatAttachmentTray` tiles.
+- Add picker, paste, drop, validation, progress, retry, and removal.
+- Add `ChatImageGrid` to user messages and connect it to the shared lightbox.
+- Introduce `AgentChat` and replace the duplicated org/spec desktop/spec mobile wiring.
+- Remove the target surfaces' obsolete raw-fetch upload path once every upload entry point uses the generated client.
+
+### 4. Verification
+
+- Frontend unit tests: bubble geometry classes/styles, collapse thresholds, attachment-only messages, tile state transitions, lightbox keyboard behavior, and clean visible text versus transport paths.
+- Go tests: authorization, image validation, transactional binding, session mismatch rejection, queue retry idempotency, direct-send/queued-send parity, and cleanup of unbound drafts.
+- Build checks: `go build ./pkg/server/ ./pkg/store/ ./pkg/types/` and `cd frontend && yarn build`.
+- Live inner-Helix desktop and mobile-width checks in both dark and light mode.
+- Org-chat E2E: start an agent, attach two images, send, verify agent receipt, reload, reopen both images in the lightbox, then send a normal text-only follow-up.
+- Spec-task E2E against a live connected Zed: attach two images to a queued prompt, verify one interaction and one delivery, reload while queued and after sent, retry a failed upload, then send the immediately following normal prompt.
+
+## Acceptance criteria
+
+- Org-chart chat and spec-task chat render through the same `AgentChat` composition.
+- Dark chat uses the documented scoped font, sizes, palette, widths, and message hierarchy.
+- User messages are right-aligned, at most 80% wide, and visually distinct without a heavy border.
+- Assistant content remains unboxed and readable.
+- Pasted, dropped, and picked images show 64 px composer previews with explicit upload state.
+- Sent images remain visible and zoomable after reload and across devices.
+- Multi-image lightbox navigation works with mouse, touch, and keyboard.
+- The visible user message never includes transport-only sandbox paths.
+- Direct org sends and queued spec-task sends preserve the same attachment metadata and retry semantics.
+- No raw frontend request is added where a generated API client method can be used.
+- Existing light mode, system prefixes, tool calls, prompt queueing, interrupt mode, auto-scroll, and live streaming still work.
+
+## Explicit non-goals
+
+- Replacing the global Helix application theme or typography.
+- Copying T3's provider/model controls, minimap, prompt stash, or review-annotation system.
+- General document/PDF attachment cards in the first pass.
+- Sending authenticated preview URLs directly to the external agent. The agent receives server-built workspace paths; the UI receives authorized filestore previews.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@hookform/resolvers": "^3.10.0",
     "@inovua/reactdatagrid-community": "^5.10.2",
     "@mui/icons-material": "^5.3.1",

--- a/frontend/src/components/common/RobustPromptInput.test.tsx
+++ b/frontend/src/components/common/RobustPromptInput.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import { PromptHistoryEntry } from '../../hooks/usePromptHistory'
 import RobustPromptInput from './RobustPromptInput'
 
@@ -157,5 +157,22 @@ describe('RobustPromptInput client-side queue pump', () => {
     // Give the pump's 500ms/300ms timers room to (not) fire.
     await new Promise((r) => setTimeout(r, 800))
     expect(onSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('RobustPromptInput active-turn controls', () => {
+  it('interrupts the current turn from the busy-state control', () => {
+    const onCancel = vi.fn()
+    render(
+      <RobustPromptInput
+        sessionId="ses_test"
+        onSend={vi.fn()}
+        isAgentBusy
+        onCancel={onCancel}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Interrupt current turn' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -1003,7 +1003,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
       previewUrl = URL.createObjectURL(file)
     }
 
-    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    const id = crypto.randomUUID()
     const attachment: PendingAttachment = {
       id,
       name: file.name,

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -49,11 +49,10 @@ import {
   Pin,
   PinOff,
   Search,
-  Image,
   Paperclip,
   FileText,
   Camera,
-  StopCircle,
+  Square,
 } from 'lucide-react'
 import {
   DndContext,
@@ -74,6 +73,8 @@ import { CSS } from '@dnd-kit/utilities'
 import { usePromptHistory, PromptHistoryEntry } from '../../hooks/usePromptHistory'
 import { Api } from '../../api/api'
 import { classifyPromptQueueEntry } from '../../utils/promptQueueStatus'
+import ImageLightbox, { LightboxImage } from '../session/ImageLightbox'
+import { CHAT_FONT_FAMILY, getChatColors } from '../session/chatStyles'
 
 // Attachment that's pending to be sent with the message
 // Supports offline queueing - file data is stored until upload completes
@@ -519,6 +520,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   const [isRestartingAgent, setIsRestartingAgent] = useState(false)
   // Pending attachments that will be sent with the message
   const [attachments, setAttachments] = useState<PendingAttachment[]>([])
+  const [selectedAttachmentImageIndex, setSelectedAttachmentImageIndex] = useState<number | null>(null)
   const [isUploading, setIsUploading] = useState(false)
 
   // Use onFileUpload if provided, otherwise fall back to onImagePaste for backwards compat
@@ -1216,12 +1218,24 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   })
   const sentHistory = history.filter(h => h.status === 'sent')
   const hasHistory = sentHistory.length > 0
+  const imageAttachments = attachments.filter(
+    (attachment) => attachment.type === 'image' && attachment.previewUrl,
+  )
+  const attachmentLightboxImages: LightboxImage[] = imageAttachments.map((attachment) => ({
+    src: attachment.previewUrl!,
+    name: attachment.name,
+  }))
 
   return (
     <Box
       className="prompt-input-container"
       data-prompt-input="true"
-      sx={{ position: 'relative', width: '100%', minWidth: 0 }}
+      sx={{
+        position: 'relative',
+        width: '100%',
+        minWidth: 0,
+        fontFamily: CHAT_FONT_FAMILY,
+      }}
     >
       {/* Queued messages display. Only rendered when this is an authoritative
           backend-backed queue (spec-task). For plain sessions (org-chat,
@@ -1354,16 +1368,88 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
           sx={{
             display: 'flex',
             flexWrap: 'wrap',
-            gap: 0.75,
+            alignItems: 'center',
+            gap: 1,
             mb: 1,
-            p: 1,
-            borderRadius: 1.5,
-            border: '1px solid',
-            borderColor: 'divider',
-            bgcolor: (theme) => alpha(theme.palette.background.paper, 0.5),
           }}
         >
-          {attachments.map((attachment) => (
+          {imageAttachments.map((attachment, imageIndex) => (
+            <Box
+              key={attachment.id}
+              sx={{
+                width: 64,
+                height: 64,
+                position: 'relative',
+                borderRadius: 1,
+                overflow: 'hidden',
+                border: '1px solid',
+                borderColor: attachment.uploadStatus === 'failed'
+                  ? 'error.main'
+                  : attachment.uploadStatus === 'uploaded'
+                    ? 'divider'
+                    : 'warning.main',
+                bgcolor: 'background.paper',
+              }}
+            >
+              <Box
+                component="button"
+                type="button"
+                onClick={() => setSelectedAttachmentImageIndex(imageIndex)}
+                aria-label={`Preview ${attachment.name}`}
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  p: 0,
+                  border: 0,
+                  background: 'transparent',
+                  cursor: 'zoom-in',
+                }}
+              >
+                <Box
+                  component="img"
+                  src={attachment.previewUrl}
+                  alt={attachment.name}
+                  sx={{ width: '100%', height: '100%', display: 'block', objectFit: 'cover' }}
+                />
+              </Box>
+              {attachment.uploadStatus !== 'uploaded' && (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    pointerEvents: 'none',
+                    bgcolor: 'rgba(0,0,0,0.46)',
+                    color: '#fff',
+                  }}
+                >
+                  {attachment.uploadStatus === 'failed'
+                    ? <CircleAlert size={18} />
+                    : <CircularProgress size={18} sx={{ color: '#fff' }} />}
+                </Box>
+              )}
+              <IconButton
+                size="small"
+                onClick={() => removeAttachment(attachment.id)}
+                aria-label={`Remove ${attachment.name}`}
+                sx={{
+                  position: 'absolute',
+                  top: 3,
+                  right: 3,
+                  width: 20,
+                  height: 20,
+                  color: '#fff',
+                  bgcolor: 'rgba(0,0,0,0.64)',
+                  '&:hover': { bgcolor: 'rgba(0,0,0,0.82)' },
+                }}
+              >
+                <X size={13} />
+              </IconButton>
+            </Box>
+          ))}
+          {attachments.filter((attachment) => attachment.type !== 'image').map((attachment) => (
             <Chip
               key={attachment.id}
               size="small"
@@ -1372,23 +1458,6 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
                   <CircularProgress size={14} sx={{ ml: 0.5 }} />
                 ) : attachment.uploadStatus === 'failed' ? (
                   <CircleAlert size={16} />
-                ) : attachment.type === 'image' ? (
-                  attachment.previewUrl ? (
-                    <Box
-                      component="img"
-                      src={attachment.previewUrl}
-                      alt=""
-                      sx={{
-                        width: 20,
-                        height: 20,
-                        objectFit: 'cover',
-                        borderRadius: 0.5,
-                        ml: 0.5,
-                      }}
-                    />
-                  ) : (
-                    <Image size={16} />
-                  )
                 ) : attachment.type === 'text' ? (
                   <FileText size={16} />
                 ) : (
@@ -1435,19 +1504,26 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
         </Box>
       )}
 
+      <ImageLightbox
+        images={attachmentLightboxImages}
+        initialIndex={selectedAttachmentImageIndex ?? 0}
+        open={selectedAttachmentImageIndex !== null}
+        onClose={() => setSelectedAttachmentImageIndex(null)}
+      />
+
       {/* Input container */}
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: 'background.paper',
+          bgcolor: (theme) => getChatColors(theme).surface,
           borderRadius: 2,
           border: '1px solid',
           borderColor: !isOnline
             ? 'warning.main'
             : historyIndex >= 0
               ? 'info.main'
-              : 'divider',
+              : (theme) => getChatColors(theme).borderStrong,
           transition: 'border-color 0.2s, box-shadow 0.2s',
           boxShadow: !isOnline
             ? (theme) => `0 0 0 2px ${alpha(theme.palette.warning.main, 0.2)}`
@@ -1455,8 +1531,8 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
               ? (theme) => `0 0 0 2px ${alpha(theme.palette.info.main, 0.2)}`
               : 'none',
           '&:focus-within': {
-            borderColor: 'primary.main',
-            boxShadow: (theme) => `0 0 0 2px ${alpha(theme.palette.primary.main, 0.2)}`,
+            borderColor: (theme) => getChatColors(theme).borderStrong,
+            boxShadow: (theme) => `0 0 0 1px ${getChatColors(theme).borderStrong}`,
           },
           p: 1,
         }}
@@ -1485,8 +1561,8 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
             bgcolor: isDraggingOver ? (theme) => alpha(theme.palette.primary.main, 0.08) : 'transparent',
             color: 'text.primary',
             fontFamily: 'inherit',
-            fontSize: '0.875rem',
-            lineHeight: 1.5,
+            fontSize: { xs: '1rem', sm: '0.875rem' },
+            lineHeight: 1.55,
             p: 0.5,
             minHeight: 50,
             maxHeight: maxHeight,
@@ -1614,6 +1690,8 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
             <IconButton
               size="small"
               onClick={() => setInterruptMode(!interruptMode)}
+              aria-label={interruptMode ? 'Switch to queue mode' : 'Switch to interrupt mode'}
+              aria-pressed={interruptMode}
               sx={{
                 flexShrink: 0,
                 color: interruptMode ? 'warning.main' : 'info.main',
@@ -1639,20 +1717,23 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
 
           {/* Cancel button - visible when agent is busy */}
           {isAgentBusy && onCancel && (
-            <Tooltip title="Cancel current turn">
+            <Tooltip title="Interrupt current turn">
               <IconButton
                 onClick={onCancel}
+                aria-label="Interrupt current turn"
                 sx={{
                   flexShrink: 0,
-                  width: 30,
-                  height: 30,
-                  color: 'warning.main',
+                  width: 32,
+                  height: 32,
+                  color: '#fff',
+                  bgcolor: 'error.main',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.28)',
                   '&:hover': {
-                    bgcolor: (theme) => alpha(theme.palette.warning.main, 0.1),
+                    bgcolor: 'error.dark',
                   },
                 }}
               >
-                <StopCircle size={18} />
+                <Square size={12} fill="currentColor" strokeWidth={0} />
               </IconButton>
             </Tooltip>
           )}
@@ -1676,6 +1757,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
                   <IconButton
                     onClick={handleSend}
                     disabled={!canSend}
+                    aria-label="Send message"
                     color={canSend ? 'secondary' : 'primary'}
                     sx={{
                       flexShrink: 0,

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -74,7 +74,7 @@ import { usePromptHistory, PromptHistoryEntry } from '../../hooks/usePromptHisto
 import { Api } from '../../api/api'
 import { classifyPromptQueueEntry } from '../../utils/promptQueueStatus'
 import ImageLightbox, { LightboxImage } from '../session/ImageLightbox'
-import { CHAT_FONT_FAMILY, getChatColors } from '../session/chatStyles'
+import { getChatColors } from '../session/chatStyles'
 
 // Attachment that's pending to be sent with the message
 // Supports offline queueing - file data is stored until upload completes
@@ -1234,7 +1234,6 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
         position: 'relative',
         width: '100%',
         minWidth: 0,
-        fontFamily: CHAT_FONT_FAMILY,
       }}
     >
       {/* Queued messages display. Only rendered when this is an authoritative

--- a/frontend/src/components/dashboard/slackManifest.test.ts
+++ b/frontend/src/components/dashboard/slackManifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildManifest, BOT_EVENTS } from './slackManifest'
+import { DARK_APP_BACKGROUND } from '../../styles/themeTokens'
 
 const REDIRECT = 'https://helix.example/api/v1/slack/oauth/callback'
 const EVENTS = 'https://helix.example/api/v1/slack/events'
@@ -41,6 +42,11 @@ describe('buildManifest', () => {
       messages_tab_read_only_enabled: false,
     })
     expect(m.oauth_config.scopes.bot.length).toBeGreaterThan(0)
+  })
+
+  it('uses the application dark canvas for Slack branding', () => {
+    const m = JSON.parse(buildManifest('rest', REDIRECT, EVENTS))
+    expect(m.display_information.background_color).toBe(DARK_APP_BACKGROUND)
   })
 
   // Every subscribed message.* event must have its matching *:history scope

--- a/frontend/src/components/dashboard/slackManifest.ts
+++ b/frontend/src/components/dashboard/slackManifest.ts
@@ -3,6 +3,8 @@
 // pure module so the manifest contract — the thing Slack validates — is
 // unit-testable without rendering the dialog.
 
+import { DARK_APP_BACKGROUND } from '../../styles/themeTokens'
+
 // Bot scopes the global app requests. The backend's defaultSlackBotScopes
 // (helix_org_slack.go) is authoritative — it's what the OAuth install
 // actually requests — so this manifest list must stay a superset of it.
@@ -64,9 +66,8 @@ export const buildManifest = (mode: 'rest' | 'socket', redirectURL: string, even
         'Mention a Worker or post in a connected channel and the right agent picks the message up, ' +
         'reads the surrounding thread, and replies right here in Slack — all backed by your own ' +
         'Helix deployment. Learn more at https://helix.ml.',
-      // Helix brand dark — matches the app icon background and the
-      // product's own theme (frontend/src/themes.tsx darkBackgroundColor).
-      background_color: '#121214',
+      // Keep generated Slack branding aligned with the application canvas.
+      background_color: DARK_APP_BACKGROUND,
     },
     features: {
       bot_user: { display_name: name, always_online: true },

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -237,7 +237,7 @@ const HelixOrgChatPanel: FC = () => {
           justifyContent: 'center',
           gap: 0.25,
           flexShrink: 0,
-          backgroundColor: 'background.paper',
+          backgroundColor: 'background.default',
         }}
       >
         <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -1,8 +1,8 @@
 // Left-rail chat for the helix-org shell — same building blocks as the
-// spec-task chat (EmbeddedSessionView + RobustPromptInput), scoped to one
+// spec-task chat (AgentChat), scoped to one
 // bot at a time. Header shows which bot you are talking to.
 
-import { FC, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FC, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -20,18 +20,13 @@ import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import StopIcon from '@mui/icons-material/Stop'
 
-import RobustPromptInput from '../common/RobustPromptInput'
 import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
-import SessionPromptQueue from '../session/SessionPromptQueue'
-import EmbeddedSessionView, {
-  EmbeddedSessionViewHandle,
-} from '../session/EmbeddedSessionView'
+import AgentChat from '../session/AgentChat'
 import useApi from '../../hooks/useApi'
 import useLightTheme from '../../hooks/useLightTheme'
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
 import { useStreaming } from '../../contexts/streaming'
-import { SESSION_TYPE_TEXT } from '../../types'
 import {
   BotDTO,
   useActivateBot,
@@ -126,7 +121,6 @@ const HelixOrgChatPanel: FC = () => {
 
   const [chatSessionId, setChatSessionId] = useState<string | null>(null)
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null)
-  const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
 
   const chatApi: WorkerChatReader = useMemo(() => ({
     getExploratorySession: async (pid: string) => {
@@ -419,34 +413,14 @@ const HelixOrgChatPanel: FC = () => {
             )}
           </Box>
         ) : view === 'chat' ? (
-          <>
-            <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-              <EmbeddedSessionView
-                ref={sessionViewRef}
-                sessionId={chatSessionId}
-                autoScrollOnMount
-                enableInteractionDebugCopy
-              />
-            </Box>
-            <SessionPromptQueue sessionId={chatSessionId} />
-            <Box sx={{ p: 1.5, flexShrink: 0 }}>
-              <RobustPromptInput
-                sessionId={chatSessionId}
-                projectId={projectID}
-                apiClient={api.getApiClient()}
-                onSend={async (message: string, interrupt?: boolean) => {
-                  await streaming.NewInference({
-                    type: SESSION_TYPE_TEXT,
-                    message,
-                    sessionId: chatSessionId,
-                    interrupt: interrupt ?? true,
-                  })
-                }}
-                onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
-                placeholder={`Message ${selectedBot?.name || selectedBotId}…`}
-              />
-            </Box>
-          </>
+          <AgentChat
+            sessionId={chatSessionId}
+            projectId={projectID}
+            autoScrollOnMount
+            enableInteractionDebugCopy
+            showSessionPromptQueue
+            placeholder={`Message ${selectedBot?.name || selectedBotId}…`}
+          />
         ) : (
           <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
             <ExternalAgentDesktopViewer

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -44,6 +44,7 @@ import { TypesAuthProvider } from '../../api/api'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
 import { orgLandingRoute } from '../../utils/organizations'
 import { useSettingsDialog } from '../../contexts/settingsDialog'
+import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 
 // Shimmer animation for login button
 const shimmer = keyframes`
@@ -104,24 +105,26 @@ interface NavButtonProps {
 const NavButton: FC<NavButtonProps> = ({ icon, tooltip, isActive, onClick, label }) => {
   const lightTheme = useLightTheme()
   const isLight = lightTheme.isLight
-  const activeText = isLight ? '#000' : '#E2E8F0'
-  // Light mode = "looking at a cheap iPad in direct sunlight" — go max
-  // contrast. Inactive icons + labels are near-black so they survive glare.
-  const inactiveText = isLight ? '#000' : '#A0AEC0'
-  const activeBg = isLight ? 'rgba(0, 0, 0, 0.12)' : 'rgba(226, 232, 240, 0.15)'
-  const activeBorder = isLight ? 'rgba(0, 0, 0, 0.30)' : 'rgba(226, 232, 240, 0.3)'
+  const activeText = isLight ? LIGHT_SIDEBAR_COLORS.foreground : '#E2E8F0'
+  const inactiveText = isLight ? LIGHT_SIDEBAR_COLORS.icon : '#A0AEC0'
+  const activeBg = isLight ? LIGHT_SIDEBAR_COLORS.rowSelected : 'rgba(226, 232, 240, 0.15)'
+  const activeBorder = isLight ? LIGHT_SIDEBAR_COLORS.border : 'rgba(226, 232, 240, 0.3)'
   const hoverBg = isLight
-    ? (isActive ? 'rgba(0, 0, 0, 0.16)' : 'rgba(0, 0, 0, 0.08)')
+    ? (isActive ? LIGHT_SIDEBAR_COLORS.rowSelected : LIGHT_SIDEBAR_COLORS.rowHover)
     : (isActive ? 'rgba(226, 232, 240, 0.2)' : 'rgba(226, 232, 240, 0.1)')
-  const labelInactive = isLight ? '#000' : '#6B7280'
+  const labelInactive = isLight ? LIGHT_SIDEBAR_COLORS.mutedForeground : '#6B7280'
   return (
     <Tooltip title={tooltip} placement="right">
       <Box
         onClick={onClick}
+        data-compact-nav-item={label}
         sx={{
           mt: 1,
-          width: AVATAR_SIZE + 8,
-          height: AVATAR_SIZE + 8,
+          width: 52,
+          height: 56,
+          px: 0.5,
+          py: 0.5,
+          boxSizing: 'border-box',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -131,13 +134,11 @@ const NavButton: FC<NavButtonProps> = ({ icon, tooltip, isActive, onClick, label
           backgroundColor: isActive ? activeBg : 'transparent',
           borderRadius: 1,
           border: isActive ? `1px solid ${activeBorder}` : '1px solid transparent',
-          transform: isActive ? 'scale(1.05)' : 'scale(1)',
           '&:hover': {
             color: activeText,
-            transform: isActive ? 'scale(1.08)' : 'scale(1.1)',
             backgroundColor: hoverBg,
           },
-          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          transition: 'color 150ms ease, background-color 150ms ease, border-color 150ms ease',
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -145,13 +146,18 @@ const NavButton: FC<NavButtonProps> = ({ icon, tooltip, isActive, onClick, label
         </Box>
         <Typography
           variant="caption"
+          data-compact-nav-label={label}
           sx={{
             fontSize: '0.65rem',
             color: isActive ? activeText : labelInactive,
             textAlign: 'center',
-            lineHeight: 1,
-            mt: 0.8,
-            fontWeight: isActive ? 'bold' : (isLight ? 600 : 'normal'),
+            lineHeight: 1.05,
+            mt: 0.75,
+            fontWeight: isLight ? 500 : (isActive ? 600 : 400),
+            width: '100%',
+            whiteSpace: 'normal',
+            overflowWrap: 'normal',
+            wordBreak: 'normal',
           }}
         >
           {label}
@@ -395,7 +401,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         tooltip: "View org chart",
         isActive: router.name.startsWith('helix_org'),
         onClick: handleHelixOrgClick,
-        label: "Org Chart",
+        label: "Chart",
       }] : []),
       {
         icon: <Kanban size={NAV_BUTTON_SIZE} />,

--- a/frontend/src/components/project/CreateProjectDialog.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.tsx
@@ -134,7 +134,7 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
   // Fetch GitHub repos when connected with repo scope
   const { data: githubReposData, isLoading: githubReposLoading, isFetching: githubReposFetching, error: githubReposError } =
     useListOAuthConnectionRepositories(
-      githubHasRepoScope && externalType === TypesExternalRepositoryType.ExternalRepositoryTypeGitHub
+      open && repoMode === 'link' && githubHasRepoScope && externalType === TypesExternalRepositoryType.ExternalRepositoryTypeGitHub
         ? (githubConnection?.id || '')
         : ''
     )

--- a/frontend/src/components/project/ProjectsListView.tsx
+++ b/frontend/src/components/project/ProjectsListView.tsx
@@ -152,7 +152,12 @@ const ProjectCard: FC<{
         backgroundColor: 'background.paper',
         border: '1px solid',
         borderColor: isPinned ? 'rgba(167, 139, 250, 0.3)' : 'rgba(0, 0, 0, 0.08)',
-        borderLeft: isPinned ? '3px solid #a78bfa' : '3px solid transparent',
+        borderLeft: isPinned ? '3px solid #a78bfa' : '1px solid',
+        borderLeftColor: isPinned
+          ? '#a78bfa'
+          : lightTheme.isLight
+            ? 'rgba(0, 0, 0, 0.08)'
+            : 'rgba(255, 255, 255, 0.08)',
         borderRadius: 1,
         boxShadow: 'none',
         transition: 'all 0.15s ease-in-out',

--- a/frontend/src/components/project/RepositoriesListView.tsx
+++ b/frontend/src/components/project/RepositoriesListView.tsx
@@ -22,7 +22,7 @@ import {
 import WarningIcon from '@mui/icons-material/Warning'
 import SearchIcon from '@mui/icons-material/Search'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
-import { GitBranch, Link as LinkIcon, Brain, RefreshCw, Trash, Plus, FolderSearch } from 'lucide-react'
+import { GitBranch, Link as LinkIcon, RefreshCw, Trash, Plus, FolderSearch } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import SimpleTable from '../widgets/SimpleTable'
@@ -37,7 +37,6 @@ import type { TypesGitRepository } from '../../api/api'
 
 interface RepositoriesListViewProps {
   repositories: TypesGitRepository[]
-  ownerSlug: string
   searchQuery: string
   onSearchChange: (query: string) => void
   page: number
@@ -54,7 +53,6 @@ interface RepositoriesListViewProps {
 
 const RepositoriesListView: FC<RepositoriesListViewProps> = ({
   repositories,
-  ownerSlug,
   searchQuery,
   onSearchChange,
   page,
@@ -164,7 +162,7 @@ const RepositoriesListView: FC<RepositoriesListViewProps> = ({
                     onViewRepository(repo)
                   }}
                 >
-                  {ownerSlug}/{repo.name || repo.id}
+                  {repo.name || repo.id}
                 </a>
               </Typography>
               {repo.description && (
@@ -181,15 +179,6 @@ const RepositoriesListView: FC<RepositoriesListViewProps> = ({
                     sx={{ height: 20, fontSize: '0.75rem' }}
                   />
                 )}
-                {repo.kodit_indexing && (
-                  <Chip
-                    icon={<Brain size={12} />}
-                    label="Code Intelligence"
-                    size="small"
-                    color="success"
-                    sx={{ height: 20, fontSize: '0.75rem' }}
-                  />
-                )}
               </Box>
             </Cell>
           </Row>
@@ -201,7 +190,7 @@ const RepositoriesListView: FC<RepositoriesListViewProps> = ({
         ),
       }
     })
-  }, [paginatedRepositories, ownerSlug, theme, onViewRepository])
+  }, [paginatedRepositories, theme, onViewRepository])
 
   const getActions = useCallback((repo: any) => {
     return (
@@ -232,13 +221,11 @@ const RepositoriesListView: FC<RepositoriesListViewProps> = ({
 
   return (
     <>
-      {/* GitHub-style header with owner/repositories */}
+      {/* Repository page header */}
       <Box sx={{ mb: 3, pb: 2 }}>
         <Box sx={{ mb: 2 }}>
           <Typography variant="h4" component="h1" sx={{ fontWeight: 400, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <span style={{ color: theme.palette.secondary.main, cursor: 'pointer' }}>{ownerSlug}</span>
-            <span style={{ color: 'text.secondary', fontWeight: 300 }}>/</span>
-            <span style={{ fontWeight: 600 }}>repositories</span>
+            <span style={{ fontWeight: 600 }}>Repositories</span>
           </Typography>
         </Box>
       </Box>

--- a/frontend/src/components/sandboxes/SandboxTerminal.tsx
+++ b/frontend/src/components/sandboxes/SandboxTerminal.tsx
@@ -39,14 +39,8 @@ interface Props {
 
 const sessionStorageKey = (sandboxId: string) => `helix.sandbox.${sandboxId}.terminalSession`
 
-const generateSessionName = (): string => {
-  // crypto.randomUUID is available in modern browsers; fall back to a
-  // timestamp+random string for older environments.
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID().replace(/-/g, '').slice(0, 12)
-  }
-  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
-}
+const generateSessionName = (): string =>
+  crypto.randomUUID().replace(/-/g, '').slice(0, 12)
 
 const readStoredSession = (sandboxId: string): string | undefined => {
   try {

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -108,7 +108,7 @@ const AgentChat: FC<AgentChatProps> = ({
         backgroundColor: (theme) => getChatColors(theme).canvas,
       }}
     >
-      <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex' }}>
+      <Box sx={{ flex: 1, minHeight: 0, minWidth: 0, width: '100%', overflow: 'hidden', display: 'flex' }}>
         <EmbeddedSessionView
           ref={sessionViewRef}
           sessionId={sessionId}
@@ -122,7 +122,11 @@ const AgentChat: FC<AgentChatProps> = ({
       <Box
         sx={{
           flexShrink: 0,
-          px: { xs: 1.5, sm: 2.5 },
+          pl: { xs: 1.5, sm: 2.5 },
+          pr: { xs: 1.5, sm: 2.5 },
+          '@media (pointer: fine)': {
+            pl: 4.5,
+          },
           pt: 1.25,
           pb: { xs: 1.25, sm: 1.75 },
           borderTop: '1px solid',

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -11,7 +11,7 @@ import { SESSION_TYPE_TEXT } from '../../types'
 import RobustPromptInput from '../common/RobustPromptInput'
 import EmbeddedSessionView, { EmbeddedSessionViewHandle } from './EmbeddedSessionView'
 import SessionPromptQueue from './SessionPromptQueue'
-import { CHAT_FONT_FAMILY, getChatColors } from './chatStyles'
+import { getChatColors } from './chatStyles'
 
 interface AgentChatProps {
   sessionId: string
@@ -104,7 +104,6 @@ const AgentChat: FC<AgentChatProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        fontFamily: CHAT_FONT_FAMILY,
         color: (theme) => getChatColors(theme).foreground,
         backgroundColor: (theme) => getChatColors(theme).canvas,
       }}

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -1,0 +1,155 @@
+import { FC, useCallback, useMemo, useRef } from 'react'
+import Box from '@mui/material/Box'
+import { alpha } from '@mui/material/styles'
+
+import { TypesInteractionState } from '../../api/api'
+import { useStreaming } from '../../contexts/streaming'
+import useApi from '../../hooks/useApi'
+import useSnackbar from '../../hooks/useSnackbar'
+import { useListInteractions } from '../../services/sessionService'
+import { SESSION_TYPE_TEXT } from '../../types'
+import RobustPromptInput from '../common/RobustPromptInput'
+import EmbeddedSessionView, { EmbeddedSessionViewHandle } from './EmbeddedSessionView'
+import SessionPromptQueue from './SessionPromptQueue'
+import { CHAT_FONT_FAMILY, getChatColors } from './chatStyles'
+
+interface AgentChatProps {
+  sessionId: string
+  projectId?: string
+  specTaskId?: string
+  placeholder?: string
+  disabled?: boolean
+  showSessionPromptQueue?: boolean
+  autoScrollOnMount?: boolean
+  enableInteractionDebugCopy?: boolean
+  onWillSend?: () => void
+}
+
+/** Shared org/spec-task conversation surface. */
+const AgentChat: FC<AgentChatProps> = ({
+  sessionId,
+  projectId,
+  specTaskId,
+  placeholder,
+  disabled,
+  showSessionPromptQueue = false,
+  autoScrollOnMount,
+  enableInteractionDebugCopy,
+  onWillSend,
+}) => {
+  const api = useApi()
+  const snackbar = useSnackbar()
+  const streaming = useStreaming()
+  const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
+  const apiClient = api.getApiClient()
+
+  const { data: latestInteractionsResponse } = useListInteractions(
+    sessionId,
+    0,
+    1,
+    'desc',
+    { enabled: !!sessionId, refetchInterval: 3000 },
+  )
+  const isAgentBusy = useMemo(
+    () => latestInteractionsResponse?.data?.interactions?.[0]?.state ===
+      TypesInteractionState.InteractionStateWaiting,
+    [latestInteractionsResponse?.data?.interactions?.[0]?.state],
+  )
+
+  const handleSend = useCallback(async (message: string, interrupt?: boolean) => {
+    await streaming.NewInference({
+      type: SESSION_TYPE_TEXT,
+      message,
+      sessionId,
+      interrupt: interrupt ?? true,
+    })
+    // streaming is a context object; sessionId is the only value that should
+    // rebind this callback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId])
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await api.getApiClient().v1SessionsCancelCreate(sessionId)
+    } catch (error: any) {
+      snackbar.error(error?.message || 'Failed to interrupt current turn')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId])
+
+  const handleFileUpload = useCallback(async (file: File): Promise<string | null> => {
+    try {
+      const response = await api.getApiClient().v1ExternalAgentsUploadCreate(
+        sessionId,
+        { file },
+        { open_file_manager: false },
+      )
+      if (!response.data?.path) return null
+      return response.data.path
+    } catch (error) {
+      console.error('Chat attachment upload failed:', error)
+      snackbar.error(`Failed to upload ${file.name}`)
+      return null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId])
+
+  return (
+    <Box
+      data-agent-chat
+      sx={{
+        flex: 1,
+        minHeight: 0,
+        minWidth: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        fontFamily: CHAT_FONT_FAMILY,
+        color: (theme) => getChatColors(theme).foreground,
+        backgroundColor: (theme) => getChatColors(theme).canvas,
+      }}
+    >
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex' }}>
+        <EmbeddedSessionView
+          ref={sessionViewRef}
+          sessionId={sessionId}
+          autoScrollOnMount={autoScrollOnMount}
+          enableInteractionDebugCopy={enableInteractionDebugCopy}
+        />
+      </Box>
+
+      {showSessionPromptQueue && <SessionPromptQueue sessionId={sessionId} />}
+
+      <Box
+        sx={{
+          flexShrink: 0,
+          px: { xs: 1.5, sm: 2.5 },
+          pt: 1.25,
+          pb: { xs: 1.25, sm: 1.75 },
+          borderTop: '1px solid',
+          borderColor: (theme) => getChatColors(theme).border,
+          backgroundColor: (theme) => alpha(getChatColors(theme).canvas, 0.96),
+        }}
+      >
+        <Box sx={{ width: '100%', maxWidth: 768, mx: 'auto' }}>
+          <RobustPromptInput
+            sessionId={sessionId}
+            specTaskId={specTaskId}
+            projectId={projectId}
+            apiClient={apiClient}
+            onSend={handleSend}
+            onWillSend={onWillSend}
+            onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
+            onFileUpload={handleFileUpload}
+            onCancel={handleCancel}
+            isAgentBusy={isAgentBusy}
+            placeholder={placeholder}
+            disabled={disabled}
+          />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default AgentChat

--- a/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { describe, expect, it, vi } from 'vitest'
+
+import ChatTurnNavigator from './ChatTurnNavigator'
+
+const items = [
+  { id: 'first', userText: 'First user message', assistantText: 'First assistant response' },
+  { id: 'second', userText: 'Second user message', assistantText: 'Second assistant response' },
+]
+
+const renderNavigator = (onSelect = vi.fn()) => {
+  render(
+    <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
+      <ChatTurnNavigator items={items} scrollContainer={null} onSelect={onSelect} />
+    </ThemeProvider>,
+  )
+  return { button: screen.getByRole('button', { hidden: true }), onSelect }
+}
+
+describe('ChatTurnNavigator interactions', () => {
+  it('previews the nearest turn under the pointer', () => {
+    const { button } = renderNavigator()
+    vi.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 140,
+      left: 0,
+      right: 300,
+      width: 300,
+      height: 40,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.mouseMove(button, { clientY: 140 })
+
+    expect(screen.getByText('Second user message')).toBeInTheDocument()
+    expect(screen.getByText('Second assistant response')).toBeInTheDocument()
+  })
+
+  it('supports keyboard browsing and selection', () => {
+    const { button, onSelect } = renderNavigator()
+
+    fireEvent.focus(button)
+    fireEvent.keyDown(button, { key: 'End' })
+    expect(button).toHaveAttribute('aria-label', 'Jump to message: Second user message')
+
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledWith(items[1])
+  })
+})

--- a/frontend/src/components/session/ChatTurnNavigator.logic.ts
+++ b/frontend/src/components/session/ChatTurnNavigator.logic.ts
@@ -1,0 +1,55 @@
+export const CHAT_TURN_NAVIGATOR_MIN_ITEMS = 2
+export const CHAT_TURN_NAVIGATOR_ITEM_SPACING = 8
+
+export interface ChatTurnNavigatorItem {
+  id: string
+  userText: string | null
+  assistantText: string | null
+}
+
+export const compactChatTurnPreview = (text: string | null | undefined) => {
+  const compact = text?.replace(/\s+/g, ' ').trim() ?? ''
+  return compact || null
+}
+
+export const resolveChatTurnAssistantPreview = (
+  responseMessage: string | null | undefined,
+  responseEntries: Array<{ type?: string; content?: string }> | null | undefined,
+) => {
+  const legacyResponse = compactChatTurnPreview(responseMessage)
+  if (legacyResponse) return legacyResponse
+
+  for (let index = (responseEntries?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const entry = responseEntries?.[index]
+    if (entry?.type !== 'text' || typeof entry.content !== 'string') continue
+    const withoutThinking = entry.content
+      .replace(/<thinking>[\s\S]*?<\/thinking>/gi, ' ')
+      .replace(/<think>[\s\S]*?<\/think>/gi, ' ')
+    const preview = compactChatTurnPreview(withoutThinking)
+    if (preview) return preview
+  }
+  return null
+}
+
+export const resolveChatTurnNavigatorTopPercent = (index: number, itemCount: number) => {
+  if (itemCount <= 1) return 0
+  const boundedIndex = Math.max(0, Math.min(index, itemCount - 1))
+  return (boundedIndex / (itemCount - 1)) * 100
+}
+
+export const resolveChatTurnNavigatorIndexFromPointer = ({
+  itemCount,
+  railTop,
+  railHeight,
+  pointerY,
+}: {
+  itemCount: number
+  railTop: number
+  railHeight: number
+  pointerY: number
+}) => {
+  if (itemCount <= 0 || railHeight <= 0) return null
+  if (itemCount === 1) return 0
+  const progress = Math.max(0, Math.min(1, (pointerY - railTop) / railHeight))
+  return Math.max(0, Math.min(itemCount - 1, Math.round(progress * (itemCount - 1))))
+}

--- a/frontend/src/components/session/ChatTurnNavigator.test.ts
+++ b/frontend/src/components/session/ChatTurnNavigator.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compactChatTurnPreview,
+  resolveChatTurnAssistantPreview,
+  resolveChatTurnNavigatorIndexFromPointer,
+  resolveChatTurnNavigatorTopPercent,
+} from './ChatTurnNavigator.logic'
+
+describe('ChatTurnNavigator', () => {
+  it('compacts message previews without inventing fallback text', () => {
+    expect(compactChatTurnPreview('  A message\n\nwith   spacing  ')).toBe('A message with spacing')
+    expect(compactChatTurnPreview('   ')).toBeNull()
+    expect(compactChatTurnPreview(undefined)).toBeNull()
+  })
+
+  it('uses the latest assistant prose and skips tool calls or thinking-only entries', () => {
+    expect(resolveChatTurnAssistantPreview('', [
+      { type: 'text', content: '<thinking>private reasoning</thinking>Earlier update.' },
+      { type: 'tool_call', content: 'Tool output' },
+      { type: 'text', content: '<thinking>more private reasoning</thinking>' },
+    ])).toBe('Earlier update.')
+    expect(resolveChatTurnAssistantPreview('Legacy response', [])).toBe('Legacy response')
+  })
+
+  it('distributes markers evenly from the start to the end of the rail', () => {
+    expect(resolveChatTurnNavigatorTopPercent(0, 5)).toBe(0)
+    expect(resolveChatTurnNavigatorTopPercent(2, 5)).toBe(50)
+    expect(resolveChatTurnNavigatorTopPercent(4, 5)).toBe(100)
+  })
+
+  it('selects the nearest marker and clamps pointers outside the rail', () => {
+    const input = { itemCount: 5, railTop: 100, railHeight: 80 }
+    expect(resolveChatTurnNavigatorIndexFromPointer({ ...input, pointerY: 100 })).toBe(0)
+    expect(resolveChatTurnNavigatorIndexFromPointer({ ...input, pointerY: 141 })).toBe(2)
+    expect(resolveChatTurnNavigatorIndexFromPointer({ ...input, pointerY: 500 })).toBe(4)
+    expect(resolveChatTurnNavigatorIndexFromPointer({ ...input, pointerY: 0 })).toBe(0)
+  })
+})

--- a/frontend/src/components/session/ChatTurnNavigator.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.tsx
@@ -1,0 +1,292 @@
+import React, { FC, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import { alpha, useTheme } from '@mui/material/styles'
+
+import { getChatColors } from './chatStyles'
+import {
+  CHAT_TURN_NAVIGATOR_ITEM_SPACING,
+  CHAT_TURN_NAVIGATOR_MIN_ITEMS,
+  ChatTurnNavigatorItem,
+  resolveChatTurnNavigatorIndexFromPointer,
+  resolveChatTurnNavigatorTopPercent,
+} from './ChatTurnNavigator.logic'
+
+const eventTargetsPreview = (target: EventTarget) =>
+  target instanceof Element && target.closest('[data-chat-turn-preview]') !== null
+
+interface ChatTurnNavigatorProps {
+  items: ChatTurnNavigatorItem[]
+  scrollContainer: HTMLDivElement | null
+  onSelect: (item: ChatTurnNavigatorItem) => void
+}
+
+const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
+  items,
+  scrollContainer,
+  onSelect,
+}) => {
+  const theme = useTheme()
+  const colors = getChatColors(theme)
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  const markerRefs = useRef(new Map<string, HTMLSpanElement>())
+
+  const resolvedActiveIndex = activeIndex !== null && activeIndex < items.length
+    ? activeIndex
+    : null
+  const activeItem = resolvedActiveIndex === null ? null : items[resolvedActiveIndex]
+  const activeTop = resolvedActiveIndex === null
+    ? 0
+    : resolveChatTurnNavigatorTopPercent(resolvedActiveIndex, items.length)
+  const activeTranslate = resolvedActiveIndex === 0
+    ? '0%'
+    : resolvedActiveIndex === items.length - 1
+      ? '-100%'
+      : '-50%'
+  const naturalHeight = Math.max(1, (items.length - 1) * CHAT_TURN_NAVIGATOR_ITEM_SPACING)
+
+  const turnElements = useMemo(() => {
+    if (!scrollContainer) return new Map<string, HTMLElement>()
+    const elements = new Map<string, HTMLElement>()
+    scrollContainer.querySelectorAll<HTMLElement>('[data-chat-turn]').forEach((element) => {
+      const id = element.dataset.chatTurn
+      if (id) elements.set(id, element)
+    })
+    return elements
+  }, [items, scrollContainer])
+
+  const updateVisibleMarkers = useCallback(() => {
+    if (!scrollContainer) return
+    const viewport = scrollContainer.getBoundingClientRect()
+    items.forEach((item) => {
+      const marker = markerRefs.current.get(item.id)
+      const turn = turnElements.get(item.id)
+      if (!marker || !turn) return
+      const rect = turn.getBoundingClientRect()
+      const inView = rect.top < viewport.bottom && rect.bottom > viewport.top
+      marker.dataset.inView = inView ? 'true' : 'false'
+    })
+  }, [items, scrollContainer, turnElements])
+
+  useEffect(() => {
+    if (!scrollContainer) return
+    const frame = requestAnimationFrame(updateVisibleMarkers)
+    const observer = new ResizeObserver(updateVisibleMarkers)
+    observer.observe(scrollContainer)
+    if (scrollContainer.firstElementChild) observer.observe(scrollContainer.firstElementChild)
+    scrollContainer.addEventListener('scroll', updateVisibleMarkers, { passive: true })
+    return () => {
+      cancelAnimationFrame(frame)
+      observer.disconnect()
+      scrollContainer.removeEventListener('scroll', updateVisibleMarkers)
+    }
+  }, [scrollContainer, updateVisibleMarkers])
+
+  const resolveIndexFromPointer = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    return resolveChatTurnNavigatorIndexFromPointer({
+      itemCount: items.length,
+      railTop: rect.top,
+      railHeight: rect.height,
+      pointerY: event.clientY,
+    })
+  }, [items.length])
+
+  const moveActiveIndex = useCallback((delta: number) => {
+    setActiveIndex((current) => {
+      const base = current ?? 0
+      return Math.max(0, Math.min(items.length - 1, base + delta))
+    })
+  }, [items.length])
+
+  if (items.length < CHAT_TURN_NAVIGATOR_MIN_ITEMS) return null
+
+  return (
+    <Box
+      data-chat-turn-navigator
+      sx={{
+        pointerEvents: 'none',
+        position: 'absolute',
+        inset: 0,
+        right: 'auto',
+        zIndex: 4,
+        width: '100%',
+        display: 'none',
+        '@media (pointer: fine)': {
+          display: 'block',
+        },
+      }}
+    >
+      <Box
+        component="button"
+        type="button"
+        aria-label={`Jump to message: ${activeItem?.userText ?? 'User message'}`}
+        onBlur={() => setActiveIndex(null)}
+        onFocus={() => setActiveIndex((current) => current ?? 0)}
+        onMouseLeave={() => setActiveIndex(null)}
+        onMouseMove={(event: MouseEvent<HTMLButtonElement>) => {
+          const next = resolveIndexFromPointer(event)
+          setActiveIndex((current) => current === next ? current : next)
+        }}
+        onMouseDown={(event: MouseEvent<HTMLButtonElement>) => {
+          if (!eventTargetsPreview(event.target)) event.preventDefault()
+        }}
+        onClick={(event: MouseEvent<HTMLButtonElement>) => {
+          if (eventTargetsPreview(event.target)) return
+          const index = resolveIndexFromPointer(event)
+          const item = index === null ? null : items[index]
+          if (item) onSelect(item)
+          event.currentTarget.blur()
+        }}
+        onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault()
+            moveActiveIndex(1)
+          } else if (event.key === 'ArrowUp') {
+            event.preventDefault()
+            moveActiveIndex(-1)
+          } else if (event.key === 'Home') {
+            event.preventDefault()
+            setActiveIndex(0)
+          } else if (event.key === 'End') {
+            event.preventDefault()
+            setActiveIndex(items.length - 1)
+          } else if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            if (activeItem) onSelect(activeItem)
+          }
+        }}
+        sx={{
+          pointerEvents: 'auto',
+          position: 'absolute',
+          top: '50%',
+          left: 12,
+          transform: 'translateY(-50%)',
+          width: activeItem ? 'calc(100% - 20px)' : 24,
+          height: `min(${naturalHeight}px, calc(100% - 48px))`,
+          m: 0,
+          p: 0,
+          border: 0,
+          background: 'transparent',
+          cursor: 'pointer',
+          color: colors.muted,
+          textAlign: 'left',
+          '&:focus-visible': {
+            outline: `2px solid ${alpha(colors.foreground, 0.55)}`,
+            outlineOffset: -2,
+          },
+        }}
+      >
+        <Box
+          aria-hidden
+          sx={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 12,
+            width: '1px',
+            backgroundColor: alpha(colors.muted, 0.14),
+          }}
+        />
+        {items.map((item, index) => {
+          const distance = resolvedActiveIndex === null
+            ? null
+            : Math.abs(index - resolvedActiveIndex)
+          const width = distance === 0 ? 24 : distance === 1 ? 16 : distance === 2 ? 10 : 8
+          return (
+            <Box
+              component="span"
+              aria-hidden
+              data-chat-turn-marker
+              data-in-view="false"
+              key={item.id}
+              ref={(node: HTMLSpanElement | null) => {
+                if (node) markerRefs.current.set(item.id, node)
+                else markerRefs.current.delete(item.id)
+              }}
+              sx={{
+                pointerEvents: 'none',
+                position: 'absolute',
+                top: `${resolveChatTurnNavigatorTopPercent(index, items.length)}%`,
+                left: 0,
+                width,
+                height: 2,
+                transform: 'translateY(-50%)',
+                borderRadius: 999,
+                backgroundColor: alpha(colors.muted, distance === 0 ? 0.78 : 0.38),
+                transition: 'width 150ms ease, background-color 150ms ease',
+                '&[data-in-view="true"]': {
+                  backgroundColor: alpha(colors.foreground, 0.92),
+                },
+              }}
+            />
+          )
+        })}
+        {activeItem && (
+          <Box
+            component="span"
+            data-chat-turn-preview
+            onMouseMove={(event: MouseEvent<HTMLSpanElement>) => event.stopPropagation()}
+            sx={{
+              pointerEvents: 'auto',
+              position: 'absolute',
+              top: `${activeTop}%`,
+              left: 32,
+              right: 0,
+              transform: `translateY(${activeTranslate})`,
+              cursor: 'text',
+              userSelect: 'text',
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: 'block',
+                p: 1.5,
+                borderRadius: 3,
+                border: `1px solid ${colors.borderStrong}`,
+                backgroundColor: alpha(colors.surfaceRaised, 0.96),
+                color: colors.foreground,
+                boxShadow: '0 12px 30px rgba(0,0,0,0.28)',
+                backdropFilter: 'blur(12px)',
+              }}
+            >
+              <Box
+                component="span"
+                sx={{
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: '0.875rem',
+                  fontWeight: 500,
+                  lineHeight: 1.45,
+                }}
+              >
+                {activeItem.userText ?? 'User message'}
+              </Box>
+              {activeItem.assistantText && (
+                <Box
+                  component="span"
+                  sx={{
+                    display: '-webkit-box',
+                    mt: 0.5,
+                    overflow: 'hidden',
+                    WebkitBoxOrient: 'vertical',
+                    WebkitLineClamp: 3,
+                    color: colors.muted,
+                    fontSize: '0.875rem',
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {activeItem.assistantText}
+                </Box>
+              )}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default ChatTurnNavigator

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -52,7 +52,7 @@ import { useStreaming } from "../../contexts/streaming";
 import { TypesInteraction, TypesInteractionState } from "../../api/api";
 import useLightTheme from "../../hooks/useLightTheme";
 import { SESSION_TYPE_TEXT } from "../../types";
-import { CHAT_FONT_FAMILY, getChatColors } from "./chatStyles";
+import { getChatColors } from "./chatStyles";
 
 interface EmbeddedSessionViewProps {
   sessionId: string;
@@ -665,7 +665,6 @@ const EmbeddedSessionView = forwardRef<
         position: "relative",
         display: "flex",
         flexDirection: "column",
-        fontFamily: CHAT_FONT_FAMILY,
         backgroundColor: (theme) => getChatColors(theme).canvas,
       }}
     >

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -53,6 +53,13 @@ import { TypesInteraction, TypesInteractionState } from "../../api/api";
 import useLightTheme from "../../hooks/useLightTheme";
 import { SESSION_TYPE_TEXT } from "../../types";
 import { getChatColors } from "./chatStyles";
+import ChatTurnNavigator from "./ChatTurnNavigator";
+import {
+  ChatTurnNavigatorItem,
+  compactChatTurnPreview,
+  resolveChatTurnAssistantPreview,
+} from "./ChatTurnNavigator.logic";
+import { splitSystemPrefix } from "./CollapsibleSystemPrefix";
 
 interface EmbeddedSessionViewProps {
   sessionId: string;
@@ -177,6 +184,8 @@ const EmbeddedSessionView = forwardRef<
   // so the resulting onScroll event sees no delta and doesn't falsely
   // re-enable auto-scroll.
   const lastScrollTopRef = useRef(0);
+  const navigatorScrollSequenceRef = useRef(0);
+  const isNavigatorScrollingRef = useRef(false);
 
   // Pagination state: track which page we've loaded up to (page 0 = newest)
   const [oldestPageLoaded, setOldestPageLoaded] = useState(0);
@@ -209,6 +218,7 @@ const EmbeddedSessionView = forwardRef<
     const currScrollTop = container.scrollTop;
     lastScrollTopRef.current = currScrollTop;
 
+    if (isNavigatorScrollingRef.current) return;
     if (autoScrollRef.current) return;
     if (!isNearBottom()) return;
 
@@ -577,6 +587,38 @@ const EmbeddedSessionView = forwardRef<
     return [...olderInteractions, ...newestInteractions];
   }, [olderInteractions, newestInteractions]);
 
+  const navigatorItems = useMemo<ChatTurnNavigatorItem[]>(() => {
+    return visibleInteractions.flatMap((interaction) => {
+      if (!interaction.id || interaction.trigger === "fork_seed") return [];
+      const contentText = interaction.prompt_message_content?.parts?.find(
+        (part): part is { text: string } =>
+          typeof part === "object" &&
+          part !== null &&
+          "text" in part &&
+          typeof part.text === "string",
+      )?.text;
+      const rawUserText = interaction.display_message || interaction.prompt_message || contentText;
+      const splitUserText = splitSystemPrefix(rawUserText || "");
+      const userText = compactChatTurnPreview(
+        splitUserText.prefix
+          ? splitUserText.userText ||
+            (splitUserText.kind === "approval"
+              ? "Spec approved · Implementation instructions"
+              : splitUserText.label || "Planning Instructions")
+          : rawUserText,
+      );
+      if (!userText) return [];
+      return [{
+        id: interaction.id,
+        userText,
+        assistantText: resolveChatTurnAssistantPreview(
+          interaction.response_message,
+          interaction.response_entries as unknown as Array<{ type?: string; content?: string }>,
+        ),
+      }];
+    });
+  }, [visibleInteractions]);
+
   const totalInteractions = visibleInteractions.length;
 
   // Check if there are more pages to load
@@ -586,6 +628,38 @@ const EmbeddedSessionView = forwardRef<
   const remainingOlderCount = Math.max(0, totalCount - totalInteractions);
 
   const isOwner = account.user?.id === session?.owner;
+
+  const handleNavigateToTurn = useCallback((item: ChatTurnNavigatorItem) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const target = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-chat-turn]"),
+    ).find((element) => element.dataset.chatTurn === item.id);
+    if (!target) return;
+
+    setAutoScroll(false);
+    autoScrollRef.current = false;
+    upwardAccumRef.current = 0;
+    isNavigatorScrollingRef.current = true;
+    const navigationSequence = ++navigatorScrollSequenceRef.current;
+    const viewport = container.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    container.scrollTo({
+      top: container.scrollTop + targetRect.top - viewport.top - 24,
+      behavior: "smooth",
+    });
+    const finishNavigation = () => {
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (navigatorScrollSequenceRef.current === navigationSequence) {
+          isNavigatorScrollingRef.current = false;
+          lastScrollTopRef.current = container.scrollTop;
+        }
+      }));
+    };
+    container.addEventListener("scrollend", finishNavigation, { once: true });
+    const targetIndex = navigatorItems.findIndex((candidate) => candidate.id === item.id);
+    setHasNewBelow(targetIndex >= 0 && targetIndex < navigatorItems.length - 1);
+  }, [navigatorItems, setAutoScroll]);
 
   // Show loading state while fetching session
   // Error state — a failed session fetch (no data) degrades to a clear
@@ -662,9 +736,12 @@ const EmbeddedSessionView = forwardRef<
       sx={{
         flex: 1,
         minHeight: 0,
+        minWidth: 0,
+        width: "100%",
         position: "relative",
         display: "flex",
         flexDirection: "column",
+        overflow: "hidden",
         backgroundColor: (theme) => getChatColors(theme).canvas,
       }}
     >
@@ -692,7 +769,8 @@ const EmbeddedSessionView = forwardRef<
           // Without height: 0, the container may expand to fit content on iOS
           height: 0,
           flex: 1,
-          overflow: "auto",
+          overflowY: "auto",
+          overflowX: "hidden",
           display: "flex",
           flexDirection: "column",
           minHeight: 0,
@@ -708,7 +786,11 @@ const EmbeddedSessionView = forwardRef<
             width: "100%",
             maxWidth: 768,
             mx: "auto",
-            px: { xs: 1.5, sm: 2.5 },
+            pl: { xs: 1.5, sm: 2.5 },
+            pr: { xs: 1.5, sm: 2.5 },
+            "@media (pointer: fine)": {
+              pl: 4.5,
+            },
             py: 2.5,
             display: "flex",
             flexDirection: "column",
@@ -772,6 +854,12 @@ const EmbeddedSessionView = forwardRef<
           })}
         </Box>
       </Box>
+
+      <ChatTurnNavigator
+        items={navigatorItems}
+        scrollContainer={scrollContainerEl}
+        onSelect={handleNavigateToTurn}
+      />
 
       {/* Auto-scroll toggle (bottom-right) — stark filled/outlined treatment
           so the on/off state is visible at a glance. */}

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -52,6 +52,7 @@ import { useStreaming } from "../../contexts/streaming";
 import { TypesInteraction, TypesInteractionState } from "../../api/api";
 import useLightTheme from "../../hooks/useLightTheme";
 import { SESSION_TYPE_TEXT } from "../../types";
+import { CHAT_FONT_FAMILY, getChatColors } from "./chatStyles";
 
 interface EmbeddedSessionViewProps {
   sessionId: string;
@@ -100,8 +101,35 @@ const EmbeddedSessionView = forwardRef<
   const api = useApi();
   const lightTheme = useLightTheme();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  const setScrollContainerRef = useCallback((el: HTMLDivElement | null) => {
+    containerRef.current = el;
+    setScrollContainerEl(el);
+  }, []);
   const queryClient = useQueryClient();
   const { NewInference } = useStreaming();
+
+  // Keep the active turn one viewport tall. When the last interaction enters
+  // Waiting, scroll-to-bottom places its user message at the top and leaves
+  // room for the response to grow beneath it. This mirrors T3's anchored-turn
+  // mechanic without fighting the existing manual-scroll lock.
+  useEffect(() => {
+    if (!scrollContainerEl) return;
+
+    const measure = () => {
+      scrollContainerEl.style.setProperty(
+        "--chat-viewport-height",
+        `${scrollContainerEl.clientHeight}px`,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(scrollContainerEl);
+    return () => {
+      observer.disconnect();
+      scrollContainerEl.style.removeProperty("--chat-viewport-height");
+    };
+  }, [scrollContainerEl]);
 
   // Global on/off preference for auto-scroll. Default ON.
   const [autoScroll, setAutoScroll] = useAutoScrollPreference();
@@ -637,6 +665,8 @@ const EmbeddedSessionView = forwardRef<
         position: "relative",
         display: "flex",
         flexDirection: "column",
+        fontFamily: CHAT_FONT_FAMILY,
+        backgroundColor: (theme) => getChatColors(theme).canvas,
       }}
     >
       {session && (
@@ -650,7 +680,7 @@ const EmbeddedSessionView = forwardRef<
         </>
       )}
       <Box
-        ref={containerRef}
+        ref={setScrollContainerRef}
         data-session-scroll-container
         onScroll={handleScroll}
         onWheel={handleWheel}
@@ -677,10 +707,10 @@ const EmbeddedSessionView = forwardRef<
           ref={setContentRef}
           sx={{
             width: "100%",
-            maxWidth: 700,
+            maxWidth: 768,
             mx: "auto",
-            px: 2,
-            py: 2,
+            px: { xs: 1.5, sm: 2.5 },
+            py: 2.5,
             display: "flex",
             flexDirection: "column",
             gap: 2,
@@ -727,6 +757,7 @@ const EmbeddedSessionView = forwardRef<
                 session_id={sessionId}
                 sessionSteps={sessionSteps?.data || []}
                 enableDebugCopy={enableInteractionDebugCopy}
+                anchorToViewport={isLive}
               >
                 {isLive && (isOwner || account.admin) && (
                   <InteractionLiveStream

--- a/frontend/src/components/session/ImageLightbox.tsx
+++ b/frontend/src/components/session/ImageLightbox.tsx
@@ -1,0 +1,169 @@
+import { FC, useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import Tooltip from '@mui/material/Tooltip'
+import CloseIcon from '@mui/icons-material/Close'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+
+export interface LightboxImage {
+  src: string
+  name: string
+}
+
+interface ImageLightboxProps {
+  images: LightboxImage[]
+  initialIndex: number
+  open: boolean
+  onClose: () => void
+}
+
+const ImageLightbox: FC<ImageLightboxProps> = ({ images, initialIndex, open, onClose }) => {
+  const [index, setIndex] = useState(initialIndex)
+
+  useEffect(() => {
+    if (open) setIndex(initialIndex)
+  }, [initialIndex, open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft' && images.length > 1) {
+        setIndex((current) => (current - 1 + images.length) % images.length)
+      }
+      if (event.key === 'ArrowRight' && images.length > 1) {
+        setIndex((current) => (current + 1) % images.length)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [images.length, open])
+
+  const current = images[index]
+  if (!current) return null
+
+  const previous = () => setIndex((index - 1 + images.length) % images.length)
+  const next = () => setIndex((index + 1) % images.length)
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      aria-label={`Image preview: ${current.name}`}
+      BackdropProps={{ sx: { backgroundColor: 'rgba(0, 0, 0, 0.78)' } }}
+      PaperProps={{
+        sx: {
+          width: 'min(94vw, 1200px)',
+          height: 'min(92vh, 900px)',
+          m: 0,
+          background: 'transparent',
+          boxShadow: 'none',
+          overflow: 'visible',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Box
+          component="img"
+          src={current.src}
+          alt={current.name}
+          sx={{
+            display: 'block',
+            maxWidth: '100%',
+            maxHeight: 'calc(100% - 56px)',
+            objectFit: 'contain',
+            borderRadius: 1,
+          }}
+        />
+
+        <Tooltip title="Close (Esc)">
+          <IconButton
+            onClick={onClose}
+            aria-label="Close image preview"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              color: '#fff',
+              backgroundColor: 'rgba(0,0,0,0.45)',
+              '&:hover': { backgroundColor: 'rgba(0,0,0,0.7)' },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
+
+        {images.length > 1 && (
+          <>
+            <IconButton
+              onClick={previous}
+              aria-label="Previous image"
+              sx={{
+                position: 'absolute',
+                left: 0,
+                color: '#fff',
+                backgroundColor: 'rgba(0,0,0,0.45)',
+                '&:hover': { backgroundColor: 'rgba(0,0,0,0.7)' },
+              }}
+            >
+              <ChevronLeftIcon />
+            </IconButton>
+            <IconButton
+              onClick={next}
+              aria-label="Next image"
+              sx={{
+                position: 'absolute',
+                right: 0,
+                color: '#fff',
+                backgroundColor: 'rgba(0,0,0,0.45)',
+                '&:hover': { backgroundColor: 'rgba(0,0,0,0.7)' },
+              }}
+            >
+              <ChevronRightIcon />
+            </IconButton>
+          </>
+        )}
+
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            px: 1.5,
+            py: 0.75,
+            borderRadius: 999,
+            color: '#fff',
+            backgroundColor: 'rgba(0,0,0,0.56)',
+            display: 'flex',
+            gap: 1,
+            maxWidth: '80%',
+          }}
+        >
+          <Typography variant="caption" noWrap>{current.name}</Typography>
+          {images.length > 1 && (
+            <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.68)' }}>
+              {index + 1}/{images.length}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </Dialog>
+  )
+}
+
+export default ImageLightbox

--- a/frontend/src/components/session/Interaction.test.tsx
+++ b/frontend/src/components/session/Interaction.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { Interaction } from "./Interaction";
+import { TypesInteractionState } from "../../api/api";
 
 vi.mock("./InteractionContainer", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -66,5 +67,24 @@ describe("Interaction debug copy placement", () => {
 
     expect(screen.getByRole("button", { name: "user debug copy" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "agent debug copy" })).not.toBeInTheDocument();
+  });
+
+  it("marks a waiting turn as viewport-anchored", () => {
+    const { container } = render(
+      <Interaction
+        {...baseProps}
+        anchorToViewport
+        interaction={{
+          id: "int_waiting",
+          prompt_message: "Question",
+          state: TypesInteractionState.InteractionStateWaiting,
+        }}
+      />,
+    );
+
+    expect(container.querySelector('[data-active-chat-turn="true"]')).toHaveAttribute(
+      "data-chat-turn",
+      "int_waiting",
+    );
   });
 });

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -111,6 +111,9 @@ const ForkSeedDivider: FC<{ interaction: TypesInteraction }> = ({
 
 // Prop comparison function for React.memo
 const areEqual = (prevProps: InteractionProps, nextProps: InteractionProps) => {
+  if (prevProps.anchorToViewport !== nextProps.anchorToViewport) {
+    return false;
+  }
   if (prevProps.enableDebugCopy !== nextProps.enableDebugCopy) {
     return false;
   }
@@ -199,6 +202,7 @@ interface InteractionProps {
   onRegenerate?: (interactionID: string, message: string) => void;
   sessionSteps?: any[];
   enableDebugCopy?: boolean;
+  anchorToViewport?: boolean;
 }
 
 export const Interaction: FC<InteractionProps> = ({
@@ -212,6 +216,7 @@ export const Interaction: FC<InteractionProps> = ({
   onRegenerate,
   sessionSteps = [],
   enableDebugCopy = false,
+  anchorToViewport = false,
 }) => {
   // Memoize computed values
   const displayData = useMemo(() => {
@@ -326,8 +331,13 @@ export const Interaction: FC<InteractionProps> = ({
 
   return (
     <Box
+      data-chat-turn={interaction.id}
+      data-active-chat-turn={anchorToViewport ? "true" : undefined}
       sx={{
-        mb: 2,
+        mb: anchorToViewport ? 0 : 2,
+        minHeight: anchorToViewport
+          ? "calc(var(--chat-viewport-height, 0px) - 32px)"
+          : undefined,
         display: "flex",
         flexDirection: "column",
         gap: 1,
@@ -399,6 +409,7 @@ export const Interaction: FC<InteractionProps> = ({
                 align="right"
                 border={true}
                 isAssistant={false}
+                messageRole="user"
               >
                 <InteractionInference
                   serverConfig={serverConfig}
@@ -425,6 +436,7 @@ export const Interaction: FC<InteractionProps> = ({
                 <Box
                   sx={{
                     width: "100%",
+                    maxWidth: "80%",
                     display: "flex",
                     justifyContent: "flex-end",
                     mt: 0.5,
@@ -483,6 +495,7 @@ export const Interaction: FC<InteractionProps> = ({
             align="left"
             border={false}
             isAssistant={true}
+            messageRole="assistant"
           >
             {/* Show live stream if interaction is waiting AND has children (last interaction) */}
             {isLive && children ? (

--- a/frontend/src/components/session/InteractionContainer.test.tsx
+++ b/frontend/src/components/session/InteractionContainer.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { describe, expect, it } from 'vitest'
+
+import InteractionContainer from './InteractionContainer'
+
+const darkTheme = createTheme({ palette: { mode: 'dark' } })
+
+const renderMessage = (messageRole: 'user' | 'assistant') => render(
+  <ThemeProvider theme={darkTheme}>
+    <InteractionContainer messageRole={messageRole}>Message</InteractionContainer>
+  </ThemeProvider>,
+)
+
+describe('InteractionContainer chat typography', () => {
+  it('uses T3 foreground opacity for assistant messages', () => {
+    const { container } = renderMessage('assistant')
+    const message = container.querySelector('[data-chat-message-role="assistant"]')
+
+    expect(message).toHaveStyle({ color: 'rgba(245, 245, 245, 0.8)' })
+  })
+
+  it('keeps user messages at full foreground opacity', () => {
+    const { container } = renderMessage('user')
+    const message = container.querySelector('[data-chat-message-role="user"]')
+
+    expect(message).toHaveStyle({ color: '#f5f5f5' })
+  })
+})

--- a/frontend/src/components/session/InteractionContainer.tsx
+++ b/frontend/src/components/session/InteractionContainer.tsx
@@ -44,6 +44,11 @@ export const InteractionContainer: FC<{
               ? '#0d0d0d'
               : theme.palette.background.default
             : 'transparent',
+        color: isChatMessage
+          ? assistant
+            ? chatColors.assistantForeground
+            : chatColors.foreground
+          : undefined,
         border: isChatMessage ? 'none' : border ? '1px solid #33373a' : 'none',
         // User messages: fit content but don't exceed container width
         // Assistant messages: take full width

--- a/frontend/src/components/session/InteractionContainer.tsx
+++ b/frontend/src/components/session/InteractionContainer.tsx
@@ -7,6 +7,7 @@ import Row from '../widgets/Row'
 import Cell from '../widgets/Cell'
 
 import { useTheme } from '@mui/material/styles'
+import { getChatColors } from './chatStyles'
 export const InteractionContainer: FC<{    
   background?: boolean,
   buttons?: React.ReactNode,
@@ -14,6 +15,7 @@ export const InteractionContainer: FC<{
   align?: 'left' | 'right',
   border?: boolean,
   isAssistant?: boolean,
+  messageRole?: 'user' | 'assistant',
 }> = ({
   background = false,
   buttons,
@@ -21,29 +23,36 @@ export const InteractionContainer: FC<{
   align = 'left',
   border = false,
   isAssistant = false,
+  messageRole,
 }) => {
   const theme = useTheme()
+  const chatColors = getChatColors(theme)
+  const isChatMessage = !!messageRole
+  const assistant = messageRole === 'assistant' || isAssistant
 
   return (
     <Box
+      data-chat-message-role={messageRole}
       sx={{
-        px: 2,
-        py: 0.5,
-        borderRadius: isAssistant ? 0 : 4,
-        backgroundColor: background
-          ? isAssistant && theme.palette.mode === 'dark'
-            ? '#0d0d0d'
-            : theme.palette.background.default
-          : 'transparent',
-        border: border ? '1px solid #33373a' : 'none',
+        px: isChatMessage ? (assistant ? 0 : 1.5) : 2,
+        py: isChatMessage ? (assistant ? 0 : 1.25) : 0.5,
+        borderRadius: assistant ? 0 : 2,
+        backgroundColor: isChatMessage && !assistant
+          ? chatColors.userBubble
+          : background
+            ? assistant && theme.palette.mode === 'dark'
+              ? '#0d0d0d'
+              : theme.palette.background.default
+            : 'transparent',
+        border: isChatMessage ? 'none' : border ? '1px solid #33373a' : 'none',
         // User messages: fit content but don't exceed container width
         // Assistant messages: take full width
-        maxWidth: isAssistant ? '100%' : 'min(100%, 700px)',
+        maxWidth: assistant ? '100%' : isChatMessage ? '80%' : 'min(100%, 700px)',
         minWidth: 0,
-        width: isAssistant ? '100%' : 'fit-content',
+        width: assistant ? '100%' : 'fit-content',
         ml: align === 'left' ? 0 : 'auto',
         mr: align === 'right' ? 0 : 'auto',
-        boxShadow: border ? '0 1px 2px rgba(0,0,0,0.03)' : 'none',
+        boxShadow: isChatMessage ? 'none' : border ? '0 1px 2px rgba(0,0,0,0.03)' : 'none',
         // Ensure text wraps properly
         wordBreak: 'break-word',
         overflowWrap: 'anywhere',

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -759,6 +759,7 @@ export const InteractionInference: FC<{
             <Cell
               sx={{
                 ml: 2,
+                flexShrink: 0,
               }}
             >
               <Button
@@ -766,6 +767,10 @@ export const InteractionInference: FC<{
                 color="secondary"
                 size="small"
                 endIcon={<ReplayIcon />}
+                sx={{
+                  minWidth: 92,
+                  whiteSpace: "nowrap",
+                }}
                 onClick={() =>
                   onRegenerate(
                     interaction.id || "",

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState, useEffect, useMemo } from "react";
-import { styled } from "@mui/system";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -12,6 +11,7 @@ import Markdown from "./Markdown";
 import WorkLog from "./WorkLog";
 import ActivitySummary from "./ActivitySummary";
 import { getInteractionDurationMs } from "./interactionDuration";
+import ImageLightbox, { LightboxImage } from "./ImageLightbox";
 
 /**
  * A structured response entry from the Go API.
@@ -45,27 +45,6 @@ import { useUpdateInteractionFeedback } from "../../services/interactionsService
 import { TypesServerConfigForFrontend } from "../../api/api";
 
 import { TypesInteraction, TypesSession, TypesFeedback } from "../../api/api";
-
-const GeneratedImage = styled("img")({
-  cursor: "pointer",
-  transition: "transform 0.2s ease-in-out",
-  "&:hover": {
-    transform: "scale(1.05)",
-  },
-});
-
-const ImagePreview = styled("img")({
-  height: "150px",
-  width: "150px",
-  objectFit: "cover",
-  border: "1px solid #000000",
-  borderRadius: "4px",
-  cursor: "pointer",
-  transition: "transform 0.2s ease-in-out",
-  "&:hover": {
-    transform: "scale(1.05)",
-  },
-});
 
 /**
  * Renders a message that may contain tool call blocks.
@@ -316,7 +295,8 @@ export const InteractionInference: FC<{
   const router = useRouter();
   const [viewingError, setViewingError] = useState(false);
   const [viewingExport, setViewingExport] = useState(false);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
+  const [userMessageExpanded, setUserMessageExpanded] = useState(false);
   const [internalIsEditing, setInternalIsEditing] = useState(false);
   const [internalEditedMessage, setInternalEditedMessage] = useState(
     message || "",
@@ -364,6 +344,10 @@ export const InteractionInference: FC<{
     setCurrentFeedback(interaction.feedback);
   }, [interaction.feedback]);
 
+  useEffect(() => {
+    setUserMessageExpanded(false);
+  }, [interaction.id, message]);
+
   // Filter tool steps for this interaction
   const toolSteps = sessionSteps
     .filter((step) => step.interaction_id === interaction.id)
@@ -390,6 +374,9 @@ export const InteractionInference: FC<{
       .map((e: ResponseEntry) => e.content)
       .join("\n\n");
   }, [message, interaction]);
+  const shouldCollapseUserMessage = !isFromAssistant && !!message && (
+    message.length > 600 || message.split("\n").length > 8
+  );
 
   if (!serverConfig || !serverConfig.filestore_prefix) return null;
   if (!interaction) return null;
@@ -401,32 +388,81 @@ export const InteractionInference: FC<{
     return `${serverConfig.filestore_prefix}/${url}?redirect_urls=true`;
   };
 
+  const lightboxImages: LightboxImage[] = imageURLs
+    .filter(() => !!account.user)
+    .map((imageURL, index) => {
+      const path = imageURL.split("?")[0];
+      const basename = path.split("/").pop();
+      let imageName = `Image ${index + 1}`;
+      if (basename && !basename.startsWith("data:")) {
+        try {
+          imageName = decodeURIComponent(basename);
+        } catch {
+          imageName = basename;
+        }
+      }
+      return {
+        src: getFileURL(imageURL),
+        name: imageName,
+      };
+    });
+
   return (
     <>
-      {serverConfig?.filestore_prefix &&
-        imageURLs
-          .filter((file) => {
-            return account.user ? true : false;
-          })
-          .map((imageURL: string) => {
-            const useURL = getFileURL(imageURL);
-            return (
+      {serverConfig?.filestore_prefix && lightboxImages.length > 0 && (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: lightboxImages.length === 1
+              ? "minmax(0, 1fr)"
+              : "repeat(2, minmax(0, 1fr))",
+            gap: 1,
+            width: "min(100%, 420px)",
+            mb: message ? 1.25 : 0,
+          }}
+        >
+          {lightboxImages.map((image, index) => (
+            <Box
+              key={`${image.src}-${index}`}
+              component="button"
+              type="button"
+              onClick={() => setSelectedImageIndex(index)}
+              aria-label={`Preview ${image.name}`}
+              sx={{
+                p: 0,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+                overflow: "hidden",
+                background: "transparent",
+                cursor: "zoom-in",
+                minWidth: 0,
+                lineHeight: 0,
+                "&:hover img": { transform: "scale(1.02)" },
+                "&:focus-visible": {
+                  outline: "2px solid",
+                  outlineColor: "primary.main",
+                  outlineOffset: 2,
+                },
+              }}
+            >
               <Box
+                component="img"
+                src={image.src}
+                alt={image.name}
                 sx={{
-                  mb: 2,
-                  display: "flex",
-                  gap: 1,
+                  display: "block",
+                  width: "100%",
+                  height: lightboxImages.length === 1 ? "auto" : 180,
+                  maxHeight: 220,
+                  objectFit: "cover",
+                  transition: "transform 0.15s ease",
                 }}
-                key={useURL}
-              >
-                <ImagePreview
-                  src={useURL}
-                  onClick={() => setSelectedImage(useURL)}
-                  alt="Preview"
-                />
-              </Box>
-            );
-          })}
+              />
+            </Box>
+          ))}
+        </Box>
+      )}
       {toolSteps.length > 0 && isFromAssistant && (
         <ToolStepsWidget steps={toolSteps} />
       )}
@@ -486,17 +522,54 @@ export const InteractionInference: FC<{
                     },
                   }}
                 >
-                  <MessageWithToolCalls
-                    text={message || ""}
-                    responseEntries={isFromAssistant ? (interaction as any)?.response_entries : undefined}
-                    session={session}
-                    getFileURL={getFileURL}
-                    showBlinker={false}
-                    isStreaming={false}
-                    durationMs={getInteractionDurationMs(interaction)}
-                    showActivitySummary={isFromAssistant}
-                    onFilterDocument={onFilterDocument}
-                  />
+                  <Box
+                    sx={{
+                      position: "relative",
+                      maxHeight: shouldCollapseUserMessage && !userMessageExpanded ? 176 : "none",
+                      overflow: shouldCollapseUserMessage && !userMessageExpanded ? "hidden" : "visible",
+                      "&::after": shouldCollapseUserMessage && !userMessageExpanded
+                        ? {
+                            content: '""',
+                            position: "absolute",
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            height: 48,
+                            pointerEvents: "none",
+                            background: (theme) => `linear-gradient(transparent, ${theme.palette.mode === "dark" ? "#1c1c1f" : "#f0f0f2"})`,
+                          }
+                        : undefined,
+                    }}
+                  >
+                    <MessageWithToolCalls
+                      text={message || ""}
+                      responseEntries={isFromAssistant ? (interaction as any)?.response_entries : undefined}
+                      session={session}
+                      getFileURL={getFileURL}
+                      showBlinker={false}
+                      isStreaming={false}
+                      durationMs={getInteractionDurationMs(interaction)}
+                      showActivitySummary={isFromAssistant}
+                      onFilterDocument={onFilterDocument}
+                    />
+                  </Box>
+                  {shouldCollapseUserMessage && (
+                    <Button
+                      size="small"
+                      onClick={() => setUserMessageExpanded((expanded) => !expanded)}
+                      sx={{
+                        minHeight: 24,
+                        px: 0,
+                        mt: 0.5,
+                        textTransform: "none",
+                        color: "text.secondary",
+                        fontSize: "0.75rem",
+                        "&:hover": { background: "transparent", color: "text.primary" },
+                      }}
+                    >
+                      {userMessageExpanded ? "Show less" : "Show full message"}
+                    </Button>
+                  )}
                   {isFromAssistant && onRegenerate && (
                     <Box
                       className="action-buttons"
@@ -728,33 +801,12 @@ export const InteractionInference: FC<{
           />
         </ExportDocument>
       )}
-      {selectedImage && (
-        <Box
-          sx={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            bgcolor: "rgba(0, 0, 0, 0.8)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 9999,
-          }}
-          onClick={() => setSelectedImage(null)}
-        >
-          <GeneratedImage
-            src={selectedImage}
-            sx={{
-              maxHeight: "90vh",
-              maxWidth: "90vw",
-              objectFit: "contain",
-            }}
-            onClick={(e) => e.stopPropagation()}
-          />
-        </Box>
-      )}
+      <ImageLightbox
+        images={lightboxImages}
+        initialIndex={selectedImageIndex ?? 0}
+        open={selectedImageIndex !== null}
+        onClose={() => setSelectedImageIndex(null)}
+      />
     </>
   );
 };

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -1031,9 +1031,20 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
   return (
     <>
       <Box
+        data-chat-markdown
         sx={{
           fontSize: "0.875rem",
           lineHeight: 1.625,
+          "& .interactionMessage > *": {
+            marginTop: 0,
+            marginBottom: 0,
+          },
+          "& .interactionMessage > * + *": {
+            marginTop: 1.75,
+          },
+          "& + [data-chat-markdown]": {
+            marginTop: 1.75,
+          },
           "& pre": {
             padding: "1em",
             borderRadius: "4px",

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -30,6 +30,7 @@ import ThinkingWidget from "./ThinkingWidget";
 
 // Import chat stats collector for performance monitoring
 import { getGlobalStatsCollector } from "./ChatStatsOverlay";
+import { CHAT_MONO_FONT_FAMILY } from "./chatStyles";
 
 const SyntaxHighlighter = SyntaxHighlighterTS as any;
 
@@ -1031,7 +1032,8 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
     <>
       <Box
         sx={{
-          fontSize: "0.9rem",
+          fontSize: "0.875rem",
+          lineHeight: 1.625,
           "& pre": {
             padding: "1em",
             borderRadius: "4px",
@@ -1044,7 +1046,8 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
           },
           "& code": {
             backgroundColor: "transparent",
-            fontSize: "0.9rem",
+            fontSize: "0.875rem",
+            fontFamily: CHAT_MONO_FONT_FAMILY,
           },
           "& :not(pre) > code": {
             backgroundColor: theme.palette.mode === "light" ? "#ccc" : "#333",

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -30,7 +30,7 @@ import ThinkingWidget from "./ThinkingWidget";
 
 // Import chat stats collector for performance monitoring
 import { getGlobalStatsCollector } from "./ChatStatsOverlay";
-import { CHAT_MONO_FONT_FAMILY } from "./chatStyles";
+import { APP_MONO_FONT_FAMILY } from "../../styles/typography";
 
 const SyntaxHighlighter = SyntaxHighlighterTS as any;
 
@@ -1047,7 +1047,7 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
           "& code": {
             backgroundColor: "transparent",
             fontSize: "0.875rem",
-            fontFamily: CHAT_MONO_FONT_FAMILY,
+            fontFamily: APP_MONO_FONT_FAMILY,
           },
           "& :not(pre) > code": {
             backgroundColor: theme.palette.mode === "light" ? "#ccc" : "#333",

--- a/frontend/src/components/session/MarkdownLayout.test.tsx
+++ b/frontend/src/components/session/MarkdownLayout.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { describe, expect, it } from 'vitest'
+
+import { TypesSession } from '../../api/api'
+import Markdown from './Markdown'
+
+const session = { id: 'session-1', config: {} } as TypesSession
+const theme = createTheme({ palette: { mode: 'dark' } })
+
+describe('Markdown chat spacing', () => {
+  it('keeps block spacing stable across adjacent streamed response entries', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Markdown text={'First entry\n\nFirst continuation'} session={session} getFileURL={() => ''} isStreaming />
+        <Markdown text={'Second entry\n\nSecond continuation'} session={session} getFileURL={() => ''} isStreaming />
+      </ThemeProvider>,
+    )
+
+    const roots = container.querySelectorAll<HTMLElement>('[data-chat-markdown]')
+    roots.forEach((root) => {
+      root.innerHTML = '<div class="interactionMessage"><p>First paragraph</p><p>Last paragraph</p></div>'
+    })
+    const messages = container.querySelectorAll<HTMLElement>('.interactionMessage')
+
+    expect(messages[0].firstElementChild).toHaveStyle({ marginTop: '0px' })
+    expect(messages[0].lastElementChild).toHaveStyle({ marginBottom: '0px' })
+    expect(messages[0].lastElementChild).toHaveStyle({ marginTop: '14px' })
+    expect(messages[1].firstElementChild).toHaveStyle({ marginTop: '0px' })
+    expect(messages[1].lastElementChild).toHaveStyle({ marginBottom: '0px' })
+    expect(roots[1]).toHaveStyle({ marginTop: '14px' })
+  })
+})

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -7,7 +7,7 @@ export const getChatColors = (theme: Theme) => {
   const dark = theme.palette.mode === 'dark'
 
   return {
-    canvas: dark ? '#121214' : '#fafafa',
+    canvas: dark ? '#0a0a0a' : '#fafafa',
     surface: dark ? '#18181b' : '#ffffff',
     surfaceRaised: dark ? '#1f1f23' : '#f4f4f5',
     userBubble: dark ? 'rgba(255, 255, 255, 0.045)' : '#f0f0f2',

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -1,0 +1,19 @@
+import { Theme } from '@mui/material/styles'
+
+export const CHAT_FONT_FAMILY = '"DM Sans Variable", "DM Sans", Inter, system-ui, sans-serif'
+export const CHAT_MONO_FONT_FAMILY = '"JetBrains Mono Variable", "SFMono-Regular", Consolas, monospace'
+
+export const getChatColors = (theme: Theme) => {
+  const dark = theme.palette.mode === 'dark'
+
+  return {
+    canvas: dark ? '#121214' : '#fafafa',
+    surface: dark ? '#18181b' : '#ffffff',
+    surfaceRaised: dark ? '#1f1f23' : '#f4f4f5',
+    userBubble: dark ? 'rgba(255, 255, 255, 0.045)' : '#f0f0f2',
+    border: dark ? 'rgba(255, 255, 255, 0.07)' : 'rgba(0, 0, 0, 0.09)',
+    borderStrong: dark ? 'rgba(255, 255, 255, 0.13)' : 'rgba(0, 0, 0, 0.16)',
+    foreground: dark ? '#f4f4f5' : '#18181b',
+    muted: dark ? '#a1a1aa' : '#71717a',
+  }
+}

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -4,7 +4,7 @@ export const getChatColors = (theme: Theme) => {
   const dark = theme.palette.mode === 'dark'
 
   return {
-    canvas: dark ? '#0a0a0a' : '#fafafa',
+    canvas: dark ? theme.palette.background.default : '#fafafa',
     surface: dark ? '#18181b' : '#ffffff',
     surfaceRaised: dark ? '#1f1f23' : '#f4f4f5',
     userBubble: dark ? 'rgba(255, 255, 255, 0.045)' : '#f0f0f2',

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -13,7 +13,8 @@ export const getChatColors = (theme: Theme) => {
     userBubble: dark ? 'rgba(255, 255, 255, 0.045)' : '#f0f0f2',
     border: dark ? 'rgba(255, 255, 255, 0.07)' : 'rgba(0, 0, 0, 0.09)',
     borderStrong: dark ? 'rgba(255, 255, 255, 0.13)' : 'rgba(0, 0, 0, 0.16)',
-    foreground: dark ? '#f4f4f5' : '#18181b',
+    foreground: dark ? '#f5f5f5' : '#18181b',
+    assistantForeground: dark ? 'rgba(245, 245, 245, 0.8)' : 'rgba(24, 24, 27, 0.8)',
     muted: dark ? '#a1a1aa' : '#71717a',
   }
 }

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -1,8 +1,5 @@
 import { Theme } from '@mui/material/styles'
 
-export const CHAT_FONT_FAMILY = '"DM Sans Variable", "DM Sans", Inter, system-ui, sans-serif'
-export const CHAT_MONO_FONT_FAMILY = '"JetBrains Mono Variable", "SFMono-Regular", Consolas, monospace'
-
 export const getChatColors = (theme: Theme) => {
   const dark = theme.palette.mode === 'dark'
 

--- a/frontend/src/components/system/AppBar.tsx
+++ b/frontend/src/components/system/AppBar.tsx
@@ -42,6 +42,7 @@ const AppBar: React.FC<{
       sx={{
         height,
         borderBottom: lightTheme.border,
+        backgroundColor: lightTheme.backgroundColor,
         width: '100%',
       }}
     >

--- a/frontend/src/components/system/ContextSidebar.tsx
+++ b/frontend/src/components/system/ContextSidebar.tsx
@@ -9,6 +9,7 @@ import Box from '@mui/material/Box'
 
 import SlideMenuContainer from './SlideMenuContainer'
 import useLightTheme from '../../hooks/useLightTheme'
+import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 
 export interface ContextSidebarItem {
   id: string
@@ -62,13 +63,13 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
         {section.items.map((item) => (
           <ListItem
             key={item.id}
+            data-context-sidebar-item={item.id}
             sx={{
-              borderRadius: '12px',
+              borderRadius: '8px',
               cursor: 'pointer',
-              mx: 1,
-              transition: 'all 0.2s ease-in-out',
-              '&:hover': {
-                backgroundColor: lightTheme.isLight ? 'rgba(0, 0, 0, 0.04)' : 'rgba(255, 255, 255, 0.05)',
+              mb: 0.5,
+              '&:last-child': {
+                mb: 0,
               },
             }}
             disablePadding
@@ -77,34 +78,32 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
               selected={item.isActive}
               onClick={item.onClick}
               sx={{
-                borderRadius: '12px',
-                py: isCompact ? 0.875 : 1.25,
-                px: isCompact ? 1.5 : 2,
-                minHeight: isCompact ? 40 : 48,
+                borderRadius: '8px',
+                py: isCompact ? 0.875 : 0.75,
+                px: isCompact ? 1.5 : 1.25,
+                minHeight: isCompact ? 40 : 32,
                 '&.Mui-selected': {
-                  backgroundColor: lightTheme.isLight ? 'rgba(0, 0, 0, 0.06)' : 'rgba(255, 255, 255, 0.08)',
+                  backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.rowSelected : 'rgba(255, 255, 255, 0.08)',
                   '&:hover': {
-                    backgroundColor: lightTheme.isLight ? 'rgba(0, 0, 0, 0.10)' : 'rgba(255, 255, 255, 0.12)',
+                    backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.rowSelected : 'rgba(255, 255, 255, 0.12)',
                   },
                 },
                 '&:hover': {
-                  backgroundColor: lightTheme.isLight ? 'rgba(0, 0, 0, 0.04)' : 'rgba(255, 255, 255, 0.05)',
+                  backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.rowHover : 'rgba(255, 255, 255, 0.05)',
                 },
               }}
             >
               <ListItemIcon
                 sx={{
-                  minWidth: isCompact ? 34 : 40,
-                  // Light mode = sunlit-iPad mode. Inactive icons go near-black,
-                  // not the default faded grey, so they survive glare.
+                  minWidth: isCompact ? 34 : 24,
                   color: item.isActive
-                    ? (lightTheme.isLight ? '#0e7490' : '#00E5FF')
-                    : (lightTheme.isLight ? '#000' : lightTheme.textColorFaded),
-                  transition: 'color 0.2s ease-in-out',
+                    ? (lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.foreground : '#00E5FF')
+                    : (lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.icon : lightTheme.textColorFaded),
+                  transition: 'color 150ms ease',
                   '& svg': {
-                    fontSize: isCompact ? 18 : 22,
-                    width: isCompact ? 18 : 22,
-                    height: isCompact ? 18 : 22,
+                    fontSize: isCompact ? 18 : 16,
+                    width: isCompact ? 18 : 16,
+                    height: isCompact ? 18 : 16,
                   },
                 }}
               >
@@ -113,16 +112,18 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
               <ListItemText
                 primary={item.label}
                 sx={{
+                  my: 0,
                   '& .MuiListItemText-primary': {
-                    transition: 'all 0.2s ease-in-out',
+                    transition: 'color 150ms ease',
                   }
                 }}
                 primaryTypographyProps={{
-                  fontSize: isCompact ? '0.78rem' : '0.85rem',
-                  fontWeight: item.isActive ? 700 : (lightTheme.isLight ? 700 : 500),
+                  fontSize: isCompact ? '0.78rem' : '0.875rem',
+                  lineHeight: 1.25,
+                  fontWeight: 500,
                   color: item.isActive
-                    ? lightTheme.textColor
-                    : (lightTheme.isLight ? '#000' : lightTheme.textColorFaded),
+                    ? (lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.foreground : lightTheme.textColor)
+                    : (lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.mutedForeground : lightTheme.textColorFaded),
                 }}
               />
             </ListItemButton>
@@ -136,16 +137,17 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
     <SlideMenuContainer menuType={menuType}>
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
         {header && (
-          <Box sx={{ px: 2, py: 1.5, borderBottom: `1px solid ${lightTheme.border}` }}>
+          <Box sx={{ px: 2, py: 1.5, borderBottom: lightTheme.isLight ? `1px solid ${LIGHT_SIDEBAR_COLORS.border}` : lightTheme.border }}>
             {header}
           </Box>
         )}
         <List sx={{ 
-          py: 0, 
-          px: 1, 
+          p: 1,
           flexGrow: 1,
-          overflow: 'auto', // Enable scrollbar when content exceeds height
-          width: '100%', // Ensure it doesn't exceed container width
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          boxSizing: 'border-box',
+          width: '100%',
         }}>
           {sections.map((section, index) => renderSection(section, index))}
         </List>
@@ -154,4 +156,4 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
   )
 }
 
-export default ContextSidebar 
+export default ContextSidebar

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -307,10 +307,14 @@ const Page: React.FC<{
                   }}
                   sx={{
                     width: 200,
+                    height: 32,
                     mr: 2,
                     flexShrink: 0,
                     cursor: 'pointer',
                     '& .MuiOutlinedInput-root': {
+                      height: 32,
+                      minHeight: 32,
+                      py: 0,
                       cursor: 'pointer',
                       background: lightTheme.isLight ? '#fff' : 'rgba(255,255,255,0.03)',
                       '& fieldset': {
@@ -325,6 +329,7 @@ const Page: React.FC<{
                       },
                     },
                     '& .MuiInputBase-input': {
+                      py: 0,
                       cursor: 'pointer',
                       color: lightTheme.textColor,
                       fontWeight: lightTheme.isLight ? 500 : 400,
@@ -336,7 +341,21 @@ const Page: React.FC<{
                   }}
                 />
               )}
-              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  '& .MuiButton-root': {
+                    minHeight: 32,
+                    height: 32,
+                    py: 0,
+                  },
+                  '& .MuiButtonGroup-root': {
+                    height: 32,
+                  },
+                }}
+              >
                 { topbarContent }
                 <Tooltip title={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
                   <IconButton onClick={toggleMode} size="small" sx={{ color: lightTheme.textColorFaded }}>

--- a/frontend/src/components/system/Sidebar.tsx
+++ b/frontend/src/components/system/Sidebar.tsx
@@ -30,6 +30,7 @@ import SlideMenuContainer from './SlideMenuContainer'
 import SidebarContextHeader from './SidebarContextHeader'
 // import UnifiedSearchBar from '../common/UnifiedSearchBar'
 import { SidebarProvider, useSidebarContext } from '../../contexts/sidebarContext'
+import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 
 
 const shimmer = keyframes`
@@ -245,8 +246,8 @@ const SidebarContentInner: React.FC<{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          borderRight: lightTheme.border,
-          backgroundColor: lightTheme.backgroundColor,
+          borderRight: lightTheme.isLight ? `1px solid ${LIGHT_SIDEBAR_COLORS.border}` : lightTheme.border,
+          backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
           width: '100%',
         }}
       >
@@ -374,11 +375,13 @@ const SidebarContentInner: React.FC<{
           sx={{
             flexGrow: 1,
             width: '100%',
-            height: '100%', // Fixed height to fill available space
-            overflow: 'auto', // Enable scrollbar when content exceeds height
-            boxShadow: 'none', // Remove shadow for a more flat/minimalist design
-            borderRight: 'none', // Remove the border if present
-            mr: 3,
+            minWidth: 0,
+            height: '100%',
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            boxSizing: 'border-box',
+            boxShadow: 'none',
+            borderRight: 'none',
             mt: 1,
             ...lightTheme.scrollbar,
           }}

--- a/frontend/src/components/system/SidebarContextHeader.tsx
+++ b/frontend/src/components/system/SidebarContextHeader.tsx
@@ -6,6 +6,7 @@ import useRouter from '../../hooks/useRouter'
 import useLightTheme from '../../hooks/useLightTheme'
 import { TOOLBAR_HEIGHT } from '../../config'
 import TokenExpiryCounter from '../auth/TokenExpiryCounter'
+import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 
 const SidebarContextHeader: React.FC = () => {
   const account = useAccount()
@@ -29,20 +30,22 @@ const SidebarContextHeader: React.FC = () => {
         py: 2,
         display: 'flex',
         alignItems: 'center',
-        background: lightTheme.isLight ? lightTheme.panelColor : 'linear-gradient(90deg, #32042a 0%, #2a1a6e 100%)',
-        borderBottom: lightTheme.border,
+        background: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : 'linear-gradient(90deg, #32042a 0%, #2a1a6e 100%)',
+        borderBottom: lightTheme.isLight ? `1px solid ${LIGHT_SIDEBAR_COLORS.border}` : lightTheme.border,
         minHeight: TOOLBAR_HEIGHT + 15,
         boxShadow: lightTheme.isLight ? 'none' : '0 2px 8px 0 rgba(0,229,255,0.08)',
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, overflow: 'hidden' }}>
         <Typography
-          variant="subtitle1"
+          variant="body2"
           onClick={handleNameClick}
           sx={{
-            color: lightTheme.textColor,
-            fontWeight: 'bold',
-            letterSpacing: 0.2,
+            color: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.foreground : lightTheme.textColor,
+            fontSize: '0.875rem',
+            lineHeight: 1.25,
+            fontWeight: 500,
+            letterSpacing: '-0.01em',
             textShadow: lightTheme.isLight ? 'none' : '0 1px 4px rgba(0,0,0,0.12)',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -62,4 +65,4 @@ const SidebarContextHeader: React.FC = () => {
   )
 }
 
-export default SidebarContextHeader 
+export default SidebarContextHeader

--- a/frontend/src/components/system/SlideMenuContainer.tsx
+++ b/frontend/src/components/system/SlideMenuContainer.tsx
@@ -13,8 +13,11 @@ const SlideMenuContainer: FC<SlideMenuContainerProps> = ({
     <Box
       sx={{
         width: '100%',
-        height: '100%', // Fixed height to fill available space
-        overflow: 'auto', // Prevent container from growing beyond parent
+        minWidth: 0,
+        height: '100%',
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
       }}
@@ -24,4 +27,4 @@ const SlideMenuContainer: FC<SlideMenuContainerProps> = ({
   )
 }
 
-export default SlideMenuContainer 
+export default SlideMenuContainer

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -76,7 +76,6 @@ import {
   useGetSession,
   GET_SESSION_QUERY_KEY,
 } from "../../services/sessionService";
-import { SESSION_TYPE_TEXT } from "../../types";
 import { isSpecTaskSwitchableAgent } from "../../utils/apps";
 import {
   useUpdateSpecTask,
@@ -99,11 +98,8 @@ import SpecTaskShareDialog from "./SpecTaskShareDialog";
 import AgentDropdown from "../agent/AgentDropdown";
 import CloneGroupProgressFull from "../specTask/CloneGroupProgress";
 import ArchiveConfirmDialog from "./ArchiveConfirmDialog";
-import RobustPromptInput from "../common/RobustPromptInput";
 import { optimisticallyMarkSessionStarting } from "../../utils/optimisticSessionStarting";
-import EmbeddedSessionView, {
-  EmbeddedSessionViewHandle,
-} from "../session/EmbeddedSessionView";
+import AgentChat from "../session/AgentChat";
 import SwitchAgentControl from "../session/SwitchAgentControl";
 import SharePreviewSection from "./SharePreviewSection";
 import {
@@ -350,8 +346,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     [currentView, router, syncViewWithUrl],
   );
 
-  // Ref for EmbeddedSessionView to trigger scroll on height changes
-  const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null);
 
   // Design review state
   const [docViewerOpen, setDocViewerOpen] = useState(false);
@@ -596,20 +590,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSessionId, isDesktopRunning, isSessionPaused]);
 
-  const isAgentBusy = useMemo(() => {
-    const interactions = sessionData?.interactions;
-    if (!interactions || interactions.length === 0) return false;
-    return interactions[interactions.length - 1].state === 'waiting';
-  }, [sessionData?.interactions]);
-
-  const handleCancelTurn = useCallback(async () => {
-    if (!activeSessionId) return;
-    try {
-      await api.getApiClient().v1SessionsCancelCreate(activeSessionId);
-    } catch (error: any) {
-      snackbar.error(error?.message || "Failed to cancel");
-    }
-  }, [activeSessionId, api, snackbar]);
   const taskMetadataError =
     typeof task?.metadata?.error === "string" ? task.metadata.error : "";
 
@@ -1978,37 +1958,19 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                     </IconButton>
                   </Tooltip>
                 </Box>
-                <EmbeddedSessionView
-                  ref={sessionViewRef}
+                <AgentChat
                   sessionId={activeSessionId}
+                  specTaskId={task.id}
+                  projectId={task.project_id}
                   enableInteractionDebugCopy
+                  onWillSend={handleWillSend}
+                  placeholder={
+                    sessionData?.config?.paused
+                      ? "This session is paused — open the forked child to keep chatting"
+                      : "Send message to agent..."
+                  }
+                  disabled={!!sessionData?.config?.paused}
                 />
-                <Box sx={{ p: 1.5, flexShrink: 0 }}>
-                  <RobustPromptInput
-                    sessionId={activeSessionId}
-                    specTaskId={task.id}
-                    projectId={task.project_id}
-                    apiClient={api.getApiClient()}
-                    onSend={async (message: string, interrupt?: boolean) => {
-                      await streaming.NewInference({
-                        type: SESSION_TYPE_TEXT,
-                        message,
-                        sessionId: activeSessionId,
-                        interrupt: interrupt ?? true,
-                      });
-                    }}
-                    onWillSend={handleWillSend}
-                    onHeightChange={() =>
-                      sessionViewRef.current?.scrollToBottom()
-                    }
-                    placeholder={
-                      sessionData?.config?.paused
-                        ? "This session is paused — open the forked child to keep chatting"
-                        : "Send message to agent..."
-                    }
-                    disabled={!!sessionData?.config?.paused}
-                  />
-                </Box>
               </Box>
             </Panel>
 
@@ -2794,44 +2756,19 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                     </Box>
                   );
                 })()}
-                <EmbeddedSessionView
-                  ref={sessionViewRef}
+                <AgentChat
                   sessionId={activeSessionId}
+                  specTaskId={task.id}
+                  projectId={task.project_id}
                   enableInteractionDebugCopy
+                  onWillSend={handleWillSend}
+                  placeholder={
+                    sessionData?.config?.paused
+                      ? "This session is paused — open the forked child to keep chatting"
+                      : "Send message to agent..."
+                  }
+                  disabled={!!sessionData?.config?.paused}
                 />
-                <Box
-                  sx={{
-                    p: 1.5,
-                    flexShrink: 0,
-                    display: "flex",
-                    alignItems: "flex-start",
-                    gap: 1,
-                  }}
-                >
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <RobustPromptInput
-                      sessionId={activeSessionId}
-                      specTaskId={task.id}
-                      projectId={task.project_id}
-                      apiClient={api.getApiClient()}
-                      onSend={async (message: string, interrupt?: boolean) => {
-                        await streaming.NewInference({
-                          type: SESSION_TYPE_TEXT,
-                          message,
-                          sessionId: activeSessionId,
-                          interrupt: interrupt ?? true,
-                        });
-                      }}
-                      onWillSend={handleWillSend}
-                      onHeightChange={() =>
-                        sessionViewRef.current?.scrollToBottom()
-                      }
-                      placeholder="Send message to agent..."
-                      onCancel={activeSessionId ? handleCancelTurn : undefined}
-                      isAgentBusy={isAgentBusy}
-                    />
-                  </Box>
-                </Box>
               </Box>
             )}
 

--- a/frontend/src/components/tasks/TabsView.tsx
+++ b/frontend/src/components/tasks/TabsView.tsx
@@ -121,9 +121,7 @@ const useAgentActivityCheck = (
   return { isActive, needsAttention, markAsSeen };
 };
 
-// Generate unique panel IDs using timestamp + random to avoid collisions
-const generatePanelId = () =>
-  `panel-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+const generatePanelId = () => `panel-${crypto.randomUUID()}`;
 
 interface TabData {
   id: string;

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -115,11 +115,13 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
           styleOverrides: {
             html: {
               fontFamily: APP_FONT_FAMILY,
-              WebkitFontSmoothing: 'antialiased',
-              MozOsxFontSmoothing: 'grayscale',
+              WebkitFontSmoothing: 'auto',
+              MozOsxFontSmoothing: 'auto',
             },
             body: {
               fontFamily: APP_FONT_FAMILY,
+              WebkitFontSmoothing: 'auto',
+              MozOsxFontSmoothing: 'auto',
               backgroundColor: bg,
               ...scrollbarStyles,
             },

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -3,6 +3,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles'
 import useThemeConfig from '../hooks/useThemeConfig'
 import useApi from '../hooks/useApi'
 import { PaletteMode } from '@mui/material'
+import { APP_FONT_FAMILY, APP_MONO_FONT_FAMILY } from '../styles/typography'
 
 function getInitialMode(): PaletteMode {
   if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
@@ -93,7 +94,8 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
         },
       },
       typography: {
-        fontFamily: "IBM Plex Sans, Helvetica, Arial, sans-serif",
+        fontFamily: APP_FONT_FAMILY,
+        fontFamilyMono: APP_MONO_FONT_FAMILY,
         fontSize: 14,
         // Light mode is often viewed in sunlight — bump weights for readability.
         ...(isLight && {
@@ -111,9 +113,18 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
       components: {
         MuiCssBaseline: {
           styleOverrides: {
+            html: {
+              fontFamily: APP_FONT_FAMILY,
+              WebkitFontSmoothing: 'antialiased',
+              MozOsxFontSmoothing: 'grayscale',
+            },
             body: {
+              fontFamily: APP_FONT_FAMILY,
               backgroundColor: bg,
               ...scrollbarStyles,
+            },
+            'button, input, optgroup, select, textarea': {
+              fontFamily: 'inherit',
             },
             '*': scrollbarStyles,
           },

--- a/frontend/src/hooks/usePromptHistory.ts
+++ b/frontend/src/hooks/usePromptHistory.ts
@@ -109,7 +109,7 @@ interface UsePromptHistoryReturn {
 }
 
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  return crypto.randomUUID()
 }
 
 function getStorageKey(specTaskId?: string): string {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,6 @@
 import { createRoot } from 'react-dom/client';
+import '@fontsource-variable/dm-sans'
+import '@fontsource-variable/jetbrains-mono'
 import App from './App'
 import ErrorBoundary from './components/system/ErrorBoundary'
 import { isMobileOrTablet } from './utils/isMobileOrTablet'

--- a/frontend/src/pages/GitRepoDetail.tsx
+++ b/frontend/src/pages/GitRepoDetail.tsx
@@ -26,7 +26,6 @@ import {
   Tab,
   Tooltip,
   Paper,
-  useTheme,
 } from '@mui/material'
 import {
   GitBranch,
@@ -130,10 +129,8 @@ const GitRepoDetail: FC = () => {
   const queryClient = useQueryClient()
   const api = useApi()
   const snackbar = useSnackbar()
-  const theme = useTheme()
 
   const currentOrg = account.organizationTools.organization
-  const ownerSlug = currentOrg?.name || account.userMeta?.slug || 'user'
 
   const { data: repository, isLoading, error } = useGitRepository(repoId || '')
 
@@ -687,7 +684,7 @@ const GitRepoDetail: FC = () => {
       orgBreadcrumbs={true}
     >
         <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
-          {/* GitHub-style header */}
+          {/* Repository header */}
         <Box sx={{ mb: 3 }}>
 
           {/* Repo name and actions */}
@@ -695,14 +692,6 @@ const GitRepoDetail: FC = () => {
             <Box sx={{ flex: 1 }}>
               <Typography variant="h4" component="h1" sx={{ fontWeight: 400, display: 'flex', alignItems: 'center', gap: 1, mb: 1, color: 'text.primary' }}>
                 <GitBranch size={24} style={{ color: 'currentColor', opacity: 0.6 }} />
-                <Box
-                  component="span"
-                  onClick={() => account.orgNavigate('projects', { tab: 'repositories' })}
-                  sx={{ color: theme.palette.secondary.main, cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
-                >
-                  {ownerSlug}
-                </Box>
-                <Box component="span" sx={{ color: 'text.secondary', fontWeight: 300 }}>/</Box>
                 <Box component="span" sx={{ fontWeight: 600 }}>{repository.name}</Box>
               </Typography>
 

--- a/frontend/src/pages/HelixOrgTopics.tsx
+++ b/frontend/src/pages/HelixOrgTopics.tsx
@@ -115,26 +115,30 @@ const HelixOrgTopics: FC = () => {
     _data: s,
     _isHighlighted: highlightId === s.id,
     name: (
-      <Typography variant="body1">
+      <Stack spacing={0.25}>
         <a
           href="#"
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); openTopicDetail(s.id) }}
           style={{
-            fontWeight: 'bold',
-            color: highlightId === s.id
-              ? theme.palette.warning.main
-              : theme.palette.mode === 'dark' ? theme.palette.text.primary : theme.palette.text.secondary,
-            fontFamily: 'monospace',
+            fontWeight: 600,
+            color: highlightId === s.id ? theme.palette.warning.main : 'inherit',
             textDecoration: 'none',
             cursor: 'pointer',
           }}
         >
-          {s.id}
+          {s.name}
         </a>
-      </Typography>
-    ),
-    nameField: (
-      <Typography variant="body2" color="text.secondary">{s.name}</Typography>
+        <Typography
+          variant="caption"
+          sx={{
+            fontFamily: 'monospace',
+            fontSize: '0.7rem',
+            color: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.5)' : 'text.secondary',
+          }}
+        >
+          {s.id}
+        </Typography>
+      </Stack>
     ),
     kind: (
       <Typography variant="body2" sx={{ fontFamily: 'monospace', color: 'text.secondary' }}>{s.kind}</Typography>
@@ -204,8 +208,7 @@ const HelixOrgTopics: FC = () => {
             <SimpleTable
               authenticated={true}
               fields={[
-                { name: 'name', title: 'ID' },
-                { name: 'nameField', title: 'Name' },
+                { name: 'name', title: 'Name' },
                 { name: 'kind', title: 'Transport' },
                 { name: 'subscribers', title: 'Subscribers' },
                 { name: 'created', title: 'Created' },

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -52,6 +52,7 @@ import useThemeConfig from "../hooks/useThemeConfig";
 import useIsBigScreen from "../hooks/useIsBigScreen";
 import useApps from "../hooks/useApps";
 import useUserMenuHeight from "../hooks/useUserMenuHeight";
+import { LIGHT_SIDEBAR_COLORS } from "../styles/themeTokens";
 
 // Admin and Connected Services are rendered as full-screen dialog overlays
 // so the user stays within their current org-scoped URL
@@ -579,8 +580,8 @@ const Layout: FC<{
           onClose={() => account.setMobileMenuOpen(false)}
           PaperProps={{
             sx: {
-              background: lightTheme.backgroundColor,
-              backgroundColor: lightTheme.backgroundColor,
+              background: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
+              backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
               // For mobile (temporary), let MUI handle positioning (fixed)
               // For desktop (permanent), use relative positioning
               position: isBigScreen ? "relative" : undefined,
@@ -632,11 +633,11 @@ const Layout: FC<{
                 py: 0,
                 ...(shouldShowSidebar
                   ? {
-                      borderRight: lightTheme.border,
-                      bgcolor: lightTheme.backgroundColor,
+                      borderRight: lightTheme.isLight ? `1px solid ${LIGHT_SIDEBAR_COLORS.border}` : lightTheme.border,
+                      bgcolor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
                     }
                   : {
-                      bgcolor: lightTheme.backgroundColor,
+                      bgcolor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
                     }),
               }}
             >

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -2,21 +2,16 @@ import React, { FC, useState } from "react";
 import {
   Container,
   Box,
-  Button,
   Menu,
   MenuItem,
   CircularProgress,
 } from "@mui/material";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { Plus, Link, FolderSearch } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import Page from "../components/system/Page";
 import CreateProjectButton from "../components/project/CreateProjectButton";
 import CreateProjectDialog from "../components/project/CreateProjectDialog";
-import CreateRepositoryDialog from "../components/project/CreateRepositoryDialog";
-import LinkExternalRepositoryDialog from "../components/project/LinkExternalRepositoryDialog";
-import BrowseProvidersDialog from "../components/project/BrowseProvidersDialog";
 import AgentSelectionModal from "../components/project/AgentSelectionModal";
 import SampleProjectWizard from "../components/project/SampleProjectWizard";
 import ProjectsListView from "../components/project/ProjectsListView";
@@ -41,14 +36,11 @@ import {
   useUnpinProject,
 } from "../services";
 import { useGitRepositories } from "../services/gitRepositoryService";
+import { matchesAllTokens } from "../utils/searchUtils";
 import type {
   TypesExternalRepositoryType,
   TypesGitRepository,
   TypesAzureDevOps,
-  TypesGitHub,
-  TypesGitLab,
-  TypesBitbucket,
-  TypesRepositoryInfo,
 } from "../api/api";
 
 const Projects: FC = () => {
@@ -143,8 +135,6 @@ const Projects: FC = () => {
 
   // Repository management
   const currentOrg = account.organizationTools.organization;
-  const ownerId = account.user?.id || "";
-  const ownerSlug = currentOrg?.name || account.userMeta?.slug || "user";
   // List repos by organization_id when in org context, or by owner_id for personal workspace
   const { data: repositories = [], isLoading: reposLoading } =
     useGitRepositories(
@@ -152,10 +142,6 @@ const Projects: FC = () => {
         ? { organizationId: currentOrg.id, enabled: isLoggedIn }
         : { ownerId: account.user?.id, enabled: isLoggedIn },
     );
-
-  // Repository dialog states
-  const [createRepoDialogOpen, setCreateRepoDialogOpen] = useState(false);
-  const [linkRepoDialogOpen, setLinkRepoDialogOpen] = useState(false);
 
   // Agent selection modal state for sample project fork
   const [agentModalOpen, setAgentModalOpen] = useState(false);
@@ -171,13 +157,6 @@ const Projects: FC = () => {
   const [selectedAgentForWizard, setSelectedAgentForWizard] = useState<
     string | undefined
   >(undefined);
-
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState<string>("");
-
-  // Browse providers dialog state
-  const [browseProvidersOpen, setBrowseProvidersOpen] = useState(false);
-  const [linkingFromBrowser, setLinkingFromBrowser] = useState(false);
 
   // Pagination for projects
   const [projectsPage, setProjectsPage] = useState(0);
@@ -199,11 +178,9 @@ const Projects: FC = () => {
     filteredProjects.length / projectsPerPage,
   );
 
-  // Filter and paginate repositories
   const filteredRepositories = repositories.filter(
     (repo: TypesGitRepository) =>
-      repo.name?.toLowerCase().includes(reposSearchQuery.toLowerCase()) ||
-      repo.description?.toLowerCase().includes(reposSearchQuery.toLowerCase()),
+      matchesAllTokens(reposSearchQuery, repo.name, repo.description),
   );
   const paginatedRepositories = filteredRepositories.slice(
     reposPage * reposPerPage,
@@ -303,6 +280,10 @@ const Projects: FC = () => {
     account.orgNavigate("project-specs", { id: project.id });
   };
 
+  const handleViewRepository = (repo: TypesGitRepository) => {
+    account.orgNavigate("git-repo-detail", { repoId: repo.id });
+  };
+
   const handleProjectSettings = () => {
     if (selectedProject) {
       openDialog('project-settings', { projectId: selectedProject.id });
@@ -372,259 +353,7 @@ const Projects: FC = () => {
     }
   };
 
-  const handleCreateCustomRepo = async (
-    name: string,
-    description: string,
-    koditIndexing: boolean,
-  ) => {
-    if (!name.trim() || !account.user?.id) return;
-
-    setCreating(true);
-    setCreateError("");
-    try {
-      const apiClient = api.getApiClient();
-      await apiClient.v1GitRepositoriesCreate({
-        name,
-        description,
-        owner_id: account.user.id, // Always use user ID, not org ID
-        organization_id: currentOrg?.id,
-        repo_type: "code" as any, // Helix-hosted code repository
-        default_branch: "main",
-        kodit_indexing: koditIndexing,
-      });
-
-      // Invalidate and refetch git repositories query (use base key to match all variants)
-      await queryClient.invalidateQueries({ queryKey: ["git-repositories"] });
-
-      // Reset pagination to show the new repo at the top
-      setReposPage(0);
-      setReposSearchQuery("");
-
-      setCreateRepoDialogOpen(false);
-      setCreateError("");
-      snackbar.success("Repository created successfully");
-    } catch (error) {
-      console.error("Failed to create repository:", error);
-      setCreateError(
-        error instanceof Error ? error.message : "Failed to create repository",
-      );
-      snackbar.error("Failed to create repository");
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleLinkExternalRepo = async (
-    url: string,
-    name: string,
-    type: "github" | "gitlab" | "ado" | "other",
-    koditIndexing: boolean,
-    username?: string,
-    password?: string,
-    organizationUrl?: string,
-    token?: string,
-    gitlabBaseUrl?: string,
-  ) => {
-    if (!url.trim() || !ownerId) return;
-
-    setCreating(true);
-    try {
-      const apiClient = api.getApiClient();
-
-      // Extract repo name from URL if not provided
-      let repoName = name.trim();
-      if (!repoName) {
-        // Try to extract from URL (e.g., github.com/org/repo.git -> repo)
-        const match = url.match(/\/([^\/]+?)(\.git)?$/);
-        repoName = match ? match[1] : "external-repo";
-      }
-
-      // Build provider-specific config objects
-      let azureDevOps: TypesAzureDevOps | undefined;
-      let github: TypesGitHub | undefined;
-      let gitlab: TypesGitLab | undefined;
-
-      if (type === "ado" && organizationUrl && token) {
-        azureDevOps = {
-          organization_url: organizationUrl,
-          personal_access_token: token,
-        };
-      }
-
-      if (type === "github" && token) {
-        github = {
-          personal_access_token: token,
-        };
-      }
-
-      if (type === "gitlab" && (token || gitlabBaseUrl)) {
-        gitlab = {
-          personal_access_token: token,
-          base_url: gitlabBaseUrl,
-        };
-      }
-
-      await apiClient.v1GitRepositoriesCreate({
-        name: repoName,
-        description: `External ${type} repository`,
-        owner_id: account.user?.id || "", // Always use user ID, not org ID
-        organization_id: currentOrg?.id,
-        repo_type: "project" as any,
-        default_branch: "main",
-        // Remote URL
-        external_url: url,
-        // Repository provider (github, gitlab, ado, etc.)
-        external_type: type as TypesExternalRepositoryType,
-        // Auth details
-        username: username,
-        password: password,
-        // Provider-specific config
-        azure_devops: azureDevOps,
-        github: github,
-        gitlab: gitlab,
-        // Code intelligence
-        kodit_indexing: koditIndexing,
-      });
-
-      // Invalidate and refetch git repositories query (use base key to match all variants)
-      await queryClient.invalidateQueries({ queryKey: ["git-repositories"] });
-
-      // Reset pagination to show the new repo at the top
-      setReposPage(0);
-      setReposSearchQuery("");
-
-      setLinkRepoDialogOpen(false);
-      snackbar.success("External repository linked successfully");
-    } catch (error) {
-      console.error("Failed to link external repository:", error);
-      snackbar.error("Failed to link external repository");
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleViewRepository = (repo: TypesGitRepository) => {
-    account.orgNavigate("git-repo-detail", { repoId: repo.id });
-  };
-
-  // Handle repository selection from OAuth browser or PAT flow
-  const handleBrowseSelectRepository = async (
-    repo: TypesRepositoryInfo,
-    providerTypeOrCreds: string,
-    oauthConnectionId?: string,
-    patConnectionId?: string,
-  ) => {
-    if (!account.user?.id) return;
-
-    setLinkingFromBrowser(true);
-    try {
-      const apiClient = api.getApiClient();
-
-      // Check if providerTypeOrCreds is JSON (PAT credentials) or plain provider type
-      let providerType: string;
-      let patCredentials: {
-        pat?: string;
-        username?: string;
-        orgUrl?: string;
-        gitlabBaseUrl?: string;
-        githubBaseUrl?: string;
-        bitbucketBaseUrl?: string;
-      } | null = null;
-
-      try {
-        const parsed = JSON.parse(providerTypeOrCreds);
-        providerType = parsed.type;
-        patCredentials = {
-          pat: parsed.pat,
-          username: parsed.username,
-          orgUrl: parsed.orgUrl,
-          gitlabBaseUrl: parsed.gitlabBaseUrl,
-          githubBaseUrl: parsed.githubBaseUrl,
-          bitbucketBaseUrl: parsed.bitbucketBaseUrl,
-        };
-      } catch {
-        // Not JSON, it's a plain provider type (OAuth flow)
-        providerType = providerTypeOrCreds;
-      }
-
-      // Map provider type to external type
-      const externalTypeMap: Record<string, TypesExternalRepositoryType> = {
-        github: "github" as TypesExternalRepositoryType,
-        gitlab: "gitlab" as TypesExternalRepositoryType,
-        "azure-devops": "ado" as TypesExternalRepositoryType,
-        bitbucket: "bitbucket" as TypesExternalRepositoryType,
-      };
-
-      // Build provider-specific config if using PAT
-      let github: TypesGitHub | undefined;
-      let gitlab: TypesGitLab | undefined;
-      let azureDevOps: TypesAzureDevOps | undefined;
-      let bitbucket: TypesBitbucket | undefined;
-
-      if (patCredentials?.pat) {
-        if (providerType === "github") {
-          github = {
-            personal_access_token: patCredentials.pat,
-            base_url: patCredentials.githubBaseUrl,
-          };
-        } else if (providerType === "gitlab") {
-          gitlab = {
-            personal_access_token: patCredentials.pat,
-            base_url: patCredentials.gitlabBaseUrl,
-          };
-        } else if (providerType === "azure-devops") {
-          azureDevOps = {
-            organization_url: patCredentials.orgUrl || "",
-            personal_access_token: patCredentials.pat,
-          };
-        } else if (providerType === "bitbucket") {
-          bitbucket = {
-            username: patCredentials.username || "",
-            app_password: patCredentials.pat,
-            base_url: patCredentials.bitbucketBaseUrl,
-          };
-        }
-      }
-
-      await apiClient.v1GitRepositoriesCreate({
-        name: repo.name || "repository",
-        description: repo.description || `${providerType} repository`,
-        owner_id: account.user.id,
-        organization_id: currentOrg?.id,
-        repo_type: "code" as any,
-        default_branch: repo.default_branch || "main",
-        is_external: true,
-        external_url: repo.clone_url || repo.html_url || "",
-        external_type:
-          externalTypeMap[providerType] ||
-          ("github" as TypesExternalRepositoryType),
-        kodit_indexing: true,
-        github,
-        gitlab,
-        azure_devops: azureDevOps,
-        bitbucket,
-        oauth_connection_id: oauthConnectionId,
-        git_provider_connection_id: patConnectionId,
-      });
-
-      // Invalidate and refetch git repositories query
-      await queryClient.invalidateQueries({ queryKey: ["git-repositories"] });
-
-      // Reset pagination to show the new repo at the top
-      setReposPage(0);
-      setReposSearchQuery("");
-
-      setBrowseProvidersOpen(false);
-      snackbar.success("Repository linked successfully");
-    } catch (error) {
-      console.error("Failed to link repository from browser:", error);
-      snackbar.error("Failed to link repository");
-    } finally {
-      setLinkingFromBrowser(false);
-    }
-  };
-
-  if (isProjectsLoading || reposLoading) {
+  if (isProjectsLoading) {
     return (
       <Page breadcrumbTitle="Projects" orgBreadcrumbs={true}>
         <Container maxWidth="lg">
@@ -680,42 +409,6 @@ const Projects: FC = () => {
             variant="contained"
             color="secondary"
           />
-        ) : currentView === "repositories" ? (
-          <>
-            <Button
-              variant="contained"
-              color="secondary"
-              startIcon={<FolderSearch size={20} />}
-              onClick={() => {
-                if (!requireLogin()) return;
-                setBrowseProvidersOpen(true);
-              }}
-              sx={{ mr: 1 }}
-            >
-              Connect & Browse
-            </Button>
-            <Button
-              variant="outlined"
-              startIcon={<Link size={20} />}
-              onClick={() => {
-                if (!requireLogin()) return;
-                setLinkRepoDialogOpen(true);
-              }}
-              sx={{ mr: 1 }}
-            >
-              Link Manually
-            </Button>
-            <Button
-              variant="outlined"
-              startIcon={<Plus size={20} />}
-              onClick={() => {
-                if (!requireLogin()) return;
-                setCreateRepoDialogOpen(true);
-              }}
-            >
-              New Empty
-            </Button>
-          </>
         ) : null
       }
     >
@@ -752,7 +445,6 @@ const Projects: FC = () => {
           {currentView === "repositories" && (
             <RepositoriesListView
               repositories={repositories}
-              ownerSlug={ownerSlug}
               searchQuery={reposSearchQuery}
               onSearchChange={setReposSearchQuery}
               page={reposPage}
@@ -761,14 +453,6 @@ const Projects: FC = () => {
               paginatedRepositories={paginatedRepositories}
               totalPages={reposTotalPages}
               onViewRepository={handleViewRepository}
-              onCreateRepo={() => {
-                if (!requireLogin()) return;
-                setCreateRepoDialogOpen(true);
-              }}
-              onLinkExternalRepo={() => {
-                if (!requireLogin()) return;
-                setLinkRepoDialogOpen(true);
-              }}
             />
           )}
 
@@ -807,26 +491,6 @@ const Projects: FC = () => {
         onLinkRepo={handleLinkRepoForProject}
       />
 
-      {/* Custom Repository Dialog */}
-      <CreateRepositoryDialog
-        open={createRepoDialogOpen}
-        onClose={() => {
-          setCreateRepoDialogOpen(false);
-          setCreateError("");
-        }}
-        onSubmit={handleCreateCustomRepo}
-        isCreating={creating}
-        error={createError}
-      />
-
-      {/* Link External Repository Dialog */}
-      <LinkExternalRepositoryDialog
-        open={linkRepoDialogOpen}
-        onClose={() => setLinkRepoDialogOpen(false)}
-        onSubmit={handleLinkExternalRepo}
-        isCreating={creating}
-      />
-
       {/* Agent Selection Modal for Sample Project Fork */}
       <AgentSelectionModal
         open={agentModalOpen}
@@ -857,14 +521,6 @@ const Projects: FC = () => {
         selectedAgentId={selectedAgentForWizard}
       />
 
-      {/* Browse Connected Providers Dialog */}
-      <BrowseProvidersDialog
-        open={browseProvidersOpen}
-        onClose={() => setBrowseProvidersOpen(false)}
-        onSelectRepository={handleBrowseSelectRepository}
-        isLinking={linkingFromBrowser}
-        organizationName={currentOrg?.name}
-      />
     </Page>
   );
 };

--- a/frontend/src/styles/themeTokens.ts
+++ b/frontend/src/styles/themeTokens.ts
@@ -1,0 +1,12 @@
+export const DARK_APP_BACKGROUND = '#0a0a0a'
+
+export const LIGHT_SIDEBAR_COLORS = {
+  background: '#fafafa',
+  foreground: '#27272a',
+  mutedForeground: '#71717a',
+  icon: '#a1a1aa',
+  controlSurface: '#f4f4f5',
+  rowHover: '#fdfdfd',
+  rowSelected: '#ffffff',
+  border: '#e4e4e7',
+} as const

--- a/frontend/src/styles/typography.ts
+++ b/frontend/src/styles/typography.ts
@@ -1,0 +1,16 @@
+export const APP_FONT_FAMILY = [
+  '"DM Sans Variable"',
+  '"DM Sans"',
+  '-apple-system',
+  'BlinkMacSystemFont',
+  '"Segoe UI"',
+  'system-ui',
+  'sans-serif',
+].join(', ')
+
+export const APP_MONO_FONT_FAMILY = [
+  '"JetBrains Mono Variable"',
+  '"SFMono-Regular"',
+  'Consolas',
+  'monospace',
+].join(', ')

--- a/frontend/src/themes.tsx
+++ b/frontend/src/themes.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import Box from '@mui/material/Box'
+import { DARK_APP_BACKGROUND } from './styles/themeTokens'
 
 const DEFAULT_THEME_NAME = 'helix'
 
@@ -104,8 +105,8 @@ export const THEMES: Record<string, ITheme> = {
     darkScrollbar: '#23232e',
     darkScrollbarThumb: '#35354a',
     darkScrollbarHover: '#505070',
-    darkBackgroundColor: "#121214",
-    darkBackgroundImage: "linear-gradient(135deg, #101014 0%, #18181c 100%)",
+    darkBackgroundColor: DARK_APP_BACKGROUND,
+    darkBackgroundImage: "none",
     darkBorder: "1px solid #282838",
     darkText: "#e0e0e0",
     darkTextFaded: "#a0a0b0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     allowedHosts: true,  // Allow access from any hostname
   },
   publicDir: 'assets',
+  optimizeDeps: {
+    include: ['@react-pdf/renderer', '@uiw/react-md-editor'],
+  },
   build: {
     rollupOptions: {
       output: {
@@ -27,6 +30,7 @@ export default defineConfig({
     },
   },
   resolve: {
+    dedupe: ['react', 'react-dom'],
     alias: {
       '#minpath': path.resolve(__dirname, 'src/polyfills/path.js'),
       '#minproc': path.resolve(__dirname, 'src/polyfills/process.js'),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -636,6 +636,16 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
   integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
 
+"@fontsource-variable/dm-sans@^5.2.8":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/dm-sans/-/dm-sans-5.3.0.tgz#691f0c9cb3de0306984a6bddf4fbfc725f135ff9"
+  integrity sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==
+
+"@fontsource-variable/jetbrains-mono@^5.2.8":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz#5738dedd3af40606b0d9b7626f4ba7c4586cb39b"
+  integrity sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==
+
 "@hookform/resolvers@^3.10.0":
   version "3.10.0"
   resolved "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz"


### PR DESCRIPTION
## Summary

- redesign the shared org-chart and spec-task chat around T3 Code's typography, dark palette, message hierarchy, composer behavior, interrupt control, and image presentation
- add a desktop turn navigator with hover previews, active-message markers, click/keyboard navigation, and auto-follow pausing
- align application chrome and sidebar spacing, typography, light-mode states, and dark background tokens
- fix narrow chat-pane overflow, missing right padding, and markdown layout shifts during streaming
- improve connected GitHub repository loading and repository-page rendering
- harden SPA asset fallback behavior and the PDF export React dependency path

## Why

The shared chat had inconsistent typography, backgrounds, message geometry, and streaming behavior across org chat and spec-task chat. Narrow split panes could also overflow and lose their right margin. The repositories view could wait on sequential GitHub pagination, while SPA asset fallback could mask missing module assets.

## Impact

Org and spec-task chats now share the same T3-inspired presentation and mechanics. Desktop users can navigate long conversations from the transcript minimap, while touch layouts remain unchanged. The surrounding navigation is denser and more consistent in dark and light mode. Repository loading and SPA asset handling are also more predictable.

## Validation

- live browser verification on the affected spec-task route, including streaming layout, right padding, hover previews, click navigation, keyboard navigation, and auto-follow behavior
- `yarn vitest run src`: 306 passed, 1 skipped
- `yarn tsc --noEmit`
- `yarn build`
- `go test ./pkg/agent/skill/github ./pkg/server/spa`
