### PR TITLE
fix(frontend): route notification replies to agent chat

### DIFF
--- a/frontend/src/components/helix-org/HelixOrgChatPanel.test.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.test.tsx
@@ -1,0 +1,73 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { chatBotStorageKey, focusChatBot } from './chatBotFocus'
+import HelixOrgChatPanel from './HelixOrgChatPanel'
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    params: { org_id: 'acme' } as Record<string, string>,
+    navigate: vi.fn(),
+  },
+  setCurrentSessionId: vi.fn(),
+}))
+
+const bots = [
+  { id: 'bot-one', name: 'Agent One', kind: 'bot', agent_status: 'running' },
+  { id: 'bot-two', name: 'Agent Two', kind: 'bot', agent_status: 'running' },
+]
+
+vi.mock('../../hooks/useRouter', () => ({ default: () => mocks.router }))
+vi.mock('../../hooks/useApi', () => ({ default: () => ({ getApiClient: vi.fn() }) }))
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+vi.mock('../../hooks/useLightTheme', () => ({
+  default: () => ({ isLight: true }),
+}))
+vi.mock('../../contexts/streaming', () => ({
+  useStreaming: () => ({ setCurrentSessionId: mocks.setCurrentSessionId }),
+}))
+vi.mock('../../services/helixOrgService', () => ({
+  useListHelixOrgBots: () => ({ data: bots }),
+  useHelixOrgBot: (botId?: string) => ({ data: botId ? { project_id: `project-${botId}` } : undefined, refetch: vi.fn() }),
+  useActivateBot: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useStopBotAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRestartBotAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+vi.mock('../../services/workerChatSession', () => ({
+  fetchExistingWorkerSession: (projectId: string) => Promise.resolve(`session-${projectId}`),
+}))
+vi.mock('../session/AgentChat', () => ({
+  default: ({ placeholder }: { placeholder: string }) => <div>{placeholder}</div>,
+}))
+vi.mock('../external-agent/ExternalAgentDesktopViewer', () => ({
+  default: () => <div>Desktop viewer</div>,
+}))
+vi.mock('./HelixOrgBotPanelTab', () => ({ default: () => <div>Tasks view</div> }))
+
+describe('HelixOrgChatPanel query selection', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mocks.router.params = { org_id: 'acme' }
+    mocks.setCurrentSessionId.mockReset()
+  })
+
+  it('prioritizes bot_id and switches back to chat when the query changes', async () => {
+    const view = render(<HelixOrgChatPanel />)
+    await screen.findByText('Message Agent One…')
+    fireEvent.click(screen.getByRole('button', { name: 'Desktop' }))
+    expect(await screen.findByText('Desktop viewer')).toBeInTheDocument()
+
+    mocks.router.params = { org_id: 'acme', bot_id: 'bot-two' }
+    view.rerender(<HelixOrgChatPanel />)
+
+    expect(await screen.findByText('Message Agent Two…')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(localStorage.getItem(chatBotStorageKey('acme'))).toBe('bot-two')
+    })
+
+    act(() => focusChatBot('acme', 'bot-one'))
+    expect(await screen.findByText('Message Agent One…')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -2,7 +2,7 @@
 // spec-task chat (AgentChat), scoped to one
 // bot at a time. Header shows which bot you are talking to.
 
-import { FC, MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import { FC, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -57,6 +57,7 @@ const HelixOrgChatPanel: FC = () => {
   const snackbar = useSnackbar()
   const streaming = useStreaming()
   const orgId = (router.params.org_id as string) || ''
+  const queryBotId = (router.params.bot_id as string) || ''
 
   const { data: botsData } = useListHelixOrgBots({ refetchInterval: 5000 })
   const agents = useMemo(
@@ -66,6 +67,7 @@ const HelixOrgChatPanel: FC = () => {
 
   const [selectedBotId, setSelectedBotId] = useState<string>('')
   const [view, setView] = useState<HelixOrgBotPanelView>('chat')
+  const queryFocusRef = useRef('')
   // Persist only bot ids that exist in this org's agent list and match the
   // chart-handle charset (CodeQL: no free-form / secret-like localStorage).
   const persistSelection = useCallback((botId: string) => {
@@ -77,6 +79,15 @@ const HelixOrgChatPanel: FC = () => {
   // Restore last-used bot (or pick a sensible default once the list loads).
   useEffect(() => {
     if (agents.length === 0) return
+    const queryFocusKey = `${orgId}:${queryBotId}`
+    if (isValidBotId(queryBotId) && agents.some((b) => b.id === queryBotId) && queryFocusRef.current !== queryFocusKey) {
+      queryFocusRef.current = queryFocusKey
+      setSelectedBotId(queryBotId)
+      setView('chat')
+      focusChatBot(orgId, queryBotId)
+      return
+    }
+    if (!queryBotId) queryFocusRef.current = ''
     const saved = orgId ? loadFocusedBotId(orgId) : null
     // Only restore ids that still exist in this org's bot list.
     if (saved && agents.some((b) => b.id === saved)) {
@@ -91,7 +102,7 @@ const HelixOrgChatPanel: FC = () => {
       setSelectedBotId(id)
       if (id) persistSelection(id)
     }
-  }, [agents, orgId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [agents, orgId, queryBotId, persistSelection]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Chart node click (and any other focusChatBot caller) switches the rail.
   useEffect(() => {

--- a/frontend/src/components/system/GlobalNotifications.test.tsx
+++ b/frontend/src/components/system/GlobalNotifications.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import GlobalNotifications from './GlobalNotifications'
+
+const mocks = vi.hoisted(() => ({
+  acknowledge: vi.fn(),
+  fireNotification: vi.fn(),
+  navigate: vi.fn(),
+  browserNotificationsEnabled: false,
+}))
+
+const event = {
+  id: 'event-1',
+  user_id: 'user-1',
+  organization_id: 'org-1',
+  project_id: '',
+  spec_task_id: '',
+  event_type: 'org_message' as const,
+  title: 'Message from Agent Two',
+  description: 'Please review this.',
+  created_at: new Date().toISOString(),
+  metadata: { bot_id: 'bot-two' },
+}
+
+vi.mock('../../router', () => ({
+  default: {
+    buildPath: (_name: string, params: Record<string, string>) => `/orgs/${params.org_id}/chart?bot_id=${params.bot_id}`,
+    navigate: mocks.navigate,
+  },
+}))
+vi.mock('../../hooks/useAccount', () => ({
+  default: () => ({
+    orgNavigate: vi.fn(),
+    organizationTools: { organizations: [{ id: 'org-1', name: 'acme', display_name: 'Acme' }] },
+  }),
+}))
+vi.mock('../../hooks/useApi', () => ({ default: () => ({ getApiClient: vi.fn() }) }))
+vi.mock('../../hooks/useLightTheme', () => ({
+  default: () => ({
+    isLight: true,
+    textColor: '#111',
+    textColorFaded: '#666',
+    panelColor: '#fff',
+    border: '1px solid #ddd',
+  }),
+}))
+vi.mock('../../hooks/useNavigationHistory', () => ({ useNavigationHistory: () => [] }))
+vi.mock('../../hooks/useAttentionEvents', () => ({
+  useAttentionEvents: () => ({
+    events: [event],
+    newEvents: [event],
+    acknowledge: mocks.acknowledge,
+    dismiss: vi.fn(),
+    snooze: vi.fn(),
+    dismissAll: vi.fn(),
+  }),
+}))
+vi.mock('../../hooks/useBrowserNotifications', () => ({
+  useBrowserNotifications: () => ({
+    shouldPrompt: false,
+    isEnabled: mocks.browserNotificationsEnabled,
+    disabledByUser: false,
+    requestPermission: vi.fn(),
+    setOptOut: vi.fn(),
+    fireNotification: mocks.fireNotification,
+  }),
+}))
+
+describe('org message notifications', () => {
+  beforeEach(() => {
+    mocks.acknowledge.mockReset()
+    mocks.fireNotification.mockReset()
+    mocks.navigate.mockReset()
+    mocks.browserNotificationsEnabled = false
+  })
+
+  it('links to the agent chat and acknowledges before navigating', () => {
+    render(<GlobalNotifications />)
+    fireEvent.click(screen.getAllByRole('button')[0])
+
+    expect(screen.queryByText('Respond')).not.toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Open agent chat' })
+    expect(link).toHaveAttribute('href', '/orgs/acme/chart?bot_id=bot-two')
+    fireEvent.click(link)
+
+    expect(mocks.acknowledge).toHaveBeenCalledWith('event-1')
+    expect(mocks.navigate).toHaveBeenCalledWith('helix_org_chart', {
+      org_id: 'acme',
+      bot_id: 'bot-two',
+    })
+  })
+
+  it('opens the same agent chat from a browser notification', async () => {
+    mocks.browserNotificationsEnabled = true
+    render(<GlobalNotifications />)
+
+    await waitFor(() => expect(mocks.fireNotification).toHaveBeenCalledOnce())
+    mocks.fireNotification.mock.calls[0][3]()
+
+    expect(mocks.acknowledge).toHaveBeenCalledWith('event-1')
+    expect(mocks.navigate).toHaveBeenCalledWith('helix_org_chart', {
+      org_id: 'acme',
+      bot_id: 'bot-two',
+    })
+  })
+})

--- a/frontend/src/components/system/GlobalNotifications.test.tsx
+++ b/frontend/src/components/system/GlobalNotifications.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import GlobalNotifications from './GlobalNotifications'
@@ -20,6 +20,7 @@ const event = {
   title: 'Message from Agent Two',
   description: 'Please review this.',
   created_at: new Date().toISOString(),
+  acknowledged_at: undefined as string | undefined,
   metadata: { bot_id: 'bot-two' },
 }
 
@@ -73,6 +74,7 @@ describe('org message notifications', () => {
     mocks.fireNotification.mockReset()
     mocks.navigate.mockReset()
     mocks.browserNotificationsEnabled = false
+    event.acknowledged_at = undefined
   })
 
   it('links to the agent chat and acknowledges before navigating', () => {
@@ -80,7 +82,7 @@ describe('org message notifications', () => {
     fireEvent.click(screen.getAllByRole('button')[0])
 
     expect(screen.queryByText('Respond')).not.toBeInTheDocument()
-    const link = screen.getByRole('link', { name: 'Open agent chat' })
+    const link = screen.getByRole('link', { name: 'Continue in agent chat' })
     expect(link).toHaveAttribute('href', '/orgs/acme/chart?bot_id=bot-two')
     fireEvent.click(link)
 
@@ -89,6 +91,17 @@ describe('org message notifications', () => {
       org_id: 'acme',
       bot_id: 'bot-two',
     })
+  })
+
+  it('hides the bell badge for read notifications while retaining the panel total', () => {
+    event.acknowledged_at = new Date().toISOString()
+    render(<GlobalNotifications />)
+
+    const bellButton = screen.getAllByRole('button')[0]
+    expect(within(bellButton).queryByText('1')).not.toBeInTheDocument()
+
+    fireEvent.click(bellButton)
+    expect(screen.getByText('1')).toBeInTheDocument()
   })
 
   it('opens the same agent chat from a browser notification', async () => {

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -8,7 +8,7 @@ import Button from '@mui/material/Button'
 import Tooltip from '@mui/material/Tooltip'
 import Stack from '@mui/material/Stack'
 import ReactMarkdown from 'react-markdown'
-import { Bell, X, BellOff, BellRing, Sparkles, Hand, AlertCircle, GitMerge, ExternalLink, MessageSquare } from 'lucide-react'
+import { Bell, X, BellOff, BellRing, Sparkles, Hand, AlertCircle, GitMerge, ExternalLink, MessageSquare, ArrowRight } from 'lucide-react'
 
 import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
@@ -310,13 +310,36 @@ const AttentionEventItem: React.FC<{
             component="a"
             href={router.buildPath('helix_org_chart', { org_id: orgForEvent.name, bot_id: botId })}
             size="small"
+            variant="outlined"
+            endIcon={<ArrowRight size={13} />}
             onClick={(e) => {
               e.preventDefault()
               onNavigate(event)
             }}
-            sx={{ mt: 1, textTransform: 'none' }}
+            sx={{
+              mt: 1,
+              px: 1.25,
+              py: 0.5,
+              minHeight: 0,
+              borderRadius: 1.5,
+              textTransform: 'none',
+              fontSize: '0.75rem',
+              fontWeight: 700,
+              color: isLight ? '#0f766e' : '#2dd4bf',
+              borderColor: isLight ? 'rgba(13,148,136,0.4)' : 'rgba(45,212,191,0.35)',
+              backgroundColor: isLight ? 'rgba(13,148,136,0.06)' : 'rgba(45,212,191,0.08)',
+              '&:hover': {
+                color: isLight ? '#115e59' : '#5eead4',
+                borderColor: isLight ? '#0d9488' : '#2dd4bf',
+                backgroundColor: isLight ? 'rgba(13,148,136,0.12)' : 'rgba(45,212,191,0.14)',
+              },
+              '&.Mui-focusVisible': {
+                outline: '2px solid rgba(20,184,166,0.55)',
+                outlineOffset: 2,
+              },
+            }}
           >
-            Open agent chat
+            Continue in agent chat
           </Button>
         )}
       </Box>
@@ -657,8 +680,8 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
         }}
       >
         <Badge
-          badgeContent={deduplicatedHasNew ? deduplicatedUnreadCount : deduplicatedTotalCount}
-          color={deduplicatedHasNew ? 'error' : 'default'}
+          badgeContent={deduplicatedUnreadCount}
+          color="error"
           overlap="circular"
           sx={{
             '& .MuiBadge-badge': {
@@ -674,10 +697,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
                   '0%, 100%': { boxShadow: '0 0 0 2px rgba(239,68,68,0.35)' },
                   '50%': { boxShadow: '0 0 0 5px rgba(239,68,68,0.0)' },
                 },
-              }),
-              ...(!deduplicatedHasNew && deduplicatedTotalCount > 0 && {
-                backgroundColor: lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.25)',
-                color: lightTheme.isLight ? '#fff' : 'rgba(0,0,0,0.7)',
               }),
             },
           }}

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -7,20 +7,16 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import Tooltip from '@mui/material/Tooltip'
 import Stack from '@mui/material/Stack'
-import TextField from '@mui/material/TextField'
-import CircularProgress from '@mui/material/CircularProgress'
 import ReactMarkdown from 'react-markdown'
-import { Bell, X, BellOff, BellRing, Sparkles, Hand, AlertCircle, GitMerge, ExternalLink, MessageSquare, CornerUpLeft } from 'lucide-react'
+import { Bell, X, BellOff, BellRing, Sparkles, Hand, AlertCircle, GitMerge, ExternalLink, MessageSquare } from 'lucide-react'
 
 import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
-import useSnackbar from '../../hooks/useSnackbar'
 import useLightTheme from '../../hooks/useLightTheme'
 import { useAttentionEvents, AttentionEvent, AttentionEventType } from '../../hooks/useAttentionEvents'
 import { useBrowserNotifications } from '../../hooks/useBrowserNotifications'
 import { useNavigationHistory, NavHistoryEntry } from '../../hooks/useNavigationHistory'
 import router from '../../router'
-import { Api } from '../../api/api'
 
 interface GlobalNotificationsProps {
   organizationId?: string
@@ -42,26 +38,6 @@ function eventIcon(eventType: AttentionEventType, color: string): React.ReactEle
 
 function timeAgoMs(ms: number): string {
   return timeAgo(new Date(ms).toISOString())
-}
-
-// replyToOrgMessage sends the human's reply to the bot that asked (via
-// ask_human) without leaving the notification. It resolves the bot's
-// exploratory session (bot → project → session) and posts the reply there —
-// the same session the agent runs in, so it lands as the agent's next turn.
-async function replyToOrgMessage(
-  apiClient: Api<unknown>['api'],
-  event: AttentionEvent,
-  text: string,
-): Promise<void> {
-  const botId = (event.metadata as { bot_id?: string } | undefined)?.bot_id
-  if (!botId || !event.organization_id) throw new Error('missing bot or org on notification')
-  const bot = await apiClient.v1OrgsBotsDetail2(botId, event.organization_id)
-  const projectId = bot.data?.project_id
-  if (!projectId) throw new Error('could not resolve the bot’s project')
-  const session = await apiClient.v1ProjectsExploratorySessionDetail(projectId)
-  const sessionId = session.data?.id
-  if (!sessionId) throw new Error('the bot has no active session yet')
-  await apiClient.v1SessionsMessagesCreate(sessionId, { content: text, interrupt: true })
 }
 
 function eventAccentColor(eventType: AttentionEventType): string {
@@ -263,8 +239,7 @@ const AttentionEventItem: React.FC<{
   groupedWith?: AttentionEvent
   onNavigate: (event: AttentionEvent) => void
   onDismiss: (eventId: string) => void
-  onReplied: (eventId: string) => Promise<void>
-}> = ({ event, groupedWith, onNavigate, onDismiss, onReplied }) => {
+}> = ({ event, groupedWith, onNavigate, onDismiss }) => {
   const accentColor = eventAccentColor(event.event_type)
   // org_message (a bot messaging a person) has no spec task/project — its
   // headline is the title ("Message from …") and the body is the message.
@@ -272,12 +247,7 @@ const AttentionEventItem: React.FC<{
   const isAcknowledged = !!event.acknowledged_at && (!groupedWith || !!groupedWith.acknowledged_at)
   const lightTheme = useLightTheme()
   const isLight = lightTheme.isLight
-  const api = useApi()
   const account = useAccount()
-  const snackbar = useSnackbar()
-  const [replyOpen, setReplyOpen] = useState(false)
-  const [reply, setReply] = useState('')
-  const [sending, setSending] = useState(false)
 
   // Which org this org_message is from — several orgs each have a Chief of
   // Staff, so "Message from chief-of-staff" alone is ambiguous. Resolve the
@@ -287,41 +257,15 @@ const AttentionEventItem: React.FC<{
   )
   const orgName = orgForEvent?.display_name || orgForEvent?.name
 
-  // org_message (a bot's ask_human) is read and answered inline here — the
-  // message rendered as markdown, with a Respond form that posts the reply to
-  // the bot's session. Everything stays in the notification (no navigation),
-  // which keeps it usable on mobile / small screens.
   if (isOrgMessage) {
-    const sendReply = async () => {
-      const text = reply.trim()
-      if (!text || sending) return
-      setSending(true)
-      try {
-        await replyToOrgMessage(api.getApiClient(), event, text)
-        setReply('')
-        setReplyOpen(false)
-        // Keep the message in the panel, marked "Replied", so the user has a
-        // record it came through and was answered (don't dismiss it).
-        await onReplied(event.id)
-        snackbar.success('Reply sent')
-      } catch (e: any) {
-        snackbar.error(e?.message || 'Failed to send reply')
-      } finally {
-        setSending(false)
-      }
-    }
-    const meta = event.metadata as { bot_id?: string; no_reply?: unknown } | undefined
-    const isReplied = !!event.replied_at
-    // Informational messages (e.g. "Chief of Staff is starting up") carry
-    // no_reply and have no repliable session — render them read-only.
-    const canReply = !isReplied && !!meta?.bot_id && meta?.no_reply !== true && meta?.no_reply !== 'true'
+    const botId = typeof event.metadata?.bot_id === 'string' ? event.metadata.bot_id : ''
     return (
       <Box
         sx={{
           px: 1.5,
           py: 1.25,
           borderLeft: `3px solid ${accentColor}`,
-          ...(isReplied || isAcknowledged ? { opacity: 0.7 } : {}),
+          ...(isAcknowledged ? { opacity: 0.7 } : {}),
         }}
       >
         <Stack direction="row" alignItems="flex-start" spacing={1} sx={{ mb: 0.75 }}>
@@ -361,65 +305,20 @@ const AttentionEventItem: React.FC<{
         >
           <ReactMarkdown>{event.description || ''}</ReactMarkdown>
         </Box>
-        {isReplied && (
-          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 1, color: accentColor }}>
-            <CornerUpLeft size={12} />
-            <Typography variant="caption" sx={{ fontWeight: 600 }}>
-              Replied
-            </Typography>
-          </Stack>
-        )}
-        {canReply && (!replyOpen ? (
+        {botId && orgForEvent?.name && (
           <Button
+            component="a"
+            href={router.buildPath('helix_org_chart', { org_id: orgForEvent.name, bot_id: botId })}
             size="small"
-            startIcon={<CornerUpLeft size={13} />}
-            onClick={() => setReplyOpen(true)}
+            onClick={(e) => {
+              e.preventDefault()
+              onNavigate(event)
+            }}
             sx={{ mt: 1, textTransform: 'none' }}
           >
-            Respond
+            Open agent chat
           </Button>
-        ) : (
-          <Box sx={{ mt: 1 }}>
-            <TextField
-              fullWidth
-              multiline
-              minRows={2}
-              maxRows={6}
-              size="small"
-              autoFocus
-              placeholder="Type your reply…"
-              value={reply}
-              onChange={(e) => setReply(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault()
-                  void sendReply()
-                }
-              }}
-              disabled={sending}
-            />
-            <Stack direction="row" justifyContent="flex-end" spacing={1} sx={{ mt: 1 }}>
-              <Button
-                size="small"
-                onClick={() => { setReplyOpen(false); setReply('') }}
-                disabled={sending}
-                sx={{ textTransform: 'none' }}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={() => void sendReply()}
-                disabled={!reply.trim() || sending}
-                startIcon={sending ? <CircularProgress size={13} color="inherit" /> : undefined}
-                sx={{ textTransform: 'none' }}
-              >
-                {sending ? 'Sending…' : 'Send reply'}
-              </Button>
-            </Stack>
-          </Box>
-        ))}
+        )}
       </Box>
     )
   }
@@ -563,7 +462,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
     events,
     newEvents,
     acknowledge,
-    markReplied,
     dismiss,
     snooze,
     dismissAll,
@@ -610,8 +508,16 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
           isOrgMessage ? (event.description || '') : `${event.spec_task_name || ''} · ${event.project_name || ''}`,
           () => {
             acknowledge(event.id)
-            // org_message is read/replied inline in the panel — just mark read.
-            if (isOrgMessage) return
+            if (isOrgMessage) {
+              const botId = typeof event.metadata?.bot_id === 'string' ? event.metadata.bot_id : ''
+              const orgSlug = account.organizationTools?.organizations?.find(
+                (org) => org.id === event.organization_id,
+              )?.name
+              if (botId && orgSlug) {
+                router.navigate('helix_org_chart', { org_id: orgSlug, bot_id: botId })
+              }
+              return
+            }
             account.orgNavigate('project-task-detail', {
               id: event.project_id,
               taskId: event.spec_task_id,
@@ -637,10 +543,16 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
     // Mark as read on explicit click
     acknowledge(event.id)
 
-    // org_message (a bot messaging a person) is read and replied to inline in
-    // the notification itself (see AttentionEventItem) — clicking the row just
-    // marks it read, no navigation.
-    if (event.event_type === 'org_message') return
+    if (event.event_type === 'org_message') {
+      const botId = typeof event.metadata?.bot_id === 'string' ? event.metadata.bot_id : ''
+      const orgSlug = account.organizationTools?.organizations?.find(
+        (org) => org.id === event.organization_id,
+      )?.name
+      if (botId && orgSlug) {
+        router.navigate('helix_org_chart', { org_id: orgSlug, bot_id: botId })
+      }
+      return
+    }
 
     // Don't close the panel — user wants to keep it open while working
     if (event.event_type === 'specs_pushed') {
@@ -670,10 +582,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
   const handleDismiss = useCallback((eventId: string) => {
     dismiss(eventId)
   }, [dismiss])
-
-  const handleReplied = useCallback((eventId: string) => {
-    return markReplied(eventId)
-  }, [markReplied])
 
   const handleDismissAll = useCallback(() => {
     dismissAll()
@@ -965,7 +873,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
                         dismiss(group.secondary.id)
                         handleDismiss(id)
                       }}
-                      onReplied={handleReplied}
                     />
                   )
                 }
@@ -975,7 +882,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
                     event={group.event}
                     onNavigate={handleNavigate}
                     onDismiss={handleDismiss}
-                    onReplied={handleReplied}
                   />
                 )
               })}

--- a/frontend/src/hooks/useAttentionEvents.ts
+++ b/frontend/src/hooks/useAttentionEvents.ts
@@ -13,7 +13,6 @@ export interface AttentionEvent {
   description?: string
   created_at: string
   acknowledged_at?: string | null
-  replied_at?: string | null
   dismissed_at?: string | null
   snoozed_until?: string | null
   idempotency_key?: string
@@ -82,15 +81,6 @@ export function useAttentionEvents(enabled: boolean = true, filterMine: boolean 
     onSuccess: invalidate,
   })
 
-  const replyMutation = useMutation({
-    mutationFn: async (eventId: string) => {
-      await api.put(`/api/v1/attention-events/${eventId}`, { reply: true }, undefined, {
-        snackbar: false,
-      })
-    },
-    onSuccess: invalidate,
-  })
-
   const dismissMutation = useMutation({
     mutationFn: async (eventId: string) => {
       await api.put(`/api/v1/attention-events/${eventId}`, { dismiss: true }, undefined, {
@@ -126,11 +116,6 @@ export function useAttentionEvents(enabled: boolean = true, filterMine: boolean 
     [acknowledgeMutation],
   )
 
-  const markReplied = useCallback(
-    (eventId: string) => replyMutation.mutateAsync(eventId),
-    [replyMutation],
-  )
-
   const dismiss = useCallback(
     (eventId: string) => dismissMutation.mutate(eventId),
     [dismissMutation],
@@ -156,7 +141,6 @@ export function useAttentionEvents(enabled: boolean = true, filterMine: boolean 
     unreadCount: (query.data ?? []).filter(e => !e.acknowledged_at).length,
     hasNew: (query.data ?? []).some(e => !e.acknowledged_at),
     acknowledge,
-    markReplied,
     dismiss,
     snooze,
     dismissAll,


### PR DESCRIPTION
## Summary
- remove inline replies from org message notifications
- deep-link notifications to the sending agent in the org chart chat panel
- show bell badges only for unread notifications and refine the chat handoff action

## Verification
- `yarn test src/components/system/GlobalNotifications.test.tsx src/components/helix-org/HelixOrgChatPanel.test.tsx`
- `yarn build`
- verified the notification panel and agent selection on https://prime.helix.ml with standalone Playwright