### PR TITLE
Persist chat panel size across navigation

### DIFF
--- a/frontend/src/components/helix-org/HelixOrgShell.tsx
+++ b/frontend/src/components/helix-org/HelixOrgShell.tsx
@@ -19,6 +19,7 @@ import HelixOrgTopNav from './HelixOrgTopNav'
 import useAccount from '../../hooks/useAccount'
 import useIsBigScreen from '../../hooks/useIsBigScreen'
 import useLightTheme from '../../hooks/useLightTheme'
+import useRouter from '../../hooks/useRouter'
 import { loadPanelLayout, savePanelLayout } from '../../lib/panelLayoutStorage'
 import { IPageBreadcrumb } from '../../types'
 
@@ -45,10 +46,16 @@ const HelixOrgShell: FC<HelixOrgShellProps> = ({
   children,
 }) => {
   const account = useAccount()
+  const router = useRouter()
   const isBigScreen = useIsBigScreen()
   const lightTheme = useLightTheme()
   const isLight = lightTheme.isLight
-  const orgId = account.organizationTools.organization?.id ?? ''
+  // The route org identifier is available on the first render. Using the
+  // asynchronously resolved account org id here would briefly render the
+  // default layout before the saved layout could be loaded.
+  const orgId = (router.params.org_id as string | undefined)
+    || account.organizationTools.organization?.id
+    || ''
   const orgChatPanelIds = ['helix-org-chat', 'helix-org-content'] as const
   const orgChatLayoutKey = orgId ? `helix.orgChat.layout.${orgId}` : ''
   const savedOrgChatLayout = loadPanelLayout(orgChatLayoutKey, orgChatPanelIds)

--- a/frontend/src/components/helix-org/HelixOrgShell.tsx
+++ b/frontend/src/components/helix-org/HelixOrgShell.tsx
@@ -19,6 +19,7 @@ import HelixOrgTopNav from './HelixOrgTopNav'
 import useAccount from '../../hooks/useAccount'
 import useIsBigScreen from '../../hooks/useIsBigScreen'
 import useLightTheme from '../../hooks/useLightTheme'
+import { loadPanelLayout, savePanelLayout } from '../../lib/panelLayoutStorage'
 import { IPageBreadcrumb } from '../../types'
 
 export type HelixOrgShellProps = {
@@ -47,6 +48,10 @@ const HelixOrgShell: FC<HelixOrgShellProps> = ({
   const isBigScreen = useIsBigScreen()
   const lightTheme = useLightTheme()
   const isLight = lightTheme.isLight
+  const orgId = account.organizationTools.organization?.id ?? ''
+  const orgChatPanelIds = ['helix-org-chat', 'helix-org-content'] as const
+  const orgChatLayoutKey = orgId ? `helix.orgChat.layout.${orgId}` : ''
+  const savedOrgChatLayout = loadPanelLayout(orgChatLayoutKey, orgChatPanelIds)
 
   const content = (
     <Box
@@ -102,15 +107,18 @@ const HelixOrgShell: FC<HelixOrgShellProps> = ({
           }}
         >
           <PanelGroup
+            key={orgId || 'helix-org'}
             id="helix-org-shell"
             orientation="horizontal"
+            defaultLayout={savedOrgChatLayout ?? { 'helix-org-chat': 32, 'helix-org-content': 68 }}
+            onLayoutChange={(layout) => savePanelLayout(orgChatLayoutKey, layout, orgChatPanelIds)}
             style={{ height: '100%', width: '100%' }}
           >
             <Panel
               id="helix-org-chat"
               defaultSize="32%"
               minSize="20%"
-              maxSize="50%"
+              maxSize="75%"
               style={{ overflow: 'hidden', minWidth: 0, minHeight: 0 }}
             >
               <Box sx={{ height: '100%', width: '100%', minHeight: 0, minWidth: 0, overflow: 'hidden' }}>
@@ -132,7 +140,7 @@ const HelixOrgShell: FC<HelixOrgShellProps> = ({
             <Panel
               id="helix-org-content"
               defaultSize="68%"
-              minSize="40%"
+              minSize="25%"
               style={{ overflow: 'hidden', minWidth: 0, minHeight: 0 }}
             >
               {content}

--- a/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
@@ -37,6 +37,7 @@ describe('ChatTurnNavigator interactions', () => {
 
     expect(screen.getByText('Second user message')).toBeInTheDocument()
     expect(screen.getByText('Second assistant response')).toBeInTheDocument()
+    expect(document.querySelector('[data-chat-turn-preview]')).toHaveStyle({ maxWidth: '150px' })
   })
 
   it('supports keyboard browsing and selection', () => {

--- a/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
@@ -37,7 +37,7 @@ describe('ChatTurnNavigator interactions', () => {
 
     expect(screen.getByText('Second user message')).toBeInTheDocument()
     expect(screen.getByText('Second assistant response')).toBeInTheDocument()
-    expect(document.querySelector('[data-chat-turn-preview]')).toHaveStyle({ maxWidth: '150px' })
+    expect(document.querySelector('[data-chat-turn-preview]')).toHaveStyle({ maxWidth: '300px' })
   })
 
   it('supports keyboard browsing and selection', () => {

--- a/frontend/src/components/session/ChatTurnNavigator.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.tsx
@@ -232,6 +232,7 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
               top: `${activeTop}%`,
               left: 32,
               right: 0,
+              maxWidth: 150,
               transform: `translateY(${activeTranslate})`,
               cursor: 'text',
               userSelect: 'text',

--- a/frontend/src/components/session/ChatTurnNavigator.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.tsx
@@ -232,7 +232,7 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
               top: `${activeTop}%`,
               left: 32,
               right: 0,
-              maxWidth: 150,
+              maxWidth: 300,
               transform: `translateY(${activeTranslate})`,
               cursor: 'text',
               userSelect: 'text',

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -372,34 +372,15 @@ const AttentionEventItem: React.FC<{
       </Box>
       <Tooltip
         title={
-          <Box sx={{ maxWidth: 150 }}>
-            <Typography
-              variant="body2"
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontWeight: 600,
-              }}
-            >
-              {isOrgMessage
-                ? event.title
-                : (event.spec_task_description || event.spec_task_name || event.spec_task_id || '')}
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
-            >
-              {isOrgMessage
-                ? (event.description || '')
-                : (groupedWith ? 'Spec ready & agent finished' : event.title)}
-            </Typography>
-          </Box>
+          <span style={{ whiteSpace: 'pre-wrap' }}>
+            {isOrgMessage
+              ? `${event.title}\n${event.description || ''}`
+              : `${event.spec_task_description || event.spec_task_name || event.spec_task_id || ''}\n${groupedWith ? 'Spec ready & agent finished' : event.title}`}
+          </span>
         }
         placement="left"
         enterDelay={500}
         arrow
-        componentsProps={{ tooltip: { sx: { maxWidth: 150 } } }}
       >
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -372,15 +372,34 @@ const AttentionEventItem: React.FC<{
       </Box>
       <Tooltip
         title={
-          <span style={{ whiteSpace: 'pre-wrap' }}>
-            {isOrgMessage
-              ? `${event.title}\n${event.description || ''}`
-              : `${event.spec_task_description || event.spec_task_name || event.spec_task_id || ''}\n${groupedWith ? 'Spec ready & agent finished' : event.title}`}
-          </span>
+          <Box sx={{ maxWidth: 150 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                fontWeight: 600,
+              }}
+            >
+              {isOrgMessage
+                ? event.title
+                : (event.spec_task_description || event.spec_task_name || event.spec_task_id || '')}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+            >
+              {isOrgMessage
+                ? (event.description || '')
+                : (groupedWith ? 'Spec ready & agent finished' : event.title)}
+            </Typography>
+          </Box>
         }
         placement="left"
         enterDelay={500}
         arrow
+        componentsProps={{ tooltip: { sx: { maxWidth: 150 } } }}
       >
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -121,6 +121,10 @@ import {
 } from "lucide-react";
 
 import { getAutoOpenedSpecTasks, addAutoOpenedSpecTask } from "../../lib/specTaskAutoOpen";
+import { loadPanelLayout, savePanelLayout } from "../../lib/panelLayoutStorage";
+
+const SPEC_TASK_CHAT_PANEL_IDS = ["spec-task-chat", "spec-task-content"] as const;
+const SPEC_TASK_CHAT_LAYOUT_KEY = "helix.specTaskChat.layout";
 
 interface SpecTaskDetailContentProps {
   taskId: string;
@@ -166,6 +170,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // Use md breakpoint (900px) to enable split view on tablets
   const isBigScreen = useIsBigScreen({ breakpoint: "md" });
   const lightTheme = useLightTheme();
+  const savedSpecTaskChatLayout = loadPanelLayout(
+    SPEC_TASK_CHAT_LAYOUT_KEY,
+    SPEC_TASK_CHAT_PANEL_IDS,
+  );
 
   // Fetch task data
   const { data: task } = useSpecTask(taskId, {
@@ -1794,11 +1802,16 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         {/* When chatCollapsed is true, use mobile-style tab layout even on desktop */}
         {activeSessionId && isBigScreen && !chatCollapsed ? (
           <PanelGroup
+            key="spec-task-chat-layout"
             orientation="horizontal"
+            defaultLayout={savedSpecTaskChatLayout ?? { "spec-task-chat": 30, "spec-task-content": 70 }}
+            onLayoutChange={(layout) =>
+              savePanelLayout(SPEC_TASK_CHAT_LAYOUT_KEY, layout, SPEC_TASK_CHAT_PANEL_IDS)
+            }
             style={{ height: "100%", flex: 1 }}
           >
             {/* Left: Chat panel - always visible on desktop */}
-            <Panel defaultSize={30} minSize={15} style={{ overflow: "hidden" }}>
+            <Panel id="spec-task-chat" defaultSize={30} minSize={15} style={{ overflow: "hidden" }}>
               <Box
                 sx={{
                   height: "100%",
@@ -1995,7 +2008,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             </PanelResizeHandle>
 
             {/* Right: Content panel - switches between desktop/changes/details */}
-            <Panel defaultSize={70} minSize={25} style={{ overflow: "hidden" }}>
+            <Panel id="spec-task-content" defaultSize={70} minSize={25} style={{ overflow: "hidden" }}>
               <Box
                 sx={{
                   height: "100%",

--- a/frontend/src/lib/panelLayoutStorage.test.ts
+++ b/frontend/src/lib/panelLayoutStorage.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+
+import { loadPanelLayout, savePanelLayout } from './panelLayoutStorage'
+
+const storageKey = 'helix.panel-layout.test'
+const panelIds = ['chat', 'content'] as const
+
+describe('panelLayoutStorage', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('round-trips a valid layout', () => {
+    const layout = { chat: 62.5, content: 37.5 }
+
+    savePanelLayout(storageKey, layout, panelIds)
+
+    expect(loadPanelLayout(storageKey, panelIds)).toEqual(layout)
+  })
+
+  it('rejects layouts for a different panel group', () => {
+    savePanelLayout(storageKey, { chat: 62.5, content: 37.5 }, panelIds)
+
+    expect(loadPanelLayout(storageKey, ['left', 'right'])).toBeNull()
+  })
+
+  it('ignores malformed stored layouts', () => {
+    localStorage.setItem(storageKey, JSON.stringify({ chat: 90, content: 5 }))
+
+    expect(loadPanelLayout(storageKey, panelIds)).toBeNull()
+  })
+})

--- a/frontend/src/lib/panelLayoutStorage.ts
+++ b/frontend/src/lib/panelLayoutStorage.ts
@@ -1,0 +1,47 @@
+export type PanelLayout = Record<string, number>
+
+const isValidLayout = (value: unknown, panelIds: readonly string[]): value is PanelLayout => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const layout = value as Record<string, unknown>
+  const keys = Object.keys(layout)
+  if (keys.length !== panelIds.length || panelIds.some((id) => !keys.includes(id))) return false
+
+  const sizes = panelIds.map((id) => layout[id] as number)
+  if (sizes.some((size) => typeof size !== 'number' || !Number.isFinite(size) || size <= 0 || size > 100)) {
+    return false
+  }
+
+  const total = sizes.reduce((sum, size) => sum + size, 0)
+  return Math.abs(total - 100) < 0.1
+}
+
+export const loadPanelLayout = (
+  storageKey: string,
+  panelIds: readonly string[],
+): PanelLayout | null => {
+  if (!storageKey || panelIds.length === 0) return null
+
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    return isValidLayout(parsed, panelIds) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export const savePanelLayout = (
+  storageKey: string,
+  layout: PanelLayout,
+  panelIds: readonly string[],
+): void => {
+  if (!storageKey || !isValidLayout(layout, panelIds)) return
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(layout))
+  } catch {
+    // Private mode / quota — the current layout still works in memory.
+  }
+}


### PR DESCRIPTION
## What changed

- Allow the Helix org chat pane to expand to 75% of the workspace.
- Persist org-chat and spec-task-chat panel layouts in localStorage.
- Add explicit panel IDs and validated layout storage tests.

## Why

Chat panel resizing was available, but the org chat was capped at 50% and panel sizes were lost after refreshes or navigation.

## Validation

- `yarn test panelLayoutStorage.test.ts --run`
- `yarn tsc --noEmit`
- `yarn build`
- Verified org-chat expansion and restoration after navigation and browser reload in the local app.
