### PR TITLE
fix(frontend): keep streaming status in chat flow

### DIFF
--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -86,7 +86,10 @@ Long user messages collapse when they exceed either 600 characters or eight line
 
 ### Turn and interrupt mechanics
 
-T3 gives a newly submitted turn a viewport-sized end spacer. Scrolling to the end therefore places the new user message near the top of the transcript, with a clean response area below it. As the response exceeds that reserved area, normal tail-following resumes. Manual upward scrolling still disengages auto-scroll.
+T3 gives a newly submitted turn a viewport-sized end spacer. Helix keeps the
+streaming status in the normal transcript flow instead: reserving that height
+on the whole interaction created a large blank region and visually displaced
+the status row. Manual upward scrolling still disengages auto-scroll.
 
 During an active turn, the composer swaps in a prominent destructive stop control: a red circular button with a white square. It is absent while idle. The control cancels the current turn without clearing the composer or changing the active session, so the next normal send continues in the same thread.
 
@@ -221,9 +224,11 @@ The component owns scroll-to-bottom coordination, upload integration, attachment
 
 ### Turn mechanics
 
-- While the newest interaction is `waiting`, give that turn a minimum height of one transcript viewport minus the normal gutters.
-- Continue using the existing scroll-to-bottom operation: the minimum height makes the user message land at the viewport top without a second competing scroll algorithm.
-- Remove the reserved height when the interaction completes or is interrupted.
+- Keep the newest interaction in normal document flow while it is `waiting`.
+- Continue using the existing scroll-to-bottom operation without adding a
+  second viewport-sized layout allocation.
+- Keep the streaming activity summary adjacent to the rendered response so an
+  invisible spacer cannot push it away from the transcript.
 - Respect the existing manual-scroll unlock. Do not force the viewport back to the active turn after the operator scrolls up.
 - Derive busy state inside `AgentChat` from the newest interaction so org chat and both spec-task layouts show the same red interrupt control.
 - After interrupting, keep the composer enabled and preserve session identity; the next send is the required lifecycle seam test.

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -116,28 +116,6 @@ const EmbeddedSessionView = forwardRef<
   const queryClient = useQueryClient();
   const { NewInference } = useStreaming();
 
-  // Keep the active turn one viewport tall. When the last interaction enters
-  // Waiting, scroll-to-bottom places its user message at the top and leaves
-  // room for the response to grow beneath it. This mirrors T3's anchored-turn
-  // mechanic without fighting the existing manual-scroll lock.
-  useEffect(() => {
-    if (!scrollContainerEl) return;
-
-    const measure = () => {
-      scrollContainerEl.style.setProperty(
-        "--chat-viewport-height",
-        `${scrollContainerEl.clientHeight}px`,
-      );
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(scrollContainerEl);
-    return () => {
-      observer.disconnect();
-      scrollContainerEl.style.removeProperty("--chat-viewport-height");
-    };
-  }, [scrollContainerEl]);
-
   // Global on/off preference for auto-scroll. Default ON.
   const [autoScroll, setAutoScroll] = useAutoScrollPreference();
   const autoScrollRef = useRef(autoScroll);
@@ -838,7 +816,6 @@ const EmbeddedSessionView = forwardRef<
                 session_id={sessionId}
                 sessionSteps={sessionSteps?.data || []}
                 enableDebugCopy={enableInteractionDebugCopy}
-                anchorToViewport={isLive}
               >
                 {isLive && (isOwner || account.admin) && (
                   <InteractionLiveStream

--- a/frontend/src/components/session/Interaction.test.tsx
+++ b/frontend/src/components/session/Interaction.test.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { Interaction } from "./Interaction";
-import { TypesInteractionState } from "../../api/api";
 
 vi.mock("./InteractionContainer", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -75,25 +74,6 @@ describe("Interaction debug copy placement", () => {
 
     expect(screen.getByRole("button", { name: "user debug copy" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "agent debug copy" })).not.toBeInTheDocument();
-  });
-
-  it("marks a waiting turn as viewport-anchored", () => {
-    const { container } = render(
-      <Interaction
-        {...baseProps}
-        anchorToViewport
-        interaction={{
-          id: "int_waiting",
-          prompt_message: "Question",
-          state: TypesInteractionState.InteractionStateWaiting,
-        }}
-      />,
-    );
-
-    expect(container.querySelector('[data-active-chat-turn="true"]')).toHaveAttribute(
-      "data-chat-turn",
-      "int_waiting",
-    );
   });
 
   it("renders workspace attachments without exposing the transport manifest", () => {

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -112,9 +112,6 @@ const ForkSeedDivider: FC<{ interaction: TypesInteraction }> = ({
 
 // Prop comparison function for React.memo
 const areEqual = (prevProps: InteractionProps, nextProps: InteractionProps) => {
-  if (prevProps.anchorToViewport !== nextProps.anchorToViewport) {
-    return false;
-  }
   if (prevProps.enableDebugCopy !== nextProps.enableDebugCopy) {
     return false;
   }
@@ -203,7 +200,6 @@ interface InteractionProps {
   onRegenerate?: (interactionID: string, message: string) => void;
   sessionSteps?: any[];
   enableDebugCopy?: boolean;
-  anchorToViewport?: boolean;
 }
 
 export const Interaction: FC<InteractionProps> = ({
@@ -217,7 +213,6 @@ export const Interaction: FC<InteractionProps> = ({
   onRegenerate,
   sessionSteps = [],
   enableDebugCopy = false,
-  anchorToViewport = false,
 }) => {
   // Memoize computed values
   const displayData = useMemo(() => {
@@ -335,12 +330,8 @@ export const Interaction: FC<InteractionProps> = ({
   return (
     <Box
       data-chat-turn={interaction.id}
-      data-active-chat-turn={anchorToViewport ? "true" : undefined}
       sx={{
-        mb: anchorToViewport ? 0 : 2,
-        minHeight: anchorToViewport
-          ? "calc(var(--chat-viewport-height, 0px) - 32px)"
-          : undefined,
+        mb: 2,
         display: "flex",
         flexDirection: "column",
         gap: 1,


### PR DESCRIPTION
## Summary

- remove the viewport-sized minimum height from the active chat interaction
- keep the streaming activity summary in normal transcript flow
- remove the unused viewport measurement and anchor plumbing
- document the corrected layout behavior

## Root cause

The shared chat redesign measured the scroll viewport and applied that height as a minimum height to the live interaction. That invisible allocation created a large blank region and visually displaced the “Working for …” status row.

## Validation

- `yarn vitest run src/components/session/Interaction.test.tsx src/components/session/ChatTurnNavigator.test.ts src/components/session/ChatTurnNavigator.component.test.tsx`
- `yarn tsc --noEmit`
- `yarn build`

The remote target URL could not be inspected directly because it redirected to login and the available test registration landed on the waitlist.
