### PR TITLE
fix(frontend): reposition org agents action

### DIFF
--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -2,7 +2,8 @@ import React, { FC, useCallback, useEffect, useState } from 'react'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import Container from '@mui/material/Container'
-import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 
 import Page from '../components/system/Page'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
@@ -96,10 +97,12 @@ const Apps: FC = () => {
         maxWidth="xl"
         sx={{
           mb: 4,
+          pt: 3,
         }}
       >
-        <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Stack spacing={2}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography variant="h5">Agents</Typography>
             <Button
               id="new-app-button"
               variant="contained"
@@ -109,15 +112,20 @@ const Apps: FC = () => {
             >
               New Agent
             </Button>
-          </Box>
-          <AppsTable
-            authenticated={ !!account.user }
-            data={ apps.apps }
-            onEdit={ onEditApp }
-            onDelete={ setDeletingApp }
-            orgId={ account.organizationTools.organization?.id || '' }
-          />
-        </Paywall>
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Agents in this org. Click an agent to edit instructions, tools and subscriptions.
+          </Typography>
+          <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
+            <AppsTable
+              authenticated={ !!account.user }
+              data={ apps.apps }
+              onEdit={ onEditApp }
+              onDelete={ setDeletingApp }
+              orgId={ account.organizationTools.organization?.id || '' }
+            />
+          </Paywall>
+        </Stack>
       </Container>
       {
         deletingApp && (

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback, useEffect, useState } from 'react'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import Container from '@mui/material/Container'
-import LockIcon from '@mui/icons-material/Lock'
 import Box from '@mui/material/Box'
 
 import Page from '../components/system/Page'
@@ -54,12 +53,6 @@ const Apps: FC = () => {
     await createBlankAgent()
   }
 
-  const onNewSecret = () => {
-    if(!checkLoginStatus()) return
-
-    account.orgNavigate('secrets')
-  }
-
   const onDeleteApp = useCallback(async () => {
     if(!deletingApp) return
     const result = await apps.deleteApp(deletingApp.id)
@@ -96,25 +89,6 @@ const Apps: FC = () => {
       topbarContent={(
         <>
           <HelixOrgTopNav />
-          <Button
-            id="secrets-button"
-            variant="contained"
-            color="secondary"
-            endIcon={<LockIcon />}
-            onClick={onNewSecret}
-            sx={{ mr: 2 }}
-          >
-            Secrets
-          </Button>
-          <Button
-            id="new-app-button"
-            variant="contained"
-            color="secondary"
-            endIcon={<AddIcon />}
-            onClick={onNewAgent}
-          >
-            New Agent
-          </Button>
         </>
       )}
     >
@@ -125,6 +99,17 @@ const Apps: FC = () => {
         }}
       >
         <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+            <Button
+              id="new-app-button"
+              variant="contained"
+              color="secondary"
+              startIcon={<AddIcon />}
+              onClick={onNewAgent}
+            >
+              New Agent
+            </Button>
+          </Box>
           <AppsTable
             authenticated={ !!account.user }
             data={ apps.apps }

--- a/frontend/src/pages/HelixOrgTopics.tsx
+++ b/frontend/src/pages/HelixOrgTopics.tsx
@@ -167,25 +167,24 @@ const HelixOrgTopics: FC = () => {
       <Box sx={{ height: '100%', overflow: 'auto' }}>
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
-          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="body2" color="text.secondary">
-                Named event channels Workers can subscribe to. Each topic carries a Transport (local
-                pub/sub, GitHub webhooks, Postmark inbound email, plain webhooks). Workers subscribe via
-                the <code>subscribe</code> MCP tool; the chart shows the resulting (worker → topic)
-                edges as dashed lines.
-              </Typography>
-            </Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography variant="h5">Topics</Typography>
             <Button
               variant="contained"
               color="secondary"
               startIcon={<AddIcon />}
               onClick={() => setCreateOpen(true)}
-              sx={{ flexShrink: 0, mt: 0.5 }}
+              sx={{ flexShrink: 0 }}
             >
               New topic
             </Button>
           </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Named event channels Workers can subscribe to. Each topic carries a Transport (local
+            pub/sub, GitHub webhooks, Postmark inbound email, plain webhooks). Workers subscribe via
+            the <code>subscribe</code> MCP tool; the chart shows the resulting (worker → topic)
+            edges as dashed lines.
+          </Typography>
 
           {isLoading ? (
             <LoadingSpinner />


### PR DESCRIPTION
## Summary
- move the New Agent action from the org agents top bar to above the table
- remove the Secrets action from the org agents page

## Verification
- `yarn build`
- `yarn tsc --noEmit`
- live preview at `http://localhost:8080/orgs/unmanned-org/agents` confirms New Agent is above the table and Secrets is absent
