### PR TITLE
fix(api): wake stopped org agents on chat

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -1662,6 +1662,19 @@ func (s *HelixAPIServer) handleExternalAgentStreaming(ctx context.Context, sessi
 
 // waitForExternalAgentReady waits for the external agent WebSocket connection to be established
 func (s *HelixAPIServer) waitForExternalAgentReady(ctx context.Context, sessionID string, timeout time.Duration) error {
+	// Existing /sessions/chat requests reach this waiter before SendCommand.
+	// SendCommand normally wakes a disconnected desktop, but it cannot do that
+	// while this function is still waiting for the WebSocket it expects the
+	// desktop to create. Kick the same canonical auto-start path immediately so
+	// stopped exploratory/org-worker sessions do not sit here until the
+	// stuck-interaction watchdog eventually notices them.
+	if _, connected := s.externalAgentWSManager.getConnection(sessionID); !connected {
+		log.Info().
+			Str("session_id", sessionID).
+			Msg("External agent is disconnected; starting desktop before readiness wait")
+		go s.autoStartDevContainerForSession(sessionID)
+	}
+
 	log.Info().
 		Str("session_id", sessionID).
 		Dur("timeout", timeout).

--- a/api/pkg/server/start_dev_container_test.go
+++ b/api/pkg/server/start_dev_container_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/controller"
 	external_agent "github.com/helixml/helix/api/pkg/external-agent"
@@ -34,8 +35,9 @@ func (s *StartDevContainerForSessionSuite) SetupTest() {
 	s.executor = external_agent.NewMockExecutor(s.ctrl)
 
 	s.server = &HelixAPIServer{
-		Store:                 s.store,
-		externalAgentExecutor: s.executor,
+		Store:                  s.store,
+		externalAgentExecutor:  s.executor,
+		externalAgentWSManager: NewExternalAgentWSManager(),
 		Controller: &controller.Controller{
 			Options: controller.Options{Store: s.store, PubSub: pubsub.NewNoop()},
 		},
@@ -182,4 +184,46 @@ func (s *StartDevContainerForSessionSuite) TestNoExecutor() {
 	}
 	err := s.server.startDevContainerForSession(context.Background(), session)
 	s.Error(err)
+}
+
+// TestReadinessWaitWakesStoppedExploratorySession covers the /sessions/chat
+// path: RunExternalAgent waits for a WebSocket before SendCommand gets a
+// chance to run, so the readiness waiter itself must start a stopped desktop.
+func (s *StartDevContainerForSessionSuite) TestReadinessWaitWakesStoppedExploratorySession() {
+	started := make(chan struct{})
+	session := &types.Session{
+		ID:             "ses_stopped_worker",
+		Owner:          "user-1",
+		OrganizationID: "org-worker",
+		Metadata: types.SessionMetadata{
+			AgentType: "zed_external",
+			ProjectID: "prj-worker",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, agent *types.DesktopAgent) (*types.DesktopAgentResponse, error) {
+			s.Equal(session.ID, agent.SessionID)
+			s.Equal("prj-worker", agent.ProjectID)
+			close(started)
+			return &types.DesktopAgentResponse{}, nil
+		},
+	)
+	s.store.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(session, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.server.waitForExternalAgentReady(ctx, session.ID, time.Second)
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(time.Second):
+		s.FailNow("desktop was not started before readiness wait")
+	}
+	s.ErrorContains(<-errCh, "timeout waiting for external agent to be ready")
 }


### PR DESCRIPTION
## Summary

- start a disconnected external-agent desktop before entering the WebSocket readiness wait
- reuse the existing canonical auto-start path for stopped org workers and exploratory sessions
- add regression coverage for the readiness-before-send lifecycle

## Root cause

RunExternalAgent waits for the external-agent WebSocket before calling SendCommand, but SendCommand was the code path that woke a disconnected desktop. A stopped org worker therefore waited for a connection that could not appear until the delayed stuck-interaction watchdog started the desktop.

## Testing

- CGO_ENABLED=1 go test ./pkg/server -run TestStartDevContainerForSessionSuite -count=1
- CGO_ENABLED=1 go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- live stopped-to-send test against unmanned-org: stopped b-alex, sent a non-streaming chat request, observed the desktop auto-start immediately, the Zed WebSocket reconnect, and the exact response WAKE-E2E-2924