### PR TITLE
fix(frontend): avoid spacing empty chat markdown

### DIFF
--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -1028,10 +1028,16 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
     };
   }, [text, isStreaming, processContent]);
 
+  const hasVisibleContent =
+    (renderContent && processedContent.trim().length > 0) ||
+    (renderThinkingWidget && Boolean(thinkingWidgetContent?.trim())) ||
+    Boolean(citationData?.excerpts?.length);
+
   return (
     <>
       <Box
         data-chat-markdown
+        data-chat-markdown-visible={hasVisibleContent ? "true" : undefined}
         sx={{
           fontSize: "0.875rem",
           lineHeight: 1.625,
@@ -1042,7 +1048,9 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
           "& .interactionMessage > * + *": {
             marginTop: 1.75,
           },
-          "& + [data-chat-markdown]": {
+          // Empty response entries remain in the DOM, but must not receive
+          // spacing of their own.
+          "& + [data-chat-markdown][data-chat-markdown-visible='true']": {
             marginTop: 1.75,
           },
           "& pre": {

--- a/frontend/src/components/session/MarkdownLayout.test.tsx
+++ b/frontend/src/components/session/MarkdownLayout.test.tsx
@@ -19,6 +19,9 @@ describe('Markdown chat spacing', () => {
 
     const roots = container.querySelectorAll<HTMLElement>('[data-chat-markdown]')
     roots.forEach((root) => {
+      root.setAttribute('data-chat-markdown-visible', 'true')
+    })
+    roots.forEach((root) => {
       root.innerHTML = '<div class="interactionMessage"><p>First paragraph</p><p>Last paragraph</p></div>'
     })
     const messages = container.querySelectorAll<HTMLElement>('.interactionMessage')
@@ -29,5 +32,25 @@ describe('Markdown chat spacing', () => {
     expect(messages[1].firstElementChild).toHaveStyle({ marginTop: '0px' })
     expect(messages[1].lastElementChild).toHaveStyle({ marginBottom: '0px' })
     expect(roots[1]).toHaveStyle({ marginTop: '14px' })
+  })
+
+  it('does not add spacing to empty response entries', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Markdown text={'Visible entry'} session={session} getFileURL={() => ''} isStreaming />
+        <Markdown
+          text={'<think>Hidden entry</think>'}
+          session={session}
+          getFileURL={() => ''}
+          isStreaming={false}
+          renderThinkingWidget={false}
+        />
+      </ThemeProvider>,
+    )
+
+    const roots = container.querySelectorAll<HTMLElement>('[data-chat-markdown]')
+    expect(roots[0]).toHaveAttribute('data-chat-markdown-visible', 'true')
+    expect(roots[1]).not.toHaveAttribute('data-chat-markdown-visible')
+    expect(roots[1]).not.toHaveStyle({ marginTop: '14px' })
   })
 })


### PR DESCRIPTION
## What changed

- Mark markdown roots only when they contain rendered content.
- Apply inter-entry spacing only to visible markdown roots.
- Keep empty response-entry components in the DOM.
- Add coverage for hidden thinking-only entries.

## Why

Thinking-only response entries are rendered as empty markdown wrappers after their content is moved to the work log. The existing adjacent-root spacing rule still added 14px for every empty wrapper, producing large gaps in assistant responses.

## Validation

- `yarn test src/components/session/Markdown.test.tsx src/components/session/MarkdownLayout.test.tsx --run`
- `yarn build`
