### PR TITLE
fix(frontend): keep chat navigator from blocking scroll

### DIFF
--- a/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.component.test.tsx
@@ -84,11 +84,19 @@ describe('ChatTurnNavigator interactions', () => {
       toJSON: () => ({}),
     })
 
-    fireEvent.mouseMove(button, { clientY: 140 })
+    fireEvent.mouseMove(document.querySelector('[data-chat-turn-rail-hit-target]')!, { clientY: 140 })
 
     expect(screen.getByText('Second user message')).toBeInTheDocument()
     expect(screen.getByText('Second assistant response')).toBeInTheDocument()
-    expect(document.querySelector('[data-chat-turn-preview]')).toHaveStyle({ maxWidth: '300px' })
+    expect(button).toHaveStyle({ pointerEvents: 'none' })
+    expect(document.querySelector('[data-chat-turn-rail-hit-target]')).toHaveStyle({
+      pointerEvents: 'auto',
+      width: '24px',
+    })
+    expect(document.querySelector('[data-chat-turn-preview]')).toHaveStyle({
+      pointerEvents: 'none',
+      maxWidth: '300px',
+    })
   })
 
   it('supports keyboard browsing and selection', () => {

--- a/frontend/src/components/session/ChatTurnNavigator.tsx
+++ b/frontend/src/components/session/ChatTurnNavigator.tsx
@@ -11,9 +11,6 @@ import {
   resolveChatTurnNavigatorTopPercent,
 } from './ChatTurnNavigator.logic'
 
-const eventTargetsPreview = (target: EventTarget) =>
-  target instanceof Element && target.closest('[data-chat-turn-preview]') !== null
-
 interface ChatTurnNavigatorProps {
   items: ChatTurnNavigatorItem[]
   scrollContainer: HTMLDivElement | null
@@ -124,10 +121,9 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
           setActiveIndex((current) => current === next ? current : next)
         }}
         onMouseDown={(event: MouseEvent<HTMLButtonElement>) => {
-          if (!eventTargetsPreview(event.target)) event.preventDefault()
+          event.preventDefault()
         }}
         onClick={(event: MouseEvent<HTMLButtonElement>) => {
-          if (eventTargetsPreview(event.target)) return
           const index = resolveIndexFromPointer(event)
           const item = index === null ? null : items[index]
           if (item) onSelect(item)
@@ -152,7 +148,7 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
           }
         }}
         sx={{
-          pointerEvents: 'auto',
+          pointerEvents: 'none',
           position: 'absolute',
           top: '50%',
           left: 12,
@@ -172,6 +168,17 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
           },
         }}
       >
+        <Box
+          component="span"
+          aria-hidden
+          data-chat-turn-rail-hit-target
+          sx={{
+            pointerEvents: 'auto',
+            position: 'absolute',
+            inset: 0,
+            width: 24,
+          }}
+        />
         <Box
           aria-hidden
           sx={{
@@ -221,17 +228,14 @@ const ChatTurnNavigator: FC<ChatTurnNavigatorProps> = ({
           <Box
             component="span"
             data-chat-turn-preview
-            onMouseMove={(event: MouseEvent<HTMLSpanElement>) => event.stopPropagation()}
             sx={{
-              pointerEvents: 'auto',
+              pointerEvents: 'none',
               position: 'absolute',
               top: `${activeTop}%`,
               left: 32,
               right: 0,
               maxWidth: 300,
               transform: `translateY(${activeTranslate})`,
-              cursor: 'text',
-              userSelect: 'text',
             }}
           >
             <Box


### PR DESCRIPTION
## Summary
- limit pointer input to the 24px chat turn navigator rail
- make the hover preview display-only so it cannot cover the transcript
- add regression coverage for the pointer-event topology

## Verification
- `yarn vitest run src/components/session/ChatTurnNavigator.test.ts src/components/session/ChatTurnNavigator.component.test.tsx` (7 passed)
- `yarn build`
- live spec-task verification on `https://prime.helix.ml`
- `git diff --check`