### PR TITLE
ci: run CodeQL after merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     # Weekly catch-all so main keeps a fresh scan even with no pushes.
     - cron: '23 4 * * 1'


### PR DESCRIPTION
## Summary
- stop running all-language CodeQL scans on pull requests
- retain CodeQL scans on every push to `main`
- retain the weekly full-repository scan

## Verification
- Ruby YAML parse
- `git diff --check`
- independent review: no findings