### PR TITLE
refactor(frontend): split agent configuration tabs

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -178,9 +178,19 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		if err != nil {
 			log.Warn().Err(err).Str("project_id", agent.ProjectID).Str("session_id", agent.SessionID).Msg("Failed to load project secrets, continuing without them")
 		} else if len(projectSecrets) > 0 {
-			agent.Env = append(agent.Env, projectSecrets...)
-			log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", agent.ProjectID).Str("session_id", agent.SessionID).Msg("Injected project secrets into desktop env")
+			before := len(agent.Env)
+			agent.Env = appendProjectSecrets(agent.Env, projectSecrets)
+			injected := len(agent.Env) - before
+			log.Info().Int("secret_count", injected).Str("project_id", agent.ProjectID).Str("session_id", agent.SessionID).Msg("Injected project secrets into desktop env")
 		}
+	}
+
+	// Org-worker identity is session state, not project state: SpecTask and
+	// human exploratory sessions can share the same project and must not inherit
+	// it. Materialize both agent-native instruction files before the container
+	// starts; the workspace bind mount persists them across desktop restarts.
+	if err := h.attachSessionBootstrap(ctx, agent); err != nil {
+		return nil, err
 	}
 
 	// Call OnBeforeCreate hook inside the lock to refresh API keys.
@@ -363,21 +373,22 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	// NOTE: GPUVendor is empty - Hydra reads it from its own GPU_VENDOR env var
 	// Privileged mode is required for the inner dockerd (overlay2 needs it)
 	req := &hydra.CreateDevContainerRequest{
-		SessionID:     agent.SessionID,
-		Image:         image,
-		ContainerName: containerName,
-		Hostname:      containerName,
-		Env:           env,
-		Mounts:        mounts,
-		DisplayWidth:  agent.DisplayWidth,
-		DisplayHeight: agent.DisplayHeight,
-		DisplayFPS:    agent.DisplayRefreshRate,
-		ContainerType: hydra.DevContainerType(containerType),
-		UserID:        agent.UserID,
-		Network:       "bridge",
-		Privileged:    true, // Required for inner dockerd (docker-in-desktop mode)
-		ProjectID:     agent.ProjectID,
-		GoldenBuild:   agent.GoldenBuild,
+		SessionID:      agent.SessionID,
+		Image:          image,
+		ContainerName:  containerName,
+		Hostname:       containerName,
+		Env:            env,
+		Mounts:         mounts,
+		WorkspaceFiles: agent.WorkspaceFiles,
+		DisplayWidth:   agent.DisplayWidth,
+		DisplayHeight:  agent.DisplayHeight,
+		DisplayFPS:     agent.DisplayRefreshRate,
+		ContainerType:  hydra.DevContainerType(containerType),
+		UserID:         agent.UserID,
+		Network:        "bridge",
+		Privileged:     true, // Required for inner dockerd (docker-in-desktop mode)
+		ProjectID:      agent.ProjectID,
+		GoldenBuild:    agent.GoldenBuild,
 	}
 
 	// Create dev container via Hydra
@@ -565,6 +576,45 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		SandboxID:      sandboxID,
 		DevContainerID: resp.ContainerID, // Container ID for exploratory session tracking
 	}, nil
+}
+
+func (h *HydraExecutor) attachSessionBootstrap(ctx context.Context, agent *types.DesktopAgent) error {
+	session, err := h.store.GetSession(ctx, agent.SessionID)
+	if err != nil {
+		return fmt.Errorf("load session bootstrap state for %s: %w", agent.SessionID, err)
+	}
+	return applySessionBootstrap(session.Metadata, agent)
+}
+
+func applySessionBootstrap(metadata types.SessionMetadata, agent *types.DesktopAgent) error {
+	workerID := metadata.OrgWorkerID
+	instructions := metadata.RuntimeInstructions
+	if workerID == "" && instructions == "" {
+		return nil
+	}
+	if workerID == "" || instructions == "" {
+		return fmt.Errorf("incomplete org-worker bootstrap state for session %s", agent.SessionID)
+	}
+	agent.Env = append(agent.Env, "HELIX_WORKER_ID="+workerID)
+	if agent.WorkspaceFiles == nil {
+		agent.WorkspaceFiles = make(map[string][]byte, 2)
+	}
+	agent.WorkspaceFiles["AGENTS.md"] = []byte(instructions)
+	agent.WorkspaceFiles["CLAUDE.md"] = []byte(instructions)
+	return nil
+}
+
+func appendProjectSecrets(env, secrets []string) []string {
+	for _, secret := range secrets {
+		// HELIX_WORKER_ID used to be stored at project scope. Never propagate
+		// that legacy value: only session bootstrap may identify a desktop as
+		// an org worker.
+		if strings.HasPrefix(secret, "HELIX_WORKER_ID=") {
+			continue
+		}
+		env = append(env, secret)
+	}
+	return env
 }
 
 // StopDesktop stops a dev container using Hydra

--- a/api/pkg/external-agent/hydra_executor_bootstrap_test.go
+++ b/api/pkg/external-agent/hydra_executor_bootstrap_test.go
@@ -1,0 +1,64 @@
+package external_agent
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestApplySessionBootstrapScopesInstructionsToOrgWorker(t *testing.T) {
+	agent := &types.DesktopAgent{SessionID: "ses_worker"}
+	err := applySessionBootstrap(types.SessionMetadata{
+		OrgWorkerID:         "b-alex",
+		RuntimeInstructions: "worker instructions",
+	}, agent)
+	if err != nil {
+		t.Fatalf("applySessionBootstrap: %v", err)
+	}
+	if len(agent.Env) != 1 || agent.Env[0] != "HELIX_WORKER_ID=b-alex" {
+		t.Fatalf("agent env = %v", agent.Env)
+	}
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+		if got := string(agent.WorkspaceFiles[name]); got != "worker instructions" {
+			t.Errorf("%s = %q", name, got)
+		}
+	}
+}
+
+func TestApplySessionBootstrapLeavesSpecTaskUnchanged(t *testing.T) {
+	agent := &types.DesktopAgent{SessionID: "ses_spec", SpecTaskID: "spt_test"}
+	if err := applySessionBootstrap(types.SessionMetadata{SpecTaskID: "spt_test"}, agent); err != nil {
+		t.Fatalf("applySessionBootstrap: %v", err)
+	}
+	if len(agent.Env) != 0 || len(agent.WorkspaceFiles) != 0 {
+		t.Fatalf("spec task inherited worker bootstrap: env=%v files=%v", agent.Env, agent.WorkspaceFiles)
+	}
+}
+
+func TestAppendProjectSecretsDropsLegacyWorkerIdentity(t *testing.T) {
+	got := appendProjectSecrets([]string{"BASE=1"}, []string{
+		"HELIX_ORG_URL=http://helix",
+		"HELIX_WORKER_ID=b-alex",
+		"TOKEN=value",
+	})
+	want := []string{"BASE=1", "HELIX_ORG_URL=http://helix", "TOKEN=value"}
+	if len(got) != len(want) {
+		t.Fatalf("env = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("env = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestApplySessionBootstrapRejectsPartialState(t *testing.T) {
+	for _, metadata := range []types.SessionMetadata{
+		{OrgWorkerID: "b-alex"},
+		{RuntimeInstructions: "instructions"},
+	} {
+		if err := applySessionBootstrap(metadata, &types.DesktopAgent{SessionID: "ses_bad"}); err == nil {
+			t.Fatalf("applySessionBootstrap accepted partial state: %+v", metadata)
+		}
+	}
+}

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -517,6 +518,9 @@ func (dm *DevContainerManager) CreateDevContainer(ctx context.Context, req *Crea
 			log.Debug().Str("path", m.Source).Msg("Ensured mount source directory exists")
 		}
 	}
+	if err := materializeWorkspaceFiles(req.Mounts, req.WorkspaceFiles); err != nil {
+		return nil, fmt.Errorf("materialize workspace files: %w", err)
+	}
 
 	// Apply a timeout for the Docker operations that follow. This is separate
 	// from the golden cache copy (which can take minutes for 50+ GB) — that
@@ -782,6 +786,56 @@ func (dm *DevContainerManager) CreateDevContainer(ctx context.Context, req *Crea
 		GPUVendor:      gpuVendor,
 		RenderNode:     renderNode,
 	}, nil
+}
+
+func materializeWorkspaceFiles(mounts []MountConfig, files map[string][]byte) error {
+	if len(files) == 0 {
+		return nil
+	}
+	var workspaceRoot string
+	for _, mount := range mounts {
+		if mount.Type != "volume" && mount.Destination == "/home/retro/work" {
+			workspaceRoot = mount.Source
+			break
+		}
+	}
+	if workspaceRoot == "" {
+		return errors.New("workspace bind mount not found")
+	}
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		return fmt.Errorf("create workspace root: %w", err)
+	}
+	for name, content := range files {
+		if name == "" || filepath.Base(name) != name || name == "." || name == ".." {
+			return fmt.Errorf("invalid workspace filename %q", name)
+		}
+		tmp, err := os.CreateTemp(workspaceRoot, ".helix-bootstrap-*")
+		if err != nil {
+			return fmt.Errorf("create temporary file for %s: %w", name, err)
+		}
+		tmpPath := tmp.Name()
+		cleanup := func() {
+			tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+		if err := tmp.Chmod(0o644); err != nil {
+			cleanup()
+			return fmt.Errorf("chmod temporary file for %s: %w", name, err)
+		}
+		if _, err := tmp.Write(content); err != nil {
+			cleanup()
+			return fmt.Errorf("write temporary file for %s: %w", name, err)
+		}
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("close temporary file for %s: %w", name, err)
+		}
+		if err := os.Rename(tmpPath, filepath.Join(workspaceRoot, name)); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("install %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 // buildEnv builds environment variables for the container

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -114,6 +114,47 @@ func TestResolveRegistryImage(t *testing.T) {
 	})
 }
 
+func TestMaterializeWorkspaceFiles(t *testing.T) {
+	root := t.TempDir()
+	mounts := []MountConfig{{Source: root, Destination: "/home/retro/work"}}
+	files := map[string][]byte{
+		"AGENTS.md": []byte("agent instructions"),
+		"CLAUDE.md": []byte("claude instructions"),
+	}
+	if err := materializeWorkspaceFiles(mounts, files); err != nil {
+		t.Fatalf("materializeWorkspaceFiles: %v", err)
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+
+	files["AGENTS.md"] = []byte("updated")
+	if err := materializeWorkspaceFiles(mounts, files); err != nil {
+		t.Fatalf("refresh workspace files: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil || string(got) != "updated" {
+		t.Fatalf("refreshed AGENTS.md = %q, %v", got, err)
+	}
+}
+
+func TestMaterializeWorkspaceFilesRejectsUnsafeNames(t *testing.T) {
+	mounts := []MountConfig{{Source: t.TempDir(), Destination: "/home/retro/work"}}
+	for _, name := range []string{"", "../AGENTS.md", "nested/AGENTS.md", "/AGENTS.md"} {
+		t.Run(name, func(t *testing.T) {
+			if err := materializeWorkspaceFiles(mounts, map[string][]byte{name: []byte("x")}); err == nil {
+				t.Fatalf("materializeWorkspaceFiles accepted %q", name)
+			}
+		})
+	}
+}
+
 // stageFakeSysfs builds a synthetic /dev/dri + /sys/class/drm tree for
 // tests. devs is a list of {render, card, pci, driver} tuples — render
 // and card are basenames (e.g. "renderD129", "card1"); pci is a BDF

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -65,6 +65,10 @@ type CreateDevContainerRequest struct {
 	Hostname      string        `json:"hostname"`
 	Env           []string      `json:"env"` // KEY=value format
 	Mounts        []MountConfig `json:"mounts"`
+	// WorkspaceFiles are materialized into the bind mount targeting
+	// /home/retro/work before the container starts. Keys are root filenames;
+	// byte values are base64-encoded by JSON.
+	WorkspaceFiles map[string][]byte `json:"workspace_files,omitempty"`
 
 	// Display settings (optional - headless containers omit these)
 	DisplayWidth  int `json:"display_width,omitempty"`

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -172,9 +172,8 @@ type CreateResult struct {
 // This is the single implementation the MCP create_bot tool and the
 // REST POST /bots handler both call.
 //
-// State lives in the domain DB, with runtime instructions mirrored to the per-Node
-// helix-specs branch for workspace workflows. A Node's MCP tool surface is
-// derived live from Node.Tools.
+// State lives in the domain DB. A Node's MCP tool surface is derived live from
+// Node.Tools.
 func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (CreateResult, error) {
 	if s.NewID == nil || s.Now == nil {
 		return CreateResult{}, fmt.Errorf("lifecycle: clock/id-generator not wired")

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -172,7 +172,7 @@ type CreateResult struct {
 // This is the single implementation the MCP create_bot tool and the
 // REST POST /bots handler both call.
 //
-// State lives in the domain DB, with role.md mirrored to the per-Node
+// State lives in the domain DB, with runtime instructions mirrored to the per-Node
 // helix-specs branch for workspace workflows. A Node's MCP tool surface is
 // derived live from Node.Tools.
 func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (CreateResult, error) {

--- a/api/pkg/org/domain/briefing/prompt.go
+++ b/api/pkg/org/domain/briefing/prompt.go
@@ -9,19 +9,30 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 )
 
-// BuildPrompt assembles the per-activation prompt: identity hint +
-// mandate + the triggers that woke the Worker up. The dispatcher
+// BuildInstructions assembles the durable runtime instructions loaded by
+// Codex and Claude from AGENTS.md / CLAUDE.md before an activation starts.
+// The mandate is the canonical role text resolved by the runtime.
+func BuildInstructions(workerID orgchart.NodeID, mandate string) string {
+	return fmt.Sprintf(`You are Bot %s, running inside helix-org. Your environment is
+the current working directory. Each activation is a single turn — do
+the work and exit.
+
+=== Instructions ===
+%s
+`, workerID, mandate)
+}
+
+// BuildPrompt assembles the per-activation user message from only the
+// triggers that woke the Worker up. Durable identity and role instructions
+// live in the runtime's AGENTS.md / CLAUDE.md instead of being repeated in
+// every interaction. The dispatcher
 // coalesces bursts, so a single activation may carry multiple triggers
 // — the prompt frames them as a numbered list when that happens, so
 // the agent can read all of them before deciding what to do (often the
 // most recent supersedes the earlier ones). Tools are exposed natively
 // via MCP under the "helix" server (tool names appear as
 // mcp__helix__<name>); Claude figures the rest out from tools/list.
-//
-// `mandate` is the static text the agent reads first — for the Helix
-// runtime it's a short pointer at the helix-specs branch, which carries
-// the real policy text the Worker reads before acting.
-func BuildPrompt(workerID orgchart.NodeID, mandate string, triggers []activation.Trigger) string {
+func BuildPrompt(triggers []activation.Trigger) string {
 	var ctx strings.Builder
 
 	if len(triggers) > 1 {
@@ -38,7 +49,7 @@ func BuildPrompt(workerID orgchart.NodeID, mandate string, triggers []activation
 		case activation.TriggerEvent:
 			ctx.WriteString(renderTrigger(t))
 		case activation.TriggerManual:
-			ctx.WriteString("An operator manually woke you up from the worker UI. Re-read your role and identity (per the mandate above), summarise your current state, and stand by — the operator will follow up with instructions on the next message.\n")
+			ctx.WriteString("Manual activation. An operator woke you from the worker UI. Summarise your current state and stand by — the operator will follow up with instructions on the next message.\n")
 		default:
 			fmt.Fprintf(&ctx, "Activation kind: %q.\n", t.Kind)
 		}
@@ -47,17 +58,11 @@ func BuildPrompt(workerID orgchart.NodeID, mandate string, triggers []activation
 		}
 	}
 
-	return fmt.Sprintf(`You are Bot %s, running inside helix-org. Your environment is
-the current working directory. Each activation is a single turn — do
-the work and exit.
-
-%s
-
-=== Trigger ===
+	return fmt.Sprintf(`=== Trigger ===
 %s=== end trigger ===
 
 Act now. No preamble.
-`, workerID, mandate, ctx.String())
+`, ctx.String())
 }
 
 // renderTrigger formats an event-kind activation.Trigger for the activation

--- a/api/pkg/org/domain/briefing/prompt.go
+++ b/api/pkg/org/domain/briefing/prompt.go
@@ -58,7 +58,9 @@ func BuildPrompt(triggers []activation.Trigger) string {
 		}
 	}
 
-	return fmt.Sprintf(`=== Trigger ===
+	return fmt.Sprintf(`Re-read /home/retro/work/AGENTS.md or /home/retro/work/CLAUDE.md before acting so you use the current worker instructions.
+
+=== Trigger ===
 %s=== end trigger ===
 
 Act now. No preamble.

--- a/api/pkg/org/domain/briefing/prompt_test.go
+++ b/api/pkg/org/domain/briefing/prompt_test.go
@@ -168,6 +168,9 @@ func TestBuildPromptIncludesEnvelope(t *testing.T) {
 func TestBuildPromptManualTrigger(t *testing.T) {
 	t.Parallel()
 	prompt := BuildPrompt([]activation.Trigger{{Kind: activation.TriggerManual}})
+	if !strings.Contains(prompt, "/home/retro/work/AGENTS.md") || !strings.Contains(prompt, "/home/retro/work/CLAUDE.md") {
+		t.Errorf("activation prompt does not point the harness at sandbox instructions\n%s", prompt)
+	}
 	if !strings.Contains(prompt, "operator woke you") {
 		t.Errorf("manual trigger body missing\n%s", prompt)
 	}

--- a/api/pkg/org/domain/briefing/prompt_test.go
+++ b/api/pkg/org/domain/briefing/prompt_test.go
@@ -144,7 +144,7 @@ func TestBuildPromptIncludesEnvelope(t *testing.T) {
 			Extra:   []byte(`{"event":"issues","action":"opened"}`),
 		},
 	}
-	prompt := BuildPrompt("w-doc-engineer", "[role.md contents]", []activation.Trigger{tr})
+	prompt := BuildPrompt([]activation.Trigger{tr})
 
 	if !strings.Contains(prompt, "=== Trigger ===") || !strings.Contains(prompt, "=== end trigger ===") {
 		t.Fatalf("trigger fences missing\n%s", prompt)
@@ -163,18 +163,35 @@ func TestBuildPromptIncludesEnvelope(t *testing.T) {
 // TestBuildPromptManualTrigger pins the operator-driven activation path.
 // The prompt body must be operator-aware so the Worker doesn't treat the
 // activation as either a hire (first-time setup) or an event (no event
-// envelope to read). Standard wrapper still renders the mandate so the
-// Worker re-reads its role / identity per the helix-specs branch.
+// envelope to read). Identity is deliberately absent: the runtime loads it
+// from AGENTS.md / CLAUDE.md before this user message is delivered.
 func TestBuildPromptManualTrigger(t *testing.T) {
 	t.Parallel()
-	prompt := BuildPrompt("w-eng", "[mandate]", []activation.Trigger{{Kind: activation.TriggerManual}})
-	if !strings.Contains(prompt, "operator manually woke you up") {
+	prompt := BuildPrompt([]activation.Trigger{{Kind: activation.TriggerManual}})
+	if !strings.Contains(prompt, "operator woke you") {
 		t.Errorf("manual trigger body missing\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "[mandate]") {
-		t.Errorf("mandate wrapper missing\n%s", prompt)
+	for _, excluded := range []string{"You are Bot", "[mandate]", "Instructions"} {
+		if strings.Contains(prompt, excluded) {
+			t.Errorf("activation prompt contains durable instruction %q\n%s", excluded, prompt)
+		}
 	}
 	if got := DescribeTrigger(activation.Trigger{Kind: activation.TriggerManual}); got != "manual" {
 		t.Errorf("DescribeTrigger(manual) = %q, want %q", got, "manual")
+	}
+}
+
+func TestBuildInstructionsIncludesIdentityAndMandate(t *testing.T) {
+	t.Parallel()
+	instructions := BuildInstructions("w-eng", "# Engineer\nBuild the product.")
+	for _, want := range []string{
+		"You are Bot w-eng, running inside helix-org",
+		"Each activation is a single turn",
+		"=== Instructions ===",
+		"# Engineer\nBuild the product.",
+	} {
+		if !strings.Contains(instructions, want) {
+			t.Errorf("instructions missing %q\n%s", want, instructions)
+		}
 	}
 }

--- a/api/pkg/org/domain/orgchart/node.go
+++ b/api/pkg/org/domain/orgchart/node.go
@@ -29,7 +29,7 @@ const NodeKindHuman NodeKind = "human"
 // never ID.
 //
 // Content is the canonical markdown the Node's agent reads on activation
-// (it lands in role.md inside the Node's runtime environment). Tools is
+// (it lands in the runtime instruction file). Tools is
 // the live source of truth for the Node's MCP surface: the helix-org MCP
 // server registers exactly the tools in Node.Tools on every request, so
 // editing a Node's Tools changes its capability on the next MCP request.

--- a/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
@@ -207,6 +207,7 @@ func (noopProjectService) UpdateProject(_ context.Context, _ string, _ types.Pro
 	return types.Project{}, nil
 }
 func (noopProjectService) PutProjectSecret(_ context.Context, _, _, _ string) error { return nil }
+func (noopProjectService) DeleteProjectSecret(_ context.Context, _, _ string) error { return nil }
 func (noopProjectService) ListProjectSecrets(_ context.Context, _ string) (map[string]string, error) {
 	return nil, nil
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -138,9 +138,9 @@ type ProjectService interface {
 // needs a per-Worker project so the org-graph MCP server can be wired
 // in via the project's auto-provisioned Agent App.
 //
-// Idempotent: ensuring a Bot that already has a project is
-// a no-op for the project itself, but always re-pushes the canonical
-// role.md file so update_role changes land.
+// Idempotent: ensuring a Bot that already has a project is a no-op for the
+// project itself. Runtime instructions are published by the activation
+// spawner after it resolves Bot content, linked Agent content, and overrides.
 //
 // WorkerProject routes the project / git / app calls through the
 // ProjectService interface and the file pushes through ProjectGit
@@ -148,12 +148,7 @@ type ProjectService interface {
 // api/pkg/server/helix_org.go satisfies ProjectService with the
 // in-process adapter that calls HelixAPIServer handlers directly.
 type WorkerProject struct {
-	Service ProjectService
-	// Workspace owns the on-branch file layout — WorkerProject
-	// delegates role.md pushes
-	// through it so there is exactly one place in the helix runtime
-	// that knows the `workers/<id>/.context/` path convention.
-	Workspace   *Workspace
+	Service     ProjectService
 	Store       *store.Store
 	HelixOrgURL string
 	OrgID       string
@@ -346,7 +341,6 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 					if a.Logger != nil {
 						a.Logger.Warn("project applier: rename to display name failed, skipping refresh to avoid orphan", "worker", workerID, "project", state.ProjectID, "want_name", projectName, "err", err)
 					}
-					a.republishWorkerFiles(ctx, workerID, state.RepoID, roleContent)
 					return state.ProjectID, state.AgentID, state.RepoID, nil
 				}
 			}
@@ -384,10 +378,6 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 					a.Logger.Warn("verify persisted repo failed; keeping existing id", "worker", workerID, "repo", repoID, "err", gerr)
 				}
 			}
-			// Keep the role.md workspace mirror current for tools and
-			// workflows that use the helix-specs branch. Activation prompts
-			// read Bot.Content directly. The writes are idempotent.
-			a.republishWorkerFiles(ctx, workerID, repoID, roleContent)
 			return state.ProjectID, state.AgentID, repoID, nil
 		}
 	}
@@ -422,8 +412,8 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	//   - HELIX_REPOSITORIES is set from the project's attached repos
 	//     when hydra launches the desktop; an empty list means the
 	//     bringup script has nothing for Zed to open.
-	//   - update_role writes role.md into the repo on the helix-specs
-	//     branch — without a repo it has nowhere to go.
+	//   - runtime instructions live in the repo's helix-specs branch —
+	//     without a repo the activation has nowhere to publish them.
 	//
 	// Earlier versions of this code logged a warning on failure and
 	// returned a project with empty RepoID, which surfaced as a 5-min
@@ -443,7 +433,6 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 			return "", "", "", fmt.Errorf("apply project for %s: %w", workerID, rerr)
 		}
 	}
-	a.republishWorkerFiles(ctx, workerID, repoID, roleContent)
 	// NB: helix-org MCP attachment is NOT done here. applyProject
 	// (helix project handler) wholesale-replaces agentApp.Config.Helix
 	// on update, so anything we attach now is clobbered on the next
@@ -530,26 +519,4 @@ func (a *WorkerProject) ensureWorkerRepo(ctx context.Context, projectID, orgID s
 		a.Logger.Info("helix repo created and attached", "worker", workerID, "repo", repo.ID)
 	}
 	return repo.ID, nil
-}
-
-// republishWorkerFiles writes the bot's role.md file on the bot's
-// helix-specs branch through the Workspace, so the on-branch path
-// layout is owned in exactly one place (workspace.go). A bot has no
-// separate identity — its Content IS its prompt, written to role.md.
-// Best-effort: errors are logged, not returned — a single failed file
-// shouldn't block the rest of the apply.
-func (a *WorkerProject) republishWorkerFiles(ctx context.Context, workerID orgchart.NodeID, repoID, roleContent string) {
-	if repoID == "" || a.Workspace == nil {
-		return
-	}
-	if err := a.Workspace.EnsureBranch(ctx, repoID, "main"); err != nil {
-		if a.Logger != nil {
-			a.Logger.Warn("republish bot files: create helix-specs branch", "bot", workerID, "err", err)
-		}
-	}
-	if roleContent != "" {
-		if err := a.Workspace.WriteWorkerFile(ctx, workerID, repoID, "role.md", roleContent, "republish role.md"); err != nil && a.Logger != nil {
-			a.Logger.Warn("republish bot files: role.md", "bot", workerID, "err", err)
-		}
-	}
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -79,6 +79,7 @@ type ProjectService interface {
 	// PutProjectSecret upserts an env-var injected into the agent's
 	// container at session start.
 	PutProjectSecret(ctx context.Context, projectID, name, value string) error
+	DeleteProjectSecret(ctx context.Context, projectID, name string) error
 
 	// ListProjectSecrets returns the project's dev-scoped secrets as a
 	// decrypted name→value map, read live. Backs list_secrets so a bot can
@@ -378,6 +379,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 					a.Logger.Warn("verify persisted repo failed; keeping existing id", "worker", workerID, "repo", repoID, "err", gerr)
 				}
 			}
+			a.syncProjectRuntimeSecrets(ctx, state.ProjectID, workerID)
 			return state.ProjectID, state.AgentID, repoID, nil
 		}
 	}
@@ -396,15 +398,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 			return "", "", "", fmt.Errorf("enable org member access to project %s for %s: %w", resp.ProjectID, workerID, err)
 		}
 	}
-	// Project secrets — env-var injection. The worker needs these to reach
-	// the org runtime, so a failure is worth surfacing (logged, not fatal:
-	// a re-apply on the next activation retries the upsert).
-	if err := a.Service.PutProjectSecret(ctx, resp.ProjectID, "HELIX_ORG_URL", a.HelixOrgURL); err != nil && a.Logger != nil {
-		a.Logger.Warn("put project secret HELIX_ORG_URL", "worker", workerID, "project", resp.ProjectID, "err", err)
-	}
-	if err := a.Service.PutProjectSecret(ctx, resp.ProjectID, "HELIX_WORKER_ID", string(workerID)); err != nil && a.Logger != nil {
-		a.Logger.Warn("put project secret HELIX_WORKER_ID", "worker", workerID, "project", resp.ProjectID, "err", err)
-	}
+	a.syncProjectRuntimeSecrets(ctx, resp.ProjectID, workerID)
 	repoID = project.DefaultRepoID
 	// Helix's project-apply does NOT auto-create a default repo. We
 	// MUST create one and attach it as primary, because:
@@ -412,8 +406,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	//   - HELIX_REPOSITORIES is set from the project's attached repos
 	//     when hydra launches the desktop; an empty list means the
 	//     bringup script has nothing for Zed to open.
-	//   - runtime instructions live in the repo's helix-specs branch —
-	//     without a repo the activation has nowhere to publish them.
+	//   - Zed needs a real repository workspace to open.
 	//
 	// Earlier versions of this code logged a warning on failure and
 	// returned a project with empty RepoID, which surfaced as a 5-min
@@ -452,6 +445,19 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		)
 	}
 	return resp.ProjectID, resp.AgentAppID, repoID, nil
+}
+
+func (a *WorkerProject) syncProjectRuntimeSecrets(ctx context.Context, projectID string, workerID orgchart.NodeID) {
+	// The org URL is project capability shared by every session in the worker's
+	// project. Worker identity is not: remove the legacy project secret so
+	// SpecTask sessions cannot inherit it. The spawner now stores identity and
+	// instructions on the org worker's session only.
+	if err := a.Service.PutProjectSecret(ctx, projectID, "HELIX_ORG_URL", a.HelixOrgURL); err != nil && a.Logger != nil {
+		a.Logger.Warn("put project secret HELIX_ORG_URL", "worker", workerID, "project", projectID, "err", err)
+	}
+	if err := a.Service.DeleteProjectSecret(ctx, projectID, "HELIX_WORKER_ID"); err != nil && a.Logger != nil {
+		a.Logger.Warn("delete legacy project secret HELIX_WORKER_ID", "worker", workerID, "project", projectID, "err", err)
+	}
 }
 
 // ensureWorkerRepo returns the project's per-Worker repo, creating and attaching

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -38,6 +38,7 @@ type fakeProjectService struct {
 	updateProjectErr        error
 	putSecretCalls          int
 	putSecretLast           map[string]string
+	deletedSecrets          []string
 	listSecretsProjectID    string
 	listSecretsResp         map[string]string
 	listSecretsErr          error
@@ -142,6 +143,13 @@ func (f *fakeProjectService) PutProjectSecret(_ context.Context, _, name, value 
 	defer f.mu.Unlock()
 	f.putSecretCalls++
 	f.putSecretLast[name] = value
+	return nil
+}
+
+func (f *fakeProjectService) DeleteProjectSecret(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletedSecrets = append(f.deletedSecrets, name)
 	return nil
 }
 
@@ -328,8 +336,11 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	if svc.putSecretLast["HELIX_ORG_URL"] != "http://helix-org:8081" {
 		t.Errorf("HELIX_ORG_URL = %q", svc.putSecretLast["HELIX_ORG_URL"])
 	}
-	if svc.putSecretLast["HELIX_WORKER_ID"] != "w-eng" {
-		t.Errorf("HELIX_WORKER_ID = %q", svc.putSecretLast["HELIX_WORKER_ID"])
+	if _, ok := svc.putSecretLast["HELIX_WORKER_ID"]; ok {
+		t.Errorf("HELIX_WORKER_ID must not be stored as a project secret")
+	}
+	if len(svc.deletedSecrets) != 1 || svc.deletedSecrets[0] != "HELIX_WORKER_ID" {
+		t.Errorf("deleted secrets = %v, want [HELIX_WORKER_ID]", svc.deletedSecrets)
 	}
 	if svc.createGitRepoCalls != 1 {
 		t.Errorf("CreateGitRepo calls = %d, want 1", svc.createGitRepoCalls)

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -237,7 +237,6 @@ func (f *fakeProjectService) DeleteApp(_ context.Context, id string) error {
 // fakeGitWriter but with an additional path map.
 type fakeGitForProject struct {
 	mu            sync.Mutex
-	branchCalls   int32
 	putFileCalls  int32
 	putFileByPath map[string]string
 	putFileErr    error
@@ -248,7 +247,6 @@ func newFakeGitForProject() *fakeGitForProject {
 }
 
 func (f *fakeGitForProject) CreateBranch(_ context.Context, _, _, _ string) error {
-	atomic.AddInt32(&f.branchCalls, 1)
 	return nil
 }
 
@@ -268,9 +266,8 @@ func newProjectTestStore(t *testing.T, roleContent string) (*store.Store, orgcha
 	t.Helper()
 	st := orggorm.GetOrgTestDB(t)
 	ctx := context.Background()
-	// The Bot IS the role: its Content is the prompt that lands in
-	// role.md. Keep the `w-eng` handle so the on-branch path assertions
-	// (workers/w-eng/.context/role.md) stay meaningful.
+	// The Bot's Content is its canonical instruction text. Keep the `w-eng`
+	// handle so runtime instruction path assertions stay meaningful.
 	b, err := orgchart.NewNode("w-eng", roleContent, nil, time.Now().UTC(), "org-test")
 	if err != nil {
 		t.Fatalf("new bot: %v", err)
@@ -282,9 +279,9 @@ func newProjectTestStore(t *testing.T, roleContent string) (*store.Store, orgcha
 }
 
 func newApplier(svc ProjectService, ws *Workspace, st *store.Store) *WorkerProject {
+	_ = ws
 	return &WorkerProject{
 		Service:     svc,
-		Workspace:   ws,
 		Store:       st,
 		HelixOrgURL: "http://helix-org:8081",
 		Logger:      discardLogger(),
@@ -340,13 +337,8 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	if svc.attachRepoCalls != 1 {
 		t.Errorf("AttachRepoToProject calls = %d, want 1", svc.attachRepoCalls)
 	}
-	if atomic.LoadInt32(&git.branchCalls) < 1 {
-		t.Errorf("CreateBranch calls = %d, want >=1", atomic.LoadInt32(&git.branchCalls))
-	}
-	git.mu.Lock()
-	defer git.mu.Unlock()
-	if _, ok := git.putFileByPath["workers/w-eng/.context/role.md"]; !ok {
-		t.Errorf("path %q not pushed", "workers/w-eng/.context/role.md")
+	if got := atomic.LoadInt32(&git.putFileCalls); got != 0 {
+		t.Errorf("WorkerProject published %d deprecated role files; instruction publishing belongs to Spawner", got)
 	}
 	state, err := LoadState(context.Background(), st, "org-test", wid)
 	if err != nil {
@@ -560,13 +552,8 @@ func TestEnsureFastPathReprovisionsDeletedRepo(t *testing.T) {
 //     CreateGitRepo / AttachRepoToProject calls)
 //   - leave the existing app configuration untouched; worker.* values
 //     are provisioning defaults and the app UI/API owns later edits.
-//   - re-publish role.md from the DB to the helix-specs branch so DB edits that don't
-//     go through update_role / update_identity (e.g. direct store
-//     mutation, role-reconciler reseeding) still reach Workers
-//     without a fire+re-hire round trip. The original feature lived at
-//     commit 4a6cb33c51, regressed at 4f7837ac0c.
-//     See TestEnsureFastPathPropagatesRoleEdits for the propagation
-//     assertion.
+//   - leave runtime instruction publishing to the activation spawner, which
+//     resolves linked Agent content and org-level overrides.
 func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role v1")
@@ -605,15 +592,8 @@ func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
 	if svc.attachRepoCalls != 0 {
 		t.Errorf("fast path must not attach a repo; got %d", svc.attachRepoCalls)
 	}
-	// Fast path MUST ensure-branch + republish canonical files so DB
-	// edits propagate to the helix-specs branch on every activation.
-	if atomic.LoadInt32(&git.branchCalls) == 0 {
-		t.Errorf("fast path MUST ensure helix-specs branch exists before republish; got 0 CreateBranch calls")
-	}
-	git.mu.Lock()
-	defer git.mu.Unlock()
-	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v1" {
-		t.Errorf("fast path MUST republish role.md from DB; got %q, want %q", got, "# Role v1")
+	if got := atomic.LoadInt32(&git.putFileCalls); got != 0 {
+		t.Errorf("fast path published %d deprecated role files", got)
 	}
 }
 
@@ -814,64 +794,6 @@ func TestEnsureFastPathRepairsStaleRuntimeAgentApp(t *testing.T) {
 	}
 }
 
-// TestEnsureFastPathPropagatesRoleEdits pins live-edit propagation: a
-// role.Content mutation made directly in the store (bypassing the
-// update_role MCP tool's MirrorFile push) must reach the helix-specs
-// branch on the next activation, without a fire+re-hire.
-//
-// This is the contract the original feature commit 4a6cb33c51 validated
-// end-to-end. It silently regressed in commit 4f7837ac0c when the fast-path
-// republish was removed.
-func TestEnsureFastPathPropagatesRoleEdits(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	st, wid := newProjectTestStore(t, "# Role v1")
-	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app_existing", "repo_existing"); err != nil {
-		t.Fatalf("save project: %v", err)
-	}
-	svc := newFakeProjectService()
-	svc.getProjectResp = types.Project{ID: "prj_existing", DefaultRepoID: "repo_existing"}
-	git := newFakeGitForProject()
-	a := newApplierGit(svc, git, st)
-
-	// First activation: republishes v1 to the branch.
-	if _, _, _, err := a.Ensure(ctx, "org-test", wid); err != nil {
-		t.Fatalf("first Ensure: %v", err)
-	}
-	git.mu.Lock()
-	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v1" {
-		git.mu.Unlock()
-		t.Fatalf("after first Ensure, role.md on branch = %q, want %q", got, "# Role v1")
-	}
-	// Reset capture so the second-call assertion only sees the second
-	// activation's push.
-	git.putFileByPath = map[string]string{}
-	git.mu.Unlock()
-
-	// Mutate the role's Content in the store, simulating any edit path
-	// that bypasses update_role/MirrorFile (direct DB edit,
-	// RoleReconciler reseed, restore-from-backup, …). The DB is the
-	// source of truth; the branch must reflect it on next activation.
-	existing, err := st.Nodes.Get(ctx, "org-test", "w-eng")
-	if err != nil {
-		t.Fatalf("get bot: %v", err)
-	}
-	existing = existing.WithContent("# Role v2").WithUpdatedAt(time.Now().UTC())
-	if err := st.Nodes.Update(ctx, existing); err != nil {
-		t.Fatalf("update bot: %v", err)
-	}
-
-	// Second activation: must republish v2.
-	if _, _, _, err := a.Ensure(ctx, "org-test", wid); err != nil {
-		t.Fatalf("second Ensure: %v", err)
-	}
-	git.mu.Lock()
-	defer git.mu.Unlock()
-	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v2" {
-		t.Errorf("after second Ensure, role.md on branch = %q, want %q — live-edit did not propagate", got, "# Role v2")
-	}
-}
-
 // TestEnsureClearsStateOnGetProject404 verifies that on
 // ErrProjectNotFound, ClearProject runs and a fresh apply follows.
 func TestEnsureClearsStateOnGetProject404(t *testing.T) {
@@ -965,9 +887,9 @@ func TestEnsureDoesNotTouchAgentAppMCPs(t *testing.T) {
 	}
 }
 
-// TestEnsureRolePropagatesContent verifies the Bot's Content lands in
-// role.md on the helix-specs branch.
-func TestEnsureRolePropagatesContent(t *testing.T) {
+// TestEnsureDoesNotPublishDeprecatedRoleFile pins the single-instruction-file
+// contract: project provisioning must not recreate role.md.
+func TestEnsureDoesNotPublishDeprecatedRoleFile(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role: ChiefEngineer")
 	svc := newFakeProjectService()
@@ -977,24 +899,8 @@ func TestEnsureRolePropagatesContent(t *testing.T) {
 	if _, _, _, err := a.Ensure(context.Background(), "org-test", wid); err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	git.mu.Lock()
-	defer git.mu.Unlock()
-	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role: ChiefEngineer" {
-		t.Errorf("role.md content = %q", got)
-	}
-}
-
-// TestEnsureLogsButDoesNotFailOnPutFileError.
-func TestEnsureLogsButDoesNotFailOnPutFileError(t *testing.T) {
-	t.Parallel()
-	st, wid := newProjectTestStore(t, "# Role")
-	svc := newFakeProjectService()
-	git := newFakeGitForProject()
-	git.putFileErr = errors.New("disk full")
-	a := newApplierGit(svc, git, st)
-
-	if _, _, _, err := a.Ensure(context.Background(), "org-test", wid); err != nil {
-		t.Fatalf("Ensure must not fail on PutFile error; got %v", err)
+	if got := atomic.LoadInt32(&git.putFileCalls); got != 0 {
+		t.Errorf("WorkerProject published %d files, want 0", got)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/sessions.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sessions.go
@@ -33,6 +33,7 @@ type SessionClient interface {
 // The adapter always sets session_role "exploratory" so it's resolvable
 // by the mirror's GetProjectExploratorySession lookup.
 type StartSessionParams struct {
+	Name           string
 	ProjectID      string
 	OrganizationID string
 	AppID          string
@@ -66,6 +67,11 @@ type SpawnerClient interface {
 	// instead of growing one long-lived session until it hits the model
 	// limit and compacts. See SpawnerConfig.ensureSession.
 	ClearSession(ctx context.Context, sessionID string) error
+	// SyncAgentProfile updates the durable display name on an existing session
+	// and, when its desktop is running, refreshes the runtime-native instruction
+	// files before a new ACP thread is created. A stopped desktop still gets the
+	// name update; its startup path projects the canonical instruction file.
+	SyncAgentProfile(ctx context.Context, sessionID, sessionName, instructions string) error
 }
 
 // checkDesktopQuota pre-flights the desktop quota gate before
@@ -103,6 +109,7 @@ func checkDesktopQuota(ctx context.Context, client SessionClient) error {
 // itself stays free of side-effects beyond the StartChat call.
 type SendPromptParams struct {
 	SessionID      string
+	SessionName    string
 	ProjectID      string
 	OrganizationID string
 	AppID          string
@@ -146,6 +153,7 @@ func EnsureAndSend(ctx context.Context, client SessionClient, params SendPromptP
 		return "", false, err
 	}
 	sid, err := client.StartSession(ctx, StartSessionParams{
+		Name:           params.SessionName,
 		ProjectID:      params.ProjectID,
 		OrganizationID: params.OrganizationID,
 		AppID:          params.AppID,

--- a/api/pkg/org/infrastructure/runtime/helix/sessions.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sessions.go
@@ -41,6 +41,8 @@ type StartSessionParams struct {
 	Provider       string
 	Model          string
 	Prompt         string
+	WorkerID       string
+	Instructions   string
 }
 
 // SpawnerClient is the chat-session surface the helix Spawner uses
@@ -68,10 +70,10 @@ type SpawnerClient interface {
 	// limit and compacts. See SpawnerConfig.ensureSession.
 	ClearSession(ctx context.Context, sessionID string) error
 	// SyncAgentProfile updates the durable display name on an existing session
-	// and, when its desktop is running, refreshes the runtime-native instruction
-	// files before a new ACP thread is created. A stopped desktop still gets the
-	// name update; its startup path projects the canonical instruction file.
-	SyncAgentProfile(ctx context.Context, sessionID, sessionName, instructions string) error
+	// and its session-scoped worker identity/instructions. When the desktop is
+	// running it also refreshes the runtime-native files before a new ACP thread
+	// is created; a stopped desktop receives them from session state on restart.
+	SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string) error
 }
 
 // checkDesktopQuota pre-flights the desktop quota gate before
@@ -117,6 +119,8 @@ type SendPromptParams struct {
 	Provider       string
 	Model          string
 	Prompt         string
+	WorkerID       string
+	Instructions   string
 	OnSessionID    func(sessionID string)
 }
 
@@ -161,6 +165,8 @@ func EnsureAndSend(ctx context.Context, client SessionClient, params SendPromptP
 		Provider:       params.Provider,
 		Model:          params.Model,
 		Prompt:         params.Prompt,
+		WorkerID:       params.WorkerID,
+		Instructions:   params.Instructions,
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("start helix session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -291,7 +291,7 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		}
 		mandate := cfg.SpecsMandate
 		if mandate == "" {
-			instructions := bot.Content
+			mandate = bot.Content
 			if bot.AgentID != "" {
 				if cfg.ProjectService == nil {
 					return errors.New("load canonical agent instructions: project service is nil")
@@ -303,12 +303,20 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 				if len(appConfig.Helix.Assistants) != 1 {
 					return fmt.Errorf("linked agent %s must contain exactly one assistant", bot.AgentID)
 				}
-				instructions = appConfig.Helix.Assistants[0].SystemPrompt
+				mandate = appConfig.Helix.Assistants[0].SystemPrompt
 			}
-			mandate = "=== Current role ===\n" + instructions
 		}
-		prompt := briefing.BuildPrompt(workerID, mandate, triggers)
-		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, prompt, bot.PreserveContext, publish)
+		sessionName := bot.Name
+		if sessionName == "" {
+			sessionName = string(workerID)
+		}
+		instructions := briefing.BuildInstructions(workerID, mandate)
+		if err := cfg.prepareAgentInstructions(startupCtx, orgID, workerID, sessionName, instructions); err != nil {
+			publish(activation.OutcomeFromError(err).Marker())
+			return err
+		}
+		prompt := briefing.BuildPrompt(triggers)
+		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, prompt, bot.PreserveContext, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
@@ -327,6 +335,37 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		publish(activation.OutcomeFromError(err).Marker())
 		return err
 	}
+}
+
+const runtimeInstructionsFile = "runtime-instructions.md"
+
+// prepareAgentInstructions publishes the canonical instructions for both
+// cold and warm activation paths. Cold desktops copy the helix-specs file to
+// AGENTS.md / CLAUDE.md during workspace setup. Warm desktops receive the
+// same content directly before ensureSession clears the old ACP thread.
+func (c SpawnerConfig) prepareAgentInstructions(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions string) error {
+	if c.Workspace == nil {
+		return errors.New("prepare agent instructions: workspace is nil")
+	}
+	state, err := LoadState(ctx, c.Store, orgID, workerID)
+	if err != nil {
+		return fmt.Errorf("prepare agent instructions: load worker state: %w", err)
+	}
+	if state.RepoID == "" {
+		return fmt.Errorf("prepare agent instructions: worker %s has no repository", workerID)
+	}
+	if err := c.Workspace.EnsureBranch(ctx, state.RepoID, "main"); err != nil {
+		return fmt.Errorf("prepare agent instructions: ensure helix-specs branch: %w", err)
+	}
+	if err := c.Workspace.WriteWorkerFile(ctx, workerID, state.RepoID, runtimeInstructionsFile, instructions, "update runtime instructions"); err != nil {
+		return fmt.Errorf("prepare agent instructions: publish canonical file: %w", err)
+	}
+	if state.SessionID != "" {
+		if err := c.Client.SyncAgentProfile(ctx, state.SessionID, sessionName, instructions); err != nil {
+			return fmt.Errorf("prepare agent instructions: sync existing session: %w", err)
+		}
+	}
+	return nil
 }
 
 // newActivationRecord builds a fresh activation.Activation for one
@@ -365,7 +404,6 @@ func newActivationRecord(cfg SpawnerConfig, orgID string, workerID orgchart.Node
 func (c SpawnerConfig) ensureProject(ctx context.Context, orgID string, workerID orgchart.NodeID) error {
 	a := &WorkerProject{
 		Service:        c.ProjectService,
-		Workspace:      c.Workspace,
 		Store:          c.Store,
 		HelixOrgURL:    c.HelixOrgURL,
 		OrgID:          c.OrgID,
@@ -439,7 +477,7 @@ func sanitizeLogValue(value string) string {
 //     connect; if it does (hadWSError) we immediately re-queue the
 //     same prompt via the durable /messages endpoint so it lands as
 //     soon as the agent dials home.
-func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
+func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return "", "", err
@@ -508,8 +546,9 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 	// one shared primitive the two paths drift apart and develop
 	// independent stale-session bugs.
 	sid, fresh, err := EnsureAndSend(ctx, c.Client, SendPromptParams{
-		SessionID: state.SessionID,
-		ProjectID: state.ProjectID,
+		SessionID:   state.SessionID,
+		SessionName: sessionName,
+		ProjectID:   state.ProjectID,
 		// OrganizationID tags the session row with the Worker's org so
 		// authorizeUserToSession can grant access to org members (e.g. the
 		// operator viewing the inline transcript). Without it the session

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -36,7 +36,6 @@ const DefaultMaxInflight = 8
 type SpawnerConfig struct {
 	Client         SpawnerClient
 	ProjectService ProjectService
-	Workspace      *Workspace
 	// PubSub + Snapshotter back SubscribeSessionUpdates, which topics
 	// per-session WebsocketEvent frames to in-process subscribers.
 	PubSub      pubsub.PubSub
@@ -316,7 +315,7 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			return err
 		}
 		prompt := briefing.BuildPrompt(triggers)
-		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, prompt, bot.PreserveContext, publish)
+		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, instructions, prompt, bot.PreserveContext, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
@@ -337,31 +336,17 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 	}
 }
 
-const runtimeInstructionsFile = "runtime-instructions.md"
-
-// prepareAgentInstructions publishes the canonical instructions for both
-// cold and warm activation paths. Cold desktops copy the helix-specs file to
-// AGENTS.md / CLAUDE.md during workspace setup. Warm desktops receive the
-// same content directly before ensureSession clears the old ACP thread.
+// prepareAgentInstructions refreshes an existing session before its old ACP
+// thread is cleared. Fresh sessions receive the same content through
+// StartSessionParams, which stores it on the session for Hydra to materialize
+// before the desktop starts.
 func (c SpawnerConfig) prepareAgentInstructions(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions string) error {
-	if c.Workspace == nil {
-		return errors.New("prepare agent instructions: workspace is nil")
-	}
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return fmt.Errorf("prepare agent instructions: load worker state: %w", err)
 	}
-	if state.RepoID == "" {
-		return fmt.Errorf("prepare agent instructions: worker %s has no repository", workerID)
-	}
-	if err := c.Workspace.EnsureBranch(ctx, state.RepoID, "main"); err != nil {
-		return fmt.Errorf("prepare agent instructions: ensure helix-specs branch: %w", err)
-	}
-	if err := c.Workspace.WriteWorkerFile(ctx, workerID, state.RepoID, runtimeInstructionsFile, instructions, "update runtime instructions"); err != nil {
-		return fmt.Errorf("prepare agent instructions: publish canonical file: %w", err)
-	}
 	if state.SessionID != "" {
-		if err := c.Client.SyncAgentProfile(ctx, state.SessionID, sessionName, instructions); err != nil {
+		if err := c.Client.SyncAgentProfile(ctx, state.SessionID, sessionName, string(workerID), instructions); err != nil {
 			return fmt.Errorf("prepare agent instructions: sync existing session: %w", err)
 		}
 	}
@@ -477,7 +462,7 @@ func sanitizeLogValue(value string) string {
 //     connect; if it does (hadWSError) we immediately re-queue the
 //     same prompt via the durable /messages endpoint so it lands as
 //     soon as the agent dials home.
-func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
+func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return "", "", err
@@ -559,6 +544,8 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 		AppID:          state.AgentID,
 		AgentType:      AgentType,
 		Prompt:         prompt,
+		WorkerID:       string(workerID),
+		Instructions:   instructions,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("ensure session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -44,6 +44,7 @@ type fakeHelixClient struct {
 	syncCalls          int32
 	lastSyncSID        string
 	lastSessionName    string
+	lastWorkerID       string
 	lastInstructions   string
 	syncedBeforeClear  bool
 	// clearedBeforeSend records whether ClearSession ran before the
@@ -102,12 +103,13 @@ func (f *fakeHelixClient) ClearSession(_ context.Context, sessionID string) erro
 	return clearErr
 }
 
-func (f *fakeHelixClient) SyncAgentProfile(_ context.Context, sessionID, sessionName, instructions string) error {
+func (f *fakeHelixClient) SyncAgentProfile(_ context.Context, sessionID, sessionName, workerID, instructions string) error {
 	atomic.AddInt32(&f.syncCalls, 1)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.lastSyncSID = sessionID
 	f.lastSessionName = sessionName
+	f.lastWorkerID = workerID
 	f.lastInstructions = instructions
 	if atomic.LoadInt32(&f.clearCalls) == 0 {
 		f.syncedBeforeClear = true
@@ -177,7 +179,6 @@ func newHelixCfg(t *testing.T, fc SpawnerClient, s *store.Store) SpawnerConfig {
 	return SpawnerConfig{
 		Client:                 fc,
 		ProjectService:         newFakeProjectService(),
-		Workspace:              NewWorkspace(newFakeGitForProject(), s, "helix-specs", "helix-org", "ho@example.com"),
 		PubSub:                 newFakePubSub(),
 		Snapshotter:            NoopSessionPreamble{},
 		HelixOrgURL:            "http://helix-org:8081",
@@ -193,17 +194,6 @@ func newHelixCfg(t *testing.T, fc SpawnerClient, s *store.Store) SpawnerConfig {
 		Now:                    func() time.Time { return time.Now().UTC() },
 		NewID:                  func() string { return "id" },
 	}
-}
-
-func publishedRuntimeInstructions(t *testing.T, cfg SpawnerConfig, workerID orgchart.NodeID) string {
-	t.Helper()
-	git, ok := cfg.Workspace.git.(*fakeGitForProject)
-	if !ok {
-		t.Fatalf("workspace git = %T, want *fakeGitForProject", cfg.Workspace.git)
-	}
-	git.mu.Lock()
-	defer git.mu.Unlock()
-	return git.putFileByPath["workers/"+string(workerID)+"/.context/"+runtimeInstructionsFile]
 }
 
 func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
@@ -248,6 +238,12 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	if fc.lastStartParams.Name != "w-eng" {
 		t.Errorf("StartSession Name = %q (want w-eng)", fc.lastStartParams.Name)
 	}
+	if fc.lastStartParams.WorkerID != "w-eng" {
+		t.Errorf("StartSession WorkerID = %q (want w-eng)", fc.lastStartParams.WorkerID)
+	}
+	if !strings.Contains(fc.lastStartParams.Instructions, "=== Instructions ===\n# Role: Engineer") {
+		t.Errorf("StartSession instructions = %q", fc.lastStartParams.Instructions)
+	}
 }
 
 func TestSpawnerSpecsMandateRemainsFullOverride(t *testing.T) {
@@ -263,7 +259,7 @@ func TestSpawnerSpecsMandateRemainsFullOverride(t *testing.T) {
 	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	instructions := fc.lastStartParams.Instructions
 	if !strings.Contains(instructions, "Operator policy: keep replies concise.") {
 		t.Fatalf("runtime instructions missing mandate override: %q", instructions)
 	}
@@ -301,6 +297,7 @@ func TestSpawnerEmbedsFreshBotContentByDefault(t *testing.T) {
 	instructions := fc.lastInstructions
 	lastSyncSID := fc.lastSyncSID
 	lastSessionName := fc.lastSessionName
+	lastWorkerID := fc.lastWorkerID
 	syncedBeforeClear := fc.syncedBeforeClear
 	fc.mu.Unlock()
 	if !strings.Contains(instructions, "=== Instructions ===\n# Role: Principal Engineer") {
@@ -314,6 +311,9 @@ func TestSpawnerEmbedsFreshBotContentByDefault(t *testing.T) {
 	}
 	if lastSessionName != "w-eng" {
 		t.Fatalf("warm session name = %q, want w-eng", lastSessionName)
+	}
+	if lastWorkerID != "w-eng" {
+		t.Fatalf("warm worker ID = %q, want w-eng", lastWorkerID)
 	}
 	if !syncedBeforeClear {
 		t.Fatal("warm instruction sync must happen before ClearSession resets the ACP thread")
@@ -350,7 +350,7 @@ func TestSpawnerUsesLinkedAgentInstructions(t *testing.T) {
 	if err := Spawner(cfg)(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	instructions := fc.lastStartParams.Instructions
 	if !strings.Contains(instructions, "=== Instructions ===\n# Canonical agent instructions") {
 		t.Fatalf("runtime instructions did not use linked Agent instructions: %q", instructions)
 	}
@@ -388,7 +388,7 @@ func TestSpawnerReadsBotAfterProjectEnsure(t *testing.T) {
 	if err := <-result; err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	instructions := fc.lastStartParams.Instructions
 	if !strings.Contains(instructions, "# Role: Updated During Ensure") {
 		t.Fatalf("runtime instructions used role read before project ensure: %q", instructions)
 	}
@@ -906,7 +906,7 @@ func (c *concurrencyClient) ClearSession(ctx context.Context, sessionID string) 
 	return c.inner.ClearSession(ctx, sessionID)
 }
 
-func (c *concurrencyClient) SyncAgentProfile(context.Context, string, string, string) error {
+func (c *concurrencyClient) SyncAgentProfile(context.Context, string, string, string, string) error {
 	return nil
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -41,6 +41,11 @@ type fakeHelixClient struct {
 	lastSendBody       string
 	clearCalls         int32
 	lastClearSID       string
+	syncCalls          int32
+	lastSyncSID        string
+	lastSessionName    string
+	lastInstructions   string
+	syncedBeforeClear  bool
 	// clearedBeforeSend records whether ClearSession ran before the
 	// first SendMessage, so tests can assert the activation clears the
 	// prior conversation ahead of dispatching the new prompt.
@@ -95,6 +100,19 @@ func (f *fakeHelixClient) ClearSession(_ context.Context, sessionID string) erro
 	clearErr := f.clearErr
 	f.mu.Unlock()
 	return clearErr
+}
+
+func (f *fakeHelixClient) SyncAgentProfile(_ context.Context, sessionID, sessionName, instructions string) error {
+	atomic.AddInt32(&f.syncCalls, 1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastSyncSID = sessionID
+	f.lastSessionName = sessionName
+	f.lastInstructions = instructions
+	if atomic.LoadInt32(&f.clearCalls) == 0 {
+		f.syncedBeforeClear = true
+	}
+	return nil
 }
 
 func (f *fakeHelixClient) GetOutput(_ context.Context, _ string) (types.SessionOutputResponse, error) {
@@ -177,6 +195,17 @@ func newHelixCfg(t *testing.T, fc SpawnerClient, s *store.Store) SpawnerConfig {
 	}
 }
 
+func publishedRuntimeInstructions(t *testing.T, cfg SpawnerConfig, workerID orgchart.NodeID) string {
+	t.Helper()
+	git, ok := cfg.Workspace.git.(*fakeGitForProject)
+	if !ok {
+		t.Fatalf("workspace git = %T, want *fakeGitForProject", cfg.Workspace.git)
+	}
+	git.mu.Lock()
+	defer git.mu.Unlock()
+	return git.putFileByPath["workers/"+string(workerID)+"/.context/"+runtimeInstructionsFile]
+}
+
 func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	t.Parallel()
 	s, wid := newHelixTestStore(t)
@@ -216,6 +245,9 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	if fc.lastStartParams.AppID != "app_test" {
 		t.Errorf("StartSession AppID = %q (want app_test)", fc.lastStartParams.AppID)
 	}
+	if fc.lastStartParams.Name != "w-eng" {
+		t.Errorf("StartSession Name = %q (want w-eng)", fc.lastStartParams.Name)
+	}
 }
 
 func TestSpawnerSpecsMandateRemainsFullOverride(t *testing.T) {
@@ -231,11 +263,15 @@ func TestSpawnerSpecsMandateRemainsFullOverride(t *testing.T) {
 	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	if !strings.Contains(fc.lastStartParams.Prompt, "Operator policy: keep replies concise.") {
-		t.Fatalf("prompt missing mandate override: %q", fc.lastStartParams.Prompt)
+	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	if !strings.Contains(instructions, "Operator policy: keep replies concise.") {
+		t.Fatalf("runtime instructions missing mandate override: %q", instructions)
 	}
-	if strings.Contains(fc.lastStartParams.Prompt, "=== Current role ===") || strings.Contains(fc.lastStartParams.Prompt, "# Role: Engineer") {
-		t.Fatalf("explicit mandate must remain a full override: %q", fc.lastStartParams.Prompt)
+	if strings.Contains(instructions, "# Role: Engineer") {
+		t.Fatalf("explicit mandate must remain a full override: %q", instructions)
+	}
+	if strings.Contains(fc.lastStartParams.Prompt, "Operator policy") || strings.Contains(fc.lastStartParams.Prompt, "You are Bot") {
+		t.Fatalf("activation prompt contains durable instructions: %q", fc.lastStartParams.Prompt)
 	}
 }
 
@@ -262,9 +298,25 @@ func TestSpawnerEmbedsFreshBotContentByDefault(t *testing.T) {
 	}
 	fc.mu.Lock()
 	followUp := fc.lastSendBody
+	instructions := fc.lastInstructions
+	lastSyncSID := fc.lastSyncSID
+	lastSessionName := fc.lastSessionName
+	syncedBeforeClear := fc.syncedBeforeClear
 	fc.mu.Unlock()
-	if !strings.Contains(followUp, "=== Current role ===\n# Role: Principal Engineer") {
-		t.Fatalf("follow-up prompt did not use fresh Bot.Content: %q", followUp)
+	if !strings.Contains(instructions, "=== Instructions ===\n# Role: Principal Engineer") {
+		t.Fatalf("runtime instructions did not use fresh Bot.Content: %q", instructions)
+	}
+	if strings.Contains(followUp, "Principal Engineer") || strings.Contains(followUp, "You are Bot") {
+		t.Fatalf("follow-up prompt contains durable instructions: %q", followUp)
+	}
+	if got := atomic.LoadInt32(&fc.syncCalls); got != 1 || lastSyncSID != "ses_new" {
+		t.Fatalf("warm instruction sync = (%d, %q), want (1, ses_new)", got, lastSyncSID)
+	}
+	if lastSessionName != "w-eng" {
+		t.Fatalf("warm session name = %q, want w-eng", lastSessionName)
+	}
+	if !syncedBeforeClear {
+		t.Fatal("warm instruction sync must happen before ClearSession resets the ACP thread")
 	}
 	for _, staleBootstrap := range []string{"agent.md", "git pull", "git worktree", "cat ~/work"} {
 		if strings.Contains(followUp, staleBootstrap) {
@@ -298,11 +350,12 @@ func TestSpawnerUsesLinkedAgentInstructions(t *testing.T) {
 	if err := Spawner(cfg)(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	if !strings.Contains(fc.lastStartParams.Prompt, "=== Current role ===\n# Canonical agent instructions") {
-		t.Fatalf("prompt did not use linked Agent instructions: %q", fc.lastStartParams.Prompt)
+	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	if !strings.Contains(instructions, "=== Instructions ===\n# Canonical agent instructions") {
+		t.Fatalf("runtime instructions did not use linked Agent instructions: %q", instructions)
 	}
-	if strings.Contains(fc.lastStartParams.Prompt, "# Role: Engineer") {
-		t.Fatalf("prompt used legacy Bot.Content: %q", fc.lastStartParams.Prompt)
+	if strings.Contains(instructions, "# Role: Engineer") {
+		t.Fatalf("runtime instructions used legacy Bot.Content: %q", instructions)
 	}
 }
 
@@ -335,8 +388,9 @@ func TestSpawnerReadsBotAfterProjectEnsure(t *testing.T) {
 	if err := <-result; err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	if !strings.Contains(fc.lastStartParams.Prompt, "# Role: Updated During Ensure") {
-		t.Fatalf("prompt used role read before project ensure: %q", fc.lastStartParams.Prompt)
+	instructions := publishedRuntimeInstructions(t, cfg, wid)
+	if !strings.Contains(instructions, "# Role: Updated During Ensure") {
+		t.Fatalf("runtime instructions used role read before project ensure: %q", instructions)
 	}
 }
 
@@ -850,6 +904,10 @@ func (c *concurrencyClient) SendMessage(ctx context.Context, sessionID, prompt s
 
 func (c *concurrencyClient) ClearSession(ctx context.Context, sessionID string) error {
 	return c.inner.ClearSession(ctx, sessionID)
+}
+
+func (c *concurrencyClient) SyncAgentProfile(context.Context, string, string, string) error {
+	return nil
 }
 
 func (c *concurrencyClient) ServerStatus(ctx context.Context) (ServerStatus, error) {

--- a/api/pkg/org/infrastructure/runtime/helix/workspace.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace.go
@@ -31,8 +31,8 @@ type WorkspaceGit interface {
 }
 
 // Workspace is the runtime.WorkspaceSync implementation that pushes
-// canonical instruction content to the helix-specs branch of a Bot's
-// per-Bot repo. Each call resolves the target repo from
+// Worker-scoped artifacts to the helix-specs branch of a Bot's per-Bot repo.
+// Each call resolves the target repo from
 // the Worker's runtime state (set by WorkerProject at first
 // activation) and PUTs one file onto the configured branch at
 // `workers/<workerID>/.context/<name>`.
@@ -71,7 +71,7 @@ func NewWorkspace(git WorkspaceGit, st *store.Store, branch, author, email strin
 }
 
 // MirrorFile satisfies runtime.WorkspaceSync. `name` is the logical
-// filename for this Worker (e.g. "runtime-instructions.md"); the Helix backend writes
+// filename for this Worker (e.g. "notes.md"); the Helix backend writes
 // it at `workers/<workerID>/.context/<name>` on the helix-specs
 // branch. Returns nil for Workers that aren't yet bound to a Helix
 // project — callers don't have to gate on activation status.

--- a/api/pkg/org/infrastructure/runtime/helix/workspace.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace.go
@@ -31,12 +31,11 @@ type WorkspaceGit interface {
 }
 
 // Workspace is the runtime.WorkspaceSync implementation that pushes
-// canonical role content (role.md) to the helix-specs branch of a
-// Bot's per-Bot repo. Each call resolves the target repo from
+// canonical instruction content to the helix-specs branch of a Bot's
+// per-Bot repo. Each call resolves the target repo from
 // the Worker's runtime state (set by WorkerProject at first
 // activation) and PUTs one file onto the configured branch at
-// `workers/<workerID>/.context/<name>` — the same path layout
-// WorkerProject.republishWorkerFiles writes.
+// `workers/<workerID>/.context/<name>`.
 //
 // Workers that haven't been activated against a Helix project yet
 // (RepoID == "") are no-ops; callers don't have to gate on activation
@@ -72,7 +71,7 @@ func NewWorkspace(git WorkspaceGit, st *store.Store, branch, author, email strin
 }
 
 // MirrorFile satisfies runtime.WorkspaceSync. `name` is the logical
-// filename for this Worker (e.g. "role.md"); the Helix backend writes
+// filename for this Worker (e.g. "runtime-instructions.md"); the Helix backend writes
 // it at `workers/<workerID>/.context/<name>` on the helix-specs
 // branch. Returns nil for Workers that aren't yet bound to a Helix
 // project — callers don't have to gate on activation status.

--- a/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
@@ -42,7 +42,7 @@ func newSeededStore(t *testing.T, repoID string) (*store.Store, orgchart.NodeID)
 	t.Helper()
 	s := orggorm.GetOrgTestDB(t)
 	ctx := context.Background()
-	b, _ := orgchart.NewNode("w-eng", "# Role", nil, time.Now().UTC(), "org-test")
+	b, _ := orgchart.NewNode("w-eng", "# Instructions", nil, time.Now().UTC(), "org-test")
 	_ = s.Nodes.Create(ctx, b)
 	if repoID != "" {
 		_ = SaveProject(ctx, s, "org-test", b.ID, "prj_x", "app_x", repoID)
@@ -55,14 +55,14 @@ func TestWorkspaceWritesToWorkerRepo(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "helix-org", "ho@example.com")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "role.md", "# Role", "update_role: r-eng"); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions", "update instructions"); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	if fc.lastRepoID != "repo-1" {
 		t.Errorf("repo: %q", fc.lastRepoID)
 	}
-	wantPath := "workers/" + string(wid) + "/.context/role.md"
-	if fc.lastBranch != "helix-specs" || fc.lastPath != wantPath || string(fc.lastBody) != "# Role" {
+	wantPath := "workers/" + string(wid) + "/.context/runtime-instructions.md"
+	if fc.lastBranch != "helix-specs" || fc.lastPath != wantPath || string(fc.lastBody) != "# Instructions" {
 		t.Errorf("req: repo=%q path=%q branch=%q body=%q (want path=%q)",
 			fc.lastRepoID, fc.lastPath, fc.lastBranch, fc.lastBody, wantPath)
 	}
@@ -74,7 +74,7 @@ func TestWorkspaceUnboundWorkerIsNoop(t *testing.T) {
 	s, wid := newSeededStore(t, "")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "role.md", "# Role", ""); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions", ""); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	if fc.lastRepoID != "" {
@@ -87,7 +87,7 @@ func TestWorkspaceSurfacesErrors(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{err: errors.New("boom")}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "role.md", "x", ""); err == nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "x", ""); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -97,7 +97,7 @@ func TestWorkspaceRejectsBadName(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	for _, bad := range []string{"", "/role.md", "../role.md", "a/../b"} {
+	for _, bad := range []string{"", "/runtime-instructions.md", "../runtime-instructions.md", "a/../b"} {
 		if err := w.MirrorFile(context.Background(), "org-test", wid, bad, "x", ""); err == nil {
 			t.Errorf("name %q: expected error", bad)
 		}
@@ -113,12 +113,12 @@ func TestWorkspaceEmptyWorkerIDError(t *testing.T) {
 	s, _ := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", "", "role.md", "x", ""); err == nil {
+	if err := w.MirrorFile(context.Background(), "org-test", "", "runtime-instructions.md", "x", ""); err == nil {
 		t.Fatal("expected error for empty workerID")
 	}
 }
 
-func TestWorkspacePreservesSessionOnRoleEdit(t *testing.T) {
+func TestWorkspacePreservesSessionOnInstructionEdit(t *testing.T) {
 	t.Parallel()
 	s, wid := newSeededStore(t, "repo-1")
 	if err := SaveSession(context.Background(), s, "org-test", wid, "ses_warm"); err != nil {
@@ -126,12 +126,12 @@ func TestWorkspacePreservesSessionOnRoleEdit(t *testing.T) {
 	}
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "role.md", "# Role v2", ""); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions v2", ""); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	state, _ := LoadState(context.Background(), s, "org-test", wid)
 	if state.SessionID != "ses_warm" {
-		t.Errorf("role edit must preserve warm session; got %q", state.SessionID)
+		t.Errorf("instruction edit must preserve warm session; got %q", state.SessionID)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
@@ -42,7 +42,7 @@ func newSeededStore(t *testing.T, repoID string) (*store.Store, orgchart.NodeID)
 	t.Helper()
 	s := orggorm.GetOrgTestDB(t)
 	ctx := context.Background()
-	b, _ := orgchart.NewNode("w-eng", "# Instructions", nil, time.Now().UTC(), "org-test")
+	b, _ := orgchart.NewNode("w-eng", "# Worker", nil, time.Now().UTC(), "org-test")
 	_ = s.Nodes.Create(ctx, b)
 	if repoID != "" {
 		_ = SaveProject(ctx, s, "org-test", b.ID, "prj_x", "app_x", repoID)
@@ -55,14 +55,14 @@ func TestWorkspaceWritesToWorkerRepo(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "helix-org", "ho@example.com")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions", "update instructions"); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "notes.md", "# Notes", "update notes"); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	if fc.lastRepoID != "repo-1" {
 		t.Errorf("repo: %q", fc.lastRepoID)
 	}
-	wantPath := "workers/" + string(wid) + "/.context/runtime-instructions.md"
-	if fc.lastBranch != "helix-specs" || fc.lastPath != wantPath || string(fc.lastBody) != "# Instructions" {
+	wantPath := "workers/" + string(wid) + "/.context/notes.md"
+	if fc.lastBranch != "helix-specs" || fc.lastPath != wantPath || string(fc.lastBody) != "# Notes" {
 		t.Errorf("req: repo=%q path=%q branch=%q body=%q (want path=%q)",
 			fc.lastRepoID, fc.lastPath, fc.lastBranch, fc.lastBody, wantPath)
 	}
@@ -74,7 +74,7 @@ func TestWorkspaceUnboundWorkerIsNoop(t *testing.T) {
 	s, wid := newSeededStore(t, "")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions", ""); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "notes.md", "# Notes", ""); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	if fc.lastRepoID != "" {
@@ -87,7 +87,7 @@ func TestWorkspaceSurfacesErrors(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{err: errors.New("boom")}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "x", ""); err == nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "notes.md", "x", ""); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -97,7 +97,7 @@ func TestWorkspaceRejectsBadName(t *testing.T) {
 	s, wid := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	for _, bad := range []string{"", "/runtime-instructions.md", "../runtime-instructions.md", "a/../b"} {
+	for _, bad := range []string{"", "/notes.md", "../notes.md", "a/../b"} {
 		if err := w.MirrorFile(context.Background(), "org-test", wid, bad, "x", ""); err == nil {
 			t.Errorf("name %q: expected error", bad)
 		}
@@ -113,12 +113,12 @@ func TestWorkspaceEmptyWorkerIDError(t *testing.T) {
 	s, _ := newSeededStore(t, "repo-1")
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", "", "runtime-instructions.md", "x", ""); err == nil {
+	if err := w.MirrorFile(context.Background(), "org-test", "", "notes.md", "x", ""); err == nil {
 		t.Fatal("expected error for empty workerID")
 	}
 }
 
-func TestWorkspacePreservesSessionOnInstructionEdit(t *testing.T) {
+func TestWorkspacePreservesSessionOnArtifactEdit(t *testing.T) {
 	t.Parallel()
 	s, wid := newSeededStore(t, "repo-1")
 	if err := SaveSession(context.Background(), s, "org-test", wid, "ses_warm"); err != nil {
@@ -126,12 +126,12 @@ func TestWorkspacePreservesSessionOnInstructionEdit(t *testing.T) {
 	}
 	fc := &fakeGitWriter{}
 	w := NewWorkspace(fc, s, "helix-specs", "", "")
-	if err := w.MirrorFile(context.Background(), "org-test", wid, "runtime-instructions.md", "# Instructions v2", ""); err != nil {
+	if err := w.MirrorFile(context.Background(), "org-test", wid, "notes.md", "# Notes v2", ""); err != nil {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	state, _ := LoadState(context.Background(), s, "org-test", wid)
 	if state.SessionID != "ses_warm" {
-		t.Errorf("instruction edit must preserve warm session; got %q", state.SessionID)
+		t.Errorf("artifact edit must preserve warm session; got %q", state.SessionID)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -37,22 +37,18 @@ import (
 // is correct for tests and for HumanWorker activations.
 type Spawner func(ctx context.Context, orgID string, workerID orgchart.NodeID, triggers []activation.Trigger) error
 
-// WorkspaceSync mirrors the canonical Role and Identity content of a
-// Worker into wherever that Worker's runtime reads them at activation
-// time. Tools (update_role, update_identity) call MirrorFile after
-// persisting to the DB so the next activation sees fresh content
-// without waiting for the spawner's projection step.
+// WorkspaceSync mirrors canonical Worker instructions into wherever the
+// runtime reads them at activation time. Tools call MirrorFile after
+// persisting to the DB so the next activation sees fresh content.
 //
-// `name` is a logical filename for this Worker — typically "role.md"
-// or "identity.md". The backend maps the name to its own on-target
+// `name` is a logical filename for this Worker — typically
+// "runtime-instructions.md". The backend maps the name to its own on-target
 // layout; callers must NOT include backend-specific path prefixes
 // (no "workers/<id>/.context/...", no "job/..."). The mapping today
 // (helix runtime, the sole concrete impl):
 //
 //   - workers/<workerID>/.context/<name> on the helix-specs branch
-//     of the Worker's per-Worker repo (matches what
-//     `WorkerProject.republishWorkerFiles` writes and what the
-//     activation mandate tells the agent to `git pull` and `cat`)
+//     of the Worker's per-Worker repo
 //
 // `name` must be a clean, single-segment-or-relative filename — no
 // leading slash, no "..", no escape from the Worker's namespace.

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -37,12 +37,9 @@ import (
 // is correct for tests and for HumanWorker activations.
 type Spawner func(ctx context.Context, orgID string, workerID orgchart.NodeID, triggers []activation.Trigger) error
 
-// WorkspaceSync mirrors canonical Worker instructions into wherever the
-// runtime reads them at activation time. Tools call MirrorFile after
-// persisting to the DB so the next activation sees fresh content.
+// WorkspaceSync mirrors a Worker-scoped artifact into its runtime workspace.
 //
-// `name` is a logical filename for this Worker — typically
-// "runtime-instructions.md". The backend maps the name to its own on-target
+// `name` is a logical filename for this Worker. The backend maps the name to its own on-target
 // layout; callers must NOT include backend-specific path prefixes
 // (no "workers/<id>/.context/...", no "job/..."). The mapping today
 // (helix runtime, the sole concrete impl):

--- a/api/pkg/org/infrastructure/runtime/runtime_test.go
+++ b/api/pkg/org/infrastructure/runtime/runtime_test.go
@@ -10,7 +10,7 @@ import (
 func TestNoopWorkspaceSyncIsAlwaysNil(t *testing.T) {
 	t.Parallel()
 	var ws WorkspaceSync = NoopWorkspaceSync{}
-	if err := ws.MirrorFile(context.Background(), "org-test", "w-test", "runtime-instructions.md", "x", "msg"); err != nil {
+	if err := ws.MirrorFile(context.Background(), "org-test", "w-test", "notes.md", "x", "msg"); err != nil {
 		t.Errorf("NoopWorkspaceSync.MirrorFile: %v", err)
 	}
 }
@@ -29,7 +29,7 @@ func TestNoopHireHandlerIsAlwaysNil(t *testing.T) {
 
 func TestValidateWorkspaceName(t *testing.T) {
 	t.Parallel()
-	for _, ok := range []string{"runtime-instructions.md", "notes.md", "sub/file.md"} {
+	for _, ok := range []string{"notes.md", "report.txt", "sub/file.md"} {
 		if err := ValidateWorkspaceName(ok); err != nil {
 			t.Errorf("name %q rejected: %v", ok, err)
 		}

--- a/api/pkg/org/infrastructure/runtime/runtime_test.go
+++ b/api/pkg/org/infrastructure/runtime/runtime_test.go
@@ -10,7 +10,7 @@ import (
 func TestNoopWorkspaceSyncIsAlwaysNil(t *testing.T) {
 	t.Parallel()
 	var ws WorkspaceSync = NoopWorkspaceSync{}
-	if err := ws.MirrorFile(context.Background(), "org-test", "w-test", "role.md", "x", "msg"); err != nil {
+	if err := ws.MirrorFile(context.Background(), "org-test", "w-test", "runtime-instructions.md", "x", "msg"); err != nil {
 		t.Errorf("NoopWorkspaceSync.MirrorFile: %v", err)
 	}
 }
@@ -29,7 +29,7 @@ func TestNoopHireHandlerIsAlwaysNil(t *testing.T) {
 
 func TestValidateWorkspaceName(t *testing.T) {
 	t.Parallel()
-	for _, ok := range []string{"role.md", "identity.md", "sub/file.md"} {
+	for _, ok := range []string{"runtime-instructions.md", "notes.md", "sub/file.md"} {
 		if err := ValidateWorkspaceName(ok); err != nil {
 			t.Errorf("name %q rejected: %v", ok, err)
 		}

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -97,10 +97,6 @@ type Deps struct {
 	AssetSSHProxyAddress string
 	AssetHealth          func(ctx context.Context, orgID, assetRef string) assetssh.Health
 
-	// Workspace is the per-runtime file-mirror port: set_bot_content calls
-	// MirrorFile after the service persists, so the running session sees
-	// the change before the next activation.
-	Workspace           runtime.WorkspaceSync
 	AgentContentUpdater AgentContentUpdater
 	AgentProfileReader  AgentProfileReader
 	// ProjectConfig backs get_bot_project + configure_bot_project
@@ -147,7 +143,6 @@ type Deps struct {
 // same shape as server.NewFromStore), never reached from a tool.
 //
 // Hub/Dispatcher are optional (nil → publish skips notify/dispatch).
-// Workspace defaults to a no-op for tests.
 type Config struct {
 	Store               *store.Store
 	Queries             *queries.Queries
@@ -155,7 +150,6 @@ type Config struct {
 	NewID               IDGen
 	Hub                 *wakebus.Bus
 	Dispatcher          EventDispatcher
-	Workspace           runtime.WorkspaceSync
 	AgentContentUpdater AgentContentUpdater
 	AgentProfileReader  AgentProfileReader
 	HireHook            runtime.HireHook
@@ -221,7 +215,6 @@ func (c Config) Build() Deps {
 		SandboxSSHIssuer:     c.SandboxSSHIssuer,
 		AssetSSHProxyAddress: c.AssetSSHProxyAddress,
 		AssetHealth:          c.AssetHealth,
-		Workspace:            c.Workspace,
 		AgentContentUpdater:  c.AgentContentUpdater,
 		AgentProfileReader:   c.AgentProfileReader,
 		ProjectConfig:        c.ProjectConfig,
@@ -369,17 +362,15 @@ func (c Config) topicsService() *topics.Topics {
 	})
 }
 
-// DefaultDeps wires production defaults into a Config: real UUIDs and
-// wall-clock time, a no-op WorkspaceSync that callers replace with the
-// runtime-specific implementation, and the Queries facade + Reconciler
-// built off the store. Hub and Dispatcher are left zero — composition
-// callers wire them in before calling Build().
+// DefaultDeps wires production defaults into a Config: real UUIDs,
+// wall-clock time, and the Queries facade + Reconciler built off the store.
+// Hub and Dispatcher are left zero — composition callers wire them in before
+// calling Build().
 func DefaultDeps(s *store.Store) Config {
 	c := Config{
 		Store:               s,
 		Now:                 func() time.Time { return time.Now().UTC() },
 		NewID:               uuid.NewString,
-		Workspace:           runtime.NoopWorkspaceSync{},
 		HireHook:            runtime.NoopHireHook{},
 		ProjectConfig:       runtime.NoopProjectConfig{},
 		SpecTasks:           runtime.NoopSpecTasks{},
@@ -407,9 +398,6 @@ func DefaultDeps(s *store.Store) Config {
 // mutations on the org graph plus the matching read tools. Test tools
 // (like Ping) are not included.
 func RegisterBuiltins(reg *Registry, deps Deps) error {
-	if deps.Workspace == nil {
-		return fmt.Errorf("tools.RegisterBuiltins: deps.Workspace is required (use runtime.NoopWorkspaceSync{} for tests)")
-	}
 	if deps.Publishing == nil {
 		return fmt.Errorf("tools.RegisterBuiltins: deps.Publishing is required")
 	}

--- a/api/pkg/org/interfaces/mcptools/set_bot_content.go
+++ b/api/pkg/org/interfaces/mcptools/set_bot_content.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
-	"github.com/helixml/helix/api/pkg/org/domain/briefing"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 )
@@ -16,7 +15,7 @@ import (
 // SetBotContent rewrites a Bot's markdown content (its prompt). Tools and
 // subscriptions are untouched — use attach_tool/detach_tool for tools and
 // subscribe/unsubscribe for streams. The change takes effect on the Bot's
-// next activation; the running session sees it via the workspace mirror.
+// next activation, when the spawner refreshes the session-scoped profile.
 // Owner-only.
 type SetBotContent struct {
 	deps Deps
@@ -74,8 +73,5 @@ func (t *SetBotContent) Invoke(ctx context.Context, inv tool.Invocation) (json.R
 			return nil, fmt.Errorf("update linked agent content: %w", err)
 		}
 	}
-	// Keep the single canonical instruction projection current. The spawner
-	// republishes it with any org-level override before the next activation.
-	_ = t.deps.Workspace.MirrorFile(ctx, orgID, botID, "runtime-instructions.md", briefing.BuildInstructions(botID, updated.Content), fmt.Sprintf("set_bot_content: %s", botID))
 	return json.Marshal(map[string]string{"id": string(botID)})
 }

--- a/api/pkg/org/interfaces/mcptools/set_bot_content.go
+++ b/api/pkg/org/interfaces/mcptools/set_bot_content.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
+	"github.com/helixml/helix/api/pkg/org/domain/briefing"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 )
@@ -73,8 +74,8 @@ func (t *SetBotContent) Invoke(ctx context.Context, inv tool.Invocation) (json.R
 			return nil, fmt.Errorf("update linked agent content: %w", err)
 		}
 	}
-	// Mirror the new content into the bot's Environment so a running
-	// session sees it without waiting for the next activation.
-	_ = t.deps.Workspace.MirrorFile(ctx, orgID, botID, "role.md", updated.Content, fmt.Sprintf("set_bot_content: %s", botID))
+	// Keep the single canonical instruction projection current. The spawner
+	// republishes it with any org-level override before the next activation.
+	_ = t.deps.Workspace.MirrorFile(ctx, orgID, botID, "runtime-instructions.md", briefing.BuildInstructions(botID, updated.Content), fmt.Sprintf("set_bot_content: %s", botID))
 	return json.Marshal(map[string]string{"id": string(botID)})
 }

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -36,7 +36,7 @@ type ToolDTO struct {
 }
 
 // BotDTO is one row in GET /bots and the body of GET /bots/{id}. A Bot
-// IS its own job description: Content is the canonical role.md markdown,
+// IS its own job description: Content is the canonical instruction markdown,
 // Tools is its live MCP surface. ParentIDs are the Nodes this one reports
 // to (empty for the org root). Reporting is many-to-many — a Bot may
 // report to several managers. A Bot's subscriptions are not on the bot —

--- a/api/pkg/server/exploratory_session_activation_test.go
+++ b/api/pkg/server/exploratory_session_activation_test.go
@@ -139,10 +139,12 @@ func (s *ExploratorySessionActivationSuite) TestActivationReusesExistingExplorat
 
 	// The request shape sent by helix-org's inProcHelixClient.StartSession.
 	req := &types.SessionChatRequest{
-		ProjectID:      projectID,
-		OrganizationID: orgID,
-		SessionRole:    "exploratory",
-		AgentType:      "zed_external",
+		ProjectID:           projectID,
+		OrganizationID:      orgID,
+		SessionRole:         "exploratory",
+		AgentType:           "zed_external",
+		OrgWorkerID:         "b-alex",
+		RuntimeInstructions: "worker instructions",
 		Messages: []*types.Message{{
 			Role:    "user",
 			Content: types.MessageContent{Parts: []any{"activation prompt"}},
@@ -158,6 +160,8 @@ func (s *ExploratorySessionActivationSuite) TestActivationReusesExistingExplorat
 	// because StartExternalAgentSession unconditionally generates a fresh id.
 	s.Equal(existingSID, got.ID,
 		"activation must reuse the project's existing exploratory session id, not mint a parallel one")
+	s.Equal("b-alex", got.Metadata.OrgWorkerID)
+	s.Equal("worker instructions", got.Metadata.RuntimeInstructions)
 
 	// StartDesktop must have been called with the reused id so the hydra
 	// session map key matches what GetProjectExploratorySession returns.

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -505,12 +505,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	deps.AgentContentUpdater = inProcClient
 	deps.AgentProfileReader = inProcClient
 
-	// Build the single Workspace shared by the WorkerProject (for
-	// first-apply file pushes — agent.md / role.md / identity.md)
-	// and update_role / update_identity (which call MirrorFile to
-	// re-push canonical content on demand). One place owns the
-	// on-branch path layout. Held in a local and injected into the
-	// project applier below — no package global.
+	// Build the single Workspace used by the activation spawner and
+	// set_bot_content to publish the canonical runtime instruction file.
+	// One place owns the on-branch path layout; there is no package global.
 	var orgWorkspace *runtimehelix.Workspace
 	if cfg.GitRepositoryService != nil {
 		gitWriter := cfg.GitRepositoryService.(runtimehelix.WorkspaceGit)
@@ -590,7 +587,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		projectSvc: inProcClient,
 		Store:      st,
 		helixStore: helixStore,
-		workspace:  orgWorkspace,
 		logger:     logger,
 	}
 
@@ -687,6 +683,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		SpawnerClient: inProcClient,
 		ProjectSvc:    inProcClient,
 		OrgStore:      st,
+		Workspace:     orgWorkspace,
 		Hub:           bc,
 		PubSub:        cfg.APIServer.pubsub,
 		Logger:        logger,
@@ -1260,13 +1257,7 @@ type dynamicProjectApplier struct {
 	// helixStore is the main Helix store, used only to resolve the org's
 	// display name for the `<Bot> @ <Org>` project label.
 	helixStore helixstore.Store
-	// workspace is the single on-branch Workspace shared with the
-	// update_role/update_identity tools. Injected here (rather than read
-	// from a package global) so initialisation order is explicit. nil is
-	// allowed — the applier just builds WorkerProjects without a mirror
-	// (the in-memory / no-git wirings).
-	workspace *runtimehelix.Workspace
-	logger    *slog.Logger
+	logger     *slog.Logger
 }
 
 // Ensure satisfies chat.ProjectEnsurer. Builds a fresh
@@ -1281,7 +1272,7 @@ type dynamicProjectApplier struct {
 // The Spawner does the same on its own activations; owner-chat goes
 // through this path only.
 func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, workerID orgchart.NodeID) (projectID, agentAppID, repoID string, err error) {
-	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.workspace, d.logger)
+	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.logger)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -1341,7 +1332,6 @@ func buildHelixOrgProjectApplier(
 	cfg *configregistry.Registry,
 	projectSvc runtimehelix.ProjectService,
 	orgStore *helixorgstore.Store,
-	workspace *runtimehelix.Workspace,
 	logger *slog.Logger,
 ) (*runtimehelix.WorkerProject, string, error) {
 	apiKey, _ := cfg.GetString(ctx, orgID, "helix.api_key")
@@ -1362,7 +1352,6 @@ func buildHelixOrgProjectApplier(
 	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
 	return &runtimehelix.WorkerProject{
 		Service:     projectSvc,
-		Workspace:   workspace,
 		Store:       orgStore,
 		HelixOrgURL: helixOrgURL,
 		OrgID:       orgID,
@@ -1446,6 +1435,7 @@ type spawnerDeps struct {
 	// verify the Helix project exists without a nil-deref. Required.
 	ProjectSvc runtimehelix.ProjectService
 	OrgStore   *helixorgstore.Store
+	Workspace  *runtimehelix.Workspace
 	Hub        *wakebus.Bus
 	// PubSub is the host API's NATS pubsub; the per-activation bridge
 	// calls SubscribeSessionUpdates on it. Required.
@@ -1482,6 +1472,7 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 	return runtimehelix.SpawnerConfig{
 		Client:         d.SpawnerClient,
 		ProjectService: d.ProjectSvc,
+		Workspace:      d.Workspace,
 		HelixOrgURL:    helixOrgURL,
 		OrgID:          orgID,
 		OrgDisplayName: orgDisplayName(ctx, d.HelixStore, orgID),

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -305,9 +305,8 @@ func buildOrgServices(st *helixorgstore.Store, deps *mcptools.Config, bc *wakebu
 // org-shaped route + lifecycle hook lives here.
 func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRouter, authRouter *mux.Router) error {
 	orgHandlers, err := initHelixOrgHandler(helixOrgConfig{
-		LocalFSPath:          s.Cfg.FileStore.LocalFSPath,
-		GitRepositoryService: s.gitRepositoryService,
-		APIServer:            s,
+		LocalFSPath: s.Cfg.FileStore.LocalFSPath,
+		APIServer:   s,
 	}, s.Store)
 	if err != nil {
 		return fmt.Errorf("initialise helix-org: %w", err)
@@ -505,16 +504,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	deps.AgentContentUpdater = inProcClient
 	deps.AgentProfileReader = inProcClient
 
-	// Build the single Workspace used by the activation spawner and
-	// set_bot_content to publish the canonical runtime instruction file.
-	// One place owns the on-branch path layout; there is no package global.
-	var orgWorkspace *runtimehelix.Workspace
-	if cfg.GitRepositoryService != nil {
-		gitWriter := cfg.GitRepositoryService.(runtimehelix.WorkspaceGit)
-		orgWorkspace = runtimehelix.NewWorkspace(gitWriter, st, "helix-specs", "helix-org", "helix-org@helix.local")
-		deps.Workspace = orgWorkspace
-	}
-
 	// Wire the helix-runtime HireHook so hire_worker persists the
 	// hiring user's identifier onto the new Worker's runtime state.
 	// Replaces the direct runtimehelix.SaveHiringUser call hire_worker
@@ -683,7 +672,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		SpawnerClient: inProcClient,
 		ProjectSvc:    inProcClient,
 		OrgStore:      st,
-		Workspace:     orgWorkspace,
 		Hub:           bc,
 		PubSub:        cfg.APIServer.pubsub,
 		Logger:        logger,
@@ -1235,9 +1223,8 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 // tree (falls back to os.TempDir() when empty). APIServer=nil
 // disables helix-org entirely.
 type helixOrgConfig struct {
-	LocalFSPath          string
-	GitRepositoryService runtimehelix.WorkspaceGit
-	APIServer            *HelixAPIServer
+	LocalFSPath string
+	APIServer   *HelixAPIServer
 }
 
 // dynamicProjectApplier is a chat.ProjectEnsurer that re-reads
@@ -1435,7 +1422,6 @@ type spawnerDeps struct {
 	// verify the Helix project exists without a nil-deref. Required.
 	ProjectSvc runtimehelix.ProjectService
 	OrgStore   *helixorgstore.Store
-	Workspace  *runtimehelix.Workspace
 	Hub        *wakebus.Bus
 	// PubSub is the host API's NATS pubsub; the per-activation bridge
 	// calls SubscribeSessionUpdates on it. Required.
@@ -1472,7 +1458,6 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 	return runtimehelix.SpawnerConfig{
 		Client:         d.SpawnerClient,
 		ProjectService: d.ProjectSvc,
-		Workspace:      d.Workspace,
 		HelixOrgURL:    helixOrgURL,
 		OrgID:          orgID,
 		OrgDisplayName: orgDisplayName(ctx, d.HelixStore, orgID),

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gorilla/mux"
 	"gorm.io/gorm"
 
+	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
@@ -852,6 +853,12 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 	if err != nil {
 		return "", fmt.Errorf("start external agent session: %w", err)
 	}
+	if params.Name != "" && session.Name != params.Name {
+		session.Name = params.Name
+		if _, err := c.server.Store.UpdateSession(ctx, *session); err != nil {
+			return "", fmt.Errorf("name external agent session: %w", err)
+		}
+	}
 	return session.ID, nil
 }
 
@@ -891,6 +898,46 @@ func (c *inProcHelixClient) ClearSession(ctx context.Context, sessionID string) 
 	}
 	if _, herr := c.server.clearSessionHandler(nil, r); herr != nil {
 		return fmt.Errorf("clear session %s: %s", sessionID, herr.Error())
+	}
+	return nil
+}
+
+// SyncAgentProfile refreshes the display name on every existing session and
+// the instruction files read natively by Codex and Claude on running desktops.
+// The spawner calls this before clearing the existing ACP thread.
+func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, sessionName, instructions string) error {
+	if sessionID == "" {
+		return errors.New("SyncAgentProfile: sessionID is required")
+	}
+	session, err := c.server.Store.GetSession(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("get session %s: %w", sessionID, err)
+	}
+	if sessionName != "" && session.Name != sessionName {
+		session.Name = sessionName
+		if _, err := c.server.Store.UpdateSession(ctx, *session); err != nil {
+			return fmt.Errorf("name session %s: %w", sessionID, err)
+		}
+	}
+	if c.server.externalAgentExecutor == nil {
+		return errors.New("SyncAgentProfile: external agent executor is not configured")
+	}
+	if !c.server.externalAgentExecutor.HasRunningContainer(ctx, sessionID) {
+		return nil
+	}
+	runtimeSession, err := c.server.externalAgentExecutor.GetSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("get running desktop session %s: %w", sessionID, err)
+	}
+	sandboxID := runtimeSession.SandboxID
+	if sandboxID == "" {
+		sandboxID = "local"
+	}
+	hydraClient := hydra.NewRevDialClient(c.server.connman, "hydra-"+sandboxID)
+	for _, path := range []string{"/home/retro/work/AGENTS.md", "/home/retro/work/CLAUDE.md"} {
+		if err := hydraClient.WriteSandboxFile(ctx, sessionID, path, []byte(instructions), 0o644); err != nil {
+			return fmt.Errorf("write %s for session %s: %w", path, sessionID, err)
+		}
 	}
 	return nil
 }

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -486,6 +486,34 @@ func (c *inProcHelixClient) PutProjectSecret(ctx context.Context, projectID, nam
 	return nil
 }
 
+// DeleteProjectSecret removes a named project secret when present. It is used
+// to migrate worker identity out of project scope; absence is already the
+// desired state and is therefore idempotent.
+func (c *inProcHelixClient) DeleteProjectSecret(ctx context.Context, projectID, name string) error {
+	listReq, err := c.newRequest(ctx, http.MethodGet, "/api/v1/projects/"+projectID+"/secrets", nil, map[string]string{"id": projectID})
+	if err != nil {
+		return err
+	}
+	existing, herr := c.server.listProjectSecrets(nil, listReq)
+	if herr != nil {
+		return fmt.Errorf("delete project secret (list): %s", herr.Error())
+	}
+	for _, secret := range existing {
+		if secret == nil || secret.Name != name {
+			continue
+		}
+		r, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/secrets/"+secret.ID, nil, map[string]string{"id": secret.ID})
+		if err != nil {
+			return err
+		}
+		if _, herr := c.server.deleteSecret(nil, r); herr != nil {
+			return fmt.Errorf("delete project secret: %s", herr.Error())
+		}
+		return nil
+	}
+	return nil
+}
+
 // ListProjectSecrets returns the project's dev-scoped secrets as a
 // decrypted name→value map. Reuses GetProjectSecretsAsEnvVars (the same
 // resolver the desktop-boot injection uses) so scope filtering and
@@ -843,7 +871,9 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 		SessionRole:    "exploratory",
 		// Org workers are fully autonomous — nobody is watching to click the
 		// in-chat Restart button — so recover the agent automatically on crash.
-		AutoRestartOnCrash: true,
+		AutoRestartOnCrash:  true,
+		OrgWorkerID:         params.WorkerID,
+		RuntimeInstructions: params.Instructions,
 		Messages: []*types.Message{{
 			Role:    "user",
 			Content: types.MessageContent{Parts: []any{params.Prompt}},
@@ -905,7 +935,7 @@ func (c *inProcHelixClient) ClearSession(ctx context.Context, sessionID string) 
 // SyncAgentProfile refreshes the display name on every existing session and
 // the instruction files read natively by Codex and Claude on running desktops.
 // The spawner calls this before clearing the existing ACP thread.
-func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, sessionName, instructions string) error {
+func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string) error {
 	if sessionID == "" {
 		return errors.New("SyncAgentProfile: sessionID is required")
 	}
@@ -913,10 +943,19 @@ func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, ses
 	if err != nil {
 		return fmt.Errorf("get session %s: %w", sessionID, err)
 	}
+	changed := false
 	if sessionName != "" && session.Name != sessionName {
 		session.Name = sessionName
+		changed = true
+	}
+	if session.Metadata.OrgWorkerID != workerID || session.Metadata.RuntimeInstructions != instructions {
+		session.Metadata.OrgWorkerID = workerID
+		session.Metadata.RuntimeInstructions = instructions
+		changed = true
+	}
+	if changed {
 		if _, err := c.server.Store.UpdateSession(ctx, *session); err != nil {
-			return fmt.Errorf("name session %s: %w", sessionID, err)
+			return fmt.Errorf("update agent profile for session %s: %w", sessionID, err)
 		}
 	}
 	if c.server.externalAgentExecutor == nil {

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -363,6 +363,19 @@ func TestInProcSpawnerClient_ClearSession_NoSession_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestInProcSpawnerClient_SyncAgentProfileRenamesStoppedSession(t *testing.T) {
+	_, store, client, _, ctx := newInProcTestSetup(t)
+	_, err := store.CreateSession(ctx, types.Session{ID: "ses_profile", Name: "You are Bot old"})
+	require.NoError(t, err)
+
+	err = client.SyncAgentProfile(ctx, "ses_profile", "Build Engineer", "instructions")
+	require.ErrorContains(t, err, "external agent executor is not configured")
+
+	got, err := store.GetSession(ctx, "ses_profile")
+	require.NoError(t, err)
+	require.Equal(t, "Build Engineer", got.Name)
+}
+
 // TestParseEnvVarsToMap pins the KEY=value split that backs
 // ListProjectSecrets / list_secrets. A value containing `=` (base64,
 // tokens, URL query strings) must survive intact — Cut on the FIRST `=`

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -368,12 +368,14 @@ func TestInProcSpawnerClient_SyncAgentProfileRenamesStoppedSession(t *testing.T)
 	_, err := store.CreateSession(ctx, types.Session{ID: "ses_profile", Name: "You are Bot old"})
 	require.NoError(t, err)
 
-	err = client.SyncAgentProfile(ctx, "ses_profile", "Build Engineer", "instructions")
+	err = client.SyncAgentProfile(ctx, "ses_profile", "Build Engineer", "w-build", "instructions")
 	require.ErrorContains(t, err, "external agent executor is not configured")
 
 	got, err := store.GetSession(ctx, "ses_profile")
 	require.NoError(t, err)
 	require.Equal(t, "Build Engineer", got.Name)
+	require.Equal(t, "w-build", got.Metadata.OrgWorkerID)
+	require.Equal(t, "instructions", got.Metadata.RuntimeInstructions)
 }
 
 // TestParseEnvVarsToMap pins the KEY=value split that backs

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2884,6 +2884,13 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 	if req.AutoRestartOnCrash {
 		session.Metadata.AutoRestartOnCrash = true
 	}
+	if req.OrgWorkerID != "" {
+		if req.RuntimeInstructions == "" {
+			return nil, fmt.Errorf("runtime instructions are required for org worker %s", req.OrgWorkerID)
+		}
+		session.Metadata.OrgWorkerID = req.OrgWorkerID
+		session.Metadata.RuntimeInstructions = req.RuntimeInstructions
+	}
 
 	if req.AppID != "" {
 		app, err := s.Store.GetApp(ctx, req.AppID)

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -415,10 +415,16 @@ type SessionMetadata struct {
 	DocumentGroupID         string              `json:"document_group_id"`
 	ManuallyReviewQuestions bool                `json:"manually_review_questions"`
 	SystemPrompt            string              `json:"system_prompt"`
-	HelixVersion            string              `json:"helix_version"`
-	Stream                  bool                `json:"stream"`
-	AgentType               string              `json:"agent_type,omitempty"`     // Agent type: "helix" or "zed_external"
-	SystemSession           bool                `json:"system_session,omitempty"` // True for internal system sessions (e.g., summary generation) - skip summary generation to avoid loops
+	// OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for
+	// helix-org workers. Hydra materializes the instructions as native agent
+	// files in this session's workspace before starting the desktop. Ordinary
+	// project and SpecTask sessions leave both fields empty.
+	OrgWorkerID         string `json:"org_worker_id,omitempty"`
+	RuntimeInstructions string `json:"runtime_instructions,omitempty"`
+	HelixVersion        string `json:"helix_version"`
+	Stream              bool   `json:"stream"`
+	AgentType           string `json:"agent_type,omitempty"`     // Agent type: "helix" or "zed_external"
+	SystemSession       bool   `json:"system_session,omitempty"` // True for internal system sessions (e.g., summary generation) - skip summary generation to avoid loops
 
 	// Autonomous crash recovery. Set true at session creation for surfaces with
 	// no human present to click the in-chat Restart button (spec tasks, org
@@ -561,6 +567,12 @@ type SessionChatRequest struct {
 	Provider            Provider             `json:"provider"`                        // The provider to use
 	Model               string               `json:"model"`                           // The model to use
 	Regenerate          bool                 `json:"regenerate"`                      // If true, we will regenerate the response for the last message
+	// OrgWorkerID and RuntimeInstructions are internal in-process inputs used by
+	// the helix-org spawner. They are deliberately not part of the public chat
+	// API: SpecTask and exploratory sessions in the same project must not inherit
+	// a Worker's identity.
+	OrgWorkerID         string `json:"-"`
+	RuntimeInstructions string `json:"-"`
 }
 
 // ExternalAgentConfig holds display configuration for external agent sessions
@@ -1943,6 +1955,9 @@ type DesktopAgent struct {
 	Input string `json:"input"`
 	// Environment variables for the Zed instance
 	Env []string `json:"env"`
+	// WorkspaceFiles are written into the session's /home/retro/work bind mount
+	// by Hydra before the container starts. Paths are relative to that root.
+	WorkspaceFiles map[string][]byte `json:"workspace_files,omitempty"`
 	// Working directory for the Zed instance
 	WorkDir string `json:"work_dir"`
 	// Project path to open in Zed (optional)

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -137,15 +137,16 @@ only adjacent tool calls into a run. Each run shows its newest call and a
 `+N previous tool calls` disclosure; later prose starts a new run. The last text
 entry of a completed turn remains the final answer below the work disclosure.
 While streaming, every visible prose or tool entry stays in the live timeline
-because there is not yet a reliable final-answer boundary. Internal
-thinking-only entries are represented by compact `Thoughts` disclosures rather
-than assistant prose, and do not displace the final answer. They remain at their
-original positions inside the work transcript and split tool runs, so only
-genuinely adjacent calls are collapsed together. The disclosure body renders as
-Markdown; bold-only thought summaries are presented as one list rather than
-showing literal Markdown punctuation. The bulb icon identifies thought rows, so
-their headers show the first summary directly without a repeated `Thoughts`
-label.
+because there is not yet a reliable final-answer boundary. The live activity
+surface is intentionally compact: it keeps visible progress prose, collapses all
+tool calls into one run whose newest call remains visible, and shows only the
+latest thought state. Once the turn completes, internal thinking entries return
+to their original positions inside the work transcript and split tool runs, so
+only genuinely adjacent calls are collapsed together. The disclosure body
+renders as Markdown; bold-only thought summaries are presented as one list
+rather than showing literal Markdown punctuation. The bulb icon identifies
+thought rows, so their headers show the first summary directly without a
+repeated `Thoughts` label.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -149,7 +149,10 @@ showing literal Markdown punctuation. The bulb icon identifies thought rows, so
 their headers show the first summary directly without a repeated `Thoughts`
 label. The previous-tool-call disclosure uses the same high-contrast label color
 and left icon alignment as the visible tool row, while its chevron uses the same
-subtle icon color as the tool-kind icon.
+subtle icon color as the tool-kind icon. Expanding keeps the latest call and
+disclosure fixed, inserting older calls below the disclosure so the cursor does
+not have to chase a relocated collapse control. The redundant expanded `Tool
+calls` header is omitted to keep activity-group spacing compact.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -147,6 +147,10 @@ showing literal Markdown punctuation. The bulb icon identifies thought rows, so
 their headers show the first summary directly without a repeated `Thoughts`
 label.
 
+Primary assistant prose uses a high-contrast near-white foreground in dark mode,
+including links. Reasoning summaries, command previews, durations, and other
+activity metadata remain muted to preserve the visual hierarchy.
+
 Shell results use `Ran command` plus the command preview. MCP calls use
 `Provider · tool` labels. This presentation is derived from the structured tool
 metadata and terminal result shape; it does not change or discard raw output.

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -147,7 +147,8 @@ genuinely adjacent calls are collapsed together. The disclosure body renders as
 Markdown; bold-only thought summaries are presented as one list rather than
 showing literal Markdown punctuation. The bulb icon identifies thought rows, so
 their headers show the first summary directly without a repeated `Thoughts`
-label.
+label. The previous-tool-call disclosure uses the same high-contrast label color
+and left icon alignment as the visible tool row.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -139,7 +139,10 @@ entry of a completed turn remains the final answer below the work disclosure.
 While streaming, every visible prose or tool entry stays in the live timeline
 because there is not yet a reliable final-answer boundary. Internal
 thinking-only entries are not promoted into visible progress rows and do not
-split an adjacent tool run.
+split an adjacent tool run. The final reasoning bundle remains behind one
+`Thoughts` disclosure after the work transcript. Its body renders as compact
+Markdown; bold-only thought summaries are presented as one list rather than
+showing literal Markdown punctuation or fragmenting the tool timeline.
 
 Shell results use `Ran command` plus the command preview. MCP calls use
 `Provider · tool` labels. This presentation is derived from the structured tool

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -138,11 +138,12 @@ only adjacent tool calls into a run. Each run shows its newest call and a
 entry of a completed turn remains the final answer below the work disclosure.
 While streaming, every visible prose or tool entry stays in the live timeline
 because there is not yet a reliable final-answer boundary. Internal
-thinking-only entries are not promoted into visible progress rows and do not
-split an adjacent tool run. The final reasoning bundle remains behind one
-`Thoughts` disclosure after the work transcript. Its body renders as compact
+thinking-only entries are represented by compact `Thoughts` disclosures rather
+than assistant prose, and do not displace the final answer. They remain at their
+original positions inside the work transcript and split tool runs, so only
+genuinely adjacent calls are collapsed together. The disclosure body renders as
 Markdown; bold-only thought summaries are presented as one list rather than
-showing literal Markdown punctuation or fragmenting the tool timeline.
+showing literal Markdown punctuation.
 
 Shell results use `Ran command` plus the command preview. MCP calls use
 `Provider · tool` labels. This presentation is derived from the structured tool

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -149,7 +149,10 @@ label.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other
-activity metadata remain muted to preserve the visual hierarchy.
+activity metadata use two brighter gray tiers rather than opacity-composited
+text: readable secondary labels and quieter tertiary details. Activity rows use
+the shared application mono font so their metrics are consistent with the T3
+Code-style work log.
 
 Shell results use `Ran command` plus the command preview. MCP calls use
 `Provider · tool` labels. This presentation is derived from the structured tool

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -148,7 +148,8 @@ Markdown; bold-only thought summaries are presented as one list rather than
 showing literal Markdown punctuation. The bulb icon identifies thought rows, so
 their headers show the first summary directly without a repeated `Thoughts`
 label. The previous-tool-call disclosure uses the same high-contrast label color
-and left icon alignment as the visible tool row.
+and left icon alignment as the visible tool row, while its chevron uses the same
+subtle icon color as the tool-kind icon.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -129,6 +129,22 @@ Both requested surfaces share the transcript renderer and composer primitives bu
 - image rendering: `frontend/src/components/session/InteractionInference.tsx`
 - composer: `frontend/src/components/common/RobustPromptInput.tsx`
 
+### Structured activity ordering
+
+`response_entries` is an ordered transcript, not two independent collections.
+The renderer keeps assistant progress text in its original position and collapses
+only adjacent tool calls into a run. Each run shows its newest call and a
+`+N previous tool calls` disclosure; later prose starts a new run. The last text
+entry of a completed turn remains the final answer below the work disclosure.
+While streaming, every visible prose or tool entry stays in the live timeline
+because there is not yet a reliable final-answer boundary. Internal
+thinking-only entries are not promoted into visible progress rows and do not
+split an adjacent tool run.
+
+Shell results use `Ran command` plus the command preview. MCP calls use
+`Provider · tool` labels. This presentation is derived from the structured tool
+metadata and terminal result shape; it does not change or discard raw output.
+
 ### Current visual differences
 
 | Area | Helix today | T3 direction |

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -143,7 +143,9 @@ than assistant prose, and do not displace the final answer. They remain at their
 original positions inside the work transcript and split tool runs, so only
 genuinely adjacent calls are collapsed together. The disclosure body renders as
 Markdown; bold-only thought summaries are presented as one list rather than
-showing literal Markdown punctuation.
+showing literal Markdown punctuation. The bulb icon identifies thought rows, so
+their headers show the first summary directly without a repeated `Thoughts`
+label.
 
 Shell results use `Ran command` plus the command preview. MCP calls use
 `Provider · tool` labels. This presentation is derived from the structured tool

--- a/design/2026-08-03-t3-code-inspired-chat-redesign.md
+++ b/design/2026-08-03-t3-code-inspired-chat-redesign.md
@@ -139,14 +139,15 @@ entry of a completed turn remains the final answer below the work disclosure.
 While streaming, every visible prose or tool entry stays in the live timeline
 because there is not yet a reliable final-answer boundary. The live activity
 surface is intentionally compact: it keeps visible progress prose, collapses all
-tool calls into one run whose newest call remains visible, and shows only the
-latest thought state. Once the turn completes, internal thinking entries return
-to their original positions inside the work transcript and split tool runs, so
-only genuinely adjacent calls are collapsed together. The disclosure body
-renders as Markdown; bold-only thought summaries are presented as one list
-rather than showing literal Markdown punctuation. The bulb icon identifies
-thought rows, so their headers show the first summary directly without a
-repeated `Thoughts` label.
+tool calls into one run whose newest call remains visible, and hides internal
+thinking because the persistent `Working for …` status already communicates the
+active state. Once the turn completes, internal thinking entries return to their
+original positions inside the work transcript and split tool runs, so only
+genuinely adjacent calls are collapsed together. The disclosure body renders as
+Markdown; bold-only thought summaries are presented as one list rather than
+showing literal Markdown punctuation. The bulb icon identifies thought rows, so
+their headers show the first summary directly without a repeated `Thoughts`
+label.
 
 Primary assistant prose uses a high-contrast near-white foreground in dark mode,
 including links. Reasoning summaries, command previews, durations, and other

--- a/design/2026-08-05-org-worker-session-instructions.md
+++ b/design/2026-08-05-org-worker-session-instructions.md
@@ -1,0 +1,47 @@
+# Org-worker session instructions
+
+## Failure
+
+Org-worker runtime instructions were written to the worker repository's
+`helix-specs` branch, while desktop startup read them from the project's primary
+repository. A worker project with an attached user repository therefore exited
+workspace setup before launching Zed. Project-scoped `HELIX_WORKER_ID` also made
+ordinary SpecTask sessions enter the org-worker startup path.
+
+## Boundary
+
+Worker identity and resolved instructions are ephemeral session runtime state,
+not repository content or project configuration.
+
+- The spawner stores `OrgWorkerID` and `RuntimeInstructions` on only the worker's
+  exploratory session.
+- Hydra sends `AGENTS.md` and `CLAUDE.md` as pre-start workspace files and writes
+  them into the session bind mount before starting the desktop container.
+- Warm activations update the same session state and live files before clearing
+  the ACP thread.
+- Activation prompts contain only the trigger plus a short instruction-file
+  reload hint.
+- SpecTask sessions have no worker bootstrap state and receive no worker files.
+- The legacy project secret is filtered during startup and removed on the next
+  worker-project reconciliation.
+
+No runtime instruction content is committed to Git.
+
+## Verification
+
+- Unit tests cover fresh and warm spawner propagation, org-worker versus
+  SpecTask scoping, legacy secret filtering, atomic workspace materialization,
+  and session metadata refresh.
+- Live verification must start one org worker and one SpecTask in the same
+  multi-repository project. The worker must launch Zed with matching native
+  instruction files; the SpecTask must launch without those files or
+  `HELIX_WORKER_ID`.
+
+Live verification on 2026-08-05 used b-alex's multi-repository project:
+
+- Org-worker session `ses_01kz8gccz50110gva8r2t535kx` started with matching
+  root instruction files and connected Zed thread
+  `019fd106-b943-79e2-b096-3628696a11c3`.
+- SpecTask `spt_01kz8ggzahr17sh4tpm2a78851` started session
+  `ses_01kz8ghr0x66ymgysskcpywh65` without the files or worker environment and
+  connected Zed thread `019fd109-71a6-75c2-8b2e-cb902f377d6c`.

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -581,24 +581,6 @@ else
 fi
 
 # =========================================
-# Install org-worker runtime instructions
-# =========================================
-# HELIX_WORKER_ID is only present for helix-org worker projects. The API
-# publishes one canonical file to helix-specs before starting the desktop;
-# project it to both runtime-native names before Zed creates an ACP thread.
-if [ -n "${HELIX_WORKER_ID:-}" ]; then
-    WORKER_INSTRUCTIONS="$WORK_DIR/helix-specs/workers/$HELIX_WORKER_ID/.context/runtime-instructions.md"
-    if [ ! -s "$WORKER_INSTRUCTIONS" ]; then
-        echo "FATAL: Runtime instructions missing for worker $HELIX_WORKER_ID at $WORKER_INSTRUCTIONS"
-        exit 1
-    fi
-    install -m 0644 "$WORKER_INSTRUCTIONS" "$WORK_DIR/AGENTS.md"
-    install -m 0644 "$WORKER_INSTRUCTIONS" "$WORK_DIR/CLAUDE.md"
-    echo "Installed org-worker instructions for Codex and Claude"
-    echo ""
-fi
-
-# =========================================
 # Install Helix Git Hooks
 # =========================================
 if [ -f "/usr/local/bin/helix-git-hooks.sh" ]; then

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -581,6 +581,24 @@ else
 fi
 
 # =========================================
+# Install org-worker runtime instructions
+# =========================================
+# HELIX_WORKER_ID is only present for helix-org worker projects. The API
+# publishes one canonical file to helix-specs before starting the desktop;
+# project it to both runtime-native names before Zed creates an ACP thread.
+if [ -n "${HELIX_WORKER_ID:-}" ]; then
+    WORKER_INSTRUCTIONS="$WORK_DIR/helix-specs/workers/$HELIX_WORKER_ID/.context/runtime-instructions.md"
+    if [ ! -s "$WORKER_INSTRUCTIONS" ]; then
+        echo "FATAL: Runtime instructions missing for worker $HELIX_WORKER_ID at $WORKER_INSTRUCTIONS"
+        exit 1
+    fi
+    install -m 0644 "$WORKER_INSTRUCTIONS" "$WORK_DIR/AGENTS.md"
+    install -m 0644 "$WORKER_INSTRUCTIONS" "$WORK_DIR/CLAUDE.md"
+    echo "Installed org-worker instructions for Codex and Claude"
+    echo ""
+fi
+
+# =========================================
 # Install Helix Git Hooks
 # =========================================
 if [ -f "/usr/local/bin/helix-git-hooks.sh" ]; then

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { RouterProvider } from 'react-router5'
 import AllContextProvider from './contexts/all'
 import Layout from './pages/Layout'
-import router, { RenderPage } from './router'
+import router, { useApplicationRoute } from './router'
 import {
   QueryClient,
   QueryClientProvider,
@@ -16,12 +16,20 @@ function AppInner() {
   useAnalyticsInit()
   return (
     <RouterProvider router={router}>
-      <AllContextProvider>
-        <Layout>
-          <RenderPage />
-        </Layout>
-      </AllContextProvider>
+      <ApplicationRoute />
     </RouterProvider>
+  )
+}
+
+function ApplicationRoute() {
+  const appRoute = useApplicationRoute()
+
+  return (
+    <AllContextProvider appRoute={appRoute}>
+      <Layout>
+        {appRoute.render()}
+      </Layout>
+    </AllContextProvider>
   )
 }
 

--- a/frontend/src/components/app/AgentInfoPanel.tsx
+++ b/frontend/src/components/app/AgentInfoPanel.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import Box from '@mui/material/Box'
-import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 
@@ -20,45 +19,43 @@ const AgentInfoPanel: FC<{
   const status = orgAgent?.agent_status
 
   return (
-    <Box sx={{ p: 2 }}>
-      <Paper variant="outlined" sx={{ p: 2 }}>
-        <Stack spacing={2}>
+    <Box sx={{ pt: 2 }}>
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="caption" color="text.secondary">Agent ID</Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+            {orgAgent?.id ?? app.id}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="caption" color="text.secondary">Created</Typography>
+          <Typography variant="body2">{timestamp(orgAgent?.created_at ?? app.created)}</Typography>
+        </Box>
+        <Box>
+          <Typography variant="caption" color="text.secondary">Updated</Typography>
+          <Typography variant="body2">{timestamp(orgAgent?.updated_at ?? app.updated)}</Typography>
+        </Box>
+        {orgAgent && (
           <Box>
-            <Typography variant="caption" color="text.secondary">Agent ID</Typography>
-            <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-              {orgAgent?.id ?? app.id}
-            </Typography>
+            <Typography variant="caption" color="text.secondary">Status</Typography>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              {status && (
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    backgroundColor: status === 'running' ? 'success.main' : 'text.disabled',
+                  }}
+                />
+              )}
+              <Typography variant="body2">
+                {status === 'running' ? 'Running' : status ? 'Stopped' : '-'}
+              </Typography>
+            </Stack>
           </Box>
-          <Box>
-            <Typography variant="caption" color="text.secondary">Created</Typography>
-            <Typography variant="body2">{timestamp(orgAgent?.created_at ?? app.created)}</Typography>
-          </Box>
-          <Box>
-            <Typography variant="caption" color="text.secondary">Updated</Typography>
-            <Typography variant="body2">{timestamp(orgAgent?.updated_at ?? app.updated)}</Typography>
-          </Box>
-          {orgAgent && (
-            <Box>
-              <Typography variant="caption" color="text.secondary">Status</Typography>
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {status && (
-                  <Box
-                    sx={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      backgroundColor: status === 'running' ? 'success.main' : 'text.disabled',
-                    }}
-                  />
-                )}
-                <Typography variant="body2">
-                  {status === 'running' ? 'Running' : status ? 'Stopped' : '-'}
-                </Typography>
-              </Stack>
-            </Box>
-          )}
-        </Stack>
-      </Paper>
+        )}
+      </Stack>
     </Box>
   )
 }

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -117,6 +117,8 @@ interface AppSettingsProps {
   readOnly?: boolean,
   showErrors?: boolean,
   isAdmin?: boolean,
+  section: 'instructions' | 'runtime',
+  hideAgentType?: boolean,
 }
 
 const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant called Helix. Today is {{ .LocalDate }}, local time is {{ .LocalTime }}.`
@@ -187,6 +189,8 @@ const AppSettings: FC<AppSettingsProps> = ({
   readOnly = false,
   showErrors = true,
   isAdmin = false,
+  section,
+  hideAgentType = false,
 }) => {
   // Get initial showAdvanced value from URL
   const [showAdvanced, setShowAdvanced] = useState(() => {
@@ -584,9 +588,10 @@ const AppSettings: FC<AppSettingsProps> = ({
 
   return (
     <Box sx={{ mt: 2, mr: 2 }}>
+      {section === 'instructions' && (
       <Box sx={{ mb: 3 }}>
-        <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
-          Configuration
+        <Typography variant="h5" sx={{ mb: 3 }}>
+          Instructions
         </Typography>
         <TextField
           id="app-name"
@@ -637,8 +642,17 @@ const AppSettings: FC<AppSettingsProps> = ({
             Markdown supported. Cmd/Ctrl+S saves immediately.
           </Typography>
         </Box>
+      </Box>
+      )}
+
+      {section === 'runtime' && (
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" sx={{ mb: 3 }}>
+          Runtime
+        </Typography>
 
         {/* Agent Type Selection */}
+      {!hideAgentType && (
       <Box sx={{ mb: 3 }}>
         <Typography variant="subtitle1" sx={{ mb: 2 }}>Agent Type</Typography>
         <AgentTypeSelector
@@ -649,6 +663,7 @@ const AppSettings: FC<AppSettingsProps> = ({
           size="small"
         />
       </Box>
+      )}
 
       {/* External Agent Configuration */}
       {default_agent_type === AGENT_TYPE_ZED_EXTERNAL && (
@@ -1493,6 +1508,7 @@ const AppSettings: FC<AppSettingsProps> = ({
           </Box>
         )}
       </Box>
+      )}
 
     </Box>
   )

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -117,8 +117,9 @@ interface AppSettingsProps {
   readOnly?: boolean,
   showErrors?: boolean,
   isAdmin?: boolean,
-  section: 'instructions' | 'runtime',
+  section: 'general' | 'runtime',
   hideAgentType?: boolean,
+  generalAside?: React.ReactNode,
 }
 
 const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant called Helix. Today is {{ .LocalDate }}, local time is {{ .LocalTime }}.`
@@ -191,6 +192,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   isAdmin = false,
   section,
   hideAgentType = false,
+  generalAside,
 }) => {
   // Get initial showAdvanced value from URL
   const [showAdvanced, setShowAdvanced] = useState(() => {
@@ -588,26 +590,29 @@ const AppSettings: FC<AppSettingsProps> = ({
 
   return (
     <Box sx={{ mt: 2, mr: 2 }}>
-      {section === 'instructions' && (
+      {section === 'general' && (
       <Box sx={{ mb: 3 }}>
         <Typography variant="h5" sx={{ mb: 3 }}>
-          Instructions
+          General
         </Typography>
-        <TextField
-          id="app-name"
-          name="app-name"
-          label="Agent name"
-          value={name}
-          error={showErrors && !name}
-          helperText="Use a name that makes this agent easy to identify."
-          disabled={readOnly}
-          onChange={(event) => setName(event.target.value)}
-          onBlur={() => {
-            if (name !== app.name) void onUpdate({ name })
-          }}
-          fullWidth
-          sx={{ mb: 3 }}
-        />
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} alignItems="flex-start" sx={{ mb: 3 }}>
+          <TextField
+            id="app-name"
+            name="app-name"
+            label="Agent name"
+            value={name}
+            error={showErrors && !name}
+            helperText="Use a name that makes this agent easy to identify."
+            disabled={readOnly}
+            onChange={(event) => setName(event.target.value)}
+            onBlur={() => {
+              if (name !== app.name) void onUpdate({ name })
+            }}
+            fullWidth
+            sx={{ flex: 1 }}
+          />
+          {generalAside}
+        </Stack>
         <Stack direction="row" alignItems="center">
           <Typography gutterBottom>System Instructions</Typography>
           <ResetLink field="system_prompt" value={system_prompt} onClick={() => handleReset('system_prompt')} />
@@ -1000,7 +1005,9 @@ const AppSettings: FC<AppSettingsProps> = ({
 
           <Divider sx={{ my: 2 }} />
 
-          {/* Display Settings - side by side */}
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Sandbox settings
+          </Typography>
           <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1.5 }}>
             Display
           </Typography>

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -609,9 +609,21 @@ const AppSettings: FC<AppSettingsProps> = ({
               if (name !== app.name) void onUpdate({ name })
             }}
             fullWidth
-            sx={{ flex: 1 }}
+            sx={{ flex: '1 1 0', minWidth: 0 }}
           />
-          {generalAside}
+          {generalAside && (
+            <Box
+              sx={{
+                flex: '1 1 0',
+                minWidth: 0,
+                display: 'flex',
+                justifyContent: 'flex-end',
+                mt: { xs: 0, sm: -1 },
+              }}
+            >
+              {generalAside}
+            </Box>
+          )}
         </Stack>
         <Stack direction="row" alignItems="center">
           <Typography gutterBottom>System Instructions</Typography>

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -14,14 +14,11 @@ import Typography from '@mui/material/Typography'
 import Stack from '@mui/material/Stack'
 import Link from '@mui/material/Link'
 import Button from '@mui/material/Button'
-import Collapse from '@mui/material/Collapse'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import Alert from '@mui/material/Alert'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Menu from '@mui/material/Menu'
 
 import { useQuery } from '@tanstack/react-query'
@@ -194,24 +191,6 @@ const AppSettings: FC<AppSettingsProps> = ({
   hideAgentType = false,
   generalAside,
 }) => {
-  // Get initial showAdvanced value from URL
-  const [showAdvanced, setShowAdvanced] = useState(() => {
-    const params = new URLSearchParams(window.location.search)
-    return params.get('showAdvanced') === 'true'
-  })
-
-  // Update URL when showAdvanced changes
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    if (showAdvanced) {
-      params.set('showAdvanced', 'true')
-    } else {
-      params.delete('showAdvanced')
-    }
-    // Update URL without causing a page reload
-    window.history.replaceState({}, '', `${window.location.pathname}?${params}`)
-  }, [showAdvanced])
-
   // State for form fields
   const [name, setName] = useState(app.name || '')
   const [system_prompt, setSystemPrompt] = useState(app.system_prompt || '')
@@ -1203,18 +1182,8 @@ const AppSettings: FC<AppSettingsProps> = ({
         {/* Multi-Turn Agent Configuration */}
         {default_agent_type === AGENT_TYPE_HELIX_AGENT && (
           <Box sx={{ mt: 2 }}>
-            <Button
-              variant="text"
-              onClick={() => setShowAdvanced((value) => !value)}
-              endIcon={showAdvanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              aria-expanded={showAdvanced}
-              aria-controls="advanced-model-settings"
-              sx={{ px: 0, textTransform: 'none' }}
-            >
-              Advanced model settings
-            </Button>
-            <Collapse in={showAdvanced}>
-              <Box id="advanced-model-settings" sx={{ mt: 2 }}>
+            <Typography variant="subtitle1">Advanced model settings</Typography>
+            <Box id="advanced-model-settings" sx={{ mt: 2 }}>
                 <Typography variant="subtitle1" sx={{ mb: 2 }}>Multi-Turn Agent Configuration</Typography>
 
             <Box sx={{ mb: 3 }}>
@@ -1523,7 +1492,6 @@ const AppSettings: FC<AppSettingsProps> = ({
               />
             </Box>
               </Box>
-            </Collapse>
           </Box>
         )}
       </Box>

--- a/frontend/src/components/app/AppSidebar.tsx
+++ b/frontend/src/components/app/AppSidebar.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react'
 
 import {
-  ScrollText,
+  Settings,
   Cpu,
-  Palette,
   Webhook,
   LibraryBig,
   Lightbulb,
@@ -25,7 +24,7 @@ import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 const AppSidebar: FC = () => {
   const router = useRouter()
   const { tab, app_id } = router.params
-  const currentTab = !tab || tab === 'settings' ? 'instructions' : tab
+  const currentTab = !tab || ['settings', 'instructions', 'appearance'].includes(tab) ? 'general' : tab
   
   // Get app data and user access information
   const appTools = useApp(app_id)
@@ -37,11 +36,11 @@ const AppSidebar: FC = () => {
 
   const items: ContextSidebarSection['items'] = [
     {
-      id: 'instructions',
-      label: 'Instructions',
-      icon: <ScrollText size={20} />,
-      isActive: currentTab === 'instructions',
-      onClick: () => handleNavigationClick('instructions')
+      id: 'general',
+      label: 'General',
+      icon: <Settings size={20} />,
+      isActive: currentTab === 'general',
+      onClick: () => handleNavigationClick('general')
     },
     {
       id: 'runtime',
@@ -49,13 +48,6 @@ const AppSidebar: FC = () => {
       icon: <Cpu size={20} />,
       isActive: currentTab === 'runtime',
       onClick: () => handleNavigationClick('runtime')
-    },
-    {
-      id: 'appearance',
-      label: 'Appearance',
-      icon: <Palette size={20} />,
-      isActive: currentTab === 'appearance',
-      onClick: () => handleNavigationClick('appearance')
     },
     {
       id: 'triggers',

--- a/frontend/src/components/app/AppSidebar.tsx
+++ b/frontend/src/components/app/AppSidebar.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react'
 
 import {
-  Settings,
+  ScrollText,
+  Cpu,
+  Palette,
   Webhook,
   LibraryBig,
   Lightbulb,
@@ -23,7 +25,7 @@ import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 const AppSidebar: FC = () => {
   const router = useRouter()
   const { tab, app_id } = router.params
-  const currentTab = tab === 'appearance' ? 'settings' : tab || 'settings'
+  const currentTab = !tab || tab === 'settings' ? 'instructions' : tab
   
   // Get app data and user access information
   const appTools = useApp(app_id)
@@ -33,114 +35,109 @@ const AppSidebar: FC = () => {
     router.setParams({ tab: tabValue })
   }
 
-  const sections: ContextSidebarSection[] = [
+  const items: ContextSidebarSection['items'] = [
     {
-      title: 'Agent Configuration',
-      items: [
-        {
-          id: 'settings',
-          label: 'Instructions & Runtime',
-          icon: <Settings size={20} />,
-          isActive: currentTab === 'settings',
-          onClick: () => handleNavigationClick('settings')
-        },
-        {
-          id: 'triggers',
-          label: 'Triggers',
-          icon: <Webhook size={20} />,
-          isActive: currentTab === 'triggers',
-          onClick: () => handleNavigationClick('triggers')
-        }
-      ]
+      id: 'instructions',
+      label: 'Instructions',
+      icon: <ScrollText size={20} />,
+      isActive: currentTab === 'instructions',
+      onClick: () => handleNavigationClick('instructions')
     },
     {
-      title: 'Agent Capabilities',
-      items: [
-        {
-          id: 'knowledge',
-          label: 'Knowledge',
-          icon: <LibraryBig size={20} />,
-          isActive: currentTab === 'knowledge',
-          onClick: () => handleNavigationClick('knowledge')
-        },
-        {
-          id: 'skills',
-          label: app && isHelixOrgChartAgent(app) ? 'Org Tools & APIs' : 'Tools',
-          icon: <Lightbulb size={20} />,
-          isActive: currentTab === 'skills',
-          onClick: () => handleNavigationClick('skills')
-        },
-        {
-          id: 'tests',
-          label: 'Tests',
-          icon: <Bug size={20} />,
-          isActive: currentTab === 'tests',
-          onClick: () => handleNavigationClick('tests')
-        },
-        {
-          id: 'evaluation',
-          label: 'Evaluation',
-          icon: <FlaskConical size={20} />,
-          isActive: currentTab === 'evaluation',
-          onClick: () => handleNavigationClick('evaluation')
-        }
-      ]
+      id: 'runtime',
+      label: 'Runtime',
+      icon: <Cpu size={20} />,
+      isActive: currentTab === 'runtime',
+      onClick: () => handleNavigationClick('runtime')
     },
     {
-      title: 'Integration & Management',
-      items: [
-        {
-          id: 'apikeys',
-          label: 'Keys',
-          icon: <Key size={20} />,
-          isActive: currentTab === 'apikeys',
-          onClick: () => handleNavigationClick('apikeys')
-        },
-        {
-          id: 'mcp',
-          label: 'MCP',
-          icon: <Code size={20} />,
-          isActive: currentTab === 'mcp',
-          onClick: () => handleNavigationClick('mcp')
-        },
-        {
-          id: 'usage',
-          label: 'Usage',
-          icon: <ChartArea size={20} />,
-          isActive: currentTab === 'usage',
-          onClick: () => handleNavigationClick('usage')
-        },
-        {
-          id: 'memories',
-          label: 'Memories',
-          icon: <Brain size={20} />,
-          isActive: currentTab === 'memories',
-          onClick: () => handleNavigationClick('memories')
-        },
-        {
-          id: 'developers',
-          label: 'Export',
-          icon: < CloudDownload size={20} />,
-          isActive: currentTab === 'developers',
-          onClick: () => handleNavigationClick('developers')
-        }
-      ]
+      id: 'appearance',
+      label: 'Appearance',
+      icon: <Palette size={20} />,
+      isActive: currentTab === 'appearance',
+      onClick: () => handleNavigationClick('appearance')
+    },
+    {
+      id: 'triggers',
+      label: 'Triggers',
+      icon: <Webhook size={20} />,
+      isActive: currentTab === 'triggers',
+      onClick: () => handleNavigationClick('triggers')
+    },
+    {
+      id: 'knowledge',
+      label: 'Knowledge',
+      icon: <LibraryBig size={20} />,
+      isActive: currentTab === 'knowledge',
+      onClick: () => handleNavigationClick('knowledge')
+    },
+    {
+      id: 'skills',
+      label: app && isHelixOrgChartAgent(app) ? 'Org Tools & APIs' : 'Tools',
+      icon: <Lightbulb size={20} />,
+      isActive: currentTab === 'skills',
+      onClick: () => handleNavigationClick('skills')
+    },
+    {
+      id: 'tests',
+      label: 'Tests',
+      icon: <Bug size={20} />,
+      isActive: currentTab === 'tests',
+      onClick: () => handleNavigationClick('tests')
+    },
+    {
+      id: 'evaluation',
+      label: 'Evaluation',
+      icon: <FlaskConical size={20} />,
+      isActive: currentTab === 'evaluation',
+      onClick: () => handleNavigationClick('evaluation')
+    },
+    {
+      id: 'apikeys',
+      label: 'Keys',
+      icon: <Key size={20} />,
+      isActive: currentTab === 'apikeys',
+      onClick: () => handleNavigationClick('apikeys')
+    },
+    {
+      id: 'mcp',
+      label: 'MCP',
+      icon: <Code size={20} />,
+      isActive: currentTab === 'mcp',
+      onClick: () => handleNavigationClick('mcp')
+    },
+    {
+      id: 'usage',
+      label: 'Usage',
+      icon: <ChartArea size={20} />,
+      isActive: currentTab === 'usage',
+      onClick: () => handleNavigationClick('usage')
+    },
+    {
+      id: 'memories',
+      label: 'Memories',
+      icon: <Brain size={20} />,
+      isActive: currentTab === 'memories',
+      onClick: () => handleNavigationClick('memories')
+    },
+    {
+      id: 'developers',
+      label: 'Export',
+      icon: <CloudDownload size={20} />,
+      isActive: currentTab === 'developers',
+      onClick: () => handleNavigationClick('developers')
     }
   ]
 
-  // Add access management section if user is admin and organization exists
-  if (app?.organization_id && userAccess?.isAdmin) {
-    sections.push({
-      title: 'Administration',
-      items: [
-        {
-          id: 'access',
-          label: 'Access',
-          icon: <Users size={20} />,
-          isActive: currentTab === 'access',
-          onClick: () => handleNavigationClick('access')
-        }
-      ]
+  const sections: ContextSidebarSection[] = [{ items }]
+
+  if (app?.organization_id && (userAccess?.isAdmin || isHelixOrgChartAgent(app))) {
+    items.push({
+      id: 'access',
+      label: 'Access',
+      icon: <Users size={20} />,
+      isActive: currentTab === 'access',
+      onClick: () => handleNavigationClick('access')
     })
   }
 

--- a/frontend/src/components/app/AppSidebar.tsx
+++ b/frontend/src/components/app/AppSidebar.tsx
@@ -65,7 +65,7 @@ const AppSidebar: FC = () => {
     },
     {
       id: 'skills',
-      label: app && isHelixOrgChartAgent(app) ? 'Org Tools & APIs' : 'Tools',
+      label: app && isHelixOrgChartAgent(app) ? 'MCPs & APIs' : 'Tools',
       icon: <Lightbulb size={20} />,
       isActive: currentTab === 'skills',
       onClick: () => handleNavigationClick('skills')

--- a/frontend/src/components/app/AppearanceSettings.tsx
+++ b/frontend/src/components/app/AppearanceSettings.tsx
@@ -6,7 +6,6 @@ import IconButton from '@mui/material/IconButton'
 import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
 import Avatar from '@mui/material/Avatar'
-import Grid from '@mui/material/Grid'
 import { IAppFlatState } from '../../types'
 import { useUpdateAppAvatar, useDeleteAppAvatar } from '../../services/appService'
 import { getFlatStateAvatarUrl } from '../../utils/app'
@@ -20,6 +19,7 @@ interface AppearanceSettingsProps {
   readOnly?: boolean
   showErrors?: boolean
   id: string
+  section: 'conversation-starters' | 'avatar'
 }
 
 const AppearanceSettings: FC<AppearanceSettingsProps> = ({
@@ -27,6 +27,7 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
   onUpdate,
   readOnly = false,
   id,
+  section,
 }) => {
   const [conversationStarters, setConversationStarters] = useState<string[]>(app.conversation_starters || [])
   const [newStarter, setNewStarter] = useState('')
@@ -129,90 +130,67 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
     }
   }
 
+  if (section === 'avatar') {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: '0 0 auto' }}>
+        <Box
+          sx={{
+            position: 'relative',
+            cursor: readOnly ? 'default' : 'pointer',
+            '&:hover .avatar-overlay': { opacity: 1 },
+          }}
+          onClick={handleAvatarClick}
+        >
+          <Avatar
+            src={`${getFlatStateAvatarUrl(app, id)}${getFlatStateAvatarUrl(app, id).includes('?') ? '&' : '?'}t=${avatarUpdateKey}`}
+            sx={{
+              width: 112,
+              height: 112,
+              border: '2px solid',
+              borderColor: 'divider',
+            }}
+          />
+          {!readOnly && (
+            <Box
+              className="avatar-overlay"
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                borderRadius: '50%',
+                opacity: 0,
+                transition: 'opacity 0.2s',
+              }}
+            >
+              <CloudUploadIcon sx={{ color: 'white', fontSize: 32 }} />
+            </Box>
+          )}
+        </Box>
+        {!readOnly && app.avatar && (
+          <IconButton onClick={handleDeleteAvatar} size="small" color="error" sx={{ mt: 0.5 }}>
+            <DeleteForeverIcon fontSize="small" />
+          </IconButton>
+        )}
+        <input
+          type="file"
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+          accept="image/*,.svg"
+          onChange={handleFileChange}
+        />
+      </Box>
+    )
+  }
+
   return (
     <Box sx={{ mt: 2, mr: 2 }}>
-          <Grid container spacing={3}>
-            <Grid item xs={12}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  height: '100%',
-                  position: 'relative',
-                }}
-              >
-                <Box
-                  sx={{
-                    position: 'relative',
-                    cursor: readOnly ? 'default' : 'pointer',
-                    '&:hover .avatar-overlay': {
-                      opacity: 1,
-                    },
-                  }}
-                  onClick={handleAvatarClick}
-                >              
-                  <Avatar
-                    src={`${getFlatStateAvatarUrl(app, id)}${getFlatStateAvatarUrl(app, id).includes('?') ? '&' : '?'}t=${avatarUpdateKey}`}
-                    sx={{
-                      width: 200,
-                      height: 200,
-                      border: '2px solid #fff',
-                      boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
-                    }}
-                  />
-                  {!readOnly && (
-                    <Box
-                      className="avatar-overlay"
-                      sx={{
-                        position: 'absolute',
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                        borderRadius: '50%',
-                        opacity: 0,
-                        transition: 'opacity 0.2s',
-                      }}
-                    >
-                      <CloudUploadIcon sx={{ color: 'white', fontSize: 40 }} />
-                    </Box>
-                  )}
-                </Box>
-                {!readOnly && app.avatar && (
-                  <IconButton
-                    onClick={handleDeleteAvatar}
-                    sx={{
-                      mt: 2,
-                      color: 'error.main',
-                      '&:hover': {
-                        backgroundColor: 'error.light',
-                      },
-                    }}
-                  >
-                    <DeleteForeverIcon />
-                  </IconButton>
-                )}
-                <input
-                  type="file"
-                  ref={fileInputRef}
-                  style={{ display: 'none' }}
-                  accept="image/*,.svg"
-                  onChange={handleFileChange}
-                />
-              </Box>
-            </Grid>
-          </Grid>
-
           <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>
             Conversation Starters
           </Typography>
-          <Box sx={{ mb: 2 }}>
+          <Box sx={{ mb: 4 }}>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
               Add example messages that users can click to start a conversation. These help showcase the agent's capabilities.
             </Typography>

--- a/frontend/src/components/app/OrgAgentSettings.tsx
+++ b/frontend/src/components/app/OrgAgentSettings.tsx
@@ -5,7 +5,6 @@ import Button from '@mui/material/Button'
 import Checkbox from '@mui/material/Checkbox'
 import Chip from '@mui/material/Chip'
 import FormControlLabel from '@mui/material/FormControlLabel'
-import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
@@ -71,7 +70,8 @@ const OrgAgentSettings: FC<{
 
   if (section === 'runtime') {
     return (
-      <Paper variant="outlined" sx={{ p: 2, m: 3, mb: 0 }}>
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle1">Context</Typography>
         <FormControlLabel
           control={(
             <Switch
@@ -85,14 +85,14 @@ const OrgAgentSettings: FC<{
         <Typography variant="body2" color="text.secondary">
           Keep this org agent's conversation context between triggered runs.
         </Typography>
-      </Paper>
+      </Box>
     )
   }
 
   if (section === 'tools') {
     const tools = agent.tools ?? []
     return (
-      <Paper variant="outlined" sx={{ p: 2, m: 3, mb: 0 }}>
+      <Box sx={{ mt: 3, mb: 3 }}>
         <Stack spacing={1.5}>
           <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
             <Box>
@@ -130,7 +130,7 @@ const OrgAgentSettings: FC<{
             void update({ tools: selectedTools })
           }}
         />
-      </Paper>
+      </Box>
     )
   }
 

--- a/frontend/src/components/app/OrgAgentSettings.tsx
+++ b/frontend/src/components/app/OrgAgentSettings.tsx
@@ -4,7 +4,6 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Checkbox from '@mui/material/Checkbox'
 import Chip from '@mui/material/Chip'
-import FormControlLabel from '@mui/material/FormControlLabel'
 import Stack from '@mui/material/Stack'
 import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
@@ -72,16 +71,15 @@ const OrgAgentSettings: FC<{
     return (
       <Box sx={{ mt: 3 }}>
         <Typography variant="subtitle1">Context</Typography>
-        <FormControlLabel
-          control={(
-            <Switch
-              checked={agent.preserve_context ?? false}
-              onChange={(_event, checked) => void update({ preserve_context: checked })}
-              disabled={readOnly || updateAgent.isPending}
-            />
-          )}
-          label="Preserve context across triggers"
-        />
+        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+          <Typography variant="body1">Preserve context</Typography>
+          <Switch
+            checked={agent.preserve_context ?? false}
+            onChange={(_event, checked) => void update({ preserve_context: checked })}
+            disabled={readOnly || updateAgent.isPending}
+            inputProps={{ 'aria-label': 'Preserve context' }}
+          />
+        </Stack>
         <Typography variant="body2" color="text.secondary">
           Keep this org agent's conversation context between triggered runs.
         </Typography>

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -28,7 +28,7 @@ import InferenceTextField from '../create/InferenceTextField';
 import AppCreateHeader from '../appstore/CreateHeader';
 import Cell from '../widgets/Cell';
 import Row from '../widgets/Row';
-import { useRouterContext } from '../../contexts/router';
+import useRouter from '../../hooks/useRouter';
 
 import {   
   ISessionRAGResult, 
@@ -109,7 +109,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
   const isBigScreen = useIsBigScreen();
   const { NewInference, setCurrentSessionId } = useStreaming();
   const [isStreaming, setIsStreaming] = useState(false);
-  const router = useRouterContext();
+  const router = useRouter();
   const [filterMap, setFilterMap] = useState<Record<string, string>>({});
   // const [showSession, setShowSession] = useState(false);
 

--- a/frontend/src/components/orgs/OrgSidebar.tsx
+++ b/frontend/src/components/orgs/OrgSidebar.tsx
@@ -9,6 +9,9 @@ import {
   KeyRound,
   Plug,
   ClipboardList,
+  GitBranch,
+  FileText,
+  MessageSquare,
 } from 'lucide-react'
 
 import useRouter from '../../hooks/useRouter'
@@ -21,16 +24,15 @@ const OrgSidebar: FC = () => {
   const currentRouteName = router.name
   const orgId = router.params.org_id
 
-  const handleNavigationClick = (routeName: string) => {
+  const handleNavigationClick = (routeName: string, params: Record<string, string> = {}) => {
     if (orgId) {
-      router.navigate(routeName, { org_id: orgId })
+      router.navigate(routeName, { org_id: orgId, ...params })
     }
     account.setMobileMenuOpen(false)
   }
 
   const sections: ContextSidebarSection[] = [
     {
-      title: 'Settings',
       items: [
         {
           id: 'general',
@@ -39,11 +41,6 @@ const OrgSidebar: FC = () => {
           isActive: currentRouteName === 'org_general' || currentRouteName === 'org_settings',
           onClick: () => handleNavigationClick('org_general'),
         },
-      ],
-    },
-    {
-      title: 'Members',
-      items: [
         {
           id: 'people',
           label: 'People',
@@ -58,11 +55,27 @@ const OrgSidebar: FC = () => {
           isActive: currentRouteName === 'org_teams',
           onClick: () => handleNavigationClick('org_teams'),
         },
-      ],
-    },
-    {
-      title: 'Cost',
-      items: [
+        {
+          id: 'repositories',
+          label: 'Repositories',
+          icon: <GitBranch size={20} />,
+          isActive: currentRouteName === 'org_projects' && router.params.tab === 'repositories',
+          onClick: () => handleNavigationClick('org_projects', { tab: 'repositories' }),
+        },
+        {
+          id: 'guidelines',
+          label: 'Guidelines',
+          icon: <FileText size={20} />,
+          isActive: currentRouteName === 'org_projects' && router.params.tab === 'guidelines',
+          onClick: () => handleNavigationClick('org_projects', { tab: 'guidelines' }),
+        },
+        {
+          id: 'prompts',
+          label: 'Prompts',
+          icon: <MessageSquare size={20} />,
+          isActive: currentRouteName === 'org_projects' && router.params.tab === 'prompts',
+          onClick: () => handleNavigationClick('org_projects', { tab: 'prompts' }),
+        },
         {
           id: 'billing',
           label: 'Billing',
@@ -77,11 +90,6 @@ const OrgSidebar: FC = () => {
           isActive: currentRouteName === 'org_usage',
           onClick: () => handleNavigationClick('org_usage'),
         },
-      ],
-    },
-    {
-      title: 'Agent Q&A',
-      items: [
         {
           id: 'qa',
           label: 'Question Sets',
@@ -89,11 +97,6 @@ const OrgSidebar: FC = () => {
           isActive: currentRouteName === 'org_qa' || currentRouteName === 'org_qa-results',
           onClick: () => handleNavigationClick('org_qa'),
         },
-      ],
-    },
-    {
-      title: 'Access',
-      items: [
         {
           id: 'api_keys',
           label: 'API Keys',

--- a/frontend/src/components/project/ProjectsListView.tsx
+++ b/frontend/src/components/project/ProjectsListView.tsx
@@ -24,6 +24,7 @@ import { TypesProject } from '../../services'
 import type { ServerSimpleSampleProject } from '../../api/api'
 import { useGetProjectUsage } from '../../services/projectService'
 import UsageSparkline, { formatNumber } from '../usage/UsageSparkline'
+import PageSectionHeader from '../system/PageSectionHeader'
 
 interface ProjectsListViewProps {
   projects: TypesProject[]
@@ -374,21 +375,20 @@ const ProjectsListView: FC<ProjectsListViewProps> = ({
         </Alert>
       )}
 
-      {!(projects.length === 0 && !isLoading) && (
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h4" sx={{
-            fontWeight: 700,
-            mb: 1,
-            color: lightTheme.isLight ? 'rgba(0,0,0,0.87)' : 'rgba(255,255,255,0.95)',
-            letterSpacing: '-0.02em',
-          }}>
-            Projects
-          </Typography>
-          <Typography variant="body2" sx={{ color: lightTheme.isLight ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.5)' }}>
-            Each Project has a Team of Agents working in parallel to perform tasks, collaborate, or build software.
-          </Typography>
-        </Box>
-      )}
+      <PageSectionHeader
+        title="Projects"
+        description="Each Project has a Team of Agents working in parallel to perform tasks, collaborate, or build software."
+        action={
+          <CreateProjectButton
+            onCreateEmpty={onCreateEmpty}
+            onCreateFromSample={onCreateFromSample}
+            sampleProjects={sampleProjects}
+            isCreating={isCreating}
+            variant="contained"
+            color="secondary"
+          />
+        }
+      />
 
       {projects.length === 0 && !isLoading ? (
         <Box sx={{ textAlign: 'center', py: 8 }}>
@@ -402,14 +402,6 @@ const ProjectsListView: FC<ProjectsListViewProps> = ({
             Project has a Team of Agents working in parallel to perform tasks, collaborate, or build software.
 
           </Typography>
-          <CreateProjectButton
-            onCreateEmpty={onCreateEmpty}
-            onCreateFromSample={onCreateFromSample}
-            sampleProjects={sampleProjects}
-            isCreating={isCreating}
-            variant="contained"
-            color="secondary"
-          />
         </Box>
       ) : (
         <>

--- a/frontend/src/components/project/ProjectsListView.tsx
+++ b/frontend/src/components/project/ProjectsListView.tsx
@@ -386,6 +386,7 @@ const ProjectsListView: FC<ProjectsListViewProps> = ({
             isCreating={isCreating}
             variant="contained"
             color="secondary"
+            size="small"
           />
         }
       />

--- a/frontend/src/components/session/ActivitySummary.tsx
+++ b/frontend/src/components/session/ActivitySummary.tsx
@@ -6,6 +6,8 @@ import { useTheme } from "@mui/material/styles";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
 import StreamingIndicator from "./StreamingIndicator";
+import { getChatColors } from "./chatStyles";
+import { APP_MONO_FONT_FAMILY } from "../../styles/typography";
 
 export const formatActivityDuration = (durationMs: number) => {
   const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
@@ -37,11 +39,11 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
   startedAt,
 }) => {
   const theme = useTheme();
+  const chatColors = getChatColors(theme);
   const [expanded, setExpanded] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(durationMs);
   const lastElapsedMsRef = useRef(durationMs);
-  const textColor =
-    theme.palette.mode === "dark" ? "rgba(255,255,255,0.55)" : "text.secondary";
+  const textColor = theme.palette.mode === "dark" ? chatColors.subtle : "text.secondary";
 
   useEffect(() => {
     if (!isStreaming) {
@@ -98,7 +100,7 @@ const ActivitySummary: FC<ActivitySummaryProps> = ({
             flex: 1,
             fontSize: "0.76rem",
             color: "inherit",
-            fontFamily: "monospace",
+            fontFamily: APP_MONO_FONT_FAMILY,
           }}
         >
           {isStreaming

--- a/frontend/src/components/session/CollapsibleToolCall.test.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.test.tsx
@@ -12,8 +12,35 @@ describe('CollapsibleToolCall', () => {
     )
 
     expect(presentation).toEqual({
+      kind: 'command',
       label: 'Ran command',
       preview: 'Bash: git status --short',
+    })
+  })
+
+  it('recognizes raw ACP shell titles from terminal output', () => {
+    const presentation = getToolCallPresentation(
+      "git status --short",
+      "**Tool Call: git status --short**\nStatus: Completed\nTerminal:\n```\n M file.ts\n```",
+    )
+
+    expect(presentation).toEqual({
+      kind: 'command',
+      label: 'Ran command',
+      preview: 'git status --short',
+    })
+  })
+
+  it('presents MCP calls as provider and tool', () => {
+    expect(getToolCallPresentation('mcp.codex_apps.github.fetch_pr', '')).toEqual({
+      kind: 'tool',
+      label: 'GitHub · fetch_pr',
+      preview: '',
+    })
+    expect(getToolCallPresentation('mcp__t3_code__preview_snapshot', '')).toEqual({
+      kind: 'tool',
+      label: 'T3-code · preview_snapshot',
+      preview: '',
     })
   })
 

--- a/frontend/src/components/session/CollapsibleToolCall.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.tsx
@@ -13,6 +13,8 @@ import {
   Wrench,
 } from "lucide-react";
 import { preserveDisclosureExpansion } from "./disclosureScroll";
+import { getChatColors } from "./chatStyles";
+import { APP_MONO_FONT_FAMILY } from "../../styles/typography";
 
 /**
  * Represents a parsed segment of a response message.
@@ -222,6 +224,7 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
   const [expanded, setExpanded] = useState(defaultExpanded);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+  const chatColors = getChatColors(theme);
   const presentation = getToolCallPresentation(toolName, body);
 
   return (
@@ -254,14 +257,14 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
           <Terminal
             size={15}
             strokeWidth={1.8}
-            color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
+            color={isDark ? chatColors.subtle : "rgba(0,0,0,0.45)"}
             aria-hidden="true"
           />
         ) : (
           <Wrench
             size={15}
             strokeWidth={1.8}
-            color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
+            color={isDark ? chatColors.subtle : "rgba(0,0,0,0.45)"}
             aria-hidden="true"
           />
         )}
@@ -286,10 +289,10 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
                   ? "#f5f5f5"
                   : "text.primary"
                 : isDark
-                  ? "rgba(255,255,255,0.65)"
+                  ? chatColors.muted
                   : "text.secondary",
               fontWeight: presentation.preview ? 600 : 400,
-              fontFamily: "monospace",
+              fontFamily: APP_MONO_FONT_FAMILY,
             }}
           >
             {presentation.label}
@@ -302,8 +305,8 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 fontSize: dense ? "0.72rem" : "0.78rem",
-                color: isDark ? "rgba(255,255,255,0.42)" : "text.secondary",
-                fontFamily: "monospace",
+                color: isDark ? chatColors.subtle : "text.secondary",
+                fontFamily: APP_MONO_FONT_FAMILY,
               }}
             >
               {presentation.preview}
@@ -327,10 +330,10 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
             pr: 0,
             py: 1,
             fontSize: "0.8rem",
-            fontFamily: "monospace",
+            fontFamily: APP_MONO_FONT_FAMILY,
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
-            color: isDark ? "rgba(255,255,255,0.55)" : "text.secondary",
+            color: isDark ? chatColors.subtle : "text.secondary",
             backgroundColor: "transparent",
             maxHeight: "300px",
             overflow: "auto",

--- a/frontend/src/components/session/CollapsibleToolCall.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.tsx
@@ -10,6 +10,7 @@ import {
   CircleAlert,
   LoaderCircle,
   Terminal,
+  Wrench,
 } from "lucide-react";
 import { preserveDisclosureExpansion } from "./disclosureScroll";
 
@@ -123,6 +124,37 @@ const statusIcon = (status: string) => {
 
 const commandToolPattern = /^(bash|sh|zsh|shell|terminal|command)(?::\s*(.*))?$/i;
 
+const formatMCPProvider = (provider: string) => {
+  const normalized = provider.toLowerCase().replace(/_/g, "-");
+  if (normalized === "github") return "GitHub";
+  if (normalized === "t3-code") return "T3-code";
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+const parseMCPTool = (toolName: string) => {
+  if (toolName.startsWith("mcp__")) {
+    const parts = toolName.split("__");
+    if (parts.length >= 3) {
+      return {
+        provider: parts[parts.length - 2],
+        tool: parts[parts.length - 1],
+      };
+    }
+  }
+
+  if (toolName.startsWith("mcp.")) {
+    const parts = toolName.split(".");
+    if (parts.length >= 3) {
+      return {
+        provider: parts[parts.length - 2],
+        tool: parts[parts.length - 1],
+      };
+    }
+  }
+
+  return null;
+};
+
 const extractCommand = (body: string) => {
   const tableCommand = body.match(/\|\s*Command\s*\|\s*`([^`]+)`\s*\|/i);
   if (tableCommand?.[1]) return tableCommand[1].trim();
@@ -139,21 +171,35 @@ const extractCommand = (body: string) => {
 
 export const getToolCallPresentation = (toolName: string, body: string) => {
   const toolMatch = toolName.match(commandToolPattern);
+  const isTerminalResult = /(?:^|\n)Terminal:\s*/im.test(body);
   const bodyCommand = extractCommand(body);
-  const isCommand = Boolean(toolMatch || body.match(/\|\s*Command\s*\|/i));
+  const isCommand = Boolean(
+    toolMatch || isTerminalResult || body.match(/\|\s*Command\s*\|/i),
+  );
 
-  if (!isCommand) {
-    return { label: toolName, preview: "" };
+  if (isCommand) {
+    const namedCommand = toolMatch?.[2]?.trim();
+    const preview = isTerminalResult
+      ? toolName.trim()
+      : namedCommand
+        ? toolName.trim()
+        : bodyCommand
+          ? `${toolName.trim()}: ${bodyCommand}`
+          : toolName.trim();
+
+    return { kind: "command" as const, label: "Ran command", preview };
   }
 
-  const namedCommand = toolMatch?.[2]?.trim();
-  const preview = namedCommand
-    ? toolName.trim()
-    : bodyCommand
-      ? `${toolName.trim()}: ${bodyCommand}`
-      : toolName.trim();
+  const mcpTool = parseMCPTool(toolName);
+  if (mcpTool) {
+    return {
+      kind: "tool" as const,
+      label: `${formatMCPProvider(mcpTool.provider)} · ${mcpTool.tool}`,
+      preview: "",
+    };
+  }
 
-  return { label: "Ran command", preview };
+  return { kind: "tool" as const, label: toolName, preview: "" };
 };
 
 interface CollapsibleToolCallProps {
@@ -204,12 +250,21 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
           userSelect: "none",
         }}
       >
-        <Terminal
-          size={15}
-          strokeWidth={1.8}
-          color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
-          aria-hidden="true"
-        />
+        {presentation.kind === "command" ? (
+          <Terminal
+            size={15}
+            strokeWidth={1.8}
+            color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
+            aria-hidden="true"
+          />
+        ) : (
+          <Wrench
+            size={15}
+            strokeWidth={1.8}
+            color={isDark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.45)"}
+            aria-hidden="true"
+          />
+        )}
         <Box
           sx={{
             display: "flex",

--- a/frontend/src/components/session/InteractionContainer.test.tsx
+++ b/frontend/src/components/session/InteractionContainer.test.tsx
@@ -13,11 +13,11 @@ const renderMessage = (messageRole: 'user' | 'assistant') => render(
 )
 
 describe('InteractionContainer chat typography', () => {
-  it('uses T3 foreground opacity for assistant messages', () => {
+  it('uses a high-contrast T3-style foreground for assistant messages', () => {
     const { container } = renderMessage('assistant')
     const message = container.querySelector('[data-chat-message-role="assistant"]')
 
-    expect(message).toHaveStyle({ color: 'rgba(245, 245, 245, 0.8)' })
+    expect(message).toHaveStyle({ color: '#e8e8e8' })
   })
 
   it('keeps user messages at full foreground opacity', () => {

--- a/frontend/src/components/session/InteractionInference.timeline.test.ts
+++ b/frontend/src/components/session/InteractionInference.timeline.test.ts
@@ -79,7 +79,7 @@ describe("buildActivityTimeline", () => {
     ]);
   });
 
-  it("collapses the live tool history and keeps only the latest thought", () => {
+  it("collapses the live tool history and hides thoughts while working", () => {
     const entries = [
       entry("1", "text", "Visible progress update"),
       entry("2", "tool_call", "first output", "first tool"),
@@ -103,12 +103,6 @@ describe("buildActivityTimeline", () => {
           { toolName: "first tool" },
           { toolName: "second tool" },
         ],
-      },
-      {
-        type: "text",
-        entry: { content: "<thinking>Current reasoning</thinking>" },
-        renderThinking: true,
-        renderContent: false,
       },
     ]);
   });

--- a/frontend/src/components/session/InteractionInference.timeline.test.ts
+++ b/frontend/src/components/session/InteractionInference.timeline.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { buildActivityTimeline, ResponseEntry } from "./InteractionInference";
+
+const entry = (
+  message_id: string,
+  type: ResponseEntry["type"],
+  content: string,
+  tool_name?: string,
+): ResponseEntry => ({ message_id, type, content, tool_name });
+
+describe("buildActivityTimeline", () => {
+  it("preserves prose order and groups only adjacent tool calls", () => {
+    const entries = [
+      entry("1", "text", "First progress update"),
+      entry("2", "tool_call", "first output", "first tool"),
+      entry("3", "text", "<thinking>Internal-only reasoning</thinking>"),
+      entry("4", "tool_call", "second output", "second tool"),
+      entry("5", "text", "<thinking>Check this</thinking>Second progress update"),
+      entry("6", "tool_call", "third output", "third tool"),
+      entry("7", "tool_call", "fourth output", "fourth tool"),
+      entry("8", "text", "Final answer"),
+    ];
+
+    const timeline = buildActivityTimeline(entries, false);
+
+    expect(timeline.finalTextIndex).toBe(7);
+    expect(timeline.activitySegments.map((segment) => segment.type)).toEqual([
+      "text",
+      "tools",
+      "text",
+      "tools",
+    ]);
+    expect(timeline.activitySegments[1]).toMatchObject({
+      type: "tools",
+      entries: [
+        { toolName: "first tool", body: "first output" },
+        { toolName: "second tool", body: "second output" },
+      ],
+    });
+    expect(timeline.activitySegments[3]).toMatchObject({
+      type: "tools",
+      entries: [
+        { toolName: "third tool", body: "third output" },
+        { toolName: "fourth tool", body: "fourth output" },
+      ],
+    });
+  });
+
+  it("keeps the current prose in the visible timeline while streaming", () => {
+    const entries = [
+      entry("1", "tool_call", "output", "preview_snapshot"),
+      entry("2", "text", "I am checking the live page"),
+    ];
+
+    const timeline = buildActivityTimeline(entries, true);
+
+    expect(timeline.finalTextIndex).toBeUndefined();
+    expect(timeline.activitySegments).toMatchObject([
+      { type: "tools", entries: [{ toolName: "preview_snapshot" }] },
+      { type: "text", entry: { content: "I am checking the live page" } },
+    ]);
+  });
+
+  it("keeps final-entry thinking in the work transcript", () => {
+    const entries = [
+      entry("1", "text", "<thinking>Check the result</thinking>Final answer"),
+    ];
+
+    const timeline = buildActivityTimeline(entries, false);
+
+    expect(timeline.finalTextIndex).toBe(0);
+    expect(timeline.activitySegments).toMatchObject([
+      { type: "text", thinkingOnly: true },
+    ]);
+  });
+});

--- a/frontend/src/components/session/InteractionInference.timeline.test.ts
+++ b/frontend/src/components/session/InteractionInference.timeline.test.ts
@@ -79,6 +79,40 @@ describe("buildActivityTimeline", () => {
     ]);
   });
 
+  it("collapses the live tool history and keeps only the latest thought", () => {
+    const entries = [
+      entry("1", "text", "Visible progress update"),
+      entry("2", "tool_call", "first output", "first tool"),
+      entry("3", "text", "<thinking>Old reasoning</thinking>"),
+      entry("4", "tool_call", "second output", "second tool"),
+      entry("5", "text", "<thinking>Current reasoning</thinking>"),
+    ];
+
+    const timeline = buildActivityTimeline(entries, true);
+
+    expect(timeline.activitySegments).toMatchObject([
+      {
+        type: "text",
+        entry: { content: "Visible progress update" },
+        renderThinking: false,
+        renderContent: true,
+      },
+      {
+        type: "tools",
+        entries: [
+          { toolName: "first tool" },
+          { toolName: "second tool" },
+        ],
+      },
+      {
+        type: "text",
+        entry: { content: "<thinking>Current reasoning</thinking>" },
+        renderThinking: true,
+        renderContent: false,
+      },
+    ]);
+  });
+
   it("keeps final-entry thinking in the work transcript", () => {
     const entries = [
       entry("1", "text", "<thinking>Check the result</thinking>Final answer"),

--- a/frontend/src/components/session/InteractionInference.timeline.test.ts
+++ b/frontend/src/components/session/InteractionInference.timeline.test.ts
@@ -30,15 +30,27 @@ describe("buildActivityTimeline", () => {
       "tools",
       "text",
       "tools",
+      "text",
+      "tools",
     ]);
     expect(timeline.activitySegments[1]).toMatchObject({
       type: "tools",
       entries: [
         { toolName: "first tool", body: "first output" },
-        { toolName: "second tool", body: "second output" },
       ],
     });
     expect(timeline.activitySegments[3]).toMatchObject({
+      type: "tools",
+      entries: [
+        { toolName: "second tool", body: "second output" },
+      ],
+    });
+    expect(timeline.activitySegments[4]).toMatchObject({
+      type: "text",
+      renderThinking: true,
+      renderContent: true,
+    });
+    expect(timeline.activitySegments[5]).toMatchObject({
       type: "tools",
       entries: [
         { toolName: "third tool", body: "third output" },
@@ -58,7 +70,12 @@ describe("buildActivityTimeline", () => {
     expect(timeline.finalTextIndex).toBeUndefined();
     expect(timeline.activitySegments).toMatchObject([
       { type: "tools", entries: [{ toolName: "preview_snapshot" }] },
-      { type: "text", entry: { content: "I am checking the live page" } },
+      {
+        type: "text",
+        entry: { content: "I am checking the live page" },
+        renderThinking: false,
+        renderContent: true,
+      },
     ]);
   });
 
@@ -71,7 +88,21 @@ describe("buildActivityTimeline", () => {
 
     expect(timeline.finalTextIndex).toBe(0);
     expect(timeline.activitySegments).toMatchObject([
-      { type: "text", thinkingOnly: true },
+      { type: "text", renderThinking: true, renderContent: false },
+    ]);
+  });
+
+  it("does not mistake a trailing thought-only entry for the final answer", () => {
+    const entries = [
+      entry("1", "text", "Final answer"),
+      entry("2", "text", "<thinking>Finishing checks</thinking>"),
+    ];
+
+    const timeline = buildActivityTimeline(entries, false);
+
+    expect(timeline.finalTextIndex).toBe(0);
+    expect(timeline.activitySegments).toMatchObject([
+      { type: "text", renderThinking: true, renderContent: false },
     ]);
   });
 });

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -24,6 +24,87 @@ export interface ResponseEntry {
   tool_name?: string;
   tool_status?: string;
 }
+
+interface TextActivitySegment {
+  type: "text";
+  entry: ResponseEntry;
+  index: number;
+  thinkingOnly?: boolean;
+}
+
+interface ToolActivitySegment {
+  type: "tools";
+  entries: Array<{
+    id: string;
+    toolName: string;
+    status: string;
+    body: string;
+  }>;
+}
+
+type ActivitySegment = TextActivitySegment | ToolActivitySegment;
+
+const hasThinking = (content: string) => /<(?:think|thinking)>/i.test(content);
+
+const hasVisibleAssistantText = (content: string) => content
+  .replace(/<think>[\s\S]*?<\/think>/gi, "")
+  .replace(/<thinking>[\s\S]*?<\/thinking>/gi, "")
+  .replace(/<(?:think|thinking)>[\s\S]*$/gi, "")
+  .trim()
+  .length > 0;
+
+export function buildActivityTimeline(
+  responseEntries: ResponseEntry[],
+  isStreaming: boolean,
+): { activitySegments: ActivitySegment[]; finalTextIndex: number | undefined } {
+  let finalTextIndex: number | undefined;
+  if (!isStreaming) {
+    for (let index = responseEntries.length - 1; index >= 0; index -= 1) {
+      if (responseEntries[index].type === "text") {
+        finalTextIndex = index;
+        break;
+      }
+    }
+  }
+  const activitySegments: ActivitySegment[] = [];
+
+  responseEntries.forEach((entry, index) => {
+    if (index === finalTextIndex) {
+      if (hasThinking(entry.content)) {
+        activitySegments.push({ type: "text", entry, index, thinkingOnly: true });
+      }
+      return;
+    }
+
+    if (entry.type === "tool_call") {
+      const toolEntry = {
+        id: `${entry.message_id || "tool-call"}-${index}`,
+        toolName: entry.tool_name || "Tool Call",
+        status:
+          entry.tool_status ||
+          (index === responseEntries.length - 1 && isStreaming ? "Running" : "Completed"),
+        body: entry.content || "",
+      };
+      const previousSegment = activitySegments[activitySegments.length - 1];
+
+      if (previousSegment?.type === "tools") {
+        previousSegment.entries.push(toolEntry);
+      } else {
+        activitySegments.push({ type: "tools", entries: [toolEntry] });
+      }
+      return;
+    }
+
+    if (hasVisibleAssistantText(entry.content)) {
+      activitySegments.push({ type: "text", entry, index });
+    }
+  });
+
+  return {
+    activitySegments,
+    finalTextIndex,
+  };
+}
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -82,8 +163,6 @@ export const MessageWithToolCalls: FC<{
   activityStartedAt,
   showActivitySummary = true,
 }) => {
-  const hasThinking = (content: string) => /<(?:think|thinking)>/i.test(content);
-
   if (!showActivitySummary) {
     return (
       <Markdown
@@ -100,97 +179,57 @@ export const MessageWithToolCalls: FC<{
 
   // Structured path: use response_entries from the Go API (preserves type + order)
   if (responseEntries && responseEntries.length > 0) {
-    const toolCallEntries = responseEntries
-      .map((entry, index) => ({ entry, index }))
-      .filter(({ entry }) => entry.type === "tool_call");
-    const lastToolCallIndex = toolCallEntries[toolCallEntries.length - 1]?.index;
-    const lastResponseEntryIndex = responseEntries.length - 1;
-    const hasActivity = responseEntries.some(
-      (entry) => entry.type === "tool_call" || hasThinking(entry.content),
+    const { activitySegments, finalTextIndex } = buildActivityTimeline(
+      responseEntries,
+      isStreaming,
     );
-    const workLogEntries = toolCallEntries.map(({ entry: toolEntry, index }) => ({
-      id: `${toolEntry.message_id || "tool-call"}-${index}`,
-      toolName: toolEntry.tool_name || "Tool Call",
-      status:
-        toolEntry.tool_status ||
-        (index === lastResponseEntryIndex && isStreaming ? "Running" : "Completed"),
-      body: toolEntry.content || "",
-    }));
-
-    const activity = responseEntries.map((entry, i) => {
-      if (entry.type === "tool_call") {
-        if (i !== lastToolCallIndex) return null;
-        return <WorkLog key="work-log" entries={workLogEntries} showAll />;
+    const hasActivity = activitySegments.length > 0;
+    const activity = activitySegments.map((segment, segmentIndex) => {
+      if (segment.type === "tools") {
+        return <WorkLog key={`tool-run-${segmentIndex}`} entries={segment.entries} />;
       }
-      if (!hasThinking(entry.content)) return null;
+
       return (
         <Markdown
-          key={`thought-${i}`}
-          text={entry.content}
+          key={`activity-text-${segment.index}`}
+          text={segment.entry.content}
           session={session}
           getFileURL={getFileURL}
           showBlinker={false}
-          isStreaming={false}
+          isStreaming={isStreaming && segment.index === responseEntries.length - 1}
           onFilterDocument={onFilterDocument}
           compactThinking={compactThinking}
-          renderThinkingWidget
-          renderContent={false}
+          renderThinkingWidget={Boolean(segment.thinkingOnly)}
+          renderContent={!segment.thinkingOnly}
         />
       );
     });
-    const latestThought = [...responseEntries]
-      .map((entry, index) => ({ entry, index }))
-      .reverse()
-      .find(({ entry }) => entry.type === "text" && hasThinking(entry.content));
-    const streamingPreview = workLogEntries.length > 0 ? (
-      <WorkLog entries={workLogEntries} />
-    ) : latestThought ? (
+    const finalEntry = finalTextIndex === undefined ? undefined : responseEntries[finalTextIndex];
+    const finalContent = finalEntry ? (
       <Markdown
-        text={latestThought.entry.content}
+        text={finalEntry.content}
         session={session}
         getFileURL={getFileURL}
         showBlinker={false}
         isStreaming={false}
         onFilterDocument={onFilterDocument}
         compactThinking={compactThinking}
-        renderThinkingWidget
-        renderContent={false}
+        renderThinkingWidget={false}
       />
     ) : null;
 
-    const finalContent = responseEntries.map((entry, i) => {
-      if (entry.type === "tool_call") return null;
-      return (
-        <Markdown
-          key={`md-${i}`}
-          text={entry.content}
-          session={session}
-          getFileURL={getFileURL}
-          showBlinker={false}
-          isStreaming={isStreaming && i === responseEntries.length - 1}
-          onFilterDocument={onFilterDocument}
-          compactThinking={compactThinking}
-          renderThinkingWidget={false}
-        />
-      );
-    });
-
     return isStreaming ? (
       <>
-        {streamingPreview}
-        {finalContent}
+        {activity}
         <ActivitySummary
           durationMs={durationMs}
-          hasActivity={hasActivity}
+          hasActivity={false}
           isStreaming
           startedAt={activityStartedAt}
-        >
-          {activity}
-        </ActivitySummary>
+        />
       </>
     ) : (
       <>
-        {finalContent}
         <ActivitySummary
           durationMs={durationMs}
           hasActivity={hasActivity}
@@ -199,6 +238,7 @@ export const MessageWithToolCalls: FC<{
         >
           {activity}
         </ActivitySummary>
+        {finalContent}
       </>
     );
   }

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -35,6 +35,7 @@ interface TextActivitySegment {
 
 interface ToolActivitySegment {
   type: "tools";
+  index: number;
   entries: Array<{
     id: string;
     toolName: string;
@@ -54,20 +55,71 @@ const hasVisibleAssistantText = (content: string) => content
   .trim()
   .length > 0;
 
+const toolActivityEntry = (
+  entry: ResponseEntry,
+  index: number,
+  responseEntryCount: number,
+  isStreaming: boolean,
+) => ({
+  id: `${entry.message_id || "tool-call"}-${index}`,
+  toolName: entry.tool_name || "Tool Call",
+  status:
+    entry.tool_status ||
+    (index === responseEntryCount - 1 && isStreaming ? "Running" : "Completed"),
+  body: entry.content || "",
+});
+
 export function buildActivityTimeline(
   responseEntries: ResponseEntry[],
   isStreaming: boolean,
 ): { activitySegments: ActivitySegment[]; finalTextIndex: number | undefined } {
-  let finalTextIndex: number | undefined;
-  if (!isStreaming) {
-    for (let index = responseEntries.length - 1; index >= 0; index -= 1) {
-      if (
-        responseEntries[index].type === "text" &&
-        hasVisibleAssistantText(responseEntries[index].content)
-      ) {
-        finalTextIndex = index;
-        break;
+  if (isStreaming) {
+    let latestThinkingIndex = -1;
+    let latestToolIndex = -1;
+    const toolEntries: ToolActivitySegment["entries"] = [];
+
+    responseEntries.forEach((entry, index) => {
+      if (entry.type === "tool_call") {
+        latestToolIndex = index;
+        toolEntries.push(toolActivityEntry(entry, index, responseEntries.length, true));
+      } else if (hasThinking(entry.content)) {
+        latestThinkingIndex = index;
       }
+    });
+
+    const activitySegments: ActivitySegment[] = [];
+    responseEntries.forEach((entry, index) => {
+      if (entry.type !== "text") return;
+
+      const renderThinking = index === latestThinkingIndex && hasThinking(entry.content);
+      const renderContent = hasVisibleAssistantText(entry.content);
+      if (renderThinking || renderContent) {
+        activitySegments.push({
+          type: "text",
+          entry,
+          index,
+          renderThinking,
+          renderContent,
+        });
+      }
+    });
+
+    if (toolEntries.length > 0) {
+      activitySegments.push({ type: "tools", index: latestToolIndex, entries: toolEntries });
+    }
+    activitySegments.sort((left, right) => left.index - right.index);
+
+    return { activitySegments, finalTextIndex: undefined };
+  }
+
+  let finalTextIndex: number | undefined;
+  for (let index = responseEntries.length - 1; index >= 0; index -= 1) {
+    if (
+      responseEntries[index].type === "text" &&
+      hasVisibleAssistantText(responseEntries[index].content)
+    ) {
+      finalTextIndex = index;
+      break;
     }
   }
   const activitySegments: ActivitySegment[] = [];
@@ -87,20 +139,14 @@ export function buildActivityTimeline(
     }
 
     if (entry.type === "tool_call") {
-      const toolEntry = {
-        id: `${entry.message_id || "tool-call"}-${index}`,
-        toolName: entry.tool_name || "Tool Call",
-        status:
-          entry.tool_status ||
-          (index === responseEntries.length - 1 && isStreaming ? "Running" : "Completed"),
-        body: entry.content || "",
-      };
+      const toolEntry = toolActivityEntry(entry, index, responseEntries.length, false);
       const previousSegment = activitySegments[activitySegments.length - 1];
 
       if (previousSegment?.type === "tools") {
         previousSegment.entries.push(toolEntry);
+        previousSegment.index = index;
       } else {
-        activitySegments.push({ type: "tools", entries: [toolEntry] });
+        activitySegments.push({ type: "tools", index, entries: [toolEntry] });
       }
       return;
     }

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -74,7 +74,6 @@ export function buildActivityTimeline(
   isStreaming: boolean,
 ): { activitySegments: ActivitySegment[]; finalTextIndex: number | undefined } {
   if (isStreaming) {
-    let latestThinkingIndex = -1;
     let latestToolIndex = -1;
     const toolEntries: ToolActivitySegment["entries"] = [];
 
@@ -82,8 +81,6 @@ export function buildActivityTimeline(
       if (entry.type === "tool_call") {
         latestToolIndex = index;
         toolEntries.push(toolActivityEntry(entry, index, responseEntries.length, true));
-      } else if (hasThinking(entry.content)) {
-        latestThinkingIndex = index;
       }
     });
 
@@ -91,14 +88,13 @@ export function buildActivityTimeline(
     responseEntries.forEach((entry, index) => {
       if (entry.type !== "text") return;
 
-      const renderThinking = index === latestThinkingIndex && hasThinking(entry.content);
       const renderContent = hasVisibleAssistantText(entry.content);
-      if (renderThinking || renderContent) {
+      if (renderContent) {
         activitySegments.push({
           type: "text",
           entry,
           index,
-          renderThinking,
+          renderThinking: false,
           renderContent,
         });
       }

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -29,7 +29,8 @@ interface TextActivitySegment {
   type: "text";
   entry: ResponseEntry;
   index: number;
-  thinkingOnly?: boolean;
+  renderThinking: boolean;
+  renderContent: boolean;
 }
 
 interface ToolActivitySegment {
@@ -60,7 +61,10 @@ export function buildActivityTimeline(
   let finalTextIndex: number | undefined;
   if (!isStreaming) {
     for (let index = responseEntries.length - 1; index >= 0; index -= 1) {
-      if (responseEntries[index].type === "text") {
+      if (
+        responseEntries[index].type === "text" &&
+        hasVisibleAssistantText(responseEntries[index].content)
+      ) {
         finalTextIndex = index;
         break;
       }
@@ -71,7 +75,13 @@ export function buildActivityTimeline(
   responseEntries.forEach((entry, index) => {
     if (index === finalTextIndex) {
       if (hasThinking(entry.content)) {
-        activitySegments.push({ type: "text", entry, index, thinkingOnly: true });
+        activitySegments.push({
+          type: "text",
+          entry,
+          index,
+          renderThinking: true,
+          renderContent: false,
+        });
       }
       return;
     }
@@ -95,8 +105,16 @@ export function buildActivityTimeline(
       return;
     }
 
-    if (hasVisibleAssistantText(entry.content)) {
-      activitySegments.push({ type: "text", entry, index });
+    const renderThinking = hasThinking(entry.content);
+    const renderContent = hasVisibleAssistantText(entry.content);
+    if (renderThinking || renderContent) {
+      activitySegments.push({
+        type: "text",
+        entry,
+        index,
+        renderThinking,
+        renderContent,
+      });
     }
   });
 
@@ -199,8 +217,8 @@ export const MessageWithToolCalls: FC<{
           isStreaming={isStreaming && segment.index === responseEntries.length - 1}
           onFilterDocument={onFilterDocument}
           compactThinking={compactThinking}
-          renderThinkingWidget={Boolean(segment.thinkingOnly)}
-          renderContent={!segment.thinkingOnly}
+          renderThinkingWidget={segment.renderThinking}
+          renderContent={segment.renderContent}
         />
       );
     });

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -1066,7 +1066,7 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
             borderRadius: "3px",
           },
           "& a": {
-            color: theme.palette.mode === "light" ? "#333" : "#bbb",
+            color: theme.palette.mode === "light" ? "#333" : "inherit",
           },
 
           "& .doc-citation": {

--- a/frontend/src/components/session/ThinkingWidget.test.tsx
+++ b/frontend/src/components/session/ThinkingWidget.test.tsx
@@ -19,6 +19,7 @@ describe('ThinkingWidget', () => {
 
   it('removes markdown punctuation from the inline summary', () => {
     expect(thinkingSummary('**Check the `current` branch**')).toBe('Check the current branch')
+    expect(thinkingSummary('**First summary**\n\n**Second summary**')).toBe('First summary')
   })
 
   it('uses a collapsed disclosure and reveals the thought on click', () => {
@@ -30,10 +31,11 @@ describe('ThinkingWidget', () => {
       </div>,
     )
 
-    expect(screen.getByText('Thoughts')).toBeInTheDocument()
+    expect(screen.getByText('Inspect the current')).toBeInTheDocument()
+    expect(screen.queryByText('Thoughts')).not.toBeInTheDocument()
     expect(screen.queryByText('Inspect the current subscription state')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('Thoughts'))
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thoughts' }))
 
     expect(container.querySelector('[data-session-scroll-container]'))
       .toHaveAttribute('data-preserve-disclosure-expansion', 'true')
@@ -48,8 +50,8 @@ describe('ThinkingWidget', () => {
       </ThemeProvider>,
     )
 
-    expect(screen.getByText('Thoughts')).toBeInTheDocument()
     expect(screen.getByText('Check the current branch')).toBeInTheDocument()
+    expect(screen.queryByText('Thoughts')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Expand thoughts' })).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/session/ThinkingWidget.test.tsx
+++ b/frontend/src/components/session/ThinkingWidget.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import { describe, expect, it } from 'vitest'
 
-import ThinkingWidget from './ThinkingWidget'
+import ThinkingWidget, { formatThinkingMarkdown, thinkingSummary } from './ThinkingWidget'
 
 const renderWidget = (isStreaming = false) => render(
   <ThemeProvider theme={createTheme()}>
@@ -11,6 +11,16 @@ const renderWidget = (isStreaming = false) => render(
 )
 
 describe('ThinkingWidget', () => {
+  it('formats bold-only reasoning fragments as one markdown list', () => {
+    expect(formatThinkingMarkdown(
+      '**Assessing rollout risk**\n\n**Checking CI status**\n\nSupporting detail',
+    )).toBe('- **Assessing rollout risk**\n- **Checking CI status**\n\nSupporting detail')
+  })
+
+  it('removes markdown punctuation from the inline summary', () => {
+    expect(thinkingSummary('**Check the `current` branch**')).toBe('Check the current branch')
+  })
+
   it('uses a collapsed disclosure and reveals the thought on click', () => {
     const { container } = render(
       <div data-session-scroll-container>

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -8,6 +8,8 @@ import { ChevronDown, ChevronUp, Lightbulb } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { preserveDisclosureExpansion } from './disclosureScroll'
+import { getChatColors } from './chatStyles'
+import { APP_MONO_FONT_FAMILY } from '../../styles/typography'
 
 interface ThinkingWidgetProps {
   text: string
@@ -56,6 +58,7 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
   const [expanded, setExpanded] = useState(false)
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
+  const chatColors = getChatColors(theme)
   const isMultiline = text.trim().includes('\n')
   const startedAt = useRef(
     typeof startTime === 'number'
@@ -73,8 +76,8 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
     return () => window.clearInterval(interval)
   }, [isStreaming])
 
-  const iconColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.45)'
-  const textColor = isDark ? 'rgba(255,255,255,0.65)' : 'text.secondary'
+  const iconColor = isDark ? chatColors.subtle : 'rgba(0,0,0,0.45)'
+  const textColor = isDark ? chatColors.muted : 'text.secondary'
 
   return (
     <Box
@@ -112,7 +115,7 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
             whiteSpace: 'nowrap',
             fontSize: '0.76rem',
             color: textColor,
-            fontFamily: 'monospace',
+            fontFamily: APP_MONO_FONT_FAMILY,
           }}
         >
           {isStreaming ? `Thinking ${formatDuration(elapsed)}` : thinkingSummary(text)}
@@ -138,7 +141,7 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
             fontSize: '0.8rem',
             lineHeight: 1.6,
             wordBreak: 'break-word',
-            color: isDark ? 'rgba(255,255,255,0.55)' : 'text.secondary',
+            color: isDark ? chatColors.muted : 'text.secondary',
             backgroundColor: 'transparent',
             maxHeight: '300px',
             overflow: 'auto',
@@ -147,11 +150,11 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
             '& ul, & ol': { my: 0, pl: 2.5 },
             '& li + li': { mt: 0.5 },
             '& strong': {
-              color: isDark ? 'rgba(255,255,255,0.72)' : 'text.primary',
+              color: isDark ? '#d4d4d4' : 'text.primary',
               fontWeight: 600,
             },
             '& code': {
-              fontFamily: 'monospace',
+              fontFamily: APP_MONO_FONT_FAMILY,
               fontSize: '0.76rem',
             },
           }}

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -40,10 +40,15 @@ export function formatThinkingMarkdown(text: string): string {
 }
 
 export function thinkingSummary(text: string): string {
-  return text
-    .trim()
+  const firstLine = text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .find(Boolean) || ''
+
+  return firstLine
     .replace(/\*\*(.*?)\*\*/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
+    .replace(/^[-*]\s+/, '')
 }
 
 const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStreaming }) => {
@@ -100,31 +105,18 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
         <Typography
           variant="body2"
           sx={{
-            flex: isMultiline ? 1 : '0 0 auto',
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
             fontSize: '0.76rem',
             color: textColor,
             fontFamily: 'monospace',
           }}
         >
-          {isStreaming ? `Thinking ${formatDuration(elapsed)}` : 'Thoughts'}
+          {isStreaming ? `Thinking ${formatDuration(elapsed)}` : thinkingSummary(text)}
         </Typography>
-        {!isStreaming && !isMultiline && (
-          <Typography
-            variant="body2"
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              fontSize: '0.76rem',
-              color: isDark ? 'rgba(255,255,255,0.5)' : 'text.secondary',
-              fontFamily: 'monospace',
-            }}
-          >
-            {thinkingSummary(text)}
-          </Typography>
-        )}
         {isStreaming && <CircularProgress size={16} thickness={4} color="warning" />}
         {isMultiline && (
           <IconButton

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -5,6 +5,8 @@ import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/material/styles'
 import { ChevronDown, ChevronUp, Lightbulb } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { preserveDisclosureExpansion } from './disclosureScroll'
 
 interface ThinkingWidgetProps {
@@ -18,6 +20,30 @@ function formatDuration(seconds: number) {
   const minutes = Math.floor(seconds / 60)
   const remainder = seconds % 60
   return `${minutes}:${remainder.toString().padStart(2, '0')}`
+}
+
+export function formatThinkingMarkdown(text: string): string {
+  const blocks = text.trim().split(/\n{2,}/)
+  let markdown = ''
+  let previousWasSummary = false
+
+  blocks.forEach((block) => {
+    const trimmed = block.trim()
+    if (!trimmed) return
+    const isSummary = /^\*\*[\s\S]+\*\*$/.test(trimmed)
+    const separator = markdown ? (isSummary && previousWasSummary ? '\n' : '\n\n') : ''
+    markdown += `${separator}${isSummary ? `- ${trimmed}` : trimmed}`
+    previousWasSummary = isSummary
+  })
+
+  return markdown
+}
+
+export function thinkingSummary(text: string): string {
+  return text
+    .trim()
+    .replace(/\*\*(.*?)\*\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
 }
 
 const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStreaming }) => {
@@ -96,7 +122,7 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
               fontFamily: 'monospace',
             }}
           >
-            {text.trim()}
+            {thinkingSummary(text)}
           </Typography>
         )}
         {isStreaming && <CircularProgress size={16} thickness={4} color="warning" />}
@@ -118,16 +144,29 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
             pr: 0,
             py: 1,
             fontSize: '0.8rem',
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
+            lineHeight: 1.6,
             wordBreak: 'break-word',
             color: isDark ? 'rgba(255,255,255,0.55)' : 'text.secondary',
             backgroundColor: 'transparent',
             maxHeight: '300px',
             overflow: 'auto',
+            '& p': { m: 0 },
+            '& p + p': { mt: 1 },
+            '& ul, & ol': { my: 0, pl: 2.5 },
+            '& li + li': { mt: 0.5 },
+            '& strong': {
+              color: isDark ? 'rgba(255,255,255,0.72)' : 'text.primary',
+              fontWeight: 600,
+            },
+            '& code': {
+              fontFamily: 'monospace',
+              fontSize: '0.76rem',
+            },
           }}
         >
-          {text}
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {formatThinkingMarkdown(text)}
+          </ReactMarkdown>
         </Box>
       )}
     </Box>

--- a/frontend/src/components/session/WorkLog.test.tsx
+++ b/frontend/src/components/session/WorkLog.test.tsx
@@ -5,9 +5,24 @@ import { describe, expect, it } from "vitest";
 import { WorkLog } from "./WorkLog";
 
 const entries = [
-  { id: "1", toolName: "first command", status: "Completed", body: "first output" },
-  { id: "2", toolName: "second command", status: "Completed", body: "second output" },
-  { id: "3", toolName: "latest command", status: "Running", body: "latest output" },
+  {
+    id: "1",
+    toolName: "first command",
+    status: "Completed",
+    body: "first output",
+  },
+  {
+    id: "2",
+    toolName: "second command",
+    status: "Completed",
+    body: "second output",
+  },
+  {
+    id: "3",
+    toolName: "latest command",
+    status: "Running",
+    body: "latest output",
+  },
 ];
 
 const renderWorkLog = () =>
@@ -23,30 +38,50 @@ describe("WorkLog", () => {
 
     expect(screen.getByText("latest command")).toBeInTheDocument();
     expect(screen.queryByText("first command")).not.toBeInTheDocument();
-    const disclosure = screen.getByRole("button", { name: /\+2 previous tool calls/ });
+    const disclosure = screen.getByRole("button", {
+      name: /\+2 previous tool calls/,
+    });
     expect(disclosure).toBeInTheDocument();
-    expect(disclosure.querySelector(".MuiButton-startIcon")).toBeInTheDocument();
-    expect(disclosure.querySelector(".MuiButton-endIcon")).not.toBeInTheDocument();
+    expect(
+      disclosure.querySelector(".MuiButton-startIcon"),
+    ).toBeInTheDocument();
+    expect(
+      disclosure.querySelector(".MuiButton-endIcon"),
+    ).not.toBeInTheDocument();
     expect(disclosure).toHaveStyle({ color: "rgb(245, 245, 245)" });
     expect(disclosure.querySelector("svg")).toHaveStyle({
       color: "rgb(150, 150, 150)",
-      transform: "translateX(-1px)",
+      transform: "translateX(-1px) rotate(0deg)",
     });
   });
 
-  it("reveals the full log and can collapse it again", () => {
+  it("reveals previous calls below a stationary disclosure", () => {
     renderWorkLog();
 
-    fireEvent.click(screen.getByRole("button", { name: /\+2 previous tool calls/ }));
+    const disclosure = screen.getByRole("button", {
+      name: /\+2 previous tool calls/,
+    });
+    fireEvent.click(disclosure);
 
-    expect(screen.getByText("Tool calls")).toBeInTheDocument();
-    expect(screen.getByText("first command")).toBeInTheDocument();
+    const firstCommand = screen.getByText("first command");
+    expect(firstCommand).toBeInTheDocument();
     expect(screen.getByText("second command")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Show fewer tool calls/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /\+2 previous tool calls/ }),
+    ).toBe(disclosure);
+    expect(disclosure).toHaveAttribute("aria-expanded", "true");
+    expect(
+      disclosure.compareDocumentPosition(firstCommand) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /Show fewer tool calls/ }));
+    fireEvent.click(disclosure);
 
     expect(screen.queryByText("first command")).not.toBeInTheDocument();
     expect(screen.getByText("latest command")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /\+2 previous tool calls/ }),
+    ).toBe(disclosure);
+    expect(disclosure).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/frontend/src/components/session/WorkLog.test.tsx
+++ b/frontend/src/components/session/WorkLog.test.tsx
@@ -23,20 +23,20 @@ describe("WorkLog", () => {
 
     expect(screen.getByText("latest command")).toBeInTheDocument();
     expect(screen.queryByText("first command")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /\+2 previous log entries/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /\+2 previous tool calls/ })).toBeInTheDocument();
   });
 
   it("reveals the full log and can collapse it again", () => {
     renderWorkLog();
 
-    fireEvent.click(screen.getByRole("button", { name: /\+2 previous log entries/ }));
+    fireEvent.click(screen.getByRole("button", { name: /\+2 previous tool calls/ }));
 
-    expect(screen.getByText("Work Log")).toBeInTheDocument();
+    expect(screen.getByText("Tool calls")).toBeInTheDocument();
     expect(screen.getByText("first command")).toBeInTheDocument();
     expect(screen.getByText("second command")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Show fewer log entries/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Show fewer tool calls/ })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Show fewer log entries/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Show fewer tool calls/ }));
 
     expect(screen.queryByText("first command")).not.toBeInTheDocument();
     expect(screen.getByText("latest command")).toBeInTheDocument();

--- a/frontend/src/components/session/WorkLog.test.tsx
+++ b/frontend/src/components/session/WorkLog.test.tsx
@@ -23,7 +23,11 @@ describe("WorkLog", () => {
 
     expect(screen.getByText("latest command")).toBeInTheDocument();
     expect(screen.queryByText("first command")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /\+2 previous tool calls/ })).toBeInTheDocument();
+    const disclosure = screen.getByRole("button", { name: /\+2 previous tool calls/ });
+    expect(disclosure).toBeInTheDocument();
+    expect(disclosure.querySelector(".MuiButton-startIcon")).toBeInTheDocument();
+    expect(disclosure.querySelector(".MuiButton-endIcon")).not.toBeInTheDocument();
+    expect(disclosure).toHaveStyle({ color: "rgb(245, 245, 245)" });
   });
 
   it("reveals the full log and can collapse it again", () => {

--- a/frontend/src/components/session/WorkLog.test.tsx
+++ b/frontend/src/components/session/WorkLog.test.tsx
@@ -28,6 +28,10 @@ describe("WorkLog", () => {
     expect(disclosure.querySelector(".MuiButton-startIcon")).toBeInTheDocument();
     expect(disclosure.querySelector(".MuiButton-endIcon")).not.toBeInTheDocument();
     expect(disclosure).toHaveStyle({ color: "rgb(245, 245, 245)" });
+    expect(disclosure.querySelector("svg")).toHaveStyle({
+      color: "rgb(150, 150, 150)",
+      transform: "translateX(-1px)",
+    });
   });
 
   it("reveals the full log and can collapse it again", () => {

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -55,15 +55,18 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
             size="small"
             onClick={toggleExpanded}
             aria-expanded={false}
-            endIcon={<ExpandMoreIcon sx={{ fontSize: 16 }} />}
+            startIcon={<ExpandMoreIcon sx={{ fontSize: 15 }} />}
             sx={{
               minHeight: 24,
-              px: 0.5,
-              color: isDark ? chatColors.muted : "text.secondary",
+              px: 0,
+              gap: 0.75,
+              color: isDark ? chatColors.foreground : "text.primary",
               fontSize: "0.76rem",
+              fontWeight: 600,
               fontFamily: APP_MONO_FONT_FAMILY,
               textTransform: "none",
               "&:hover": { backgroundColor: "transparent" },
+              "& .MuiButton-startIcon": { m: 0 },
             }}
           >
             +{previousCount} previous tool {previousCount === 1 ? "call" : "calls"}

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -8,6 +8,8 @@ import { useTheme } from "@mui/material/styles";
 
 import { CollapsibleToolCall } from "./CollapsibleToolCall";
 import { preserveDisclosureExpansion } from "./disclosureScroll";
+import { getChatColors } from "./chatStyles";
+import { APP_MONO_FONT_FAMILY } from "../../styles/typography";
 
 export interface WorkLogEntry {
   id: string;
@@ -28,6 +30,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
   const [expanded, setExpanded] = useState(false);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
+  const chatColors = getChatColors(theme);
   const latestEntry = entries[entries.length - 1];
   const previousCount = Math.max(0, entries.length - 1);
 
@@ -56,9 +59,9 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
             sx={{
               minHeight: 24,
               px: 0.5,
-              color: isDark ? "rgba(255,255,255,0.65)" : "text.secondary",
+              color: isDark ? chatColors.muted : "text.secondary",
               fontSize: "0.76rem",
-              fontFamily: "monospace",
+              fontFamily: APP_MONO_FONT_FAMILY,
               textTransform: "none",
               "&:hover": { backgroundColor: "transparent" },
             }}
@@ -77,7 +80,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
           display: "flex",
           alignItems: "center",
           minHeight: 28,
-          color: isDark ? "rgba(255,255,255,0.7)" : "text.secondary",
+          color: isDark ? chatColors.muted : "text.secondary",
         }}
       >
         <Typography
@@ -86,7 +89,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
             flex: 1,
             fontWeight: 600,
             letterSpacing: "0.01em",
-            fontFamily: "monospace",
+            fontFamily: APP_MONO_FONT_FAMILY,
           }}
         >
           Tool calls
@@ -101,7 +104,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
             px: 0.5,
             color: "inherit",
             fontSize: "0.76rem",
-            fontFamily: "monospace",
+            fontFamily: APP_MONO_FONT_FAMILY,
             textTransform: "none",
             "&:hover": { backgroundColor: "transparent" },
           }}

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -55,7 +55,15 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
             size="small"
             onClick={toggleExpanded}
             aria-expanded={false}
-            startIcon={<ExpandMoreIcon sx={{ fontSize: 15 }} />}
+            startIcon={(
+              <ExpandMoreIcon
+                sx={{
+                  fontSize: 15,
+                  color: isDark ? chatColors.subtle : "rgba(0,0,0,0.45)",
+                  transform: "translateX(-1px)",
+                }}
+              />
+            )}
             sx={{
               minHeight: 24,
               px: 0,

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -1,8 +1,6 @@
 import React, { FC, useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useTheme } from "@mui/material/styles";
 
@@ -32,6 +30,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
   const isDark = theme.palette.mode === "dark";
   const chatColors = getChatColors(theme);
   const latestEntry = entries[entries.length - 1];
+  const previousEntries = entries.slice(0, -1);
   const previousCount = Math.max(0, entries.length - 1);
 
   if (!latestEntry) return null;
@@ -41,97 +40,55 @@ export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
     setExpanded((value) => !value);
   };
 
-  if (!expanded) {
-    return (
-      <Box sx={{ my: 1 }}>
-        <CollapsibleToolCall
-          toolName={latestEntry.toolName}
-          status={latestEntry.status}
-          body={latestEntry.body}
-          dense
-        />
-        {previousCount > 0 && (
-          <Button
-            size="small"
-            onClick={toggleExpanded}
-            aria-expanded={false}
-            startIcon={(
-              <ExpandMoreIcon
-                sx={{
-                  fontSize: 15,
-                  color: isDark ? chatColors.subtle : "rgba(0,0,0,0.45)",
-                  transform: "translateX(-1px)",
-                }}
-              />
-            )}
-            sx={{
-              minHeight: 24,
-              px: 0,
-              gap: 0.75,
-              color: isDark ? chatColors.foreground : "text.primary",
-              fontSize: "0.76rem",
-              fontWeight: 600,
-              fontFamily: APP_MONO_FONT_FAMILY,
-              textTransform: "none",
-              "&:hover": { backgroundColor: "transparent" },
-              "& .MuiButton-startIcon": { m: 0 },
-            }}
-          >
-            +{previousCount} previous tool {previousCount === 1 ? "call" : "calls"}
-          </Button>
-        )}
-      </Box>
-    );
-  }
-
   return (
-    <Box sx={{ my: 1 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          minHeight: 28,
-          color: isDark ? chatColors.muted : "text.secondary",
-        }}
-      >
-        <Typography
-          variant="caption"
-          sx={{
-            flex: 1,
-            fontWeight: 600,
-            letterSpacing: "0.01em",
-            fontFamily: APP_MONO_FONT_FAMILY,
-          }}
-        >
-          Tool calls
-        </Typography>
+    <Box sx={{ my: 0.5 }}>
+      <CollapsibleToolCall
+        toolName={latestEntry.toolName}
+        status={latestEntry.status}
+        body={latestEntry.body}
+        dense
+      />
+      {previousCount > 0 && (
         <Button
           size="small"
           onClick={toggleExpanded}
-          aria-expanded={true}
-          endIcon={<ExpandLessIcon sx={{ fontSize: 16 }} />}
+          aria-expanded={expanded}
+          startIcon={
+            <ExpandMoreIcon
+              sx={{
+                fontSize: 15,
+                color: isDark ? chatColors.subtle : "rgba(0,0,0,0.45)",
+                transform: `translateX(-1px) rotate(${expanded ? 180 : 0}deg)`,
+              }}
+            />
+          }
           sx={{
             minHeight: 24,
-            px: 0.5,
-            color: "inherit",
+            px: 0,
+            gap: 0.75,
+            color: isDark ? chatColors.foreground : "text.primary",
             fontSize: "0.76rem",
+            fontWeight: 600,
             fontFamily: APP_MONO_FONT_FAMILY,
             textTransform: "none",
             "&:hover": { backgroundColor: "transparent" },
+            "& .MuiButton-startIcon": { m: 0 },
           }}
         >
-          Show fewer tool calls
+          +{previousCount} previous tool{" "}
+          {previousCount === 1 ? "call" : "calls"}
         </Button>
-      </Box>
-      {entries.map((entry) => (
-        <CollapsibleToolCall
-          key={entry.id}
-          toolName={entry.toolName}
-          status={entry.status}
-          body={entry.body}
-          dense
-        />
-      ))}
+      )}
+      {expanded &&
+        previousEntries.map((entry) => (
+          <CollapsibleToolCall
+            key={entry.id}
+            toolName={entry.toolName}
+            status={entry.status}
+            body={entry.body}
+            dense
+          />
+        ))}
     </Box>
   );
 };

--- a/frontend/src/components/session/WorkLog.tsx
+++ b/frontend/src/components/session/WorkLog.tsx
@@ -18,14 +18,13 @@ export interface WorkLogEntry {
 
 interface WorkLogProps {
   entries: WorkLogEntry[];
-  showAll?: boolean;
 }
 
 /**
  * Keeps a long sequence of agent activity out of the main response flow.
  * The current entry remains visible; older entries are available on demand.
  */
-export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
+export const WorkLog: FC<WorkLogProps> = ({ entries }) => {
   const [expanded, setExpanded] = useState(false);
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
@@ -33,35 +32,6 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
   const previousCount = Math.max(0, entries.length - 1);
 
   if (!latestEntry) return null;
-
-  if (showAll) {
-    return (
-      <Box sx={{ my: 1 }}>
-        <Typography
-          variant="caption"
-          sx={{
-            display: "block",
-            mb: 0.25,
-            color: isDark ? "rgba(255,255,255,0.5)" : "text.secondary",
-            fontWeight: 600,
-            letterSpacing: "0.01em",
-            fontFamily: "monospace",
-          }}
-        >
-          Work Log
-        </Typography>
-        {entries.map((entry) => (
-          <CollapsibleToolCall
-            key={entry.id}
-            toolName={entry.toolName}
-            status={entry.status}
-            body={entry.body}
-            dense
-          />
-        ))}
-      </Box>
-    );
-  }
 
   const toggleExpanded = (event: React.MouseEvent<HTMLElement>) => {
     if (!expanded) preserveDisclosureExpansion(event.currentTarget);
@@ -93,7 +63,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
               "&:hover": { backgroundColor: "transparent" },
             }}
           >
-            +{previousCount} previous log {previousCount === 1 ? "entry" : "entries"}
+            +{previousCount} previous tool {previousCount === 1 ? "call" : "calls"}
           </Button>
         )}
       </Box>
@@ -119,7 +89,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
             fontFamily: "monospace",
           }}
         >
-          Work Log
+          Tool calls
         </Typography>
         <Button
           size="small"
@@ -136,7 +106,7 @@ export const WorkLog: FC<WorkLogProps> = ({ entries, showAll = false }) => {
             "&:hover": { backgroundColor: "transparent" },
           }}
         >
-          Show fewer log entries
+          Show fewer tool calls
         </Button>
       </Box>
       {entries.map((entry) => (

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -13,6 +13,7 @@ export const getChatColors = (theme: Theme) => {
     borderStrong: dark ? 'rgba(255, 255, 255, 0.13)' : 'rgba(0, 0, 0, 0.16)',
     foreground: dark ? '#f5f5f5' : '#18181b',
     assistantForeground: dark ? '#e8e8e8' : 'rgba(24, 24, 27, 0.8)',
-    muted: dark ? '#a1a1aa' : '#71717a',
+    muted: dark ? '#b8b8b8' : '#52525b',
+    subtle: dark ? '#969696' : '#71717a',
   }
 }

--- a/frontend/src/components/session/chatStyles.ts
+++ b/frontend/src/components/session/chatStyles.ts
@@ -12,7 +12,7 @@ export const getChatColors = (theme: Theme) => {
     border: dark ? 'rgba(255, 255, 255, 0.07)' : 'rgba(0, 0, 0, 0.09)',
     borderStrong: dark ? 'rgba(255, 255, 255, 0.13)' : 'rgba(0, 0, 0, 0.16)',
     foreground: dark ? '#f5f5f5' : '#18181b',
-    assistantForeground: dark ? 'rgba(245, 245, 245, 0.8)' : 'rgba(24, 24, 27, 0.8)',
+    assistantForeground: dark ? '#e8e8e8' : 'rgba(24, 24, 27, 0.8)',
     muted: dark ? '#a1a1aa' : '#71717a',
   }
 }

--- a/frontend/src/components/system/GlobalNotifications.test.tsx
+++ b/frontend/src/components/system/GlobalNotifications.test.tsx
@@ -24,11 +24,11 @@ const event = {
   metadata: { bot_id: 'bot-two' },
 }
 
-vi.mock('../../router', () => ({
-  default: {
+vi.mock('react-router5', () => ({
+  useRouter: () => ({
     buildPath: (_name: string, params: Record<string, string>) => `/orgs/${params.org_id}/chart?bot_id=${params.bot_id}`,
     navigate: mocks.navigate,
-  },
+  }),
 }))
 vi.mock('../../hooks/useAccount', () => ({
   default: () => ({

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -8,6 +8,7 @@ import Button from '@mui/material/Button'
 import Tooltip from '@mui/material/Tooltip'
 import Stack from '@mui/material/Stack'
 import ReactMarkdown from 'react-markdown'
+import { useRouter as useRouter5 } from 'react-router5'
 import { Bell, X, BellOff, BellRing, Sparkles, Hand, AlertCircle, GitMerge, ExternalLink, MessageSquare, ArrowRight } from 'lucide-react'
 
 import useAccount from '../../hooks/useAccount'
@@ -16,7 +17,6 @@ import useLightTheme from '../../hooks/useLightTheme'
 import { useAttentionEvents, AttentionEvent, AttentionEventType } from '../../hooks/useAttentionEvents'
 import { useBrowserNotifications } from '../../hooks/useBrowserNotifications'
 import { useNavigationHistory, NavHistoryEntry } from '../../hooks/useNavigationHistory'
-import router from '../../router'
 
 interface GlobalNotificationsProps {
   organizationId?: string
@@ -145,6 +145,7 @@ function groupTimestamp(group: EventGroup): number {
 const RecentPageItem: React.FC<{
   entry: NavHistoryEntry
 }> = ({ entry }) => {
+  const router = useRouter5()
   const lightTheme = useLightTheme()
   return (
     <Box
@@ -240,6 +241,7 @@ const AttentionEventItem: React.FC<{
   onNavigate: (event: AttentionEvent) => void
   onDismiss: (eventId: string) => void
 }> = ({ event, groupedWith, onNavigate, onDismiss }) => {
+  const router = useRouter5()
   const accentColor = eventAccentColor(event.event_type)
   // org_message (a bot messaging a person) has no spec task/project — its
   // headline is the title ("Message from …") and the body is the message.
@@ -452,6 +454,7 @@ const PANEL_WIDTH = 360
 const FILTER_STORAGE_KEY = 'attention-filter-mode'
 
 const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange }) => {
+  const router = useRouter5()
   const account = useAccount()
   const api = useApi()
   const lightTheme = useLightTheme()

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -241,6 +241,7 @@ const Page: React.FC<{
       {
         (useTopbarTitle || topbarContent || breadcrumbTitle || showTopbar) && (
           <Box
+            data-page-toolbar
             sx={{
               flexGrow: 0,
             }}

--- a/frontend/src/components/system/PageSectionHeader.tsx
+++ b/frontend/src/components/system/PageSectionHeader.tsx
@@ -1,0 +1,39 @@
+import { FC, ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+interface PageSectionHeaderProps {
+  title: string
+  description: string
+  action?: ReactNode
+}
+
+const PageSectionHeader: FC<PageSectionHeaderProps> = ({ title, description, action }) => (
+  <Stack
+    direction={{ xs: 'column', sm: 'row' }}
+    justifyContent="space-between"
+    alignItems={{ xs: 'stretch', sm: 'flex-start' }}
+    spacing={2}
+    sx={{ mb: 4 }}
+  >
+    <Box sx={{ minWidth: 0 }}>
+      <Typography
+        variant="h4"
+        sx={{
+          color: 'text.primary',
+          fontWeight: 700,
+          letterSpacing: '-0.02em',
+        }}
+      >
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+        {description}
+      </Typography>
+    </Box>
+    {action && <Box sx={{ flexShrink: 0 }}>{action}</Box>}
+  </Stack>
+)
+
+export default PageSectionHeader

--- a/frontend/src/components/system/Sidebar.tsx
+++ b/frontend/src/components/system/Sidebar.tsx
@@ -32,6 +32,7 @@ import SidebarContextHeader from './SidebarContextHeader'
 // import UnifiedSearchBar from '../common/UnifiedSearchBar'
 import { SidebarProvider, useSidebarContext } from '../../contexts/sidebarContext'
 import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
+import { TOOLBAR_HEIGHT } from '../../config'
 
 
 const shimmer = keyframes`
@@ -108,6 +109,7 @@ const SidebarContentInner: React.FC<{
   const account = useAccount()
   const appTools = useApp(params.app_id)
   const snackbar = useSnackbar()
+  const isConversationRoute = ['org_chat', 'org_session', 'org_new'].includes(router.name)
 
   // New file menu state
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null)
@@ -252,7 +254,7 @@ const SidebarContentInner: React.FC<{
           width: '100%',
         }}
       >
-        <SidebarContextHeader />
+        {!isConversationRoute && <SidebarContextHeader />}
         {/* Global search - available on all pages */}
         {/* <UnifiedSearchBar compact placeholder="Search..." /> */}
         <Box
@@ -276,7 +278,7 @@ const SidebarContentInner: React.FC<{
                     id="create-link"
                     onClick={handleCreateNew}
                     sx={{
-                      height: '64px',
+                      height: isConversationRoute ? TOOLBAR_HEIGHT : '64px',
                       display: 'flex',
                       '&:hover': {
                         '.MuiListItemText-root .MuiTypography-root': { color: lightTheme.textColor },

--- a/frontend/src/components/system/Sidebar.tsx
+++ b/frontend/src/components/system/Sidebar.tsx
@@ -253,10 +253,8 @@ const SidebarContentInner: React.FC<{
         }}
       >
         <SidebarContextHeader />
-        <Divider sx={{ width: '100%' }} />
         {/* Global search - available on all pages */}
         {/* <UnifiedSearchBar compact placeholder="Search..." /> */}
-        <Divider sx={{ width: '100%' }} />
         <Box
           sx={{
             flexGrow: 0,

--- a/frontend/src/components/system/SidebarContextHeader.tsx
+++ b/frontend/src/components/system/SidebarContextHeader.tsx
@@ -1,66 +1,28 @@
 import React from 'react'
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
-import useAccount from '../../hooks/useAccount'
-import useRouter from '../../hooks/useRouter'
 import useLightTheme from '../../hooks/useLightTheme'
 import { TOOLBAR_HEIGHT } from '../../config'
 import TokenExpiryCounter from '../auth/TokenExpiryCounter'
 import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 
 const SidebarContextHeader: React.FC = () => {
-  const account = useAccount()
-  const router = useRouter()
   const lightTheme = useLightTheme()
-
-  const org = account.organizationTools.organization
-  const displayName = org?.display_name || org?.name || ''
-
-  const handleNameClick = () => {
-    if (org) {
-      router.navigate('org_projects', { org_id: org.name })
-    }
-  }
 
   return (
     <Box
       sx={{
         width: '100%',
-        px: 2,
-        py: 2,
+        height: TOOLBAR_HEIGHT,
+        flex: `0 0 ${TOOLBAR_HEIGHT}px`,
+        px: 1,
         display: 'flex',
         alignItems: 'center',
-        background: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : 'linear-gradient(90deg, #32042a 0%, #2a1a6e 100%)',
+        justifyContent: 'flex-end',
+        backgroundColor: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.background : lightTheme.backgroundColor,
         borderBottom: lightTheme.isLight ? `1px solid ${LIGHT_SIDEBAR_COLORS.border}` : lightTheme.border,
-        minHeight: TOOLBAR_HEIGHT + 15,
-        boxShadow: lightTheme.isLight ? 'none' : '0 2px 8px 0 rgba(0,229,255,0.08)',
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, overflow: 'hidden' }}>
-        <Typography
-          variant="body2"
-          onClick={handleNameClick}
-          sx={{
-            color: lightTheme.isLight ? LIGHT_SIDEBAR_COLORS.foreground : lightTheme.textColor,
-            fontSize: '0.875rem',
-            lineHeight: 1.25,
-            fontWeight: 500,
-            letterSpacing: '-0.01em',
-            textShadow: lightTheme.isLight ? 'none' : '0 1px 4px rgba(0,0,0,0.12)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            cursor: 'pointer',
-            '&:hover': {
-              opacity: 0.8,
-            },
-          }}
-          title={displayName}
-        >
-          {displayName}
-        </Typography>
-        <TokenExpiryCounter />
-      </Box>
+      <TokenExpiryCounter />
     </Box>
   )
 }

--- a/frontend/src/contexts/all.tsx
+++ b/frontend/src/contexts/all.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react'
 
+import type { IApplicationRoute } from '../router'
+
 import {
   RouterContextProvider,
 } from './router'
@@ -46,9 +48,15 @@ import {
   VideoStreamProvider,
 } from './VideoStreamContext'
 
-const AllContextProvider = ({ children }: { children: ReactNode }) => {
+const AllContextProvider = ({
+  appRoute,
+  children,
+}: {
+  appRoute: IApplicationRoute,
+  children: ReactNode,
+}) => {
   return (
-    <RouterContextProvider>
+    <RouterContextProvider appRoute={appRoute}>
       <SnackbarContextProvider>
         <LoadingContextProvider>
           <ThemeProviderWrapper>

--- a/frontend/src/contexts/router.tsx
+++ b/frontend/src/contexts/router.tsx
@@ -1,6 +1,5 @@
-import React, { createContext, useMemo, useCallback, ReactNode } from 'react'
+import React, { createContext, useCallback, ReactNode } from 'react'
 import { useRoute } from 'react-router5'
-import router, { useApplicationRoute } from '../router'
 
 import {
   IRouterNavigateFunction,
@@ -28,6 +27,15 @@ export interface IRouterContext {
   },
 }
 
+interface ApplicationRoute {
+  render: () => JSX.Element,
+  meta: Record<string, any>,
+}
+
+// Keep this module independent of ../router. The application router imports every
+// page, and pages import this context through useRouter; closing that cycle makes
+// Vite refresh only the edited page instead of the entire application.
+
 export const RouterContext = createContext<IRouterContext>({
   name: '',
   params: {},
@@ -41,14 +49,9 @@ export const RouterContext = createContext<IRouterContext>({
   removeParams: () => {},
 })
 
-export const useRouterContext = (): IRouterContext => {
-  const { route } = useRoute()
-  const appRoute = useApplicationRoute()
-  const meta = useMemo(() => {
-    return appRoute.meta
-  }, [
-    appRoute,
-  ])
+const useRouterContext = (appRoute: ApplicationRoute): IRouterContext => {
+  const { route, router } = useRoute()
+  const routeParamsKey = JSON.stringify(route.params)
   const navigate = useCallback((name: string, params?: Record<string, any>) => {
     params ?
       router.navigate(name, params) :
@@ -65,21 +68,21 @@ export const useRouterContext = (): IRouterContext => {
     router.navigate(route.name, replace ? params : Object.assign({}, route.params, params))
   }, [
     route.name,
-    route.params,
+    routeParamsKey,
   ])
 
   const mergeParams = useCallback((params: Record<string, string>) => {
     router.navigate(route.name, Object.assign({}, route.params, params), { replace: true })
   }, [
     route.name,
-    route.params,
+    routeParamsKey,
   ])
 
   const replaceParams = useCallback((params: Record<string, string>) => {
     router.navigate(route.name, params, { replace: true })
   }, [
     route.name,
-    route.params,
+    routeParamsKey,
   ])
 
   const removeParams = useCallback((params: string[]) => {
@@ -92,41 +95,31 @@ export const useRouterContext = (): IRouterContext => {
     router.navigate(route.name, newParams)
   }, [
     route.name,
-    route.params,
+    routeParamsKey,
   ])
 
-  const render = useCallback(() => {
-    return appRoute.render()
-  }, [
-    appRoute,
-  ])
-
-  const contextValue = useMemo<IRouterContext>(() => ({
+  return {
     name: route.name,
     params: route.params,
-    meta,
+    meta: appRoute.meta,
     navigate,
     navigateReplace,
     setParams,
     mergeParams,
     replaceParams,
     removeParams,
-    render,
-  }), [
-    route.name,
-    route.params,
-    meta,
-    navigate,
-    navigateReplace,
-    setParams,
-    removeParams,
-    render,
-  ])
-  return contextValue
+    render: appRoute.render,
+  }
 }
 
-export const RouterContextProvider = ({ children }: { children: ReactNode }) => {
-  const value = useRouterContext()
+export const RouterContextProvider = ({
+  appRoute,
+  children,
+}: {
+  appRoute: ApplicationRoute,
+  children: ReactNode,
+}) => {
+  const value = useRouterContext(appRoute)
   return (
     <RouterContext.Provider value={ value }>
       { children }

--- a/frontend/src/contexts/settingsDialog.tsx
+++ b/frontend/src/contexts/settingsDialog.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react'
-import { router } from '../router'
+import { useRoute } from 'react-router5'
 
 export type SettingsDialogName = 'admin' | 'connected-services' | 'account' | 'project-settings'
 
@@ -73,6 +73,7 @@ const SettingsDialogContext = createContext<SettingsDialogContextType>({
 export const useSettingsDialog = () => useContext(SettingsDialogContext)
 
 export const SettingsDialogProvider = ({ children }: { children: ReactNode }) => {
+  const { route, previousRoute } = useRoute()
   const initial = getDialogFromURL()
   const [activeDialog, setActiveDialog] = useState<SettingsDialogName | null>(initial.name)
   const [dialogOptions, setDialogOptions] = useState<SettingsDialogOptions>(initial.options)
@@ -100,22 +101,13 @@ export const SettingsDialogProvider = ({ children }: { children: ReactNode }) =>
     return () => window.removeEventListener('popstate', handlePopState)
   }, [])
 
-  // Close dialog when the route changes — e.g. navigating to an agent page
+  // Close dialog when the route changes — e.g. navigating to an agent page.
   useEffect(() => {
-    const subscription = router.subscribe(({ route, previousRoute }) => {
-      if (previousRoute && route.name !== previousRoute.name) {
-        setActiveDialog(null)
-        setDialogOptions({})
-      }
-    }) as { unsubscribe: () => void } | (() => void)
-    return () => {
-      if (typeof subscription === 'function') {
-        subscription()
-      } else {
-        subscription.unsubscribe()
-      }
+    if (previousRoute && route.name !== previousRoute.name) {
+      setActiveDialog(null)
+      setDialogOptions({})
     }
-  }, [])
+  }, [route.name, previousRoute?.name])
 
   return (
     <SettingsDialogContext.Provider value={{ activeDialog, dialogOptions, openDialog, closeDialog }}>

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -68,11 +68,12 @@ const App: FC = () => {
   const [searchParams, setSearchParams] = useState(() => new URLSearchParams(window.location.search));
   const [isSearchMode, setIsSearchMode] = useState(() => searchParams.get('isSearchMode') === 'true');
   
-  const tabValue = !params.tab || params.tab === 'settings' ? 'instructions' : params.tab
+  const legacyGeneralTabs = ['settings', 'instructions', 'appearance']
+  const tabValue = !params.tab || legacyGeneralTabs.includes(params.tab) ? 'general' : params.tab
 
   useEffect(() => {
-    if (params.tab === 'settings') {
-      router.mergeParams({ tab: 'instructions' })
+    if (params.tab && legacyGeneralTabs.includes(params.tab)) {
+      router.mergeParams({ tab: 'general' })
     }
   }, [params.tab])
 
@@ -168,7 +169,7 @@ const App: FC = () => {
             }}>
               <Box sx={{ width: '100%' }}>
                 <Grid container spacing={0}>
-                  {tabValue === 'instructions' ? (
+                  {tabValue === 'general' ? (
                     <Grid item xs={12} sx={{ pb: 8 }}>
                       <Grid container spacing={4}>
                         <Grid item xs={12} md={8}>
@@ -180,8 +181,30 @@ const App: FC = () => {
                               readOnly={isReadOnly}
                               showErrors={appTools.showErrors}
                               isAdmin={account.admin}
-                              section="instructions"
+                              section="general"
+                              generalAside={(
+                                <AppearanceSettings
+                                  app={appTools.flatApp}
+                                  onUpdate={appTools.saveFlatApp}
+                                  readOnly={isReadOnly}
+                                  id={appTools.id}
+                                  section="avatar"
+                                />
+                              )}
                             />
+                          )}
+                          {appTools.flatApp && (
+                            <AppearanceSettings
+                              app={appTools.flatApp}
+                              onUpdate={appTools.saveFlatApp}
+                              readOnly={isReadOnly}
+                              showErrors={appTools.showErrors}
+                              id={appTools.id}
+                              section="conversation-starters"
+                            />
+                          )}
+                          {isOrgAgent && (
+                            <OrgAgentSettings agentID={appTools.id} section="runtime" readOnly={isReadOnly} />
                           )}
                         </Grid>
                         <Grid item xs={12} md={4}>
@@ -202,24 +225,6 @@ const App: FC = () => {
                             isAdmin={account.admin}
                             section="runtime"
                             hideAgentType={isOrgAgent}
-                          />
-                        )}
-                        {isOrgAgent && (
-                          <OrgAgentSettings agentID={appTools.id} section="runtime" readOnly={isReadOnly} />
-                        )}
-                      </Box>
-                    </Grid>
-                  ) : tabValue === 'appearance' ? (
-                    <Grid item xs={12} sx={{ pb: 8 }}>
-                      <Box sx={{ maxWidth: 960 }}>
-                        <Typography variant="h5" sx={{ mt: 2, mb: 3 }}>Appearance</Typography>
-                        {appTools.flatApp && (
-                          <AppearanceSettings
-                            app={appTools.flatApp}
-                            onUpdate={appTools.saveFlatApp}
-                            readOnly={isReadOnly}
-                            showErrors={appTools.showErrors}
-                            id={appTools.id}
                           />
                         )}
                       </Box>

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -8,7 +8,6 @@ import Grid from '@mui/material/Grid'
 import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined'
 
 import Typography from '@mui/material/Typography'
-import { useTheme } from '@mui/material/styles'
 
 
 import APIKeysSection from '../components/app/APIKeysSection'
@@ -49,7 +48,6 @@ const App: FC = () => {
   const api = useApi()
   const snackbar = useSnackbar()
   const themeConfig = useThemeConfig()
-  const theme = useTheme()
   const router = useRouter()
   const { params } = router
 
@@ -70,12 +68,11 @@ const App: FC = () => {
   const [searchParams, setSearchParams] = useState(() => new URLSearchParams(window.location.search));
   const [isSearchMode, setIsSearchMode] = useState(() => searchParams.get('isSearchMode') === 'true');
   
-  // Get tab from URL params instead of local state
-  const tabValue = params.tab === 'appearance' ? 'settings' : params.tab || 'settings';
+  const tabValue = !params.tab || params.tab === 'settings' ? 'instructions' : params.tab
 
   useEffect(() => {
-    if (params.tab === 'appearance') {
-      router.mergeParams({ tab: 'settings' })
+    if (params.tab === 'settings') {
+      router.mergeParams({ tab: 'instructions' })
     }
   }, [params.tab])
 
@@ -102,6 +99,7 @@ const App: FC = () => {
   if (!appTools.app) return null
 
   const isReadOnly = appTools.isReadOnly || !appTools.isSafeToSave
+  const isOrgAgent = isHelixOrgChartAgent(appTools.app)
 
   const openChat = async () => {
     if (!linkedOrgAgent?.id) {
@@ -140,7 +138,7 @@ const App: FC = () => {
       topbarContent={(
         <>
           <HelixOrgTopNav />
-          {isHelixOrgChartAgent(appTools.app) && (
+          {isOrgAgent && (
             <Chip label="Org Chart" size="small" color="primary" variant="outlined" />
           )}
           <Button
@@ -163,26 +161,78 @@ const App: FC = () => {
       >
         <Box sx={{ width: '100%', pl: 2, pr: 2, mt: 2 }}>
           <Grid container>
-            {/* Tab Content - Full Width */}
             <Grid item xs={12} sx={{
-              backgroundColor: lightTheme.panelColor,
               p: 0,
               mt: 2,
               mb: 2,
-              borderRadius: 2,
-              boxShadow: '0 4px 24px 0 rgba(0,0,0,0.12)',
             }}>
-              <Box sx={{ width: '100%', p: 0, pl: 4 }}>
+              <Box sx={{ width: '100%' }}>
                 <Grid container spacing={0}>
-                  {tabValue === 'usage' ? (
+                  {tabValue === 'instructions' ? (
+                    <Grid item xs={12} sx={{ pb: 8 }}>
+                      <Grid container spacing={4}>
+                        <Grid item xs={12} md={8}>
+                          {appTools.flatApp && (
+                            <AppSettings
+                              id={appTools.id}
+                              app={appTools.flatApp}
+                              onUpdate={appTools.saveFlatApp}
+                              readOnly={isReadOnly}
+                              showErrors={appTools.showErrors}
+                              isAdmin={account.admin}
+                              section="instructions"
+                            />
+                          )}
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                          <AgentInfoPanel app={appTools.app} orgAgent={linkedOrgAgent} />
+                        </Grid>
+                      </Grid>
+                    </Grid>
+                  ) : tabValue === 'runtime' ? (
+                    <Grid item xs={12} sx={{ pb: 8 }}>
+                      <Box sx={{ maxWidth: 960 }}>
+                        {appTools.flatApp && (
+                          <AppSettings
+                            id={appTools.id}
+                            app={appTools.flatApp}
+                            onUpdate={appTools.saveFlatApp}
+                            readOnly={isReadOnly}
+                            showErrors={appTools.showErrors}
+                            isAdmin={account.admin}
+                            section="runtime"
+                            hideAgentType={isOrgAgent}
+                          />
+                        )}
+                        {isOrgAgent && (
+                          <OrgAgentSettings agentID={appTools.id} section="runtime" readOnly={isReadOnly} />
+                        )}
+                      </Box>
+                    </Grid>
+                  ) : tabValue === 'appearance' ? (
+                    <Grid item xs={12} sx={{ pb: 8 }}>
+                      <Box sx={{ maxWidth: 960 }}>
+                        <Typography variant="h5" sx={{ mt: 2, mb: 3 }}>Appearance</Typography>
+                        {appTools.flatApp && (
+                          <AppearanceSettings
+                            app={appTools.flatApp}
+                            onUpdate={appTools.saveFlatApp}
+                            readOnly={isReadOnly}
+                            showErrors={appTools.showErrors}
+                            id={appTools.id}
+                          />
+                        )}
+                      </Box>
+                    </Grid>
+                  ) : tabValue === 'usage' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         <AppUsage appId={appTools.id} />
                       </Box>
                     </Grid>
                   ) : tabValue === 'skills' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         { appTools.flatApp && (
                           <Skills
                             app={appTools.flatApp}
@@ -190,11 +240,14 @@ const App: FC = () => {
                             onUpdate={appTools.saveFlatApp}
                           />
                         )}
+                        {isOrgAgent && (
+                          <OrgAgentSettings agentID={appTools.id} section="tools" readOnly={isReadOnly} />
+                        )}
                       </Box>
                     </Grid>
                   ) : tabValue === 'tests' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         { appTools.flatApp && (
                           <TestsEditor
                             app={appTools.flatApp}
@@ -206,13 +259,13 @@ const App: FC = () => {
                     </Grid>
                   ) : tabValue === 'evaluation' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         <EvaluationTab appId={appTools.id} />
                       </Box>
                     </Grid>
                   ) : tabValue === 'memories' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         <MemoriesManagement 
                           appId={appTools.id} 
                           memory={appTools.flatApp?.memory || false}
@@ -223,7 +276,7 @@ const App: FC = () => {
                     </Grid>
                   ) : tabValue === 'developers' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         <DevelopersSection
                           schema={appTools.appSchema}
                           setSchema={appTools.setAppSchema}
@@ -235,7 +288,7 @@ const App: FC = () => {
                     </Grid>
                   ) : tabValue === 'mcp' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box>
                         <IdeIntegrationSection
                           appId={appTools.id}
                         />
@@ -243,7 +296,10 @@ const App: FC = () => {
                     </Grid>
                   ) : tabValue === 'triggers' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
+                      <Box sx={{ maxWidth: 1100 }}>
+                        {isOrgAgent && (
+                          <OrgAgentSettings agentID={appTools.id} section="subscriptions" readOnly={isReadOnly} />
+                        )}
                         <Triggers
                           app={appTools.flatApp || {}}
                           appId={appTools.id}
@@ -255,56 +311,29 @@ const App: FC = () => {
                     </Grid>                  
                   ) : tabValue === 'access' ? (
                     <Grid item xs={12} sx={{ overflow: 'auto', pb: 8, ...lightTheme.scrollbar }}>
-                      <Box sx={{ mt: 2, mr: 3 }}>
-                        <AccessManagement
-                          appId={appTools.id}
-                          accessGrants={appTools.accessGrants}
-                          isLoading={false}
-                          isReadOnly={isReadOnly}
-                          onCreateGrant={appTools.createAccessGrant}
-                          onDeleteGrant={appTools.deleteAccessGrant}
-                        />
+                      <Box sx={{ mt: 2, maxWidth: 1100 }}>
+                        {isOrgAgent && (
+                          <OrgAgentSettings agentID={appTools.id} section="access" readOnly={isReadOnly} />
+                        )}
+                        {userAccess?.isAdmin && (
+                          <AccessManagement
+                            appId={appTools.id}
+                            accessGrants={appTools.accessGrants}
+                            isLoading={false}
+                            isReadOnly={isReadOnly}
+                            onCreateGrant={appTools.createAccessGrant}
+                            onDeleteGrant={appTools.deleteAccessGrant}
+                          />
+                        )}
                       </Box>
                     </Grid>
                   ) : (
                     <>
-                      <Grid item xs={12} md={tabValue === 'settings' ? 8 : appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL && tabValue !== 'apikeys' ? 12 : 6} sx={{
-                        ...((tabValue === 'settings' || appTools.flatApp?.default_agent_type !== AGENT_TYPE_ZED_EXTERNAL || tabValue === 'apikeys') && { borderRight: { xs: 'none', md: '1px solid #303047' } }),
+                      <Grid item xs={12} md={appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL && tabValue !== 'apikeys' ? 12 : 6} sx={{
                         pb: 8,
                         minHeight: 'calc(100vh - 120px)'
                       }}>
-                        <Box sx={{ mt: "-1px", borderTop: '1px solid #303047', p: 0 }}>
-                          {appTools.flatApp && (
-                            <Box sx={{
-                              display: tabValue === 'settings' ? 'block' : 'none',
-                              pb: 4
-                            }}>
-                              <AppSettings
-                                id={appTools.id}
-                                app={appTools.flatApp}
-                                onUpdate={appTools.saveFlatApp}
-                                readOnly={isReadOnly}
-                                showErrors={appTools.showErrors}
-                                isAdmin={account.admin}
-                              />
-                              {isHelixOrgChartAgent(appTools.app) && (
-                                <>
-                                  <OrgAgentSettings agentID={appTools.id} section="runtime" readOnly={isReadOnly} />
-                                  <OrgAgentSettings agentID={appTools.id} section="access" readOnly={isReadOnly} />
-                                  <OrgAgentSettings agentID={appTools.id} section="subscriptions" readOnly={isReadOnly} />
-                                  <OrgAgentSettings agentID={appTools.id} section="tools" readOnly={isReadOnly} />
-                                </>
-                              )}
-                              <AppearanceSettings
-                                app={appTools.flatApp}
-                                onUpdate={appTools.saveFlatApp}
-                                readOnly={isReadOnly}
-                                showErrors={appTools.showErrors}
-                                id={appTools.id}
-                              />
-                            </Box>
-                          )}
-
+                        <Box>
                           <Box sx={{ display: tabValue === 'knowledge' ? 'block' : 'none', height: '100%', overflow: 'auto', mr: 2 }}>
                             <Typography variant="h6" sx={{ mb: 2, mt: 2 }}>
                               Knowledge Sources
@@ -335,14 +364,7 @@ const App: FC = () => {
                           </Box>
                         </Box>
                       </Grid>
-                      {tabValue === 'settings' && appTools.flatApp ? (
-                        <Grid item xs={12} md={4}>
-                          <AgentInfoPanel
-                            app={appTools.app}
-                            orgAgent={linkedOrgAgent}
-                          />
-                        </Grid>
-                      ) : tabValue === 'apikeys' ? (
+                      {tabValue === 'apikeys' ? (
                         <CodeExamples apiKey={account.appApiKeys[0]?.key || ''} />
                       ) : appTools.flatApp?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL ? null : (
                         <PreviewPanel

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
@@ -138,10 +137,6 @@ const App: FC = () => {
       ]}
       topbarContent={(
         <>
-          <HelixOrgTopNav />
-          {isOrgAgent && (
-            <Chip label="Org Chart" size="small" color="primary" variant="outlined" />
-          )}
           <Button
             variant="contained"
             color="secondary"
@@ -151,6 +146,7 @@ const App: FC = () => {
           >
             Open chat
           </Button>
+          <HelixOrgTopNav />
         </>
       )}
     >

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -108,6 +108,7 @@ const Apps: FC = () => {
               id="new-app-button"
               variant="contained"
               color="secondary"
+              size="small"
               startIcon={<AddIcon />}
               onClick={onNewAgent}
             >

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -2,10 +2,9 @@ import React, { FC, useCallback, useEffect, useState } from 'react'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import Container from '@mui/material/Container'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
 
 import Page from '../components/system/Page'
+import PageSectionHeader from '../components/system/PageSectionHeader'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 import AppsTable from '../components/apps/AppsTable'
 
@@ -86,6 +85,7 @@ const Apps: FC = () => {
       breadcrumbTitle="Agents"
       orgBreadcrumbs={ true }
       globalSearch={true}
+      notifications={true}
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <>
@@ -94,15 +94,16 @@ const Apps: FC = () => {
       )}
     >
       <Container
-        maxWidth="xl"
+        maxWidth="lg"
         sx={{
           mb: 4,
-          pt: 3,
+          mt: 4,
         }}
       >
-        <Stack spacing={2}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-            <Typography variant="h5">Agents</Typography>
+        <PageSectionHeader
+          title="Agents"
+          description="Agents in this org. Click an agent to edit instructions, tools and subscriptions."
+          action={
             <Button
               id="new-app-button"
               variant="contained"
@@ -112,20 +113,17 @@ const Apps: FC = () => {
             >
               New Agent
             </Button>
-          </Stack>
-          <Typography variant="body2" color="text.secondary">
-            Agents in this org. Click an agent to edit instructions, tools and subscriptions.
-          </Typography>
-          <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
-            <AppsTable
-              authenticated={ !!account.user }
-              data={ apps.apps }
-              onEdit={ onEditApp }
-              onDelete={ setDeletingApp }
-              orgId={ account.organizationTools.organization?.id || '' }
-            />
-          </Paywall>
-        </Stack>
+          }
+        />
+        <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
+          <AppsTable
+            authenticated={ !!account.user }
+            data={ apps.apps }
+            onEdit={ onEditApp }
+            onDelete={ setDeletingApp }
+            orgId={ account.organizationTools.organization?.id || '' }
+          />
+        </Paywall>
       </Container>
       {
         deletingApp && (

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -53,6 +53,7 @@ import SettingsBackupRestoreIcon from '@mui/icons-material/SettingsBackupRestore
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import StopIcon from '@mui/icons-material/Stop'
 import Tooltip from '@mui/material/Tooltip'
+import { useRouter as useRouter5 } from 'react-router5'
 
 import HelixOrgShell from '../components/helix-org/HelixOrgShell'
 import AgentConfigForm, { AgentConfigValue } from '../components/helix-org/BotRuntimeForm'
@@ -62,7 +63,6 @@ import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import MonacoEditor from '../components/widgets/MonacoEditor'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 
-import router5 from '../router'
 import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
@@ -89,6 +89,7 @@ import {
 import { useSwitchAgent } from '../services/sessionService'
 
 const HelixOrgBotDetail: FC = () => {
+  const router5 = useRouter5()
   const router = useRouter()
   const snackbar = useSnackbar()
   const api = useApi()

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -415,6 +415,9 @@ const Layout: FC<{
   const isProjectsIndex =
     router.name === "org_projects" &&
     (!router.params.tab || router.params.tab === "projects");
+  const isConversationRoute = ["org_chat", "org_session", "org_new"].includes(
+    router.name,
+  );
 
   // Hide sidebar on /new page when app_id is specified, otherwise use router.meta.drawer
   const shouldShowSidebar =
@@ -683,7 +686,7 @@ const Layout: FC<{
               },
               "& [data-page-toolbar] > .MuiAppBar-root": {
                 position: "fixed",
-                left: 64,
+                left: isConversationRoute ? themeConfig.drawerWidth : 64,
                 right: 0,
                 width: "auto",
                 zIndex: (theme) => theme.zIndex.drawer + 1,

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -53,6 +53,7 @@ import useIsBigScreen from "../hooks/useIsBigScreen";
 import useApps from "../hooks/useApps";
 import useUserMenuHeight from "../hooks/useUserMenuHeight";
 import { LIGHT_SIDEBAR_COLORS } from "../styles/themeTokens";
+import { TOOLBAR_HEIGHT } from "../config";
 
 // Admin and Connected Services are rendered as full-screen dialog overlays
 // so the user stays within their current org-scoped URL
@@ -672,6 +673,19 @@ const Layout: FC<{
             display: "flex",
             flexDirection: "column",
             overflow: "hidden",
+            ...(isBigScreen && shouldShowSidebar && {
+              "& [data-page-toolbar]": {
+                height: TOOLBAR_HEIGHT,
+                minHeight: TOOLBAR_HEIGHT,
+              },
+              "& [data-page-toolbar] > .MuiAppBar-root": {
+                position: "fixed",
+                left: 64,
+                right: 0,
+                width: "auto",
+                zIndex: (theme) => theme.zIndex.drawer + 1,
+              },
+            }),
           }}
         >
           <Box

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -23,7 +23,6 @@ import AdminPanelSidebar from "../components/admin/AdminPanelSidebar";
 import AccountSidebar from "../components/account/AccountSidebar";
 import OrgSidebar from "../components/orgs/OrgSidebar";
 import AppSidebar from "../components/app/AppSidebar";
-import ProjectsSidebar from "../components/project/ProjectsSidebar";
 import ProjectSettingsSidebar from "../components/project/ProjectSettingsSidebar";
 import FullScreenDialog from "../components/dialog/FullScreenDialog";
 import Dashboard from "./Dashboard";
@@ -413,11 +412,15 @@ const Layout: FC<{
   // AppBar; chat is an in-page left rail). Still show the 64px org rail.
   const isHelixOrgRoute =
     typeof router.name === "string" && router.name.startsWith("helix_org_");
+  const isProjectsIndex =
+    router.name === "org_projects" &&
+    (!router.params.tab || router.params.tab === "projects");
 
   // Hide sidebar on /new page when app_id is specified, otherwise use router.meta.drawer
   const shouldShowSidebar =
     router.meta.drawer &&
     !isHelixOrgRoute &&
+    !isProjectsIndex &&
     !(router.name === "org_new" && router.params.app_id);
 
   if (shouldShowSidebar) {
@@ -445,7 +448,7 @@ const Layout: FC<{
   function getSidebarForRoute(routeName: string, onOpenSession: () => void) {
     switch (routeName) {
       case "org_projects":
-        return <ProjectsSidebar />;
+        return <OrgSidebar />;
 
       case "helix_org_root":
       case "helix_org_chart":

--- a/frontend/src/pages/OrgApiKeys.tsx
+++ b/frontend/src/pages/OrgApiKeys.tsx
@@ -127,11 +127,6 @@ const OrgApiKeys: FC = () => {
   return (
     <Page
       breadcrumbTitle="API Keys"
-      breadcrumbParent={{
-        title: 'Organizations',
-        routeName: 'orgs',
-        useOrgRouter: false,
-      }}
       breadcrumbShowHome={true}
       orgBreadcrumbs={true}
     >

--- a/frontend/src/pages/OrgPeople.tsx
+++ b/frontend/src/pages/OrgPeople.tsx
@@ -132,7 +132,6 @@ const OrgPeople: FC = () => {
   return (
     <Page
       breadcrumbTitle={ organization ? `People` : 'Organization People' }
-      breadcrumbParent={{ title: 'Organizations', routeName: 'orgs', useOrgRouter: false }}
       breadcrumbShowHome={ true }
       orgBreadcrumbs={ true }
       topbarContent={isOrgOwner ? (

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -198,11 +198,6 @@ const OrgSettings: FC = () => {
   return (
     <Page
       breadcrumbTitle={organization ? `General` : "General"}
-      breadcrumbParent={{
-        title: "Organizations",
-        routeName: "orgs",
-        useOrgRouter: false,
-      }}
       breadcrumbShowHome={true}
       orgBreadcrumbs={true}
     >

--- a/frontend/src/pages/OrgTeams.tsx
+++ b/frontend/src/pages/OrgTeams.tsx
@@ -88,7 +88,6 @@ const OrgTeams: FC = () => {
   return (
     <Page
       breadcrumbTitle={ organization ? `Teams` : 'Organization Teams' }
-      breadcrumbParent={{ title: 'Organizations', routeName: 'orgs', useOrgRouter: false }}
       breadcrumbShowHome={ true }
       orgBreadcrumbs={ true }
       topbarContent={isOrgOwner ? (

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -389,11 +389,6 @@ const Projects: FC = () => {
   return (
     <Page
       breadcrumbTitle={getBreadcrumbTitle()}
-      breadcrumbParent={
-        currentView !== "projects"
-          ? { title: "Projects", routeName: "projects" }
-          : undefined
-      }
       breadcrumbs={[]}
       orgBreadcrumbs={true}
       globalSearch={true}

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -10,7 +10,6 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import { useQueryClient } from "@tanstack/react-query";
 
 import Page from "../components/system/Page";
-import CreateProjectButton from "../components/project/CreateProjectButton";
 import CreateProjectDialog from "../components/project/CreateProjectDialog";
 import AgentSelectionModal from "../components/project/AgentSelectionModal";
 import SampleProjectWizard from "../components/project/SampleProjectWizard";
@@ -26,6 +25,7 @@ import useApi from "../hooks/useApi";
 import useApps from "../hooks/useApps";
 import useSubscriptionGate from "../hooks/useSubscriptionGate";
 import Paywall from "../components/subscription/Paywall";
+import HelixOrgTopNav from "../components/helix-org/HelixOrgTopNav";
 import {
   useListProjects,
   useListSampleProjects,
@@ -394,20 +394,9 @@ const Projects: FC = () => {
       globalSearch={true}
       notifications={true}
       organizationId={account.organizationTools.organization?.id}
-      topbarContent={
-        currentView === "projects" && projects.length > 0 ? (
-          <CreateProjectButton
-            onCreateEmpty={handleNewProject}
-            onCreateFromSample={handleInstantiateSample}
-            sampleProjects={sampleProjects}
-            isCreating={instantiateSampleMutation.isPending}
-            variant="contained"
-            color="secondary"
-          />
-        ) : null
-      }
+      topbarContent={<HelixOrgTopNav />}
     >
-      <Container maxWidth="lg" sx={{ mt: 4 }}>
+      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
           {/* Projects View */}
           {currentView === "projects" && (

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -66,11 +66,6 @@ const Providers: React.FC = () => {
 
   const pageProps = {
     breadcrumbTitle: 'AI providers',
-    breadcrumbParent: {
-      title: 'Organizations',
-      routeName: 'orgs',
-      useOrgRouter: false,
-    },
     breadcrumbShowHome: true,
     orgBreadcrumbs: true,
     topbarContent: null,

--- a/frontend/src/pages/Sandboxes.tsx
+++ b/frontend/src/pages/Sandboxes.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import AddIcon from '@mui/icons-material/Add'
 
 import Page from '../components/system/Page'
+import PageSectionHeader from '../components/system/PageSectionHeader'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 import ViewModeToggle from '../components/widgets/ViewModeToggle'
@@ -65,27 +66,25 @@ const Sandboxes: FC = () => {
     <Page
       breadcrumbTitle="Sandboxes"
       orgBreadcrumbs={true}
-      topbarContent={(
-        <Button
-          variant="contained"
-          color="secondary"
-          startIcon={<AddIcon />}
-          onClick={() => setCreateOpen(true)}
-        >
-          New Sandbox
-        </Button>
-      )}
     >
-      <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
+      <Container maxWidth="lg" sx={{ mb: 4, mt: 4 }}>
+        <PageSectionHeader
+          title="Sandboxes"
+          description="Ephemeral containers you can SSH into, run commands inside, and read/write files. Pinned at 1 vCPU / 2GB RAM. Nothing is persisted after deletion."
+          action={
+            <Button
+              id="new-sandbox-button"
+              variant="contained"
+              color="secondary"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={() => setCreateOpen(true)}
+            >
+              New Sandbox
+            </Button>
+          }
+        />
         <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ mb: 1 }}>Sandboxes</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Ephemeral containers you can SSH into, run commands inside, and read/write files.
-              Pinned at 1 vCPU / 2GB RAM. Nothing is persisted after deletion.
-            </Typography>
-          </Box>
-
           {isLoading ? (
             <LoadingSpinner />
           ) : sandboxes.length === 0 ? (

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -11,8 +11,7 @@ import TasksView from '../components/tasks/TasksView'
 import EmptyTasksState from '../components/tasks/EmptyTasksState'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 import ViewModeToggle from '../components/widgets/ViewModeToggle'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
+import PageSectionHeader from '../components/system/PageSectionHeader'
 
 import { useListUserCronTriggers, useDeleteAppTrigger } from '../services/appService'
 import useAccount from '../hooks/useAccount'
@@ -221,31 +220,27 @@ const Tasks: FC = () => {
     <Page
       breadcrumbTitle="Tasks"
       orgBreadcrumbs={true}
-      topbarContent={(
-        <Button
-          id="new-task-button"
-          variant="contained"
-          color="secondary"
-          endIcon={<AddIcon />}
-          onClick={() => handleCreateTask()}
-        >
-          New
-        </Button>
-      )}
     >
-      <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
-        <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ mb: 1 }}>Tasks</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Recurring agent tasks that run on a cron schedule. Each task triggers an agent
-              with a defined input on its schedule and tracks recent executions.
-            </Typography>
-          </Box>
-          <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
-            {renderContent()}
-          </Paywall>
-        </Stack>
+      <Container maxWidth="lg" sx={{ mb: 4, mt: 4 }}>
+        <PageSectionHeader
+          title="Tasks"
+          description="Recurring agent tasks that run on a cron schedule. Each task triggers an agent with a defined input on its schedule and tracks recent executions."
+          action={
+            <Button
+              id="new-task-button"
+              variant="contained"
+              color="secondary"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={() => handleCreateTask()}
+            >
+              New Task
+            </Button>
+          }
+        />
+        <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
+          {renderContent()}
+        </Paywall>
       </Container>
 
       {/* Task Dialog */}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -729,9 +729,4 @@ export function useApplicationRoute(): IApplicationRoute {
   return fullRoute
 }
 
-export function RenderPage() {
-  const route = useApplicationRoute()
-  return route.render()
-}
-
 export default router


### PR DESCRIPTION
## Summary
- flatten the agent details sidebar and split General from Runtime
- group name, avatar, instructions, conversation starters, and org context under General
- group display controls under Sandbox settings and hide fixed org-agent type controls
- move org subscriptions, tools, and project access to their matching tabs
- remove copied panel backgrounds and borders

## Verification
- `cd frontend && yarn build`
- live browser verification against an org-chart agent at `http://localhost:8080`
- verified General/Runtime sidebar navigation, legacy tab redirects, fixed agent-type visibility, and org settings placement
