### PR TITLE
fix(api): attribute app-less usage to organization

### DIFF
--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -269,7 +269,6 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 		}
 
 		ctx = oai.SetContextAppID(ctx, app.ID)
-		ctx = oai.SetContextOrganizationID(ctx, options.OrganizationID)
 
 		log.Debug().Str("app_id", options.AppID).Msg("using app_id from request")
 
@@ -289,6 +288,7 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 	}
 
 	ctx = oai.SetContextAppID(ctx, options.AppID)
+	ctx = oai.SetContextOrganizationID(ctx, options.OrganizationID)
 
 	// Non-streaming request returns the response immediately
 	if !chatCompletionRequest.Stream {

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -1,15 +1,24 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/dgraph-io/ristretto/v2"
 	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/controller"
+	"github.com/helixml/helix/api/pkg/extract"
+	"github.com/helixml/helix/api/pkg/filestore"
+	"github.com/helixml/helix/api/pkg/janitor"
+	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
+	openai "github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -132,4 +141,40 @@ func (s *FindProviderWithModelSuite) TestUnknownModel_ReturnsEmpty() {
 	provider, bare := s.server.findProviderWithModel(context.Background(), "made-up-model", "user_x", "")
 	s.Empty(provider)
 	s.Empty(bare)
+}
+
+func (s *FindProviderWithModelSuite) TestChatCompletionWithoutAppPassesOrganizationContext() {
+	client := oai.NewMockClient(s.ctrl)
+	s.manager.EXPECT().GetClient(gomock.Any(), gomock.Any()).Return(client, nil).AnyTimes()
+	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{}, nil).AnyTimes()
+	s.store.EXPECT().GetUserMeta(gomock.Any(), "user_test").Return(&types.UserMeta{}, nil)
+	client.EXPECT().BillingEnabled().Return(false)
+	client.EXPECT().CreateChatCompletion(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+			orgID, ok := oai.GetContextOrganizationID(ctx)
+			s.True(ok)
+			s.Equal("org_test", orgID)
+			return openai.ChatCompletionResponse{}, nil
+		},
+	)
+
+	controller, err := controller.NewController(context.Background(), controller.Options{
+		Config:          s.server.Cfg,
+		Store:           s.store,
+		Janitor:         janitor.NewJanitor(config.Janitor{}),
+		ProviderManager: s.manager,
+		Filestore:       filestore.NewMockFileStore(s.ctrl),
+		Extractor:       extract.NewMockExtractor(s.ctrl),
+	})
+	s.Require().NoError(err)
+	s.server.Controller = controller
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(`{"model":"openai/test-model","messages":[{"role":"user","content":"hi"}]}`))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user_test", OrganizationID: "org_test"}))
+	rw := httptest.NewRecorder()
+
+	s.server.createChatCompletion(rw, req)
+
+	s.Equal(http.StatusOK, rw.Code)
 }


### PR DESCRIPTION
## Summary
- propagate organization context for app-less OpenAI API requests
- preserve app-derived organization overrides
- add a handler regression test for spec-task API-key usage

## Tests
- CGO_ENABLED=1 go test ./api/pkg/server -run TestFindProviderWithModelSuite -count=1
- go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/
- git diff --check