### PR TITLE
fix(api): resolve and migrate legacy personal providers

### DIFF
--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -521,6 +521,7 @@ func (c *Controller) getClient(ctx context.Context, organizationID, userID, prov
 	client, err := c.providerManager.GetClient(ctx, &manager.GetClientRequest{
 		Provider: provider,
 		Owner:    owner,
+		UserID:   userID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %v", err)

--- a/api/pkg/controller/inference_agent.go
+++ b/api/pkg/controller/inference_agent.go
@@ -83,6 +83,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	reasoningModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		req.User.ID,
 		withFallbackProvider(req.Assistant.ReasoningModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.ReasoningModel)
 	if err != nil {
@@ -98,6 +99,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	generationModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		req.User.ID,
 		withFallbackProvider(req.Assistant.GenerationModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.GenerationModel)
 	if err != nil {
@@ -112,6 +114,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	smallReasoningModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		req.User.ID,
 		withFallbackProvider(req.Assistant.SmallReasoningModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.SmallReasoningModel)
 	if err != nil {
@@ -121,6 +124,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	smallGenerationModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		req.User.ID,
 		withFallbackProvider(req.Assistant.SmallGenerationModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.SmallGenerationModel)
 	if err != nil {
@@ -326,10 +330,11 @@ func withFallbackProvider(provider string, assistant *types.AssistantConfig) str
 	return provider
 }
 
-func (c *Controller) getLLMModelConfig(ctx context.Context, owner, provider, model string) (*agent.LLMModelConfig, error) {
+func (c *Controller) getLLMModelConfig(ctx context.Context, owner, userID, provider, model string) (*agent.LLMModelConfig, error) {
 	client, err := c.providerManager.GetClient(ctx, &manager.GetClientRequest{
 		Provider: provider,
 		Owner:    owner,
+		UserID:   userID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)

--- a/api/pkg/controller/inference_agent_preflight_test.go
+++ b/api/pkg/controller/inference_agent_preflight_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/config"
@@ -53,4 +54,29 @@ func TestPreflightHelixAgentModelsIgnoresTopLevelProvider(t *testing.T) {
 
 	err := c.preflightHelixAgentModels(context.Background(), &types.User{ID: "user1"}, &ChatCompletionOptions{}, assistant)
 	require.NoError(t, err)
+}
+
+func TestRunAgentPassesPersonalProviderScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	providerManager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
+		Provider: "pe_personal",
+		Owner:    "org_x",
+		UserID:   "user_x",
+	}).Return(nil, errors.New("stop after provider lookup"))
+
+	c := &Controller{
+		Options:         Options{Config: &config.ServerConfig{}},
+		providerManager: providerManager,
+	}
+	ctx := oai.SetContextAppID(context.Background(), "app_x")
+	_, _, err := c.runAgent(ctx, &runAgentRequest{
+		OrganizationID: "org_x",
+		Assistant: &types.AssistantConfig{
+			ReasoningModelProvider: "pe_personal",
+			ReasoningModel:         "model_x",
+		},
+		User: &types.User{ID: "user_x"},
+	})
+	require.ErrorContains(t, err, "stop after provider lookup")
 }

--- a/api/pkg/controller/sessions_test.go
+++ b/api/pkg/controller/sessions_test.go
@@ -1,8 +1,13 @@
 package controller
 
 import (
+	"context"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"go.uber.org/mock/gomock"
 )
@@ -148,6 +153,34 @@ func (suite *ControllerSuite) Test_getClient_explicitProvider_skipsValidation() 
 	suite.NotNil(client)
 }
 
+func (suite *ControllerSuite) Test_getClient_personalProviderInOrgSession() {
+	modelInfoProvider, err := model.NewBaseModelInfoProvider()
+	suite.Require().NoError(err)
+
+	ctrl := gomock.NewController(suite.T())
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner: "org_x", WithGlobal: true,
+	}).Return([]*types.ProviderEndpoint{}, nil)
+	mockStore.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner: "user_x", WithGlobal: true,
+	}).Return([]*types.ProviderEndpoint{{
+		ID: "pe_personal", Name: "custom", Owner: "user_x", EndpointType: types.ProviderEndpointTypeUser,
+		BaseURL: "https://user.example/v1", APIKey: "user-key",
+	}}, nil)
+
+	cfg := &config.ServerConfig{}
+	providerManager := manager.NewProviderManager(cfg, mockStore, nil, modelInfoProvider)
+	controller := &Controller{
+		Options:         Options{Config: cfg},
+		providerManager: providerManager,
+	}
+
+	client, err := controller.getClient(context.Background(), "org_x", "user_x", "pe_personal", "")
+	suite.NoError(err)
+	suite.NotNil(client)
+}
+
 func (suite *ControllerSuite) Test_getClient_emptyModel_skipsValidation() {
 	// model="" is the explicit opt-out (used by bootstrap paths where the
 	// model isn't known yet). We must not call ListModels.
@@ -197,7 +230,6 @@ func (suite *ControllerSuite) Test_getClient_defaultedProvider_modelNotServed_re
 	suite.Contains(err.Error(), `prefix the model with the target provider`)
 	suite.Contains(err.Error(), `"openai/gpt-5.4"`)
 }
-
 
 // newMockProviderManagerForGetClientTest builds a ProviderManager mock whose
 // GetClient returns an openAI client whose ListModels returns the given list.

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -22,6 +22,7 @@ import (
 type GetClientRequest struct {
 	Provider string
 	Owner    string
+	UserID   string
 	AppID    string
 }
 
@@ -401,17 +402,26 @@ func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest)
 		return client.client, nil
 	}
 
-	userProviders, err := m.store.ListProviderEndpoints(context.Background(), &store.ListProviderEndpointsQuery{
-		Owner:      req.Owner,
-		WithGlobal: true,
-	})
-	if err != nil {
-		return nil, err
+	owners := []string{req.Owner}
+	if req.UserID != "" && req.UserID != req.Owner {
+		owners = append(owners, req.UserID)
 	}
 
-	for _, provider := range userProviders {
-		if provider.Name == req.Provider || provider.ID == req.Provider {
-			return m.initializeClient(provider)
+	var userProviders []*types.ProviderEndpoint
+	for _, owner := range owners {
+		providers, err := m.store.ListProviderEndpoints(context.Background(), &store.ListProviderEndpointsQuery{
+			Owner:      owner,
+			WithGlobal: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		userProviders = append(userProviders, providers...)
+
+		for _, provider := range providers {
+			if provider.Name == req.Provider || provider.ID == req.Provider {
+				return m.initializeClient(provider)
+			}
 		}
 	}
 

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -738,12 +738,12 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 			http.Error(rw, "Could not authorize org member: "+err.Error(), http.StatusForbidden)
 			return
 		}
-	}
-
-	// Check ownership - only allow updates to owned endpoints or if user is admin
-	if existingEndpoint.Owner != user.ID && !user.Admin {
-		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
-		return
+	} else {
+		// Check ownership - only allow updates to owned endpoints or if user is admin
+		if existingEndpoint.Owner != user.ID && !user.Admin {
+			http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 
 	var updatedEndpoint types.UpdateProviderEndpoint

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -679,6 +679,50 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchUserToGlobal() 
 	s.Equal(http.StatusOK, rr.Code)
 }
 
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_OrgOwner() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "pe_org"
+	orgID := "org_id"
+
+	existing := &types.ProviderEndpoint{
+		ID: endpointID, Name: "org-endpoint", BaseURL: "http://old.example.com",
+		Owner: orgID, OwnerType: types.OwnerTypeOrg, EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: endpointID}).Return(existing, nil)
+	s.store.EXPECT().GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+		OrganizationID: orgID,
+		UserID:         "user_id",
+	}).Return(&types.OrganizationMembership{
+		OrganizationID: orgID,
+		UserID:         "user_id",
+		Role:           types.OrganizationRoleOwner,
+	}, nil)
+	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, endpoint *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+			s.Equal(orgID, endpoint.Owner)
+			s.Equal(types.OwnerTypeOrg, endpoint.OwnerType)
+			s.Equal("http://new.example.com", endpoint.BaseURL)
+			return endpoint, nil
+		})
+
+	body, err := json.Marshal(types.UpdateProviderEndpoint{
+		Name: "org-endpoint", BaseURL: "http://new.example.com",
+	})
+	s.Require().NoError(err)
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
 func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_NonAdminCannotSwitchToGlobal() {
 	s.server.Cfg.Providers.EnableCustomUserProviders = true
 	endpointID := "ep_123"

--- a/api/pkg/store/migrations/0006_move_personal_providers_to_orgs.down.sql
+++ b/api/pkg/store/migrations/0006_move_personal_providers_to_orgs.down.sql
@@ -1,0 +1,3 @@
+-- No-op rollback. The previous personal owner cannot be recovered after a
+-- provider endpoint has been transferred to its organization.
+SELECT 1;

--- a/api/pkg/store/migrations/0006_move_personal_providers_to_orgs.up.sql
+++ b/api/pkg/store/migrations/0006_move_personal_providers_to_orgs.up.sql
@@ -1,0 +1,71 @@
+-- Move legacy personal provider endpoints to the single organization whose
+-- apps reference them, but only when every persisted reference is unambiguous.
+-- Keep endpoint_type='user' because existing owner-scoped provider listings
+-- use that value for both personal and organization-owned endpoints.
+
+DO $$
+BEGIN
+    IF to_regclass('provider_endpoints') IS NULL
+        OR to_regclass('apps') IS NULL
+        OR to_regclass('sessions') IS NULL THEN
+        RETURN;
+    END IF;
+
+    WITH app_provider_refs AS (
+        SELECT DISTINCT
+            a.id AS app_id,
+            a.owner AS app_owner,
+            a.organization_id,
+            ref.provider_id
+        FROM apps a
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(a.config::jsonb->'helix'->'assistants') = 'array'
+                    THEN a.config::jsonb->'helix'->'assistants'
+                ELSE '[]'::jsonb
+            END
+        ) AS assistants(assistant)
+        CROSS JOIN LATERAL (VALUES
+            (assistant->>'provider'),
+            (assistant->>'reasoning_model_provider'),
+            (assistant->>'generation_model_provider'),
+            (assistant->>'small_reasoning_model_provider'),
+            (assistant->>'small_generation_model_provider')
+        ) ref(provider_id)
+        WHERE ref.provider_id <> ''
+    ),
+    org_candidates AS (
+        SELECT
+            pe.id,
+            MIN(ref.organization_id) AS organization_id
+        FROM provider_endpoints pe
+        JOIN app_provider_refs ref ON ref.provider_id = pe.id
+        WHERE pe.endpoint_type = 'user'
+            AND pe.owner_type = 'user'
+            AND COALESCE(ref.organization_id, '') <> ''
+        GROUP BY pe.id, pe.owner
+        HAVING COUNT(DISTINCT ref.organization_id) = 1
+            AND BOOL_AND(ref.app_owner = pe.owner)
+            AND NOT EXISTS (
+                SELECT 1
+                FROM app_provider_refs personal_ref
+                WHERE personal_ref.provider_id = pe.id
+                    AND COALESCE(personal_ref.organization_id, '') = ''
+            )
+    ),
+    safe_candidates AS (
+        SELECT candidate.id, candidate.organization_id
+        FROM org_candidates candidate
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM sessions session_ref
+            WHERE session_ref.provider = candidate.id
+                AND COALESCE(session_ref.organization_id, '') <> candidate.organization_id
+        )
+    )
+    UPDATE provider_endpoints endpoint
+    SET owner = candidate.organization_id,
+        owner_type = 'org'
+    FROM safe_candidates candidate
+    WHERE endpoint.id = candidate.id;
+END $$;

--- a/api/pkg/store/migrations_test.go
+++ b/api/pkg/store/migrations_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/gorm"
+)
+
+const providerOrgMigration = "migrations/0006_move_personal_providers_to_orgs.up.sql"
+
+func (suite *PostgresStoreTestSuite) TestMigration0006MovesOnlySafeProviderEndpoints() {
+	migration, err := fs.ReadFile(providerOrgMigration)
+	suite.Require().NoError(err)
+
+	errRollback := errors.New("rollback migration fixtures")
+	err = suite.db.gdb.Transaction(func(tx *gorm.DB) error {
+		db := *suite.db
+		db.gdb = tx
+		owner := "user_" + system.GenerateUUID()
+		createEndpoint := func() *types.ProviderEndpoint {
+			endpoint, err := db.CreateProviderEndpoint(suite.ctx, &types.ProviderEndpoint{
+				ID: "pe_" + system.GenerateUUID(), Name: "test", Owner: owner,
+				OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser,
+				BaseURL: "https://example.com/v1", APIKey: "key",
+			})
+			suite.Require().NoError(err)
+			return endpoint
+		}
+		createApp := func(endpointID, appOwner, orgID string) {
+			_, err := db.CreateApp(suite.ctx, &types.App{
+				Owner: appOwner, OwnerType: types.OwnerTypeUser, OrganizationID: orgID,
+				Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+					SmallGenerationModelProvider: endpointID,
+				}}}},
+			})
+			suite.Require().NoError(err)
+		}
+
+		safe := createEndpoint()
+		createApp(safe.ID, owner, "org_safe")
+
+		ambiguous := createEndpoint()
+		createApp(ambiguous.ID, owner, "org_one")
+		createApp(ambiguous.ID, owner, "org_two")
+
+		personalRef := createEndpoint()
+		createApp(personalRef.ID, owner, "org_personal_ref")
+		createApp(personalRef.ID, owner, "")
+
+		wrongAppOwner := createEndpoint()
+		createApp(wrongAppOwner.ID, "other_user", "org_wrong_owner")
+
+		unsafeSession := createEndpoint()
+		createApp(unsafeSession.ID, owner, "org_session")
+		_, err := db.CreateSession(suite.ctx, types.Session{
+			Owner: owner, OwnerType: types.OwnerTypeUser, Provider: unsafeSession.ID,
+		})
+		suite.Require().NoError(err)
+
+		crossOrgSession := createEndpoint()
+		createApp(crossOrgSession.ID, owner, "org_session")
+		_, err = db.CreateSession(suite.ctx, types.Session{
+			Owner: owner, OwnerType: types.OwnerTypeUser, Provider: crossOrgSession.ID,
+			OrganizationID: "org_other",
+		})
+		suite.Require().NoError(err)
+
+		suite.Require().NoError(tx.Exec(string(migration)).Error)
+
+		for _, tc := range []struct {
+			endpoint  *types.ProviderEndpoint
+			wantOwner string
+			wantType  types.OwnerType
+		}{
+			{safe, "org_safe", types.OwnerTypeOrg},
+			{ambiguous, owner, types.OwnerTypeUser},
+			{personalRef, owner, types.OwnerTypeUser},
+			{wrongAppOwner, owner, types.OwnerTypeUser},
+			{unsafeSession, owner, types.OwnerTypeUser},
+			{crossOrgSession, owner, types.OwnerTypeUser},
+		} {
+			got, err := db.GetProviderEndpoint(suite.ctx, &GetProviderEndpointsQuery{ID: tc.endpoint.ID})
+			suite.Require().NoError(err)
+			suite.Equal(tc.endpoint.ID, got.ID)
+			suite.Equal(types.ProviderEndpointTypeUser, got.EndpointType)
+			suite.Equal(tc.wantOwner, got.Owner)
+			suite.Equal(tc.wantType, got.OwnerType)
+		}
+		return errRollback
+	})
+	suite.ErrorIs(err, errRollback)
+}
+
+func (suite *PostgresStoreTestSuite) TestMigration0006NoOpWithoutTables() {
+	migration, err := fs.ReadFile(providerOrgMigration)
+	suite.Require().NoError(err)
+
+	schema := "migration_0006_" + strings.ReplaceAll(system.GenerateUUID(), "-", "")
+	errRollback := errors.New("rollback test schema")
+	err = suite.db.gdb.Transaction(func(tx *gorm.DB) error {
+		suite.Require().NoError(tx.Exec("CREATE SCHEMA " + schema).Error)
+		suite.Require().NoError(tx.Exec("SET LOCAL search_path TO " + schema).Error)
+		suite.Require().NoError(tx.Exec(string(migration)).Error)
+		return errRollback
+	})
+	suite.ErrorIs(err, errRollback)
+}

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -155,6 +155,7 @@ func (suite *CronTestSuite) TestExecuteCronTask() {
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
 		Provider: "togetherai",
 		Owner:    "test-user",
+		UserID:   "test-user",
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -283,6 +284,7 @@ func (suite *CronTestSuite) TestExecuteCronTask_Organization() {
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
 		Provider: "togetherai",
 		Owner:    "test-org",
+		UserID:   "test-user-2",
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -405,6 +407,7 @@ func (suite *CronTestSuite) TestExecuteCronTask_WithEmails() {
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
 		Provider: "togetherai",
 		Owner:    "test-user",
+		UserID:   "test-user",
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -512,6 +515,7 @@ func (suite *CronTestSuite) TestExecuteCronTask_FailureNotification_WithEmails()
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
 		Provider: "togetherai",
 		Owner:    "test-user",
+		UserID:   "test-user",
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -605,6 +609,7 @@ func (suite *CronTestSuite) TestExecuteCronTask_NoEmails_FallsBackToOwner() {
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
 		Provider: "togetherai",
 		Owner:    "test-user",
+		UserID:   "test-user",
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()


### PR DESCRIPTION
## Summary
- resolve organization-scoped providers before the authenticated user's legacy personal providers
- propagate personal-provider scope through standard and Helix-agent inference
- transfer qualifying legacy user-owned provider endpoints to the organization whose apps reference them, preserving their pe_ IDs
- keep ambiguous, personal-app, and cross-organization session references unchanged
- allow organization owners to update migrated organization-owned endpoints

## Why a migration is needed
The personal providers page was disabled by default in December 2025, but existing user-owned provider rows remained. This migration transfers those endpoints to org ownership when their persisted app and session references identify exactly one safe organization. Rows that cannot be assigned safely remain user-owned and continue to work through the compatibility lookup.

## Red reproduction
Before the runtime fix, the focused test failed with:

```text
no client found for provider: pe_personal, available providers: [helix]
```

Before the org-owned update fix, the migrated endpoint regression returned HTTP 401 and never called UpdateProviderEndpoint.

## Migration safety
A provider is moved only when:
- an exact provider ID is referenced by apps in one organization
- every referencing org app is owned by the provider owner
- no personal app references it
- no session references it outside that organization

The SQL changes `owner` from the user ID to the organization ID and changes `owner_type` from `user` to `org`. It preserves the provider ID and leaves `endpoint_type = user`, which is the existing storage value for both user-owned and organization-owned provider endpoints. Rows with ambiguous ownership remain unchanged.

## Tests
- POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55432 POSTGRES_DATABASE=postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_SCHEMA=codex_pr2939_test DATABASE_AUTO_MIGRATE=true DATABASE_SEED_MODELS=false CGO_ENABLED=1 go test ./pkg/store -run 'TestPostgresStoreSuite/TestMigration0006' -count=1 -timeout=5m
- CGO_ENABLED=1 go test ./pkg/server -run 'TestProviderHandlersSuite/TestUpdateProviderEndpoint_' -count=1
- CGO_ENABLED=1 go test ./pkg/controller -run 'TestControllerSuite/Test_getClient_personalProviderInOrgSession|TestRunAgentPassesPersonalProviderScope' -count=1
- CGO_ENABLED=1 go test ./pkg/openai/manager ./pkg/controller -count=1
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- git diff --check
