### PR TITLE
fix(specs): reject personal providers for org agents

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -122,22 +122,7 @@ func GenerateZedMCPConfig(
 	}
 	assistant := FindZedExternalAssistant(app)
 
-	// For zed_external agents the runtime selection lives in Model/Provider
-	// (CodingAgentForm writes these). GenerationModel/-Provider are the
-	// helix_agent template defaults (gpt-4o/openai) and must NOT shadow the
-	// real pick — doing so made GLM/Goose agents boot as openai/gpt-4o while a
-	// sibling Claude agent (empty GenerationModel) worked.
-	var provider, model string
-	if assistant != nil {
-		provider = assistant.Provider
-		if provider == "" {
-			provider = assistant.GenerationModelProvider
-		}
-		model = assistant.Model
-		if model == "" {
-			model = assistant.GenerationModel
-		}
-	}
+	provider, model := AssistantModelSelection(assistant)
 
 	// Decide whether the agent's stored model fields are usable. There are
 	// two failure modes we MUST NOT paper over:
@@ -565,6 +550,30 @@ func FindZedExternalAssistant(app *types.App) *types.AssistantConfig {
 	return &app.Config.Helix.Assistants[0]
 }
 
+// AssistantModelSelection returns the provider/model pair persisted by the
+// active code-agent settings UI. Explicit Claude Code API-key mode uses the
+// generation fields; other external runtimes and legacy empty credential types
+// use the top-level fields with the generation fallback.
+func AssistantModelSelection(assistant *types.AssistantConfig) (string, string) {
+	if assistant == nil {
+		return "", ""
+	}
+	if assistant.CodeAgentRuntime == types.CodeAgentRuntimeClaudeCode &&
+		assistant.CodeAgentCredentialType == types.CodeAgentCredentialTypeAPIKey &&
+		(assistant.GenerationModelProvider != "" || assistant.GenerationModel != "") {
+		return assistant.GenerationModelProvider, assistant.GenerationModel
+	}
+	provider := assistant.Provider
+	if provider == "" {
+		provider = assistant.GenerationModelProvider
+	}
+	model := assistant.Model
+	if model == "" {
+		model = assistant.GenerationModel
+	}
+	return provider, model
+}
+
 // ResolveProvider matches a stored agent token (an ID for DB-backed providers,
 // the canonical name for globals) against the provider snapshot. ID match
 // wins; if no ID matches, falls back to a case-insensitive name match
@@ -670,18 +679,7 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 	if usesUpstreamSubscription(assistant) {
 		return ""
 	}
-	// Mirror GenerateZedMCPConfig: Model/Provider is the zed_external source of
-	// truth; the GenerationModel quartet is helix_agent template default noise.
-	// The two must validate and route the same fields or the validator can
-	// green-light a stale provider the reader never uses.
-	provider := assistant.Provider
-	if provider == "" {
-		provider = assistant.GenerationModelProvider
-	}
-	model := assistant.Model
-	if model == "" {
-		model = assistant.GenerationModel
-	}
+	provider, model := AssistantModelSelection(assistant)
 	if provider == "" || model == "" {
 		return fmt.Sprintf("agent %q is missing a provider or model selection — open the agent settings and pick a provider and model", app.ID)
 	}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -689,6 +689,9 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 		return ""
 	}
 	if _, _, ok := ResolveProvider(provider, snapshot); !ok {
+		if app.OrganizationID != "" {
+			return types.OrganizationProviderUnavailableMessage
+		}
 		return fmt.Sprintf("agent %q references provider %q which does not match any current provider — the provider may have been renamed or deleted. Open the agent settings and re-pick a provider, or restore/rename the provider in admin.", app.ID, provider)
 	}
 	return ""

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -615,4 +615,20 @@ func TestValidateAssistantModelConfig_ProviderAvailability(t *testing.T) {
 	assert.Equal(t, types.OrganizationProviderUnavailableMessage, ValidateAssistantModelConfig(app("org_id"), []ProviderRef{}))
 	assert.Contains(t, ValidateAssistantModelConfig(app(""), []ProviderRef{}), "does not match any current provider")
 	assert.Empty(t, ValidateAssistantModelConfig(app("org_id"), []ProviderRef{{ID: "pe_provider", Name: "provider"}}))
+
+	claudeCodeAPIKeyApp := &types.App{
+		ID:             "app",
+		OrganizationID: "org_id",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			AgentType:               types.AgentTypeZedExternal,
+			CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+			CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+			Provider:                "anthropic",
+			Model:                   "claude-opus-4-8",
+			GenerationModelProvider: "pe_personal",
+			GenerationModel:         "scope-e2e-model",
+		}}}},
+	}
+	assert.Equal(t, types.OrganizationProviderUnavailableMessage, ValidateAssistantModelConfig(claudeCodeAPIKeyApp, []ProviderRef{{Name: "anthropic"}}))
+	assert.Empty(t, ValidateAssistantModelConfig(claudeCodeAPIKeyApp, []ProviderRef{{Name: "anthropic"}, {ID: "pe_personal", Name: "scope-good"}}))
 }

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -598,3 +598,21 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAssistantModelConfig_ProviderAvailability(t *testing.T) {
+	app := func(orgID string) *types.App {
+		return &types.App{
+			ID:             "app",
+			OrganizationID: orgID,
+			Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+				AgentType: types.AgentTypeZedExternal,
+				Provider:  "pe_provider",
+				Model:     "model",
+			}}}},
+		}
+	}
+
+	assert.Equal(t, types.OrganizationProviderUnavailableMessage, ValidateAssistantModelConfig(app("org_id"), []ProviderRef{}))
+	assert.Contains(t, ValidateAssistantModelConfig(app(""), []ProviderRef{}), "does not match any current provider")
+	assert.Empty(t, ValidateAssistantModelConfig(app("org_id"), []ProviderRef{{ID: "pe_provider", Name: "provider"}}))
+}

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -68,8 +68,8 @@ type AppCreateResponse = AgentCreateResponse
 func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *types.User, app *types.Agent, modelClasses []ModelClass) ([]ModelSubstitution, error) {
 	var substitutions []ModelSubstitution
 
-	// Use the org-aware endpoint list so an org agent referencing the user's
-	// personal provider still finds it (mirrors validateProvidersAndModels).
+	// Use the app-scoped endpoint list so organization agents only consider
+	// organization and global providers.
 	availableEndpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
 	if err != nil {
 		log.Error().
@@ -126,6 +126,9 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 					Str("original_provider", originalProvider).
 					Str("original_model", originalModel).
 					Msg("Skipping substitution for empty provider or model")
+				return
+			}
+			if app.OrganizationID != "" && strings.HasPrefix(originalProvider, system.ProviderEndpointPrefix) && !providerKnown(originalProvider) {
 				return
 			}
 
@@ -702,6 +705,9 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 					Str("provider", provider).
 					Int("available_endpoints", len(endpoints)).
 					Msg("Validation failed: provider not available")
+				if app.OrganizationID != "" {
+					return errors.New(types.OrganizationProviderUnavailableMessage)
+				}
 				return fmt.Errorf("provider '%s' is not available for %s", provider, fieldName)
 			}
 		}

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -429,7 +429,6 @@ func TestFindModelSubstitution(t *testing.T) {
 			},
 		},
 	}
-
 	t.Run("finds exact match and returns first available alternative from same class", func(t *testing.T) {
 		availableProviders := map[types.Provider]bool{
 			"helix":     true,
@@ -542,6 +541,13 @@ func TestApplyModelSubstitutions(t *testing.T) {
 			},
 		},
 	}
+	providerIDModelClasses := []ModelClass{{
+		Name: "lightweight",
+		Alternatives: []AlternativeModelOption{
+			{Provider: "pe_personal", Model: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"},
+			{Provider: "helix", Model: "llama3.1:8b-instruct-q8_0"},
+		},
+	}}
 
 	user := &types.User{ID: "user1"}
 	ctx := context.Background()
@@ -576,6 +582,58 @@ func TestApplyModelSubstitutions(t *testing.T) {
 		require.Equal(t, "llama3.1:8b-instruct-q8_0", substitutions[0].NewModel)
 
 		// Verify the substitution occurred
+		require.Equal(t, "helix", app.Config.Helix.Assistants[0].Provider)
+		require.Equal(t, "llama3.1:8b-instruct-q8_0", app.Config.Helix.Assistants[0].Model)
+	})
+
+	t.Run("leaves unavailable provider ID for organization validation", func(t *testing.T) {
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "org1").
+			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil).
+			Times(2)
+
+		app := &types.App{
+			OrganizationID: "org1",
+			Config: types.AppConfig{
+				Helix: types.AppHelixConfig{
+					Assistants: []types.AssistantConfig{{
+						Name:     "test-assistant",
+						Provider: "pe_personal",
+						Model:    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+					}},
+				},
+			},
+		}
+
+		substitutions, err := server.applyModelSubstitutions(ctx, user, app, providerIDModelClasses)
+		require.NoError(t, err)
+		require.Empty(t, substitutions)
+		require.Equal(t, "pe_personal", app.Config.Helix.Assistants[0].Provider)
+		require.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", app.Config.Helix.Assistants[0].Model)
+
+		err = server.validateProvidersAndModels(ctx, user, app)
+		require.EqualError(t, err, types.OrganizationProviderUnavailableMessage)
+	})
+
+	t.Run("substitutes unavailable provider ID for personal app", func(t *testing.T) {
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, user.ID).
+			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
+
+		app := &types.App{
+			Config: types.AppConfig{
+				Helix: types.AppHelixConfig{
+					Assistants: []types.AssistantConfig{{
+						Provider: "pe_personal",
+						Model:    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+					}},
+				},
+			},
+		}
+
+		substitutions, err := server.applyModelSubstitutions(ctx, user, app, providerIDModelClasses)
+		require.NoError(t, err)
+		require.Len(t, substitutions, 1)
 		require.Equal(t, "helix", app.Config.Helix.Assistants[0].Provider)
 		require.Equal(t, "llama3.1:8b-instruct-q8_0", app.Config.Helix.Assistants[0].Model)
 	})
@@ -1231,9 +1289,32 @@ func TestValidateProvidersAndModels_HelixAgentRequiresModelProviders(t *testing.
 	assert.Contains(t, err.Error(), "must have a provider for reasoning_model")
 }
 
-// TestListEndpointsForApp covers the org-aware behaviour added in the
-// snapshot-helper refactor: org-owned apps must see both the org bucket
-// and the actor's personal providers, with sensible de-dup.
+func TestValidateProvidersAndModels_UnavailableProviderMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+	user := &types.User{ID: "user1"}
+	app := func(orgID string) *types.App {
+		return &types.App{
+			OrganizationID: orgID,
+			Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+				Provider: "pe_provider",
+				Model:    "model",
+			}}}},
+		}
+	}
+
+	mockProviderManager.EXPECT().ListProviderEndpoints(ctx, "org1").Return([]*types.ProviderEndpoint{}, nil)
+	err := server.validateProvidersAndModels(ctx, user, app("org1"))
+	require.EqualError(t, err, types.OrganizationProviderUnavailableMessage)
+
+	mockProviderManager.EXPECT().ListProviderEndpoints(ctx, user.ID).Return([]*types.ProviderEndpoint{}, nil)
+	err = server.validateProvidersAndModels(ctx, user, app(""))
+	require.ErrorContains(t, err, "provider 'pe_provider' is not available")
+}
+
+// TestListEndpointsForApp covers app-scoped provider snapshots.
 func TestListEndpointsForApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1253,49 +1334,19 @@ func TestListEndpointsForApp(t *testing.T) {
 		require.Equal(t, "pe_user_01", eps[0].ID)
 	})
 
-	t.Run("org app merges org and user buckets and de-dups", func(t *testing.T) {
-		// Both buckets see the same env-baked global ("openai", no ID); the
-		// merge must not double-count it. The user also has a personal
-		// provider that the org bucket doesn't see — that should land.
+	t.Run("org app excludes personal bucket", func(t *testing.T) {
 		mockProviderManager.EXPECT().
 			ListProviderEndpoints(ctx, "org1").
 			Return([]*types.ProviderEndpoint{
 				{ID: "pe_org_01", Name: "org-prov"},
 				{Name: "openai"},
 			}, nil)
-		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "user1").
-			Return([]*types.ProviderEndpoint{
-				{ID: "pe_user_01", Name: "user-prov"},
-				{Name: "openai"},
-			}, nil)
-
 		app := &types.App{ID: "app1", OrganizationID: "org1"}
 		eps, err := server.listEndpointsForApp(ctx, "user1", app)
 		require.NoError(t, err)
 
-		got := map[string]bool{}
-		for _, ep := range eps {
-			got[endpointKey(ep)] = true
-		}
-		require.True(t, got["id:pe_org_01"], "org-bucket DB provider should be present")
-		require.True(t, got["id:pe_user_01"], "user-bucket DB provider should be merged in for org apps")
-		require.True(t, got["name:openai"], "global should be present exactly once")
-		require.Len(t, eps, 3, "duplicate global must not be appended twice")
-	})
-
-	t.Run("personal-bucket failure still returns org bucket", func(t *testing.T) {
-		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "org1").
-			Return([]*types.ProviderEndpoint{{ID: "pe_org_01", Name: "org-prov"}}, nil)
-		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "user1").
-			Return(nil, fmt.Errorf("transient store error"))
-
-		app := &types.App{ID: "app1", OrganizationID: "org1"}
-		eps, err := server.listEndpointsForApp(ctx, "user1", app)
-		require.NoError(t, err, "personal-bucket failure should not propagate; org bucket is still useful")
-		require.Len(t, eps, 1)
+		require.Len(t, eps, 2)
 		require.Equal(t, "pe_org_01", eps[0].ID)
+		require.Equal(t, "openai", eps[1].Name)
 	})
 }

--- a/api/pkg/server/spec_driven_task_handlers_test.go
+++ b/api/pkg/server/spec_driven_task_handlers_test.go
@@ -56,15 +56,20 @@ func TestSpecTaskProviderPreflightHandlers(t *testing.T) {
 				ID:             "app1",
 				OrganizationID: "org1",
 				Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
-					Provider: "pe_personal",
-					Model:    "model",
+					AgentType:               types.AgentTypeZedExternal,
+					CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+					CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+					Provider:                "anthropic",
+					Model:                   "claude-opus-4-8",
+					GenerationModelProvider: "pe_personal",
+					GenerationModel:         "scope-e2e-model",
 				}}}},
 			}
 
 			mockStore.EXPECT().GetSpecTask(gomock.Any(), task.ID).Return(task, nil)
 			mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil).Times(2)
 			mockStore.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
-			mockProviderManager.EXPECT().ListProviderEndpoints(gomock.Any(), app.OrganizationID).Return(nil, nil)
+			mockProviderManager.EXPECT().ListProviderEndpoints(gomock.Any(), app.OrganizationID).Return([]*types.ProviderEndpoint{{Name: "anthropic"}}, nil)
 
 			req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(tt.body))
 			req = mux.SetURLVars(req, map[string]string{"taskId": task.ID})

--- a/api/pkg/server/spec_driven_task_handlers_test.go
+++ b/api/pkg/server/spec_driven_task_handlers_test.go
@@ -1,10 +1,89 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/openai/manager"
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
+
+func TestSpecTaskProviderPreflightHandlers(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		body    string
+		handler func(*HelixAPIServer, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:    "start planning",
+			path:    "/api/v1/spec-tasks/task1/start-planning",
+			handler: (*HelixAPIServer).startPlanning,
+		},
+		{
+			name:    "approve specs",
+			path:    "/api/v1/spec-tasks/task1/approve-specs",
+			body:    `{"approved":true}`,
+			handler: (*HelixAPIServer).approveSpecs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := store.NewMockStore(ctrl)
+			mockProviderManager := manager.NewMockProviderManager(ctrl)
+			server := &HelixAPIServer{
+				Store:           mockStore,
+				providerManager: mockProviderManager,
+			}
+			user := types.User{ID: "user1"}
+			task := &types.SpecTask{
+				ID:         "task1",
+				ProjectID:  "project1",
+				HelixAppID: "app1",
+				Status:     types.TaskStatusBacklog,
+			}
+			project := &types.Project{ID: "project1", UserID: user.ID}
+			app := &types.App{
+				ID:             "app1",
+				OrganizationID: "org1",
+				Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+					Provider: "pe_personal",
+					Model:    "model",
+				}}}},
+			}
+
+			mockStore.EXPECT().GetSpecTask(gomock.Any(), task.ID).Return(task, nil)
+			mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil).Times(2)
+			mockStore.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
+			mockProviderManager.EXPECT().ListProviderEndpoints(gomock.Any(), app.OrganizationID).Return(nil, nil)
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(tt.body))
+			req = mux.SetURLVars(req, map[string]string{"taskId": task.ID})
+			req = req.WithContext(setRequestUser(req.Context(), user))
+			response := httptest.NewRecorder()
+
+			tt.handler(server, response, req)
+
+			require.Equal(t, http.StatusUnprocessableEntity, response.Code)
+			var payload struct {
+				Error   string `json:"error"`
+				Message string `json:"message"`
+			}
+			require.NoError(t, json.NewDecoder(response.Body).Decode(&payload))
+			require.Equal(t, "agent_misconfigured", payload.Error)
+			require.Equal(t, types.OrganizationProviderUnavailableMessage, payload.Message)
+		})
+	}
+}
 
 func TestDeriveAgentWorkState(t *testing.T) {
 	cases := []struct {

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -618,10 +618,8 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 }
 
 // buildCodeAgentConfigFromAssistant creates a CodeAgentConfig from an assistant configuration.
-// For zed_external agents the user's model selection lives in Model/Provider; the
-// GenerationModel quartet holds helix_agent template defaults (gpt-4o/openai) that must
-// not shadow it. This must match GenerateZedMCPConfig's precedence or CodeAgentConfig.Model
-// (fed to Goose/qwen via agent_servers) disagrees with agent.default_model.
+// Model selection must match GenerateZedMCPConfig so CodeAgentConfig.Model
+// (fed to Goose/qwen via agent_servers) agrees with agent.default_model.
 // The CodeAgentRuntime determines how the LLM is configured in Zed (built-in agent vs qwen).
 func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.Context, assistant *types.AssistantConfig, helixURL string, providerSnapshot []external_agent.ProviderRef) *types.CodeAgentConfig {
 	// Get the code agent runtime, default to zed_agent
@@ -633,16 +631,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	// Check if this agent uses subscription-based credentials (e.g., Claude OAuth)
 	isSubscription := assistant.CodeAgentCredentialType.IsSubscription()
 
-	// Model/Provider is the zed_external source of truth; GenerationModel is the
-	// stale helix_agent-template fallback (see doc comment above).
-	providerName := assistant.Provider
-	if providerName == "" {
-		providerName = assistant.GenerationModelProvider
-	}
-	modelName := assistant.Model
-	if modelName == "" {
-		modelName = assistant.GenerationModel
-	}
+	providerName, modelName := external_agent.AssistantModelSelection(assistant)
 
 	// Resolve the agent's stored provider token (ID or legacy name) to the
 	// provider's current canonical name. Required so the model prefix here

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -966,12 +966,8 @@ func (apiServer *HelixAPIServer) resolveGooseRecipeFileParams(ctx context.Contex
 // admin label). Used by zed-config code paths to resolve an agent's stored
 // provider reference to its current canonical name.
 //
-// The app argument is what makes this org-aware: when app.OrganizationID
-// is set, org-owned providers are listed first and the user's personal
-// providers are merged in (so a user running an org agent that references
-// their own personal provider still resolves). actorID may be "" when
-// there's no user context (rare; e.g. system-driven paths) — in that case
-// only the app-owner bucket is returned.
+// The app argument makes this org-aware: when app.OrganizationID is set,
+// only organization-owned and global providers are returned.
 //
 // Returning nil from this helper (e.g. when the manager isn't wired) tells
 // GenerateZedMCPConfig to skip resolution.
@@ -990,15 +986,9 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorI
 	return refs, nil
 }
 
-// listEndpointsForApp returns ProviderEndpoint records visible to the actor
-// for the given app, with the org-first + user-merge pattern that
-// validateProvidersAndModels established. Centralising it here means every
-// caller (substitution, validation, zed-config, spec-task pre-flight) sees
-// the same view of "what providers can this agent legitimately reference".
-//
-// Without the merge, an org-owned agent that references the org member's
-// personal provider would 422 at session start; with it, both buckets
-// participate in resolution.
+// listEndpointsForApp returns ProviderEndpoint records available to the app.
+// Organization apps only see their organization's and global providers;
+// personal providers must not enter organization snapshots.
 func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorID string, app *types.App) ([]*types.ProviderEndpoint, error) {
 	if apiServer.providerManager == nil {
 		return nil, nil
@@ -1007,44 +997,7 @@ func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorI
 	if app != nil && app.OrganizationID != "" {
 		owner = app.OrganizationID
 	}
-	endpoints, err := apiServer.providerManager.ListProviderEndpoints(ctx, owner)
-	if err != nil {
-		return nil, err
-	}
-	if app == nil || app.OrganizationID == "" || actorID == "" || actorID == app.OrganizationID {
-		return endpoints, nil
-	}
-	userEndpoints, uerr := apiServer.providerManager.ListProviderEndpoints(ctx, actorID)
-	if uerr != nil {
-		// Best-effort merge: a personal-provider lookup failure shouldn't
-		// hide the org bucket we already have. Log and return what we got.
-		log.Warn().Err(uerr).Str("app_id", app.ID).Str("actor_id", actorID).Msg("listEndpointsForApp: failed to list personal providers; using org bucket only")
-		return endpoints, nil
-	}
-	seen := make(map[string]struct{}, len(endpoints))
-	for _, ep := range endpoints {
-		seen[endpointKey(ep)] = struct{}{}
-	}
-	for _, ep := range userEndpoints {
-		k := endpointKey(ep)
-		if _, ok := seen[k]; ok {
-			continue
-		}
-		seen[k] = struct{}{}
-		endpoints = append(endpoints, ep)
-	}
-	return endpoints, nil
-}
-
-// endpointKey produces a stable de-dup key for a provider endpoint. ID wins
-// when present; for env-baked globals (ID=="") the name namespace is used
-// to keep "openai" from colliding with a DB-backed provider also named
-// "openai".
-func endpointKey(ep *types.ProviderEndpoint) string {
-	if ep.ID != "" {
-		return "id:" + ep.ID
-	}
-	return "name:" + ep.Name
+	return apiServer.providerManager.ListProviderEndpoints(ctx, owner)
 }
 
 // validateSpecTaskAgentConfig pre-flights the agent's provider/model snapshot

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -194,6 +194,25 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 			},
 		},
 		{
+			name: "claude_code api_key mode - generation model overrides stale top-level model",
+			assistant: &types.AssistantConfig{
+				Provider:                "anthropic",
+				Model:                   "claude-opus-4-8",
+				GenerationModelProvider: "scope-provider",
+				GenerationModel:         "scope-e2e-model",
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+			},
+			want: &types.CodeAgentConfig{
+				Provider:  "scope-provider",
+				Model:     "scope-e2e-model",
+				AgentName: "claude",
+				BaseURL:   "http://localhost:8080",
+				APIType:   "anthropic",
+				Runtime:   types.CodeAgentRuntimeClaudeCode,
+			},
+		},
+		{
 			name: "claude_code api_key mode - default when credential type empty",
 			assistant: &types.AssistantConfig{
 				GenerationModelProvider: "anthropic",
@@ -204,6 +223,24 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 			want: &types.CodeAgentConfig{
 				Provider:  "anthropic",
 				Model:     "claude-sonnet-4-20250514",
+				AgentName: "claude",
+				BaseURL:   "http://localhost:8080",
+				APIType:   "anthropic",
+				Runtime:   types.CodeAgentRuntimeClaudeCode,
+			},
+		},
+		{
+			name: "claude_code legacy empty credential - top-level model wins over stale generation model",
+			assistant: &types.AssistantConfig{
+				Provider:                "anthropic",
+				Model:                   "claude-opus-4-8",
+				GenerationModelProvider: "stale-provider",
+				GenerationModel:         "stale-model",
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+			},
+			want: &types.CodeAgentConfig{
+				Provider:  "anthropic",
+				Model:     "claude-opus-4-8",
 				AgentName: "claude",
 				BaseURL:   "http://localhost:8080",
 				APIType:   "anthropic",

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -8,6 +8,8 @@ import (
 
 type Provider string
 
+const OrganizationProviderUnavailableMessage = "This agent's provider is not available to the organization. Personal providers are no longer supported for organization agents. Configure the provider for the organization, then select it again in the agent settings."
+
 const (
 	ProviderOpenAI     Provider = "openai"
 	ProviderTogetherAI Provider = "togetherai"

--- a/frontend/src/components/specTask/CloneGroupProgress.tsx
+++ b/frontend/src/components/specTask/CloneGroupProgress.tsx
@@ -14,6 +14,7 @@ import TaskCard from '../tasks/TaskCard';
 import useRouter from '../../hooks/useRouter';
 import useApi from '../../hooks/useApi';
 import useSnackbar from '../../hooks/useSnackbar';
+import { extractErrorMessage } from '../../hooks/useErrorCallback';
 import { TypesSpecTaskWithProject } from '../../api/api';
 
 interface CloneGroupProgressProps {
@@ -298,6 +299,7 @@ const CloneGroupProgressFull: React.FC<CloneGroupProgressProps> = ({
     const apiClient = api.getApiClient();
     let successCount = 0;
     let failCount = 0;
+    let firstError = '';
 
     for (const task of tasksReadyToStart) {
       try {
@@ -309,6 +311,7 @@ const CloneGroupProgressFull: React.FC<CloneGroupProgressProps> = ({
       } catch (err) {
         console.error(`Failed to start task ${task.id}:`, err);
         failCount++;
+        firstError ||= extractErrorMessage(err);
       }
     }
 
@@ -317,9 +320,9 @@ const CloneGroupProgressFull: React.FC<CloneGroupProgressProps> = ({
     if (failCount === 0) {
       snackbar.success(`Started implementation for ${successCount} tasks`);
     } else if (successCount > 0) {
-      snackbar.warning(`Started ${successCount} tasks, ${failCount} failed`);
+      snackbar.warning(`Started ${successCount} tasks, ${failCount} failed: ${firstError}`);
     } else {
-      snackbar.error(`Failed to start all tasks`);
+      snackbar.error(`Failed to start all tasks: ${firstError}`);
     }
 
     // Refetch to update the progress display

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -705,8 +705,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           return;
         }
         throw new Error(
-          errorData.error ||
-            errorData.message ||
+          errorData.message ||
+            errorData.error ||
             `Failed to start planning: ${response.statusText}`,
         );
       }

--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -1540,8 +1540,8 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
           return;
         }
         throw new Error(
-          errorData.error ||
-            errorData.message ||
+          errorData.message ||
+            errorData.error ||
             `Failed to start planning: ${response.statusText}`,
         );
       }
@@ -1616,8 +1616,8 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
       console.error("Failed to start planning:", err);
       // Extract error message from API response
       const errorMessage =
-        err?.response?.data?.error ||
         err?.response?.data?.message ||
+        err?.response?.data?.error ||
         err?.message ||
         "Failed to start planning. Please try again.";
       setError(errorMessage);

--- a/frontend/src/components/tasks/TabsView.tsx
+++ b/frontend/src/components/tasks/TabsView.tsx
@@ -891,8 +891,8 @@ const TaskPanel: React.FC<TaskPanelProps> = ({
           return;
         }
         throw new Error(
-          errorData.error ||
-            errorData.message ||
+          errorData.message ||
+            errorData.error ||
             `Failed to start planning: ${response.statusText}`,
         );
       }

--- a/frontend/src/hooks/useSpecTasks.ts
+++ b/frontend/src/hooks/useSpecTasks.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import useApi from './useApi'
 import useSnackbar from './useSnackbar'
+import { extractErrorMessage } from './useErrorCallback'
 import {
   TypesSpecTask,
   TypesSpecTaskUpdateRequest,
@@ -78,7 +79,7 @@ export const useSpecTasks = () => {
         return result.data
       }
     } catch (error) {
-      snackbar.error('Failed to approve specifications')
+      snackbar.error(extractErrorMessage(error))
       console.error('Error approving specs:', error)
     }
     return null


### PR DESCRIPTION
## What changed

- Organization agents now resolve only organization and global providers.
- Existing organization agents that reference an unavailable personal provider are rejected before a spec task starts.
- The UI shows a friendly remediation message telling the user to configure the provider for the organization and select it again.
- Claude Code API-key agents validate and run the active generation-model selection instead of a stale top-level provider.
- Personal apps retain their existing provider behavior.
- No provider migration and no direct-inference changes.

## Verification

- `CGO_ENABLED=1 go test ./pkg/external-agent -run "TestValidateAssistantModelConfig_ProviderAvailability|TestGenerateZedMCPConfig" -count=1`
- `CGO_ENABLED=1 go test ./pkg/server -run "TestBuildCodeAgentConfigFromAssistant|TestSpecTaskProviderPreflightHandlers|TestApplyModelSubstitutions|TestListEndpointsForApp|TestValidateProvidersAndModels_UnavailableProviderMessage" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- `git diff --check`

## Live verification

- Created an organization, project, custom providers, Claude Code agent, and backlog spec task in local Helix.
- Converted the selected provider row to personal ownership while retaining its immutable provider ID.
- Start Planning returned HTTP 422 with `agent_misconfigured`, and the full friendly message was visible in both dark and light themes.
- Selected an organization-owned provider on the same agent and retried the unchanged task.
- Start Planning returned HTTP 200 and `queued_spec_generation`.

The local stack did not include a sandbox, so this verifies the spec-task preflight and immediate recovery boundary rather than a connected desktop session.
