### PR TITLE
fix(cron): run recurring tasks with external agents

### DIFF
--- a/api/pkg/prompts/prompts.go
+++ b/api/pkg/prompts/prompts.go
@@ -19,6 +19,12 @@ type BackgroundKnowledge struct {
 	Source      string // source of the document (URL)
 }
 
+// RecurringTaskSystemPrompt defines the explicit lifecycle contract for an
+// unattended recurring task. A normal text response does not complete the run.
+func RecurringTaskSystemPrompt() string {
+	return `You are executing an unattended recurring task. Complete the requested work, then call the task_completed tool exactly once when the work is fully finished. A written response alone does not complete the task. Do not call task_completed if the work failed or remains blocked.`
+}
+
 // this prompt is applied before the user prompt is forwarded to the LLM
 // we inject the list of RAG results we loaded from the vector store
 func RAGInferencePrompt(userPrompt string, rag []*RagContent) (string, error) {

--- a/api/pkg/prompts/prompts.go
+++ b/api/pkg/prompts/prompts.go
@@ -22,7 +22,7 @@ type BackgroundKnowledge struct {
 // RecurringTaskSystemPrompt defines the explicit lifecycle contract for an
 // unattended recurring task. A normal text response does not complete the run.
 func RecurringTaskSystemPrompt() string {
-	return `You are executing an unattended recurring task. Complete the requested work, then call the task_completed tool exactly once when the work is fully finished. A written response alone does not complete the task. Do not call task_completed if the work failed or remains blocked.`
+	return `You are executing an unattended recurring task. Complete the requested work, then call the task_completed tool exactly once when the work is fully finished. Use the summary argument for a concise completion report suitable for a notification. A written response alone does not complete the task. Do not call task_completed if the work failed or remains blocked.`
 }
 
 // this prompt is applied before the user prompt is forwarded to the LLM

--- a/api/pkg/server/app_trigger_handlers.go
+++ b/api/pkg/server/app_trigger_handlers.go
@@ -308,9 +308,7 @@ func (s *HelixAPIServer) executeAppTrigger(_ http.ResponseWriter, r *http.Reques
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	return &types.TriggerExecuteResponse{
-		SessionID: response,
-	}, nil
+	return response, nil
 }
 
 // listTriggerExecutions godoc

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -38957,6 +38957,9 @@ const docTemplate = `{
                 },
                 "session_id": {
                     "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.TriggerExecutionStatus"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -36356,6 +36356,10 @@ const docTemplate = `{
                 "manually_review_questions": {
                     "type": "boolean"
                 },
+                "org_worker_id": {
+                    "description": "OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for\nhelix-org workers. Hydra materializes the instructions as native agent\nfiles in this session's workspace before starting the desktop. Ordinary\nproject and SpecTask sessions leave both fields empty.",
+                    "type": "string"
+                },
                 "parent_session_id": {
                     "description": "Fork lineage — set on a session created by forking from a parent.\nSee design/tasks/002081_kickoff-mid-session/design.md.",
                     "type": "string"
@@ -36394,6 +36398,9 @@ const docTemplate = `{
                 },
                 "render_node": {
                     "description": "GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)",
+                    "type": "string"
+                },
+                "runtime_instructions": {
                     "type": "string"
                 },
                 "session_rag_results": {
@@ -38995,13 +39002,15 @@ const docTemplate = `{
                 "pending",
                 "running",
                 "success",
-                "error"
+                "error",
+                "skipped"
             ],
             "x-enum-varnames": [
                 "TriggerExecutionStatusPending",
                 "TriggerExecutionStatusRunning",
                 "TriggerExecutionStatusSuccess",
-                "TriggerExecutionStatusError"
+                "TriggerExecutionStatusError",
+                "TriggerExecutionStatusSkipped"
             ]
         },
         "types.TriggerStatus": {

--- a/api/pkg/server/mcp_backend_session.go
+++ b/api/pkg/server/mcp_backend_session.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -85,6 +87,16 @@ func NewSessionMCPBackend(s store.Store) *SessionMCPBackend {
 	)
 	backend.mcpServer.AddTool(searchSessionTool, backend.handleSearchSession)
 
+	// Add task_completed tool. It is session-scoped and only accepts recurring
+	// job sessions with an active trigger execution.
+	taskCompletedTool := mcp.NewTool("task_completed",
+		mcp.WithDescription("Mark the current recurring task execution complete. Call this exactly once, only after all requested work is finished."),
+		mcp.WithString("summary",
+			mcp.Description("Optional concise summary of the completed work"),
+		),
+	)
+	backend.mcpServer.AddTool(taskCompletedTool, backend.handleTaskCompleted)
+
 	// Create Streamable HTTP server for direct POST support
 	// Use stateless mode so each request is independent (no session tracking required)
 	backend.httpServer = server.NewStreamableHTTPServer(backend.mcpServer,
@@ -116,6 +128,39 @@ func (b *SessionMCPBackend) getSessionID(ctx context.Context, requestedID string
 	return ""
 }
 
+func (b *SessionMCPBackend) handleTaskCompleted(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sessionID := b.getSessionID(ctx, "")
+	if sessionID == "" {
+		return mcp.NewToolResultError("session_id is required"), nil
+	}
+
+	session, err := b.store.GetSession(ctx, sessionID)
+	if err != nil {
+		return mcp.NewToolResultError("failed to get session: " + err.Error()), nil
+	}
+	user, ok := ctx.Value("user").(*types.User)
+	if !ok || user == nil || session.Owner != user.ID {
+		return mcp.NewToolResultError("not authorized to complete this task"), nil
+	}
+	if session.Metadata.SessionRole != "job" {
+		return mcp.NewToolResultError("current session is not a recurring task"), nil
+	}
+
+	summary, _ := request.RequireString("summary")
+	if summary == "" {
+		summary = "Task completed"
+	}
+	execution, err := b.store.FinishTriggerExecution(ctx, sessionID, types.TriggerExecutionStatusSuccess, summary)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return mcp.NewToolResultError("no running recurring task execution exists for this session"), nil
+		}
+		return mcp.NewToolResultError("failed to complete recurring task: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Recurring task execution %s marked complete.", execution.ID)), nil
+}
+
 // handleCurrentSession returns quick overview of current session
 func (b *SessionMCPBackend) handleCurrentSession(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	sessionID := b.getSessionID(ctx, "")
@@ -138,11 +183,11 @@ func (b *SessionMCPBackend) handleCurrentSession(ctx context.Context, request mc
 	}
 
 	result := map[string]interface{}{
-		"session_id":   session.ID,
-		"name":         session.Name,
-		"total_turns":  total,
-		"created":      session.Created,
-		"updated":      session.Updated,
+		"session_id":    session.ID,
+		"name":          session.Name,
+		"total_turns":   total,
+		"created":       session.Created,
+		"updated":       session.Updated,
 		"title_changes": len(session.Metadata.TitleHistory),
 	}
 

--- a/api/pkg/server/mcp_backend_session.go
+++ b/api/pkg/server/mcp_backend_session.go
@@ -9,24 +9,28 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/helixml/helix/api/pkg/notification"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog/log"
 )
 
 // SessionMCPBackend provides session navigation MCP tools via HTTP
 // This allows AI agents to navigate their own conversation history.
 type SessionMCPBackend struct {
 	store      store.Store
+	notifier   notification.Notifier
 	mcpServer  *server.MCPServer
 	httpServer *server.StreamableHTTPServer
 }
 
 // NewSessionMCPBackend creates a new session MCP backend
-func NewSessionMCPBackend(s store.Store) *SessionMCPBackend {
+func NewSessionMCPBackend(s store.Store, notifier notification.Notifier) *SessionMCPBackend {
 	backend := &SessionMCPBackend{
-		store: s,
+		store:    s,
+		notifier: notifier,
 	}
 
 	// Create MCP server
@@ -158,7 +162,35 @@ func (b *SessionMCPBackend) handleTaskCompleted(ctx context.Context, request mcp
 		return mcp.NewToolResultError("failed to complete recurring task: " + err.Error()), nil
 	}
 
+	if err := b.notifyTaskCompleted(ctx, session, execution, summary); err != nil {
+		log.Error().Err(err).
+			Str("session_id", session.ID).
+			Str("execution_id", execution.ID).
+			Msg("recurring task completed but notification failed")
+	}
+
 	return mcp.NewToolResultText(fmt.Sprintf("Recurring task execution %s marked complete.", execution.ID)), nil
+}
+
+func (b *SessionMCPBackend) notifyTaskCompleted(ctx context.Context, session *types.Session, execution *types.TriggerExecution, summary string) error {
+	if b.notifier == nil {
+		return nil
+	}
+	triggerConfig, err := b.store.GetTriggerConfiguration(ctx, &store.GetTriggerConfigurationQuery{ID: execution.TriggerConfigurationID})
+	if err != nil {
+		return fmt.Errorf("load trigger notification configuration: %w", err)
+	}
+	if triggerConfig.Trigger.Cron == nil {
+		return fmt.Errorf("trigger %s has no cron notification configuration", triggerConfig.ID)
+	}
+	return b.notifier.Notify(ctx, &types.Notification{
+		Event:          types.EventCronTriggerComplete,
+		Session:        session,
+		Message:        summary,
+		RenderMarkdown: true,
+		Emails:         triggerConfig.Trigger.Cron.Emails,
+		CallbackURL:    triggerConfig.Trigger.Cron.CallbackURL,
+	})
 }
 
 // handleCurrentSession returns quick overview of current session

--- a/api/pkg/server/mcp_backend_session_test.go
+++ b/api/pkg/server/mcp_backend_session_test.go
@@ -96,6 +96,51 @@ func (suite *SessionMCPBackendSuite) ctxWithSessionID(sessionID string) context.
 	return context.WithValue(suite.ctx, "session_id", sessionID)
 }
 
+func (suite *SessionMCPBackendSuite) recurringTaskContext() context.Context {
+	ctx := suite.ctxWithSessionID("session-123")
+	return context.WithValue(ctx, "user", &types.User{ID: "user-123"})
+}
+
+func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_Success() {
+	session := suite.testSession()
+	session.Owner = "user-123"
+	session.Metadata.SessionRole = "job"
+	execution := &types.TriggerExecution{ID: "tex-123", SessionID: session.ID}
+
+	suite.mockStore.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	suite.mockStore.EXPECT().FinishTriggerExecution(gomock.Any(), session.ID, types.TriggerExecutionStatusSuccess, "Repository inspected").Return(execution, nil)
+
+	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Arguments: map[string]any{"summary": "Repository inspected"}},
+	})
+	suite.NoError(err)
+	suite.False(result.IsError)
+	suite.Contains(result.Content[0].(mcp.TextContent).Text, execution.ID)
+}
+
+func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_RejectsNonJobSession() {
+	session := suite.testSession()
+	session.Owner = "user-123"
+	session.Metadata.SessionRole = "exploratory"
+	suite.mockStore.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+
+	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{})
+	suite.NoError(err)
+	suite.True(result.IsError)
+}
+
+func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_RejectsTerminalExecution() {
+	session := suite.testSession()
+	session.Owner = "user-123"
+	session.Metadata.SessionRole = "job"
+	suite.mockStore.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	suite.mockStore.EXPECT().FinishTriggerExecution(gomock.Any(), session.ID, types.TriggerExecutionStatusSuccess, "Task completed").Return(nil, store.ErrNotFound)
+
+	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{})
+	suite.NoError(err)
+	suite.True(result.IsError)
+}
+
 // =============================================================================
 // Tests for handleCurrentSession
 // =============================================================================

--- a/api/pkg/server/mcp_backend_session_test.go
+++ b/api/pkg/server/mcp_backend_session_test.go
@@ -3,9 +3,11 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/helixml/helix/api/pkg/notification"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -19,6 +21,7 @@ type SessionMCPBackendSuite struct {
 	ctx       context.Context
 	ctrl      *gomock.Controller
 	mockStore *store.MockStore
+	notifier  *notification.MockNotifier
 	backend   *SessionMCPBackend
 }
 
@@ -30,7 +33,8 @@ func (suite *SessionMCPBackendSuite) SetupTest() {
 	suite.ctx = context.Background()
 	suite.ctrl = gomock.NewController(suite.T())
 	suite.mockStore = store.NewMockStore(suite.ctrl)
-	suite.backend = NewSessionMCPBackend(suite.mockStore)
+	suite.notifier = notification.NewMockNotifier(suite.ctrl)
+	suite.backend = NewSessionMCPBackend(suite.mockStore, suite.notifier)
 }
 
 func (suite *SessionMCPBackendSuite) TearDownTest() {
@@ -105,10 +109,29 @@ func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_Success() {
 	session := suite.testSession()
 	session.Owner = "user-123"
 	session.Metadata.SessionRole = "job"
-	execution := &types.TriggerExecution{ID: "tex-123", SessionID: session.ID}
+	execution := &types.TriggerExecution{ID: "tex-123", SessionID: session.ID, TriggerConfigurationID: "trigger-123"}
+	triggerConfig := &types.TriggerConfiguration{
+		ID: "trigger-123",
+		Trigger: types.Trigger{Cron: &types.CronTrigger{
+			Emails:      []string{"ops@example.com"},
+			CallbackURL: "https://example.com/task-complete",
+		}},
+	}
 
 	suite.mockStore.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
 	suite.mockStore.EXPECT().FinishTriggerExecution(gomock.Any(), session.ID, types.TriggerExecutionStatusSuccess, "Repository inspected").Return(execution, nil)
+	suite.mockStore.EXPECT().GetTriggerConfiguration(gomock.Any(), &store.GetTriggerConfigurationQuery{ID: triggerConfig.ID}).Return(triggerConfig, nil)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, n *types.Notification) error {
+			suite.Equal(types.EventCronTriggerComplete, n.Event)
+			suite.Same(session, n.Session)
+			suite.Equal("Repository inspected", n.Message)
+			suite.True(n.RenderMarkdown)
+			suite.Equal(triggerConfig.Trigger.Cron.Emails, n.Emails)
+			suite.Equal(triggerConfig.Trigger.Cron.CallbackURL, n.CallbackURL)
+			return nil
+		},
+	)
 
 	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{Arguments: map[string]any{"summary": "Repository inspected"}},
@@ -127,6 +150,24 @@ func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_RejectsNonJobSessio
 	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{})
 	suite.NoError(err)
 	suite.True(result.IsError)
+}
+
+func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_NotificationFailureDoesNotReopenTask() {
+	session := suite.testSession()
+	session.Owner = "user-123"
+	session.Metadata.SessionRole = "job"
+	execution := &types.TriggerExecution{ID: "tex-123", SessionID: session.ID, TriggerConfigurationID: "trigger-123"}
+	triggerConfig := &types.TriggerConfiguration{ID: "trigger-123", Trigger: types.Trigger{Cron: &types.CronTrigger{}}}
+
+	suite.mockStore.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	suite.mockStore.EXPECT().FinishTriggerExecution(gomock.Any(), session.ID, types.TriggerExecutionStatusSuccess, "Task completed").Return(execution, nil)
+	suite.mockStore.EXPECT().GetTriggerConfiguration(gomock.Any(), &store.GetTriggerConfigurationQuery{ID: triggerConfig.ID}).Return(triggerConfig, nil)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(errors.New("mail transport unavailable"))
+
+	result, err := suite.backend.handleTaskCompleted(suite.recurringTaskContext(), mcp.CallToolRequest{})
+	suite.NoError(err)
+	suite.False(result.IsError)
+	suite.Contains(result.Content[0].(mcp.TextContent).Text, execution.ID)
 }
 
 func (suite *SessionMCPBackendSuite) TestHandleTaskCompleted_RejectsTerminalExecution() {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -543,7 +543,7 @@ func NewServer(
 	apiServer.mcpGateway.RegisterBackend("helix", NewHelixMCPBackend(store, appController))
 
 	// Register Session MCP backend (session navigation and context tools)
-	apiServer.mcpGateway.RegisterBackend("session", NewSessionMCPBackend(store))
+	apiServer.mcpGateway.RegisterBackend("session", NewSessionMCPBackend(store, appController.Options.Notifier))
 
 	// Register External MCP backend (user-configured MCP servers)
 	// This proxies requests from Zed to external MCP servers configured in agents

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2258,6 +2258,7 @@ func (s *HelixAPIServer) stopExternalAgentSession(_ http.ResponseWriter, r *http
 			Msg("Failed to stop external Zed agent")
 		return nil, system.NewHTTPError500("failed to stop external Zed agent")
 	}
+	s.failRunningTriggerExecution(sessionID, "External agent session was stopped before task completion")
 
 	log.Info().
 		Str("session_id", sessionID).
@@ -2852,8 +2853,12 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		}
 	}
 	if session == nil {
+		sessionID := req.SessionID
+		if sessionID == "" {
+			sessionID = system.GenerateSessionID()
+		}
 		session = &types.Session{
-			ID:             system.GenerateSessionID(),
+			ID:             sessionID,
 			Name:           s.getTemporarySessionName(message),
 			Created:        time.Now(),
 			Updated:        time.Now(),

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -36352,6 +36352,10 @@
                 "manually_review_questions": {
                     "type": "boolean"
                 },
+                "org_worker_id": {
+                    "description": "OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for\nhelix-org workers. Hydra materializes the instructions as native agent\nfiles in this session's workspace before starting the desktop. Ordinary\nproject and SpecTask sessions leave both fields empty.",
+                    "type": "string"
+                },
                 "parent_session_id": {
                     "description": "Fork lineage — set on a session created by forking from a parent.\nSee design/tasks/002081_kickoff-mid-session/design.md.",
                     "type": "string"
@@ -36390,6 +36394,9 @@
                 },
                 "render_node": {
                     "description": "GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)",
+                    "type": "string"
+                },
+                "runtime_instructions": {
                     "type": "string"
                 },
                 "session_rag_results": {
@@ -38991,13 +38998,15 @@
                 "pending",
                 "running",
                 "success",
-                "error"
+                "error",
+                "skipped"
             ],
             "x-enum-varnames": [
                 "TriggerExecutionStatusPending",
                 "TriggerExecutionStatusRunning",
                 "TriggerExecutionStatusSuccess",
-                "TriggerExecutionStatusError"
+                "TriggerExecutionStatusError",
+                "TriggerExecutionStatusSkipped"
             ]
         },
         "types.TriggerStatus": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -38953,6 +38953,9 @@
                 },
                 "session_id": {
                     "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.TriggerExecutionStatus"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -9843,6 +9843,13 @@ definitions:
         type: string
       manually_review_questions:
         type: boolean
+      org_worker_id:
+        description: |-
+          OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for
+          helix-org workers. Hydra materializes the instructions as native agent
+          files in this session's workspace before starting the desktop. Ordinary
+          project and SpecTask sessions leave both fields empty.
+        type: string
       parent_session_id:
         description: |-
           Fork lineage — set on a session created by forking from a parent.
@@ -9880,6 +9887,8 @@ definitions:
         $ref: '#/definitions/types.RAGSettings'
       render_node:
         description: GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)
+        type: string
+      runtime_instructions:
         type: string
       session_rag_results:
         items:
@@ -11804,12 +11813,14 @@ definitions:
     - running
     - success
     - error
+    - skipped
     type: string
     x-enum-varnames:
     - TriggerExecutionStatusPending
     - TriggerExecutionStatusRunning
     - TriggerExecutionStatusSuccess
     - TriggerExecutionStatusError
+    - TriggerExecutionStatusSkipped
   types.TriggerStatus:
     properties:
       message:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -11781,6 +11781,8 @@ definitions:
         type: string
       session_id:
         type: string
+      status:
+        $ref: '#/definitions/types.TriggerExecutionStatus'
     type: object
   types.TriggerExecution:
     properties:

--- a/api/pkg/server/trigger_execution_lifecycle.go
+++ b/api/pkg/server/trigger_execution_lifecycle.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"context"
+	"errors"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// failRunningTriggerExecution marks a recurring job terminal when its external
+// agent or sandbox fails. The shared failure handlers also serve ordinary chat
+// sessions; those have no linked running execution and are therefore no-ops.
+func (s *HelixAPIServer) failRunningTriggerExecution(sessionID, failure string) {
+	if sessionID == "" {
+		return
+	}
+	ctx := context.Background()
+	if _, err := s.Store.FinishTriggerExecution(ctx, sessionID, types.TriggerExecutionStatusError, failure); err != nil && !errors.Is(err, store.ErrNotFound) {
+		log.Error().Err(err).Str("session_id", sessionID).Msg("failed to mark recurring task execution as failed")
+	}
+}

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -3737,6 +3737,11 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 			return nil
 		}
 	}
+	taskSessionID := helixSessionID
+	if taskSessionID == "" {
+		taskSessionID = sessionID
+	}
+	apiServer.failRunningTriggerExecution(taskSessionID, fmt.Sprintf("Thread load failed: %s", errorMsg))
 
 	// If we have a request_id, try to send error to the done channel
 	// This allows the HTTP streaming to complete with an error message
@@ -3972,6 +3977,7 @@ func (apiServer *HelixAPIServer) handleChatResponseError(sessionID string, syncM
 				log.Warn().Err(err).Str("interaction_id", interactionID).
 					Msg("chat_response_error: persist failed")
 			}
+			apiServer.failRunningTriggerExecution(interaction.SessionID, errorMsg)
 
 			// The Zed crash fix surfaces a mid-turn agent crash here as a
 			// chat_response_error (rather than wedging the turn). When the error

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -58,6 +58,11 @@ func (s *WebSocketSyncSuite) SetupTest() {
 	s.store.EXPECT().GetCommentByPromptID(gomock.Any(), gomock.Any()).
 		Return(nil, fmt.Errorf("record not found")).AnyTimes()
 
+	// External-agent failure handlers also attempt to finish a linked recurring
+	// task. Most websocket tests use ordinary sessions, so no execution exists.
+	s.store.EXPECT().FinishTriggerExecution(gomock.Any(), gomock.Any(), types.TriggerExecutionStatusError, gomock.Any()).
+		Return(nil, store.ErrNotFound).AnyTimes()
+
 	s.server = &HelixAPIServer{
 		Cfg: &config.ServerConfig{
 			WebServer: config.WebServer{

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -572,6 +572,8 @@ type Store interface {
 
 	ListTriggerExecutions(ctx context.Context, q *ListTriggerExecutionsQuery) ([]*types.TriggerExecution, error)
 	CreateTriggerExecution(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error)
+	CreateTriggerExecutionUnlessRunning(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error)
+	FinishTriggerExecution(ctx context.Context, sessionID string, status types.TriggerExecutionStatus, message string) (*types.TriggerExecution, error)
 	UpdateTriggerExecution(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error)
 	ResetRunningExecutions(ctx context.Context) error
 

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -1197,6 +1197,22 @@ func (mr *MockStoreMockRecorder) CreateTriggerExecution(ctx, execution any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTriggerExecution", reflect.TypeOf((*MockStore)(nil).CreateTriggerExecution), ctx, execution)
 }
 
+// CreateTriggerExecutionUnlessRunning mocks base method.
+func (m *MockStore) CreateTriggerExecutionUnlessRunning(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTriggerExecutionUnlessRunning", ctx, execution)
+	ret0, _ := ret[0].(*types.TriggerExecution)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateTriggerExecutionUnlessRunning indicates an expected call of CreateTriggerExecutionUnlessRunning.
+func (mr *MockStoreMockRecorder) CreateTriggerExecutionUnlessRunning(ctx, execution any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTriggerExecutionUnlessRunning", reflect.TypeOf((*MockStore)(nil).CreateTriggerExecutionUnlessRunning), ctx, execution)
+}
+
 // CreateUsageMetric mocks base method.
 func (m *MockStore) CreateUsageMetric(ctx context.Context, metric *types.UsageMetric) (*types.UsageMetric, error) {
 	m.ctrl.T.Helper()
@@ -2312,6 +2328,21 @@ func (m *MockStore) FindAvailableSandboxInstance(ctx context.Context, desktopTyp
 func (mr *MockStoreMockRecorder) FindAvailableSandboxInstance(ctx, desktopType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAvailableSandboxInstance", reflect.TypeOf((*MockStore)(nil).FindAvailableSandboxInstance), ctx, desktopType)
+}
+
+// FinishTriggerExecution mocks base method.
+func (m *MockStore) FinishTriggerExecution(ctx context.Context, sessionID string, status types.TriggerExecutionStatus, message string) (*types.TriggerExecution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FinishTriggerExecution", ctx, sessionID, status, message)
+	ret0, _ := ret[0].(*types.TriggerExecution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FinishTriggerExecution indicates an expected call of FinishTriggerExecution.
+func (mr *MockStoreMockRecorder) FinishTriggerExecution(ctx, sessionID, status, message any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishTriggerExecution", reflect.TypeOf((*MockStore)(nil).FinishTriggerExecution), ctx, sessionID, status, message)
 }
 
 // GenerateRandomState mocks base method.

--- a/api/pkg/store/store_trigger_executions.go
+++ b/api/pkg/store/store_trigger_executions.go
@@ -3,10 +3,13 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // ResetRunningExecutions on start we have to reset any running executions as we will not pick them up again to finish (we could in the future),
@@ -23,6 +26,98 @@ func (s *PostgresStore) ResetRunningExecutions(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// CreateTriggerExecutionUnlessRunning atomically reserves a trigger for one
+// execution. If another execution is still running, it records this attempt as
+// skipped and returns started=false. Locking the trigger row prevents a manual
+// execution racing a scheduled execution from starting two agent sessions.
+func (s *PostgresStore) CreateTriggerExecutionUnlessRunning(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+	if execution.TriggerConfigurationID == "" {
+		return nil, false, errors.New("trigger configuration ID is required")
+	}
+
+	started := false
+	err := s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var trigger types.TriggerConfiguration
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Select("id").
+			Where("id = ?", execution.TriggerConfigurationID).
+			First(&trigger).Error; err != nil {
+			return fmt.Errorf("lock trigger configuration: %w", err)
+		}
+
+		var running types.TriggerExecution
+		err := tx.Where("trigger_configuration_id = ? AND status = ?", execution.TriggerConfigurationID, types.TriggerExecutionStatusRunning).
+			Order("created DESC").
+			First(&running).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("find running trigger execution: %w", err)
+		}
+
+		if execution.ID == "" {
+			execution.ID = system.GenerateTriggerExecutionID()
+		}
+		execution.Created = time.Now()
+		execution.Updated = execution.Created
+		if err == nil {
+			execution.Status = types.TriggerExecutionStatusSkipped
+			execution.Error = fmt.Sprintf("Previous execution %s is still running", running.ID)
+			execution.SessionID = ""
+		} else {
+			execution.Status = types.TriggerExecutionStatusRunning
+			started = true
+		}
+
+		if err := tx.Create(execution).Error; err != nil {
+			return fmt.Errorf("create trigger execution: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return execution, started, nil
+}
+
+// FinishTriggerExecution transitions the running execution linked to a session
+// exactly once. Repeated task_completed calls and late failure events cannot
+// overwrite an already-terminal result.
+func (s *PostgresStore) FinishTriggerExecution(ctx context.Context, sessionID string, status types.TriggerExecutionStatus, message string) (*types.TriggerExecution, error) {
+	if sessionID == "" {
+		return nil, errors.New("session ID is required")
+	}
+	if status != types.TriggerExecutionStatusSuccess && status != types.TriggerExecutionStatusError {
+		return nil, fmt.Errorf("terminal trigger execution status is required, got %q", status)
+	}
+
+	var execution types.TriggerExecution
+	err := s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("session_id = ? AND status = ?", sessionID, types.TriggerExecutionStatusRunning).
+			Order("created DESC").
+			First(&execution).Error; err != nil {
+			return err
+		}
+
+		execution.Status = status
+		execution.DurationMs = time.Since(execution.Created).Milliseconds()
+		if status == types.TriggerExecutionStatusSuccess {
+			execution.Output = message
+			execution.Error = ""
+		} else {
+			execution.Error = message
+		}
+		execution.Updated = time.Now()
+		return tx.Save(&execution).Error
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &execution, nil
 }
 
 func (s *PostgresStore) CreateTriggerExecution(ctx context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {

--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -482,19 +482,49 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 		return executeExternalAgentCronTask(ctx, str, externalAgentStarter, notifier, a, userID, triggerID, trigger, sessionName, promptText)
 	}
 
-	// Default action: run a blocking session (existing behavior)
+	// Default action: run a blocking session. Reserve the trigger before
+	// creating the session so blocking agents obey the same overlap policy as
+	// external agents.
+	sessionID := system.GenerateSessionID()
+	execution, started, err := reserveCronExecution(ctx, str, triggerID, sessionName, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("reserve blocking agent trigger execution: %w", err)
+	}
+	if !started {
+		log.Info().
+			Str("app_id", a.ID).
+			Str("trigger_id", triggerID).
+			Str("execution_id", execution.ID).
+			Msg("skipped blocking agent cron execution because the previous execution is still running")
+		return "", nil
+	}
+
+	startedAt := execution.Created
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+	markFailed := func(taskErr error) error {
+		execution.Status = types.TriggerExecutionStatusError
+		execution.Error = taskErr.Error()
+		execution.DurationMs = time.Since(startedAt).Milliseconds()
+		if _, updateErr := str.UpdateTriggerExecution(ctx, execution); updateErr != nil {
+			return fmt.Errorf("%w; failed to mark trigger execution failed: %v", taskErr, updateErr)
+		}
+		return taskErr
+	}
+
 	app, err := str.GetAppWithTools(ctx, a.ID)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("app_id", a.ID).
 			Msg("failed to get app")
-		return "", err
+		return "", markFailed(err)
 	}
 
 	// Prepare new session
 	session := &types.Session{
-		ID:             system.GenerateSessionID(),
+		ID:             sessionID,
 		Name:           sessionName,
 		Created:        time.Now(),
 		Updated:        time.Now(),
@@ -519,7 +549,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Err(err).
 			Str("app_id", app.ID).
 			Msg("failed to create session")
-		return "", err
+		return "", markFailed(err)
 	}
 
 	user, err := str.GetUser(ctx, &store.GetUserQuery{
@@ -531,29 +561,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Str("app_id", app.ID).
 			Str("user_id", userID).
 			Msg("failed to get user")
-		return "", err
-	}
-
-	// Create execution
-	execution := &types.TriggerExecution{
-		ID:                     system.GenerateUUID(),
-		Name:                   sessionName,
-		TriggerConfigurationID: triggerID,
-		Created:                time.Now(),
-		Updated:                time.Now(),
-		Status:                 types.TriggerExecutionStatusRunning,
-		SessionID:              session.ID,
-	}
-
-	startedAt := time.Now()
-
-	execution, err = str.CreateTriggerExecution(ctx, execution)
-	if err != nil {
-		log.Error().
-			Err(err).
-			Str("app_id", app.ID).
-			Msg("failed to create trigger execution")
-		return "", fmt.Errorf("failed to create trigger execution: %w", err)
+		return "", markFailed(err)
 	}
 
 	resp, err := ctrl.RunBlockingSession(ctx, &controller.RunSessionRequest{
@@ -585,21 +593,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 				Msg("failed to send failure notification")
 		}
 
-		// Update execution with error
-		execution.Status = types.TriggerExecutionStatusError
-		execution.Error = err.Error()
-		execution.DurationMs = time.Since(startedAt).Milliseconds()
-
-		execution, err = str.UpdateTriggerExecution(ctx, execution)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("app_id", app.ID).
-				Str("execution_id", execution.ID).
-				Msg("failed to update execution")
-		}
-
-		return "", err
+		return "", markFailed(err)
 	}
 
 	responseText := types.TextFromInteraction(resp)
@@ -645,13 +639,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 
 func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter ExternalAgentStarter, notifier notification.Notifier, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string, promptText string) (string, error) {
 	sessionID := system.GenerateSessionID()
-	execution, started, err := str.CreateTriggerExecutionUnlessRunning(ctx, &types.TriggerExecution{
-		ID:                     system.GenerateTriggerExecutionID(),
-		Name:                   sessionName,
-		TriggerConfigurationID: triggerID,
-		Status:                 types.TriggerExecutionStatusRunning,
-		SessionID:              sessionID,
-	})
+	execution, started, err := reserveCronExecution(ctx, str, triggerID, sessionName, sessionID)
 	if err != nil {
 		return "", fmt.Errorf("reserve external agent trigger execution: %w", err)
 	}
@@ -724,6 +712,16 @@ func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter 
 		Msg("external agent cron session started")
 
 	return session.ID, nil
+}
+
+func reserveCronExecution(ctx context.Context, str store.Store, triggerID, sessionName, sessionID string) (*types.TriggerExecution, bool, error) {
+	return str.CreateTriggerExecutionUnlessRunning(ctx, &types.TriggerExecution{
+		ID:                     system.GenerateTriggerExecutionID(),
+		Name:                   sessionName,
+		TriggerConfigurationID: triggerID,
+		Status:                 types.TriggerExecutionStatusRunning,
+		SessionID:              sessionID,
+	})
 }
 
 func cronAgentType(app *types.App, trigger *types.CronTrigger) types.AgentType {

--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -475,8 +475,10 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 		}
 	}
 
-	// Handle external agent sessions (non-blocking)
-	if trigger.AgentType == "zed_external" {
+	// Tasks created from the Tasks page predate AgentType and ProjectID on
+	// CronTrigger. Infer the runtime from the selected agent so those triggers
+	// take the same path as an interactive chat with that agent.
+	if cronAgentType(a, trigger) == types.AgentTypeZedExternal {
 		return executeExternalAgentCronTask(ctx, str, externalAgentStarter, notifier, a, userID, triggerID, trigger, sessionName, promptText)
 	}
 
@@ -646,16 +648,20 @@ func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter 
 		return "", fmt.Errorf("external agent starter not configured, cannot create zed_external cron session")
 	}
 
-	projectID := trigger.ProjectID
-	if projectID == "" {
-		return "", fmt.Errorf("project_id is required for zed_external cron triggers")
+	projectID, err := externalAgentProjectID(ctx, str, a, userID, trigger.ProjectID)
+	if err != nil {
+		return "", err
 	}
 
 	session, err := starter.StartExternalAgentSession(ctx, &types.SessionChatRequest{
-		ProjectID:   projectID,
-		AgentType:   "zed_external",
-		SessionRole: "job",
-		CallbackURL: trigger.CallbackURL,
+		AppID:               a.ID,
+		AssistantID:         "0",
+		OrganizationID:      a.OrganizationID,
+		ProjectID:           projectID,
+		AgentType:           string(types.AgentTypeZedExternal),
+		ExternalAgentConfig: a.Config.Helix.ExternalAgentConfig,
+		SessionRole:         "job",
+		CallbackURL:         trigger.CallbackURL,
 		Messages: []*types.Message{
 			{
 				Role:    "user",
@@ -699,6 +705,55 @@ func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter 
 		Msg("external agent cron session started")
 
 	return session.ID, nil
+}
+
+func cronAgentType(app *types.App, trigger *types.CronTrigger) types.AgentType {
+	if trigger != nil && trigger.AgentType != "" {
+		return types.AgentType(trigger.AgentType)
+	}
+	if app == nil {
+		return ""
+	}
+	if len(app.Config.Helix.Assistants) > 0 && app.Config.Helix.Assistants[0].AgentType != "" {
+		return app.Config.Helix.Assistants[0].AgentType
+	}
+	return app.Config.Helix.DefaultAgentType
+}
+
+func externalAgentProjectID(ctx context.Context, str store.Store, app *types.App, userID, configuredProjectID string) (string, error) {
+	if configuredProjectID != "" {
+		return configuredProjectID, nil
+	}
+	if app == nil {
+		return "", fmt.Errorf("cannot resolve project for external agent: app is required")
+	}
+
+	query := &store.ListProjectsQuery{OrganizationID: app.OrganizationID}
+	if app.OrganizationID == "" {
+		query.UserID = userID
+	}
+	projects, err := str.ListProjects(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("failed to list projects for external agent %s: %w", app.ID, err)
+	}
+
+	var projectID string
+	for _, project := range projects {
+		if project.DefaultHelixAppID != app.ID &&
+			project.ProjectManagerHelixAppID != app.ID &&
+			project.PullRequestReviewerHelixAppID != app.ID {
+			continue
+		}
+		if projectID != "" {
+			return "", fmt.Errorf("multiple projects reference external agent %s; project_id is required", app.ID)
+		}
+		projectID = project.ID
+	}
+	if projectID == "" {
+		return "", fmt.Errorf("no project references external agent %s; project_id is required", app.ID)
+	}
+
+	return projectID, nil
 }
 
 func readInputFile(ctx context.Context, str store.Store, trigger *types.CronTrigger) (string, error) {

--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -459,10 +459,14 @@ func getCronJobSchedule(job gocron.Job) string {
 	return currentSchedule
 }
 
-func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Controller, notifier notification.Notifier, specTaskCreator SpecTaskCreator, externalAgentStarter ExternalAgentStarter, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string) (string, error) {
+func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Controller, notifier notification.Notifier, specTaskCreator SpecTaskCreator, externalAgentStarter ExternalAgentStarter, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string) (*types.TriggerExecuteResponse, error) {
 	// Handle spec_task action: create a spec task instead of running a session
 	if trigger.Action == "spec_task" {
-		return executeSpecTaskAction(ctx, str, specTaskCreator, notifier, a, userID, triggerID, trigger, sessionName)
+		content, err := executeSpecTaskAction(ctx, str, specTaskCreator, notifier, a, userID, triggerID, trigger, sessionName)
+		if err != nil {
+			return nil, err
+		}
+		return &types.TriggerExecuteResponse{Content: content, Status: types.TriggerExecutionStatusSuccess}, nil
 	}
 
 	// Resolve prompt: use InputFile from helix-specs worktree if set, otherwise Input
@@ -479,7 +483,15 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 	// Tasks-page triggers omit AgentType and ProjectID. Infer the runtime from
 	// the selected agent so they take the same path as an interactive chat.
 	if cronAgentType(a, trigger) == types.AgentTypeZedExternal {
-		return executeExternalAgentCronTask(ctx, str, externalAgentStarter, notifier, a, userID, triggerID, trigger, sessionName, promptText)
+		sessionID, err := executeExternalAgentCronTask(ctx, str, externalAgentStarter, notifier, a, userID, triggerID, trigger, sessionName, promptText)
+		if err != nil {
+			return nil, err
+		}
+		status := types.TriggerExecutionStatusRunning
+		if sessionID == "" {
+			status = types.TriggerExecutionStatusSkipped
+		}
+		return &types.TriggerExecuteResponse{SessionID: sessionID, Status: status}, nil
 	}
 
 	// Default action: run a blocking session. Reserve the trigger before
@@ -488,7 +500,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 	sessionID := system.GenerateSessionID()
 	execution, started, err := reserveCronExecution(ctx, str, triggerID, sessionName, sessionID)
 	if err != nil {
-		return "", fmt.Errorf("reserve blocking agent trigger execution: %w", err)
+		return nil, fmt.Errorf("reserve blocking agent trigger execution: %w", err)
 	}
 	if !started {
 		log.Info().
@@ -496,7 +508,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Str("trigger_id", triggerID).
 			Str("execution_id", execution.ID).
 			Msg("skipped blocking agent cron execution because the previous execution is still running")
-		return "", nil
+		return &types.TriggerExecuteResponse{Status: types.TriggerExecutionStatusSkipped}, nil
 	}
 
 	startedAt := execution.Created
@@ -519,7 +531,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Err(err).
 			Str("app_id", a.ID).
 			Msg("failed to get app")
-		return "", markFailed(err)
+		return nil, markFailed(err)
 	}
 
 	// Prepare new session
@@ -549,7 +561,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Err(err).
 			Str("app_id", app.ID).
 			Msg("failed to create session")
-		return "", markFailed(err)
+		return nil, markFailed(err)
 	}
 
 	user, err := str.GetUser(ctx, &store.GetUserQuery{
@@ -561,7 +573,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 			Str("app_id", app.ID).
 			Str("user_id", userID).
 			Msg("failed to get user")
-		return "", markFailed(err)
+		return nil, markFailed(err)
 	}
 
 	resp, err := ctrl.RunBlockingSession(ctx, &controller.RunSessionRequest{
@@ -593,7 +605,7 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 				Msg("failed to send failure notification")
 		}
 
-		return "", markFailed(err)
+		return nil, markFailed(err)
 	}
 
 	responseText := types.TextFromInteraction(resp)
@@ -634,7 +646,11 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 		Str("app_id", app.ID).
 		Msg("app cron job completed")
 
-	return responseText, nil
+	return &types.TriggerExecuteResponse{
+		SessionID: session.ID,
+		Content:   responseText,
+		Status:    types.TriggerExecutionStatusSuccess,
+	}, nil
 }
 
 func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter ExternalAgentStarter, notifier notification.Notifier, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string, promptText string) (string, error) {

--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -17,6 +17,7 @@ import (
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/notification"
+	"github.com/helixml/helix/api/pkg/prompts"
 	"github.com/helixml/helix/api/pkg/services"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
@@ -475,9 +476,8 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 		}
 	}
 
-	// Tasks created from the Tasks page predate AgentType and ProjectID on
-	// CronTrigger. Infer the runtime from the selected agent so those triggers
-	// take the same path as an interactive chat with that agent.
+	// Tasks-page triggers omit AgentType and ProjectID. Infer the runtime from
+	// the selected agent so they take the same path as an interactive chat.
 	if cronAgentType(a, trigger) == types.AgentTypeZedExternal {
 		return executeExternalAgentCronTask(ctx, str, externalAgentStarter, notifier, a, userID, triggerID, trigger, sessionName, promptText)
 	}
@@ -644,17 +644,56 @@ func ExecuteCronTask(ctx context.Context, str store.Store, ctrl *controller.Cont
 }
 
 func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter ExternalAgentStarter, notifier notification.Notifier, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string, promptText string) (string, error) {
+	sessionID := system.GenerateSessionID()
+	execution, started, err := str.CreateTriggerExecutionUnlessRunning(ctx, &types.TriggerExecution{
+		ID:                     system.GenerateTriggerExecutionID(),
+		Name:                   sessionName,
+		TriggerConfigurationID: triggerID,
+		Status:                 types.TriggerExecutionStatusRunning,
+		SessionID:              sessionID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("reserve external agent trigger execution: %w", err)
+	}
+	if !started {
+		log.Info().
+			Str("app_id", a.ID).
+			Str("trigger_id", triggerID).
+			Str("execution_id", execution.ID).
+			Msg("skipped external agent cron execution because the previous execution is still running")
+		return "", nil
+	}
+
+	fail := func(taskErr error) (string, error) {
+		execution.Status = types.TriggerExecutionStatusError
+		execution.Error = taskErr.Error()
+		execution.DurationMs = time.Since(execution.Created).Milliseconds()
+		if _, updateErr := str.UpdateTriggerExecution(ctx, execution); updateErr != nil {
+			log.Error().Err(updateErr).Str("execution_id", execution.ID).Msg("failed to mark external agent cron execution as failed")
+		}
+		if notifyErr := notifier.Notify(ctx, &types.Notification{
+			Event:       types.EventCronTriggerFailed,
+			Message:     taskErr.Error(),
+			Emails:      trigger.Emails,
+			CallbackURL: trigger.CallbackURL,
+		}); notifyErr != nil {
+			log.Error().Err(notifyErr).Msg("failed to send failure notification")
+		}
+		return "", taskErr
+	}
+
 	if starter == nil {
-		return "", fmt.Errorf("external agent starter not configured, cannot create zed_external cron session")
+		return fail(fmt.Errorf("external agent starter not configured, cannot create zed_external cron session"))
 	}
 
 	projectID, err := externalAgentProjectID(ctx, str, a, userID, trigger.ProjectID)
 	if err != nil {
-		return "", err
+		return fail(err)
 	}
 
 	session, err := starter.StartExternalAgentSession(ctx, &types.SessionChatRequest{
 		AppID:               a.ID,
+		SessionID:           sessionID,
 		AssistantID:         "0",
 		OrganizationID:      a.OrganizationID,
 		ProjectID:           projectID,
@@ -662,6 +701,7 @@ func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter 
 		ExternalAgentConfig: a.Config.Helix.ExternalAgentConfig,
 		SessionRole:         "job",
 		CallbackURL:         trigger.CallbackURL,
+		SystemPrompt:        prompts.RecurringTaskSystemPrompt(),
 		Messages: []*types.Message{
 			{
 				Role:    "user",
@@ -671,32 +711,11 @@ func executeExternalAgentCronTask(ctx context.Context, str store.Store, starter 
 	}, userID)
 	if err != nil {
 		log.Error().Err(err).Str("app_id", a.ID).Msg("failed to start external agent cron session")
-
-		notifyErr := notifier.Notify(ctx, &types.Notification{
-			Event:       types.EventCronTriggerFailed,
-			Message:     err.Error(),
-			Emails:      trigger.Emails,
-			CallbackURL: trigger.CallbackURL,
-		})
-		if notifyErr != nil {
-			log.Error().Err(notifyErr).Msg("failed to send failure notification")
-		}
-		return "", err
+		return fail(err)
 	}
 
-	// Create execution record
-	execution := &types.TriggerExecution{
-		ID:                     system.GenerateUUID(),
-		Name:                   sessionName,
-		TriggerConfigurationID: triggerID,
-		Created:                time.Now(),
-		Updated:                time.Now(),
-		Status:                 types.TriggerExecutionStatusRunning,
-		SessionID:              session.ID,
-	}
-	_, err = str.CreateTriggerExecution(ctx, execution)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to create trigger execution for external agent")
+	if session.ID != sessionID {
+		return fail(fmt.Errorf("external agent starter returned session %s, expected %s", session.ID, sessionID))
 	}
 
 	log.Info().

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -218,7 +218,9 @@ func (suite *CronTestSuite) TestExecuteCronTask() {
 
 	// Verify the result
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Equal("test-response", result.Content)
+	suite.NotEmpty(result.SessionID)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_Organization() {
@@ -347,7 +349,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_Organization() {
 
 	// Verify the result
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Equal("test-response", result.Content)
+	suite.NotEmpty(result.SessionID)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_WithEmails() {
@@ -454,7 +458,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_WithEmails() {
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Equal("test-response", result.Content)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_FailureNotification_WithEmails() {
@@ -650,7 +655,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_NoEmails_FallsBackToOwner() {
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Equal("test-response", result.Content)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_Error() {
@@ -703,7 +709,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_SkipsWhilePreviousBlockingExecut
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
-	suite.Empty(result)
+	suite.Equal(types.TriggerExecutionStatusSkipped, result.Status)
+	suite.Empty(result.SessionID)
 }
 
 func TestNextRunFormatted(t *testing.T) {
@@ -824,7 +831,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_InfersExternalAgentConfiguration
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, starter, app, "test-user", "trigger-123", trigger, "scheduled-review")
 	suite.NoError(err)
-	suite.NotEmpty(result)
+	suite.Equal(types.TriggerExecutionStatusRunning, result.Status)
+	suite.NotEmpty(result.SessionID)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_SkipsWhilePreviousExternalExecutionRuns() {
@@ -846,7 +854,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_SkipsWhilePreviousExternalExecut
 		},
 	}, app, "test-user", "trigger-123", trigger, "scheduled-review")
 	suite.NoError(err)
-	suite.Empty(result)
+	suite.Equal(types.TriggerExecutionStatusSkipped, result.Status)
+	suite.Empty(result.SessionID)
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_RecordsExternalStartupFailure() {
@@ -951,7 +960,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction() {
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, mockCreator, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
-	suite.Contains(result, "task-789")
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Contains(result.Content, "task-789")
 }
 
 // A scheduled run has to authenticate as the person it acts for, not as the one
@@ -996,7 +1006,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskActionCarriesCredentialO
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, mockCreator, nil, app, "svc-account", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
-	suite.Contains(result, "task-789")
+	suite.Equal(types.TriggerExecutionStatusSuccess, result.Status)
+	suite.Contains(result.Content, "task-789")
 }
 
 func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction_Error() {

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/controller"
@@ -762,6 +763,14 @@ func (suite *CronTestSuite) TestExecuteCronTask_InfersExternalAgentConfiguration
 	}
 	trigger := &types.CronTrigger{Input: "Inspect the repository"}
 
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			suite.Equal("trigger-123", execution.TriggerConfigurationID)
+			suite.NotEmpty(execution.SessionID)
+			return execution, true, nil
+		},
+	)
+
 	suite.store.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{
 		OrganizationID: "org-123",
 	}).Return([]*types.Project{{
@@ -779,24 +788,65 @@ func (suite *CronTestSuite) TestExecuteCronTask_InfersExternalAgentConfiguration
 			suite.Equal(string(types.AgentTypeZedExternal), req.AgentType)
 			suite.Same(externalAgentConfig, req.ExternalAgentConfig)
 			suite.Equal("job", req.SessionRole)
+			suite.Contains(req.SystemPrompt, "task_completed")
 			suite.Len(req.Messages, 1)
 			suite.Equal([]any{"Inspect the repository"}, req.Messages[0].Content.Parts)
-			return &types.Session{ID: "session-789"}, nil
+			return &types.Session{ID: req.SessionID}, nil
 		},
 	}
 
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
-			suite.Equal("trigger-123", execution.TriggerConfigurationID)
-			suite.Equal("session-789", execution.SessionID)
-			suite.Equal(types.TriggerExecutionStatusRunning, execution.Status)
-			return execution, nil
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, starter, app, "test-user", "trigger-123", trigger, "scheduled-review")
+	suite.NoError(err)
+	suite.NotEmpty(result)
+}
+
+func (suite *CronTestSuite) TestExecuteCronTask_SkipsWhilePreviousExternalExecutionRuns() {
+	app := &types.App{ID: "app-123", Config: types.AppConfig{Helix: types.AppHelixConfig{DefaultAgentType: types.AgentTypeZedExternal}}}
+	trigger := &types.CronTrigger{Input: "Inspect the repository"}
+
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			execution.Status = types.TriggerExecutionStatusSkipped
+			execution.Error = "Previous execution tex_123 is still running"
+			return execution, false, nil
 		},
 	)
 
-	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, starter, app, "test-user", "trigger-123", trigger, "scheduled-review")
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, &mockExternalAgentStarter{
+		startFunc: func(context.Context, *types.SessionChatRequest, string) (*types.Session, error) {
+			suite.Fail("external agent must not start for a skipped execution")
+			return nil, nil
+		},
+	}, app, "test-user", "trigger-123", trigger, "scheduled-review")
 	suite.NoError(err)
-	suite.Equal("session-789", result)
+	suite.Empty(result)
+}
+
+func (suite *CronTestSuite) TestExecuteCronTask_RecordsExternalStartupFailure() {
+	app := &types.App{ID: "app-123", Config: types.AppConfig{Helix: types.AppHelixConfig{DefaultAgentType: types.AgentTypeZedExternal}}}
+	trigger := &types.CronTrigger{Input: "Inspect the repository", ProjectID: "project-123"}
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, candidate *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			candidate.Created = time.Now()
+			return candidate, true, nil
+		},
+	)
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal(types.TriggerExecutionStatusError, updated.Status)
+			suite.Equal("sandbox unavailable", updated.Error)
+			return updated, nil
+		},
+	)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil)
+
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, &mockExternalAgentStarter{
+		startFunc: func(context.Context, *types.SessionChatRequest, string) (*types.Session, error) {
+			return nil, errors.New("sandbox unavailable")
+		},
+	}, app, "test-user", "trigger-123", trigger, "scheduled-review")
+	suite.EqualError(err, "sandbox unavailable")
+	suite.Empty(result)
 }
 
 func (suite *CronTestSuite) TestExternalAgentProjectIDRejectsAmbiguousAgent() {

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -736,6 +736,84 @@ func (m *mockSpecTaskCreator) CreateTaskFromPrompt(ctx context.Context, req *typ
 	return m.createFunc(ctx, req)
 }
 
+type mockExternalAgentStarter struct {
+	startFunc func(ctx context.Context, req *types.SessionChatRequest, userID string) (*types.Session, error)
+}
+
+func (m *mockExternalAgentStarter) StartExternalAgentSession(ctx context.Context, req *types.SessionChatRequest, userID string) (*types.Session, error) {
+	return m.startFunc(ctx, req, userID)
+}
+
+func (suite *CronTestSuite) TestExecuteCronTask_InfersExternalAgentConfiguration() {
+	externalAgentConfig := &types.ExternalAgentConfig{DesktopType: "sway"}
+	app := &types.App{
+		ID:             "app-123",
+		Owner:          "test-user",
+		OwnerType:      types.OwnerTypeUser,
+		OrganizationID: "org-123",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			DefaultAgentType:    types.AgentTypeZedExternal,
+			ExternalAgentConfig: externalAgentConfig,
+			Assistants: []types.AssistantConfig{{
+				AgentType:        types.AgentTypeZedExternal,
+				CodeAgentRuntime: types.CodeAgentRuntimeCodexCLI,
+			}},
+		}},
+	}
+	trigger := &types.CronTrigger{Input: "Inspect the repository"}
+
+	suite.store.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{
+		OrganizationID: "org-123",
+	}).Return([]*types.Project{{
+		ID:                "project-456",
+		DefaultHelixAppID: "app-123",
+	}}, nil)
+
+	starter := &mockExternalAgentStarter{
+		startFunc: func(_ context.Context, req *types.SessionChatRequest, userID string) (*types.Session, error) {
+			suite.Equal("test-user", userID)
+			suite.Equal("app-123", req.AppID)
+			suite.Equal("0", req.AssistantID)
+			suite.Equal("org-123", req.OrganizationID)
+			suite.Equal("project-456", req.ProjectID)
+			suite.Equal(string(types.AgentTypeZedExternal), req.AgentType)
+			suite.Same(externalAgentConfig, req.ExternalAgentConfig)
+			suite.Equal("job", req.SessionRole)
+			suite.Len(req.Messages, 1)
+			suite.Equal([]any{"Inspect the repository"}, req.Messages[0].Content.Parts)
+			return &types.Session{ID: "session-789"}, nil
+		},
+	}
+
+	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal("trigger-123", execution.TriggerConfigurationID)
+			suite.Equal("session-789", execution.SessionID)
+			suite.Equal(types.TriggerExecutionStatusRunning, execution.Status)
+			return execution, nil
+		},
+	)
+
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, starter, app, "test-user", "trigger-123", trigger, "scheduled-review")
+	suite.NoError(err)
+	suite.Equal("session-789", result)
+}
+
+func (suite *CronTestSuite) TestExternalAgentProjectIDRejectsAmbiguousAgent() {
+	app := &types.App{ID: "app-123", OrganizationID: "org-123"}
+	suite.store.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{
+		OrganizationID: "org-123",
+	}).Return([]*types.Project{
+		{ID: "project-1", DefaultHelixAppID: "app-123"},
+		{ID: "project-2", ProjectManagerHelixAppID: "app-123"},
+	}, nil)
+
+	projectID, err := externalAgentProjectID(suite.ctx, suite.store, app, "test-user", "")
+	suite.Error(err)
+	suite.Empty(projectID)
+	suite.Contains(err.Error(), "multiple projects")
+}
+
 func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction() {
 	app := &types.App{
 		ID:        "app-123",

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -130,12 +130,12 @@ func (suite *CronTestSuite) TestExecuteCronTask() {
 		ID: "test-user",
 	}).Return(user, nil)
 
-	// Mock CreateTriggerExecution
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+	// Mock trigger execution reservation
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
 			suite.Equal("trigger-123", execution.TriggerConfigurationID)
 			suite.Equal(types.TriggerExecutionStatusRunning, execution.Status)
-			return execution, nil
+			return execution, true, nil
 		},
 	)
 
@@ -257,12 +257,12 @@ func (suite *CronTestSuite) TestExecuteCronTask_Organization() {
 		ID: user.ID,
 	}).Return(user, nil)
 
-	// Mock CreateTriggerExecution
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+	// Mock trigger execution reservation
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
 			suite.Equal("trigger-123", execution.TriggerConfigurationID)
 			suite.Equal(types.TriggerExecutionStatusRunning, execution.Status)
-			return execution, nil
+			return execution, true, nil
 		},
 	)
 
@@ -386,10 +386,10 @@ func (suite *CronTestSuite) TestExecuteCronTask_WithEmails() {
 		ID: "test-user",
 	}).Return(user, nil)
 
-	// Mock CreateTriggerExecution
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
-			return execution, nil
+	// Mock trigger execution reservation
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			return execution, true, nil
 		},
 	)
 
@@ -493,10 +493,10 @@ func (suite *CronTestSuite) TestExecuteCronTask_FailureNotification_WithEmails()
 		ID: "test-user",
 	}).Return(user, nil)
 
-	// Mock CreateTriggerExecution
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
-			return execution, nil
+	// Mock trigger execution reservation
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			return execution, true, nil
 		},
 	)
 
@@ -553,11 +553,8 @@ func (suite *CronTestSuite) TestExecuteCronTask_FailureNotification_WithEmails()
 		},
 	)
 
-	// Note: ExecuteCronTask reassigns err from UpdateTriggerExecution, which
-	// returns nil here, so the function returns nil error despite the LLM failure.
-	// The key assertion is that the failure notification was sent with the emails.
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
-	suite.NoError(err)
+	suite.ErrorContains(err, "LLM provider error")
 	suite.Empty(result)
 }
 
@@ -590,9 +587,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_NoEmails_FallsBackToOwner() {
 	suite.store.EXPECT().GetAppWithTools(gomock.Any(), "app-123").Return(app, nil).Times(2)
 	suite.store.EXPECT().ListSecrets(gomock.Any(), gomock.Any()).Return([]*types.Secret{}, nil)
 	suite.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "test-user"}).Return(user, nil)
-	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
-			return execution, nil
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			return execution, true, nil
 		},
 	)
 	suite.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return([]*types.Interaction{}, int64(0), nil)
@@ -666,9 +663,21 @@ func (suite *CronTestSuite) TestExecuteCronTask_Error() {
 	trigger := &types.CronTrigger{
 		Input: "test input",
 	}
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			return execution, true, nil
+		},
+	)
 
 	// Mock GetAppWithTools to return error
 	suite.store.EXPECT().GetAppWithTools(suite.ctx, "app-123").Return(nil, errors.New("database error"))
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal(types.TriggerExecutionStatusError, execution.Status)
+			suite.Equal("database error", execution.Error)
+			return execution, nil
+		},
+	)
 
 	// Execute the function
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
@@ -677,6 +686,24 @@ func (suite *CronTestSuite) TestExecuteCronTask_Error() {
 	suite.Error(err)
 	suite.Empty(result)
 	suite.Contains(err.Error(), "database error")
+}
+
+func (suite *CronTestSuite) TestExecuteCronTask_SkipsWhilePreviousBlockingExecutionRuns() {
+	app := &types.App{ID: "app-123"}
+	trigger := &types.CronTrigger{Input: "test input"}
+
+	suite.store.EXPECT().CreateTriggerExecutionUnlessRunning(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, bool, error) {
+			execution.Status = types.TriggerExecutionStatusSkipped
+			execution.Error = "Previous execution execution-running is still running"
+			execution.SessionID = ""
+			return execution, false, nil
+		},
+	)
+
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
+	suite.NoError(err)
+	suite.Empty(result)
 }
 
 func TestNextRunFormatted(t *testing.T) {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3035,6 +3035,7 @@ const (
 	TriggerExecutionStatusRunning TriggerExecutionStatus = "running"
 	TriggerExecutionStatusSuccess TriggerExecutionStatus = "success"
 	TriggerExecutionStatusError   TriggerExecutionStatus = "error"
+	TriggerExecutionStatusSkipped TriggerExecutionStatus = "skipped"
 )
 
 type TriggerExecution struct {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3024,8 +3024,9 @@ type TriggerConfiguration struct {
 }
 
 type TriggerExecuteResponse struct {
-	SessionID string `json:"session_id"`
-	Content   string `json:"content"`
+	SessionID string                 `json:"session_id"`
+	Content   string                 `json:"content"`
+	Status    TriggerExecutionStatus `json:"status"`
 }
 
 type TriggerExecutionStatus string

--- a/design/2026-08-05-recurring-external-agent-lifecycle.md
+++ b/design/2026-08-05-recurring-external-agent-lifecycle.md
@@ -1,0 +1,19 @@
+# Recurring external-agent task lifecycle
+
+Recurring external-agent sessions are asynchronous. A completed chat turn is
+not evidence that the requested task is complete, so their trigger executions
+use an explicit lifecycle:
+
+- A running execution is reserved before the sandbox starts.
+- The task system prompt requires the agent to call the session-scoped
+  `task_completed` MCP tool after all work is finished.
+- `task_completed` is idempotent at the persistence boundary and is the only
+  path that marks an external-agent execution successful.
+- Agent, thread, sandbox-start, and explicit-stop failures mark the linked
+  running execution failed.
+- A trigger-row lock serializes scheduled and manual starts. If an execution is
+  already running, the new fire records a skipped execution with the active
+  execution ID and does not create a session or sandbox.
+
+The execution history renders skipped runs distinctly and displays the stored
+failure or skip explanation.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6219,6 +6219,13 @@ export interface TypesSessionMetadata {
   last_auto_restart_at?: string;
   manually_review_questions?: boolean;
   /**
+   * OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for
+   * helix-org workers. Hydra materializes the instructions as native agent
+   * files in this session's workspace before starting the desktop. Ordinary
+   * project and SpecTask sessions leave both fields empty.
+   */
+  org_worker_id?: string;
+  /**
    * Fork lineage — set on a session created by forking from a parent.
    * See design/tasks/002081_kickoff-mid-session/design.md.
    */
@@ -6248,6 +6255,7 @@ export interface TypesSessionMetadata {
   rag_settings?: TypesRAGSettings;
   /** GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE) */
   render_node?: string;
+  runtime_instructions?: string;
   session_rag_results?: TypesSessionRAGResult[];
   /** "planning", "implementation", "coordination", "exploratory" */
   session_role?: string;
@@ -7400,6 +7408,7 @@ export enum TypesTriggerExecutionStatus {
   TriggerExecutionStatusRunning = "running",
   TriggerExecutionStatusSuccess = "success",
   TriggerExecutionStatusError = "error",
+  TriggerExecutionStatusSkipped = "skipped",
 }
 
 export interface TypesTriggerStatus {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7387,6 +7387,7 @@ export interface TypesTriggerConfiguration {
 export interface TypesTriggerExecuteResponse {
   content?: string;
   session_id?: string;
+  status?: TypesTriggerExecutionStatus;
 }
 
 export interface TypesTriggerExecution {

--- a/frontend/src/components/tasks/ExecutionsHistory.tsx
+++ b/frontend/src/components/tasks/ExecutionsHistory.tsx
@@ -51,6 +51,7 @@ const ExecutionsHistory: React.FC<ExecutionsHistoryProps> = ({ taskId, taskName 
       case TypesTriggerExecutionStatus.TriggerExecutionStatusRunning:
         return '#F59E0B';
       case TypesTriggerExecutionStatus.TriggerExecutionStatusPending:
+      case TypesTriggerExecutionStatus.TriggerExecutionStatusSkipped:
         return '#6B7280';
       default:
         return '#6B7280';
@@ -77,10 +78,15 @@ const ExecutionsHistory: React.FC<ExecutionsHistoryProps> = ({ taskId, taskName 
 
   // Helper function to get duration text
   const getDurationText = (execution: TypesTriggerExecution) => {
+    if (execution.status === TypesTriggerExecutionStatus.TriggerExecutionStatusSkipped) {
+      return 'Skipped';
+    }
     const duration = formatDuration(execution.created, execution.updated, execution.status);
     
     if (execution.status === TypesTriggerExecutionStatus.TriggerExecutionStatusRunning) {
       return `Running for ${duration}`;
+    } else if (execution.status === TypesTriggerExecutionStatus.TriggerExecutionStatusError) {
+      return `Failed after ${duration}`;
     } else {
       return `Ran for ${duration}`;
     }
@@ -206,6 +212,20 @@ const ExecutionsHistory: React.FC<ExecutionsHistoryProps> = ({ taskId, taskName 
                   <Typography variant="caption" sx={{ color: '#A0AEC0' }}>
                     {formatDate(execution.created)} · {getDurationText(execution)}
                   </Typography>
+
+                  {execution.error && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        display: 'block',
+                        color: execution.status === TypesTriggerExecutionStatus.TriggerExecutionStatusError ? '#EF4444' : '#A0AEC0',
+                        mt: 0.5,
+                        wordBreak: 'break-word'
+                      }}
+                    >
+                      {execution.error}
+                    </Typography>
+                  )}
                 </Box>
               </Box>
               );
@@ -221,4 +241,4 @@ const ExecutionsHistory: React.FC<ExecutionsHistoryProps> = ({ taskId, taskName 
   );
 };
 
-export default ExecutionsHistory; 
+export default ExecutionsHistory;

--- a/frontend/src/components/tasks/TaskDialog.tsx
+++ b/frontend/src/components/tasks/TaskDialog.tsx
@@ -16,7 +16,7 @@ import TriggerCron from '../app/TriggerCron';
 import AgentSelector from './AgentSelector';
 import ExecutionsHistory from './ExecutionsHistory';
 import { IApp } from '../../types'
-import { TypesTrigger, TypesTriggerConfiguration, TypesTriggerType, TypesOwnerType } from '../../api/api'
+import { TypesTrigger, TypesTriggerConfiguration, TypesTriggerExecutionStatus, TypesTriggerType, TypesOwnerType } from '../../api/api'
 
 import { useCreateAppTrigger, useUpdateAppTrigger, useExecuteAppTrigger } from '../../services/appService';
 import useAccount from '../../hooks/useAccount';
@@ -259,8 +259,20 @@ const TaskDialog: React.FC<TaskDialogProps> = ({ open, onClose, task, apps, prep
         await updateTriggerMutation.mutateAsync(triggerConfig);
       }
 
-      await executeTriggerMutation.mutateAsync();
-      snackbar.success('Task executed successfully');
+      const response = await executeTriggerMutation.mutateAsync();
+      switch (response.data.status) {
+        case TypesTriggerExecutionStatus.TriggerExecutionStatusRunning:
+          snackbar.info('Task started');
+          break;
+        case TypesTriggerExecutionStatus.TriggerExecutionStatusSkipped:
+          snackbar.warning('Task skipped because the previous execution is still running');
+          break;
+        case TypesTriggerExecutionStatus.TriggerExecutionStatusSuccess:
+          snackbar.success('Task executed successfully');
+          break;
+        default:
+          snackbar.warning('Task execution state could not be determined');
+      }
     } catch (err) {
       console.error('Error updating or executing task:', err);
       setError(err instanceof Error ? err.message : 'Failed to update or execute task');
@@ -434,4 +446,4 @@ const TaskDialog: React.FC<TaskDialogProps> = ({ open, onClose, task, apps, prep
   );
 };
 
-export default TaskDialog; 
+export default TaskDialog;

--- a/frontend/src/components/tasks/TasksTableExecutionsChart.tsx
+++ b/frontend/src/components/tasks/TasksTableExecutionsChart.tsx
@@ -26,6 +26,7 @@ const TasksTableExecutionsChart: React.FC<TasksTableExecutionsChartProps> = ({ t
       case TypesTriggerExecutionStatus.TriggerExecutionStatusRunning:
         return '#F59E0B'; // Orange for running
       case TypesTriggerExecutionStatus.TriggerExecutionStatusPending:
+      case TypesTriggerExecutionStatus.TriggerExecutionStatusSkipped:
         return '#6B7280'; // Gray for pending
       default:
         return '#6B7280';

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -9843,6 +9843,13 @@ definitions:
         type: string
       manually_review_questions:
         type: boolean
+      org_worker_id:
+        description: |-
+          OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for
+          helix-org workers. Hydra materializes the instructions as native agent
+          files in this session's workspace before starting the desktop. Ordinary
+          project and SpecTask sessions leave both fields empty.
+        type: string
       parent_session_id:
         description: |-
           Fork lineage — set on a session created by forking from a parent.
@@ -9880,6 +9887,8 @@ definitions:
         $ref: '#/definitions/types.RAGSettings'
       render_node:
         description: GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)
+        type: string
+      runtime_instructions:
         type: string
       session_rag_results:
         items:
@@ -11804,12 +11813,14 @@ definitions:
     - running
     - success
     - error
+    - skipped
     type: string
     x-enum-varnames:
     - TriggerExecutionStatusPending
     - TriggerExecutionStatusRunning
     - TriggerExecutionStatusSuccess
     - TriggerExecutionStatusError
+    - TriggerExecutionStatusSkipped
   types.TriggerStatus:
     properties:
       message:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -11781,6 +11781,8 @@ definitions:
         type: string
       session_id:
         type: string
+      status:
+        $ref: '#/definitions/types.TriggerExecutionStatus'
     type: object
   types.TriggerExecution:
     properties:

--- a/openapi.json
+++ b/openapi.json
@@ -43550,6 +43550,9 @@
                     },
                     "session_id": {
                         "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/types.TriggerExecutionStatus"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -40949,6 +40949,10 @@
                     "manually_review_questions": {
                         "type": "boolean"
                     },
+                    "org_worker_id": {
+                        "description": "OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for\nhelix-org workers. Hydra materializes the instructions as native agent\nfiles in this session's workspace before starting the desktop. Ordinary\nproject and SpecTask sessions leave both fields empty.",
+                        "type": "string"
+                    },
                     "parent_session_id": {
                         "description": "Fork lineage — set on a session created by forking from a parent.\nSee design/tasks/002081_kickoff-mid-session/design.md.",
                         "type": "string"
@@ -40987,6 +40991,9 @@
                     },
                     "render_node": {
                         "description": "GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)",
+                        "type": "string"
+                    },
+                    "runtime_instructions": {
                         "type": "string"
                     },
                     "session_rag_results": {
@@ -43588,13 +43595,15 @@
                     "pending",
                     "running",
                     "success",
-                    "error"
+                    "error",
+                    "skipped"
                 ],
                 "x-enum-varnames": [
                     "TriggerExecutionStatusPending",
                     "TriggerExecutionStatusRunning",
                     "TriggerExecutionStatusSuccess",
-                    "TriggerExecutionStatusError"
+                    "TriggerExecutionStatusError",
+                    "TriggerExecutionStatusSkipped"
                 ]
             },
             "types.TriggerStatus": {

--- a/swagger.json
+++ b/swagger.json
@@ -36352,6 +36352,10 @@
                 "manually_review_questions": {
                     "type": "boolean"
                 },
+                "org_worker_id": {
+                    "description": "OrgWorkerID and RuntimeInstructions are session-scoped bootstrap state for\nhelix-org workers. Hydra materializes the instructions as native agent\nfiles in this session's workspace before starting the desktop. Ordinary\nproject and SpecTask sessions leave both fields empty.",
+                    "type": "string"
+                },
                 "parent_session_id": {
                     "description": "Fork lineage — set on a session created by forking from a parent.\nSee design/tasks/002081_kickoff-mid-session/design.md.",
                     "type": "string"
@@ -36390,6 +36394,9 @@
                 },
                 "render_node": {
                     "description": "GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE)",
+                    "type": "string"
+                },
+                "runtime_instructions": {
                     "type": "string"
                 },
                 "session_rag_results": {
@@ -38991,13 +38998,15 @@
                 "pending",
                 "running",
                 "success",
-                "error"
+                "error",
+                "skipped"
             ],
             "x-enum-varnames": [
                 "TriggerExecutionStatusPending",
                 "TriggerExecutionStatusRunning",
                 "TriggerExecutionStatusSuccess",
-                "TriggerExecutionStatusError"
+                "TriggerExecutionStatusError",
+                "TriggerExecutionStatusSkipped"
             ]
         },
         "types.TriggerStatus": {

--- a/swagger.json
+++ b/swagger.json
@@ -38953,6 +38953,9 @@
                 },
                 "session_id": {
                     "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.TriggerExecutionStatus"
                 }
             }
         },


### PR DESCRIPTION
## Summary
- infer the cron runtime from the selected agent when Tasks-page triggers omit `agent_type`
- resolve the selected external agent to its unique project when `project_id` is omitted
- preserve the selected app, assistant, organization, runtime, and display configuration when starting the external session
- require recurring external agents to call the session-scoped `task_completed` tool before an execution succeeds
- send the completion notification from `task_completed`, using configured recipients or the session owner's email
- mark executions failed when external session startup, agent communication, thread loading, or session shutdown fails
- serialize executions per trigger for external and blocking Helix agents, recording overlaps as skipped with an explanation
- return the execution status from the Test endpoint so the dialog says `Task started` for asynchronous runs
- show skipped and failed explanations in task execution history

## Root cause
The Tasks dialog stores only schedule and prompt fields. The cron executor required `agent_type=zed_external` and `project_id`, so a recurring task configured with an external agent fell through to the blocking Helix inference path. Once external sessions started correctly, executions also lacked an explicit completion signal and overlap protection. The original overlap fix covered only external agents; live concurrent CLI testing exposed the same gap in the ordinary blocking Helix-agent path. Finally, the asynchronous `task_completed` path updated the execution row but never invoked the cron completion notifier, so successful external runs sent no email.

## Verification
- `go test ./pkg/trigger/cron ./pkg/server ./pkg/prompts -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- live org agent called `task_completed` and changed its execution from running to success
- a concurrent org-agent fire produced a skipped execution without starting another sandbox; the next run succeeded
- live ordinary `helix_agent` returned `HELIX_TASK_OK` without changing the external sandbox count
- concurrent ordinary-agent fires produced one success and one skipped execution; the next run succeeded
- stopping a live external session changed its execution to failed
- verified skipped and failed states and explanations in the task history UI
- live `github-report` Test returned `status: running`, then completed through `task_completed` and invoked the SMTP notification for `karolis@helix.ml`