### PR TITLE
feat(frontend): refine task and message status UI

### DIFF
--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -147,6 +147,7 @@ const areEqual = (prevProps: InteractionProps, nextProps: InteractionProps) => {
       nextProps.interaction?.display_message ||
     prevProps.interaction?.response_message !==
       nextProps.interaction?.response_message ||
+    prevProps.interaction?.completed !== nextProps.interaction?.completed ||
     prevProps.interaction?.error !== nextProps.interaction?.error ||
     prevProps.interaction?.state !== nextProps.interaction?.state
   ) {

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -171,6 +171,7 @@ import RefreshIcon from "@mui/icons-material/Refresh";
 import TextField from "@mui/material/TextField";
 import CopyButtonWithCheck from "./CopyButtonWithCheck";
 import InteractionDebugCopyButton from "./InteractionDebugCopyButton";
+import MessageReceivedTimestamp from "./MessageReceivedTimestamp";
 import ToolStepsWidget from "./ToolStepsWidget";
 
 import { ThumbsUp, ThumbsDown, Download, FileText, Paperclip } from "lucide-react";
@@ -185,7 +186,12 @@ import { useUpdateInteractionFeedback } from "../../services/interactionsService
 
 import { TypesServerConfigForFrontend } from "../../api/api";
 
-import { TypesInteraction, TypesSession, TypesFeedback } from "../../api/api";
+import {
+  TypesFeedback,
+  TypesInteraction,
+  TypesInteractionState,
+  TypesSession,
+} from "../../api/api";
 import {
   ChatWorkspaceAttachment,
   workspaceAttachmentURL,
@@ -891,6 +897,12 @@ export const InteractionInference: FC<{
                           />
                         </IconButton>
                       </Tooltip>
+                      {interaction.state ===
+                        TypesInteractionState.InteractionStateComplete && (
+                        <MessageReceivedTimestamp
+                          completedAt={interaction.completed}
+                        />
+                      )}
                     </Box>
                   )}
                 </Box>

--- a/frontend/src/components/session/MessageReceivedTimestamp.test.tsx
+++ b/frontend/src/components/session/MessageReceivedTimestamp.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MessageReceivedTimestamp, {
+  formatMessageReceivedAt,
+} from "./MessageReceivedTimestamp";
+
+describe("MessageReceivedTimestamp", () => {
+  it("shows the completion time and reveals the full local date and time", async () => {
+    const completedAt = "2026-08-05T14:07:09Z";
+    const formatted = formatMessageReceivedAt(completedAt);
+
+    expect(formatted).not.toBeNull();
+    render(<MessageReceivedTimestamp completedAt={completedAt} />);
+
+    const timestamp = screen.getByText(formatted!.short);
+    expect(timestamp).toHaveAttribute("datetime", completedAt);
+
+    fireEvent.mouseOver(timestamp);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(formatted!.full);
+  });
+
+  it.each([undefined, "", "not-a-date", "0001-01-01T00:00:00Z"])(
+    "does not render an unusable completion timestamp (%s)",
+    (completedAt) => {
+      const { container } = render(
+        <MessageReceivedTimestamp completedAt={completedAt} />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+});

--- a/frontend/src/components/session/MessageReceivedTimestamp.tsx
+++ b/frontend/src/components/session/MessageReceivedTimestamp.tsx
@@ -1,0 +1,62 @@
+import { FC } from "react";
+import Box from "@mui/material/Box";
+import Tooltip from "@mui/material/Tooltip";
+
+export interface FormattedMessageReceivedAt {
+  full: string;
+  short: string;
+}
+
+export const formatMessageReceivedAt = (
+  completedAt?: string,
+): FormattedMessageReceivedAt | null => {
+  if (!completedAt) return null;
+
+  const date = new Date(completedAt);
+  if (!Number.isFinite(date.getTime()) || date.getUTCFullYear() <= 1) return null;
+
+  return {
+    short: date.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }),
+    full: date.toLocaleString(undefined, {
+      dateStyle: "full",
+      timeStyle: "long",
+    }),
+  };
+};
+
+const MessageReceivedTimestamp: FC<{ completedAt?: string }> = ({
+  completedAt,
+}) => {
+  const formatted = formatMessageReceivedAt(completedAt);
+  if (!formatted) return null;
+
+  return (
+    <Tooltip title={formatted.full} placement="top">
+      <Box
+        component="time"
+        dateTime={completedAt}
+        aria-label={`Received ${formatted.full}`}
+        sx={{
+          alignItems: "center",
+          color: "text.disabled",
+          display: "flex",
+          flexShrink: 0,
+          fontSize: "0.7rem",
+          fontVariantNumeric: "tabular-nums",
+          height: 28,
+          lineHeight: 1,
+          mt: 0.5,
+          userSelect: "none",
+        }}
+      >
+        {formatted.short}
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default MessageReceivedTimestamp;

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -20,6 +20,7 @@ import {
   SkipNext as SkipIcon,
   Replay as ReopenIcon,
 } from "@mui/icons-material";
+import { GitPullRequest } from "lucide-react";
 import {
   useApproveImplementation,
   useStopAgent,
@@ -67,6 +68,30 @@ const PRStateBadge: React.FC<{ state?: string }> = ({ state }) => {
       color={PR_STATE_CHIP_COLOR[kind]}
       sx={{ height: 20, fontSize: "0.7rem", flexShrink: 0 }}
     />
+  );
+};
+
+const PR_STATE_ICON_COLOR: Record<PRStateKind, string> = {
+  open: "#10b981",
+  merged: "#8b5cf6",
+  closed: "#6b7280",
+};
+
+const PRStateIcon: React.FC<{ state?: string }> = ({ state }) => {
+  const kind = normalizePRState(state);
+  return (
+    <Tooltip title={`${kind[0].toUpperCase()}${kind.slice(1)} pull request`}>
+      <Box
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          color: PR_STATE_ICON_COLOR[kind],
+          flexShrink: 0,
+        }}
+      >
+        <GitPullRequest size={16} />
+      </Box>
+    </Tooltip>
   );
 };
 
@@ -834,7 +859,7 @@ export default function SpecTaskActionButtons({
               target="_blank"
               rel="noopener noreferrer"
             />
-            <PRStateBadge state={onlyPR.pr_state} />
+            <PRStateIcon state={onlyPR.pr_state} />
             <CIStatusIcon prs={[onlyPR]} />
           </Box>
         );
@@ -861,10 +886,6 @@ export default function SpecTaskActionButtons({
               </Button>
             </span>
           </Tooltip>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.75 }}>
-            <PRStateBadge state={onlyPR.pr_state} />
-            <CIStatusIcon prs={[onlyPR]} />
-          </Box>
         </Box>
       );
     }

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -20,7 +20,10 @@ import {
   FormControl,
   InputLabel,
   CircularProgress,
+  Menu,
   MenuItem,
+  ListItemIcon,
+  ListItemText,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -116,6 +119,7 @@ import {
   SlidersHorizontal,
   GitCompare,
   MonitorPlay,
+  EllipsisVertical,
   Wand2,
   Share,
 } from "lucide-react";
@@ -384,6 +388,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [selectedCloneGroupId, setSelectedCloneGroupId] = useState<
     string | null
   >(null);
+  const [actionMenuAnchorEl, setActionMenuAnchorEl] =
+    useState<HTMLElement | null>(null);
 
   // Archive state
   const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
@@ -2166,41 +2172,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                             </IconButton>
                           </Tooltip>
                         )}
-                        {task.design_docs_pushed_at && (
-                          <Tooltip title="Share design docs">
-                            <IconButton
-                              size="small"
-                              onClick={() => setShareDialogOpen(true)}
-                            >
-                              <Share size={16} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {task.design_docs_pushed_at && (
-                          <Tooltip title="Clone task to other projects">
-                            <IconButton
-                              size="small"
-                              onClick={() => setShowCloneDialog(true)}
-                            >
-                              <Wand2 size={16} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {task.clone_group_id && (
-                          <Tooltip title="View batch clone progress">
-                            <IconButton
-                              size="small"
-                              onClick={() =>
-                                setSelectedCloneGroupId(
-                                  task.clone_group_id || null,
-                                )
-                              }
-                              sx={{ color: "primary.main" }}
-                            >
-                              <AccountTree sx={{ fontSize: 16 }} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
                         {/* Show Start button when desktop is paused */}
                         {effectiveIsDesktopPaused && (
                           <Tooltip title="Start desktop">
@@ -2293,6 +2264,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                               ) : (
                                 <CloudUploadIcon sx={{ fontSize: 18 }} />
                               )}
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        {(task.design_docs_pushed_at || task.clone_group_id) && (
+                          <Tooltip title="More actions">
+                            <IconButton
+                              size="small"
+                              onClick={(event) =>
+                                setActionMenuAnchorEl(event.currentTarget)
+                              }
+                            >
+                              <EllipsisVertical size={18} />
                             </IconButton>
                           </Tooltip>
                         )}
@@ -2593,39 +2576,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                         </IconButton>
                       </Tooltip>
                     )}
-                    {task.design_docs_pushed_at && (
-                      <Tooltip title="Share design docs">
-                        <IconButton
-                          size="small"
-                          onClick={() => setShareDialogOpen(true)}
-                        >
-                          <Share size={16} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {task.design_docs_pushed_at && (
-                      <Tooltip title="Clone task to other projects">
-                        <IconButton
-                          size="small"
-                          onClick={() => setShowCloneDialog(true)}
-                        >
-                          <Wand2 size={16} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {task.clone_group_id && (
-                      <Tooltip title="View batch clone progress">
-                        <IconButton
-                          size="small"
-                          onClick={() =>
-                            setSelectedCloneGroupId(task.clone_group_id || null)
-                          }
-                          sx={{ color: "primary.main" }}
-                        >
-                          <AccountTree sx={{ fontSize: 16 }} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
                     {/* Show Start button when desktop is paused */}
                     {activeSessionId && effectiveIsDesktopPaused && (
                       <Tooltip title="Start desktop">
@@ -2691,6 +2641,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           ) : (
                             <CloudUploadIcon sx={{ fontSize: 18 }} />
                           )}
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    {(task.design_docs_pushed_at || task.clone_group_id) && (
+                      <Tooltip title="More actions">
+                        <IconButton
+                          size="small"
+                          onClick={(event) =>
+                            setActionMenuAnchorEl(event.currentTarget)
+                          }
+                        >
+                          <EllipsisVertical size={18} />
                         </IconButton>
                       </Tooltip>
                     )}
@@ -2941,6 +2903,52 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           </Button>
         </DialogActions>
       </Dialog>
+
+      <Menu
+        anchorEl={actionMenuAnchorEl}
+        open={Boolean(actionMenuAnchorEl)}
+        onClose={() => setActionMenuAnchorEl(null)}
+      >
+        {task?.design_docs_pushed_at && (
+          <MenuItem
+            onClick={() => {
+              setActionMenuAnchorEl(null);
+              setShareDialogOpen(true);
+            }}
+          >
+            <ListItemIcon>
+              <Share size={18} />
+            </ListItemIcon>
+            <ListItemText>Share Design Docs</ListItemText>
+          </MenuItem>
+        )}
+        {task?.design_docs_pushed_at && (
+          <MenuItem
+            onClick={() => {
+              setActionMenuAnchorEl(null);
+              setShowCloneDialog(true);
+            }}
+          >
+            <ListItemIcon>
+              <Wand2 size={18} />
+            </ListItemIcon>
+            <ListItemText>Clone Task</ListItemText>
+          </MenuItem>
+        )}
+        {task?.clone_group_id && (
+          <MenuItem
+            onClick={() => {
+              setActionMenuAnchorEl(null);
+              setSelectedCloneGroupId(task.clone_group_id || null);
+            }}
+          >
+            <ListItemIcon>
+              <AccountTree sx={{ fontSize: 18 }} />
+            </ListItemIcon>
+            <ListItemText>View Batch Clone Progress</ListItemText>
+          </MenuItem>
+        )}
+      </Menu>
 
       {/* Clone Task Dialog */}
       <CloneTaskDialog

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -39,7 +39,12 @@ import {
   Undo as UndoIcon,
   Schedule as ScheduleIcon,
 } from "@mui/icons-material";
-import { EllipsisVertical, Wand2, UserCircle2 } from "lucide-react";
+import {
+  EllipsisVertical,
+  GitPullRequest,
+  Wand2,
+  UserCircle2,
+} from "lucide-react";
 import {
   useApproveImplementation,
   useStopAgent,
@@ -1060,6 +1065,21 @@ function TaskCardInner({
               >
                 • {runningDuration}
               </Typography>
+            )}
+            {task.phase === "pull_request" && (
+              <Tooltip title="Open pull request">
+                <Box
+                  component="span"
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    color: "#10b981",
+                    flexShrink: 0,
+                  }}
+                >
+                  <GitPullRequest size={14} />
+                </Box>
+              </Tooltip>
             )}
             <CIStatusIcon prs={task.repo_pull_requests} />
           </Box>

--- a/frontend/src/contexts/theme.test.ts
+++ b/frontend/src/contexts/theme.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTooltipStyleOverrides } from './theme'
+
+describe('tooltip theme', () => {
+  it('uses the compact bordered surface in dark mode', () => {
+    expect(getTooltipStyleOverrides(false)).toMatchObject({
+      tooltip: {
+        backgroundColor: '#1b1b1b',
+        border: '1px solid #3a3a3a',
+        borderRadius: '7px',
+        color: '#f5f5f5',
+        fontSize: '0.75rem',
+        padding: '5px 8px',
+      },
+      arrow: {
+        color: '#1b1b1b',
+      },
+    })
+  })
+
+  it('leaves light-mode tooltip styling to the MUI defaults', () => {
+    expect(getTooltipStyleOverrides(true)).toEqual({
+      tooltip: {},
+      arrow: {},
+    })
+  })
+})

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -20,6 +20,24 @@ export const ThemeContext = React.createContext({
   toggleMode: () => {},
 })
 
+export const getTooltipStyleOverrides = (isLight: boolean) => ({
+  tooltip: isLight ? {} : {
+    backgroundColor: '#1b1b1b',
+    border: '1px solid #3a3a3a',
+    borderRadius: '7px',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.35)',
+    color: '#f5f5f5',
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: '0.75rem',
+    fontWeight: 400,
+    lineHeight: 1.35,
+    padding: '5px 8px',
+  },
+  arrow: isLight ? {} : {
+    color: '#1b1b1b',
+  },
+})
+
 export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const themeConfig = useThemeConfig()
   const api = useApi()
@@ -208,6 +226,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
               },
             },
           },
+          styleOverrides: getTooltipStyleOverrides(isLight),
         },
         MuiPopover: {
           styleOverrides: {


### PR DESCRIPTION
## What changed

- show completed chat responses with a compact received timestamp and full local date/time tooltip
- rerender memoized interactions when their completion timestamp arrives
- standardize dark-mode tooltip styling
- replace textual PR-state pills with compact semantic PR icons
- remove the duplicate card-level PR status row and keep the PR/CI indicators together
- move Share Design Docs, Clone Task, and clone progress into a task-detail overflow menu

## Why

PR status was repeated across task cards and detail toolbars, while low-frequency actions consumed scarce toolbar space. Completed responses also had no visible receipt time, and dark-mode tooltips lacked a consistent compact surface.

## Impact

Task cards and detail views are less cluttered, PR state remains visible at a glance, secondary actions stay accessible from the overflow menu, and completed agent messages expose a localized receipt time.

## Validation

- `yarn test MessageReceivedTimestamp.test.tsx theme.test.ts` (7 tests passed)
- `yarn build`
- live task-detail verification: green PR icon rendered without the `open` pill; Share Design Docs and Clone Task opened their existing dialogs from the overflow menu
