### PR TITLE
fix(frontend): preserve browser back gestures over desktops

### DIFF
--- a/design/2026-08-05-spec-task-browser-back.md
+++ b/design/2026-08-05-spec-task-browser-back.md
@@ -1,0 +1,13 @@
+# Spec task browser Back gesture
+
+## Symptom
+
+Browser Back/Forward trackpad gestures stopped working after opening a spec task with a live desktop.
+
+## Cause
+
+`DesktopStreamViewer` cancelled every wheel event over the viewer. The viewer occupies much of the task detail page, so Chrome and Safari could not receive horizontal Back/Forward gestures even when the user had not interacted with the remote desktop.
+
+## Fix
+
+Only forward and cancel wheel events while focus is inside the remote desktop. Before focus, the browser owns the gesture. Clicking the viewer focuses it and preserves remote scrolling.

--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -2931,22 +2931,23 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
     return () => clearInterval(interval);
   }, [containerSize, isConnected]);
 
-  // Forward wheel events to remote desktop via WebSocketStream.
-  // We call preventDefault() (and register the listener as non-passive so it is
-  // honoured) to suppress Chrome/Safari's native swipe-to-navigate gesture
-  // (two-finger horizontal swipe for back/forward) inside the viewer. Otherwise
-  // scrolling here can accidentally navigate the whole page away from the session.
-  // This is scoped to the viewer container only — swipe-nav still works elsewhere.
+  // Forward wheel events after the user has focused the remote desktop. Until
+  // then, leave trackpad gestures to the browser so Back/Forward still works
+  // when the pointer happens to be over the viewer.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
     const wheelHandler = (event: WheelEvent) => {
+      if (!container.contains(document.activeElement)) return;
+
       const input =
         streamRef.current && "getInput" in streamRef.current
           ? (streamRef.current as WebSocketStream).getInput()
           : null;
-      input?.onMouseWheel(event);
+      if (!input) return;
+
+      input.onMouseWheel(event);
       event.preventDefault();
     };
 


### PR DESCRIPTION
## What changed

- Capture remote desktop wheel input only after the viewer has focus.
- Leave unfocused trackpad gestures to the browser so Back/Forward navigation continues to work.
- Preserve remote scrolling after the user clicks or focuses the viewer.
- Document the diagnosis and behavior change.

## Root cause

`DesktopStreamViewer` called `preventDefault()` for every wheel event over the viewer. Because the live desktop occupies much of a spec task detail page, Chrome and Safari could not receive horizontal Back/Forward trackpad gestures even before the user interacted with the remote desktop.

## User impact

Users can navigate back from a spec task while the pointer is over an untouched desktop. Once the desktop is focused, wheel input continues to control the remote machine.

## Validation

- `cd frontend && yarn build`
- Live browser regression test against a running spec task: verified the unfocused viewer does not cancel wheel gestures, the focused viewer does cancel and forward wheel input, and the immediately following browser Back operation returns to the project board.
