### PR TITLE
fix(org): route global skill installs through terminal

### DIFF
--- a/api/pkg/org/domain/briefing/prompt.go
+++ b/api/pkg/org/domain/briefing/prompt.go
@@ -17,6 +17,14 @@ func BuildInstructions(workerID orgchart.NodeID, mandate string) string {
 the current working directory. Each activation is a single turn — do
 the work and exit.
 
+=== Global agent skills ===
+Use terminal commands and the Skills CLI to install or update global agent
+skills. Never use Zed's native filesystem tools for ~/.agents/skills.
+Install: npx --yes skills add <owner/repo> --skill <skill-name> --global --agent zed --yes
+Update: npx --yes skills update <skill-name> --global --yes
+List: npx --yes skills list --global --json
+Only install third-party skills when the operator asks or the task requires one.
+
 === Instructions ===
 %s
 `, workerID, mandate)

--- a/api/pkg/org/domain/briefing/prompt_test.go
+++ b/api/pkg/org/domain/briefing/prompt_test.go
@@ -190,6 +190,11 @@ func TestBuildInstructionsIncludesIdentityAndMandate(t *testing.T) {
 	for _, want := range []string{
 		"You are Bot w-eng, running inside helix-org",
 		"Each activation is a single turn",
+		"Never use Zed's native filesystem tools for ~/.agents/skills",
+		"npx --yes skills add <owner/repo> --skill <skill-name> --global --agent zed --yes",
+		"npx --yes skills update <skill-name> --global --yes",
+		"npx --yes skills list --global --json",
+		"Only install third-party skills when the operator asks or the task requires one",
 		"=== Instructions ===",
 		"# Engineer\nBuild the product.",
 	} {


### PR DESCRIPTION
## Summary

- keep the existing Helix-managed Zed defaults that allow ordinary tools and unsandboxed terminal commands
- teach every org worker to manage global agent skills through the Skills CLI in the terminal
- avoid Zed native filesystem confirmations for ~/.agents/skills without carrying a Zed fork patch

## Test plan

- go test ./pkg/org/domain/briefing -count=1
- git diff --check
- Prime: verified tool_permissions.default=allow and sandbox_permissions.allow_unsandboxed=true
- Prime: verified terminal-based ponytail installation and global skill discovery