### PR TITLE
fix(api): resolve project MCPs in external proxy

### DIFF
--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -279,8 +280,17 @@ func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.
 		return nil, fmt.Errorf("agent not found: %w", err)
 	}
 
+	var projectSkills *types.AssistantSkills
+	if session.ProjectID != "" {
+		project, err := b.store.GetProject(ctx, session.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("project not found: %w", err)
+		}
+		projectSkills = project.Skills
+	}
+
 	// Find the MCP configuration by name
-	mcpConfig := b.findMCPConfig(app, mcpName)
+	mcpConfig := b.findMCPConfig(app, projectSkills, mcpName)
 	if mcpConfig == nil {
 		return nil, fmt.Errorf("MCP server '%s' not configured for this agent", mcpName)
 	}
@@ -355,21 +365,39 @@ func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.
 	return httpServer, nil
 }
 
-// findMCPConfig searches for an MCP configuration by name in the app's assistants
-func (b *ExternalMCPBackend) findMCPConfig(app *types.App, mcpName string) *types.AssistantMCP {
+// findMCPConfig searches project MCPs before app MCPs to match Zed config precedence.
+func (b *ExternalMCPBackend) findMCPConfig(app *types.App, projectSkills *types.AssistantSkills, mcpName string) *types.AssistantMCP {
+	if projectSkills != nil {
+		for i := range projectSkills.MCPs {
+			if sanitizeMCPName(projectSkills.MCPs[i].Name) == mcpName {
+				return &projectSkills.MCPs[i]
+			}
+		}
+	}
+
 	if app.Config.Helix.Assistants == nil {
 		return nil
 	}
 
 	for _, assistant := range app.Config.Helix.Assistants {
 		for i := range assistant.MCPs {
-			if assistant.MCPs[i].Name == mcpName {
+			if sanitizeMCPName(assistant.MCPs[i].Name) == mcpName {
 				return &assistant.MCPs[i]
 			}
 		}
 	}
 
 	return nil
+}
+
+func sanitizeMCPName(name string) string {
+	name = strings.ToLower(name)
+	return strings.Trim(strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, name), "-")
 }
 
 // buildProxyTool reconstructs the schema the proxy advertises to Zed for a

--- a/api/pkg/server/mcp_backend_external_test.go
+++ b/api/pkg/server/mcp_backend_external_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.uber.org/mock/gomock"
+
+	mcpclient "github.com/helixml/helix/api/pkg/agent/skill/mcp"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestExternalMCPBackendUsesProjectMCPOverride(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockGetter := mcpclient.NewMockClientGetter(ctrl)
+	mockClient := mcpclient.NewMockClient(ctrl)
+
+	const (
+		sessionID = "ses_project_mcp"
+		userID    = "usr_project_mcp"
+		appID     = "app_project_mcp"
+		projectID = "prj_project_mcp"
+	)
+	appMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://app.example/mcp"}
+	projectMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://project.example/mcp"}
+	app := &types.App{
+		ID: appID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			MCPs: []types.AssistantMCP{appMCP},
+		}}}},
+	}
+	project := &types.Project{
+		ID:     projectID,
+		Skills: &types.AssistantSkills{MCPs: []types.AssistantMCP{projectMCP}},
+	}
+
+	mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(&types.Session{
+		ID: sessionID, Owner: userID, ParentApp: appID, ProjectID: projectID,
+	}, nil)
+	mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(app, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), projectID).Return(project, nil)
+	mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&projectMCP)).Return(mockClient, nil)
+	mockClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil)
+
+	backend := NewExternalMCPBackend(mockStore)
+	backend.clientGetter = mockGetter
+	defer backend.Stop()
+
+	if _, err := backend.getOrCreateServer(context.Background(), &types.User{ID: userID}, sessionID, "helixos"); err != nil {
+		t.Fatalf("get project MCP proxy: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- resolve project-level MCP configuration in the external MCP proxy
- preserve project-over-agent precedence used by generated Zed configuration
- match sanitized MCP route names such as HelixOS to helixos
- add a regression test for the production failure path

## Root cause
Zed advertised project-level MCP servers, but the external proxy resolved configuration only from the session's parent agent. Project-only MCPs therefore failed tools/list with HTTP 500: MCP server 'helixos' not configured for this agent.

## Tests
- go test ./pkg/server -run '^(TestExternalMCPBackendUsesProjectMCPOverride|TestBuildProxyTool_PreservesArrayParams)$' -count=1
- go test ./pkg/external-agent -run '^TestGenerateZedMCPConfig' -count=1
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- git diff --check

## Live verification
NOT tested on Meta because this commit is not deployed. After deployment, repeat tools/list and a read-only connection_list call through /api/v1/mcp/external/helixos using a session-scoped token.