### PR TITLE
fix(spec-task): reconcile a task whose agent resumed work outside orchestration

### DIFF
--- a/api/pkg/server/spec_task_turn_reconcile.go
+++ b/api/pkg/server/spec_task_turn_reconcile.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// reconcileSpecTaskAfterTurn releases a spec task's latched failure state once
+// its agent has demonstrably resumed work.
+//
+// A task and its session are two state machines, and only the spec-task
+// orchestration routes (start-planning / start-implementation) ever cleared
+// `metadata.error` or advanced status. Work can resume without touching them:
+// the chat's Retry — and an ordinary chat message — go through session
+// inference, which has no spec-task awareness. The task then sits at
+// `backlog` with a stale error while its agent codes, and the toolbar keeps
+// offering "Retry Implementation" because that label is derived from the
+// latched error rather than from observable state.
+//
+// A completed turn is proof the failure is no longer true, so this releases
+// the latch and moves the task out of backlog. Capacity accounting is not
+// bypassed by doing so — the work is already running and already consuming a
+// slot; leaving the task in backlog is what hides it from the ledger.
+func (apiServer *HelixAPIServer) reconcileSpecTaskAfterTurn(ctx context.Context, session *types.Session) {
+	if session == nil || session.Metadata.SpecTaskID == "" {
+		return
+	}
+	store := apiServer.Store
+	if store == nil {
+		return
+	}
+	task, err := store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+	if err != nil || task == nil {
+		return
+	}
+
+	changed := false
+	for _, key := range []string{"error", "error_timestamp", types.TaskErrorCodeKey, types.TaskErrorProviderKey} {
+		if _, ok := task.Metadata[key]; ok {
+			delete(task.Metadata, key)
+			changed = true
+		}
+	}
+
+	// Only backlog is reconciled. Every other status is either a live phase the
+	// orchestrator owns or a terminal one a finished turn must not reopen.
+	if task.Status == types.TaskStatusBacklog {
+		task.Status = resumedSpecTaskStatus(task)
+		now := time.Now()
+		task.StatusUpdatedAt = &now
+		changed = true
+	}
+	if !changed {
+		return
+	}
+
+	task.UpdatedAt = time.Now()
+	if err := store.UpdateSpecTask(ctx, task); err != nil {
+		log.Warn().Err(err).
+			Str("task_id", task.ID).
+			Str("session_id", session.ID).
+			Msg("Failed to reconcile spec task after completed turn")
+		return
+	}
+	log.Info().
+		Str("task_id", task.ID).
+		Str("session_id", session.ID).
+		Str("status", string(task.Status)).
+		Msg("Reconciled spec task state after its agent resumed work")
+}
+
+// resumedSpecTaskStatus is the phase the orchestration routes would have set
+// for this task, so a reconciled task lands where a normal start would put it.
+func resumedSpecTaskStatus(task *types.SpecTask) types.SpecTaskStatus {
+	if task.JustDoItMode {
+		return types.TaskStatusImplementation
+	}
+	return types.TaskStatusSpecGeneration
+}

--- a/api/pkg/server/spec_task_turn_reconcile_test.go
+++ b/api/pkg/server/spec_task_turn_reconcile_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func failedTask(justDoIt bool) *types.SpecTask {
+	return &types.SpecTask{
+		ID:           "spt_1",
+		Status:       types.TaskStatusBacklog,
+		JustDoItMode: justDoIt,
+		Metadata: map[string]interface{}{
+			"error":                    "no active Claude subscription is available",
+			"error_timestamp":          "2026-08-07T10:07:04Z",
+			types.TaskErrorCodeKey:     types.TaskErrorSubscriptionRequired,
+			types.TaskErrorProviderKey: types.SubscriptionProviderClaude,
+			"unrelated":                "keep me",
+		},
+	}
+}
+
+func specTaskSession() *types.Session {
+	return &types.Session{ID: "ses_1", Metadata: types.SessionMetadata{SpecTaskID: "spt_1"}}
+}
+
+// The state this exists to prevent: an agent working for 40 minutes while the
+// task still reads backlog with the launch failure that has since been fixed.
+func TestReconcileSpecTaskAfterTurn_ReleasesLatchedFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	task := failedTask(true)
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(task, nil)
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			require.Equal(t, types.TaskStatusImplementation, updated.Status)
+			require.NotContains(t, updated.Metadata, "error")
+			require.NotContains(t, updated.Metadata, "error_timestamp")
+			require.NotContains(t, updated.Metadata, types.TaskErrorCodeKey)
+			require.NotContains(t, updated.Metadata, types.TaskErrorProviderKey)
+			require.Equal(t, "keep me", updated.Metadata["unrelated"], "unrelated metadata must survive")
+			require.NotNil(t, updated.StatusUpdatedAt)
+			return nil
+		})
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+// A planning task must not be dropped into implementation.
+func TestReconcileSpecTaskAfterTurn_UsesThePhaseTheTaskWouldHaveStartedIn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(failedTask(false), nil)
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			require.Equal(t, types.TaskStatusSpecGeneration, updated.Status)
+			return nil
+		})
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+// Reconciliation must not reopen a phase the orchestrator owns, nor a terminal
+// one: a turn completing on a merged task must not drag it back to work.
+func TestReconcileSpecTaskAfterTurn_LeavesNonBacklogStatusAlone(t *testing.T) {
+	for _, status := range []types.SpecTaskStatus{
+		types.TaskStatusImplementation,
+		types.TaskStatusImplementationReview,
+		types.TaskStatusDone,
+		types.TaskStatusQueuedImplementation,
+	} {
+		ctrl := gomock.NewController(t)
+		mockStore := store.NewMockStore(ctrl)
+		server := &HelixAPIServer{Store: mockStore}
+		task := failedTask(true)
+		task.Status = status
+
+		mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(task, nil)
+		// The stale error is still released — it is false either way — but the
+		// status must be left exactly as the orchestrator set it.
+		mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, updated *types.SpecTask) error {
+				require.Equal(t, status, updated.Status)
+				require.NotContains(t, updated.Metadata, "error")
+				return nil
+			})
+
+		server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+		ctrl.Finish()
+	}
+}
+
+func TestReconcileSpecTaskAfterTurn_NoWriteWhenNothingToReconcile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	// Healthy task mid-implementation: no latch, no status change, no write.
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(&types.SpecTask{
+		ID: "spt_1", Status: types.TaskStatusImplementation,
+	}, nil)
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+func TestReconcileSpecTaskAfterTurn_IgnoresPlainChatSessions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	// No SpecTaskID: the store must not be touched at all.
+	server.reconcileSpecTaskAfterTurn(context.Background(), &types.Session{ID: "ses_1"})
+	server.reconcileSpecTaskAfterTurn(context.Background(), nil)
+}

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2939,6 +2939,12 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 	// turn from the current working tree.
 	apiServer.finalizeInteractionCodeChanges(context.Background(), helixSessionID, targetInteraction)
 
+	// A completed turn proves any latched launch failure on the owning spec task
+	// is no longer true. Work can resume through session inference (the chat's
+	// Retry, or just a message), which never touches the task, leaving it at
+	// backlog with a stale error while its agent runs.
+	apiServer.reconcileSpecTaskAfterTurn(context.Background(), helixSession)
+
 	_, err = apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), targetInteraction)
 	if err != nil {
 		return fmt.Errorf("failed to update interaction %s: %w", targetInteraction.ID, err)

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1197,6 +1197,10 @@ func (s *WebSocketSyncSuite) TestMessageCompleted_SkipsAttentionWhenUserActive()
 	// was persisted after an in-memory streaming copy was created.
 	s.store.EXPECT().GetInteraction(gomock.Any(), "int-target-skip").Return(targetInteraction, nil).
 		MinTimes(1).MaxTimes(2)
+	// Completion also reconciles the owning spec task; this session has one.
+	// A healthy task means reconciliation finds nothing to release.
+	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).
+		Return(&types.SpecTask{ID: "task-skip", Status: types.TaskStatusImplementation}, nil).AnyTimes()
 	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(targetInteraction, nil)
 
 	// ListInteractions is called for both the suppression check (PerPage=1)


### PR DESCRIPTION
## Problem

A task and its session are two independent state machines, and only the spec-task orchestration routes (`start-planning` / `start-implementation`) ever cleared `metadata.error` or advanced status. Work can resume without touching them: the chat's **Retry** — and an ordinary chat message — go through session inference (`NewInference`), which has no spec-task awareness.

Observed on `spt_01kzdv1hd9jtn2d3kzhas8p5t6`:

| | timestamp |
|---|---|
| Task row `updated_at` | `10:07:04.306` — the original launch failure, never touched since |
| Session interactions created | `10:30:38` — the user's chat Retry |
| Session interaction `updated_at` | `10:48:29` — still actively working |

The task sat at `status=backlog` with a subscription error latched while its agent coded for ~40 minutes. The toolbar kept offering "Retry Implementation" because that label is derived from the latched error (`SpecTaskActionButtons.tsx:381`) rather than from observable state.

This is not specific to the Retry button — any chat message on a failed task takes the same path.

## Fix

A completed turn proves the failure is no longer true, so `handleMessageCompleted` now releases the latch and moves a backlog task into the phase a normal start would have put it in.

- Only `backlog` is reconciled. Every other status is either a live phase the orchestrator owns or a terminal one a finished turn must not reopen.
- The latched error is released regardless of status, since it is false either way.
- Unrelated metadata is preserved.
- No write when there is nothing to reconcile.

Capacity accounting is not bypassed: the work is already running and already consuming a slot. Leaving the task in `backlog` is what hid it from the ledger.

## Tests

Five cases in `spec_task_turn_reconcile_test.go`: latch release with status transition, planning vs just-do-it phase selection, non-backlog statuses left alone, no-op when healthy, and plain chat sessions never touching the store.

The two existing completion tests now expect the extra spec-task read. The attention test already asserted `GetSpecTask` is reached and its stub covers both callers, so it needed no second expectation.

Verified: `go test ./pkg/server ./pkg/desktop ./pkg/external-agent ./pkg/services` green, `go build ./pkg/...` clean.

**NOT verified:** live end-to-end against a real resumed task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)