### PR TITLE
feat(workspace): add inline task editing and chat renaming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,11 +194,25 @@ func (s *MySuite) SetupTest() { /* init ctrl, store, server */ }
 
 These rules keep our list pages visually consistent. When in doubt, mirror `Sandboxes.tsx` / `Tasks.tsx`.
 
+#### Icons, toolbars, color, and spacing
+- **Use Lucide icons from `lucide-react` for product UI.** Do not mix MUI icons and Lucide icons in the same surface. Exceptions are brand/provider logos and a pre-existing shared component whose public API supplies its own icon.
+- Use the simplest icon that communicates the action. Prefer plain panel glyphs such as `PanelLeft` / `PanelRight` over embellished `*Open` / `*Close` variants unless direction is otherwise ambiguous.
+- Standard toolbar geometry is an **18px icon inside a 30×30px `IconButton`**. Labeled toolbar/view buttons are 40px high. Keep every icon in a toolbar on the same optical size and baseline; do not mix arbitrary 14/15/17/18px glyphs.
+- Every clickable icon must be a real `<IconButton>` or `<Button>`, not an `onClick` attached to a bare `<Box>` or SVG. Add an `aria-label` and a concise tooltip. Passive status indicators may use a non-interactive wrapper, but should occupy the same 30×30px slot when aligned with toolbar buttons.
+- Use `text.secondary` for inactive utility icons, `text.primary` on hover, and `action.selected` for selected/toggled controls. Reserve green/red/amber/blue for semantic state or a primary action; do not add one-off decorative hex colors when a theme token exists.
+- Follow the 8px spacing grid. Within a tightly related icon cluster use 2px (`gap: 0.25`); between semantic groups or between a labeled action and its status cluster use 6–8px (`gap: 0.75–1`). Do not apply the tight internal gap to the whole toolbar.
+- Toolbar rows need deliberate vertical rhythm: normally 8px above controls and 4px below (`pt: 1`, `pb: 0.5`). Center all groups with `alignItems: 'center'`; do not compensate for misaligned controls with per-icon margins.
+- Reuse a shared `sx` object or component for repeated toolbar icon buttons so hit area, icon size, hover, selected state, and spacing cannot drift between desktop/mobile or expanded/collapsed layouts.
+
+#### Resizable panels
+- `react-resizable-panels` v4 treats numeric `Panel` sizes as pixels. Use percentage strings (`defaultSize="50%"`, `minSize="25%"`) when the design is proportional; `PanelGroup.defaultLayout` remains a numeric percentage map.
+- Collapsible panels must restore the user's last expanded percentage. If there is no saved valid layout, default a two-pane workspace to 50/50. Never persist a zero-width collapsed layout as the user's preferred split.
+
 #### Tables
 - **ALWAYS use `SimpleTable`** from `frontend/src/components/widgets/SimpleTable.tsx`. Don't reach for raw MUI `<Table>` / `<TableContainer>`. References: `TasksTable.tsx`, `SandboxesTable.tsx`, `AppsTable.tsx`.
 - Build rows via a `tableData` `useMemo` that maps each entity to `{ id, _data: <entity>, <field>: <ReactNode>, ... }`. Always include `_data` so action handlers can recover the typed entity.
 - Cells are `<Typography>` nodes, not raw strings. Use `variant="body2" color="text.secondary"` for non-primary cells. Make the name cell a bold link via an inline `<a>` (see `TasksTable.tsx`); call `e.preventDefault()` + `e.stopPropagation()` in its `onClick`.
-- **Row actions go in a single vertical-dot menu**, never a row of icon buttons. Implement `getActions` as one `<IconButton><MoreVertIcon/></IconButton>` that opens a `<Menu>` with `<MenuItem>` entries (each item has a leading icon: `<Icon sx={{ mr: 1, fontSize: 20 }} />`). Track the active row via `currentX` state set on menu open; clear it on close.
+- **Row actions go in a single vertical-dot menu**, never a row of icon buttons. Implement `getActions` as one `<IconButton><EllipsisVertical size={18}/></IconButton>` that opens a `<Menu>` with `<MenuItem>` entries (each item has a leading Lucide icon: `<Icon size={20} />`). Track the active row via `currentX` state set on menu open; clear it on close.
 - `e.stopPropagation()` in every menu/icon click handler so row clicks don't fire.
 - Status chips: build a small dedicated component (e.g. `SandboxStatusBadge`) rather than inlining `<Chip>` styling.
 
@@ -206,7 +220,7 @@ These rules keep our list pages visually consistent. When in doubt, mirror `Sand
 - Render via the shared `CardGrid` (`components/widgets/CardGrid.tsx`) — never roll a new MUI `Grid container` (its negative margins break flush alignment with the page title).
 - Card chrome: `<Card>` with `border: '1px solid rgba(0, 0, 0, 0.08)'`, `borderRadius: 1`, `boxShadow: 'none'`, hover bumps `borderColor` to `rgba(0,0,0,0.12)` and tints `backgroundColor: 'rgba(0,0,0,0.01)'`. `height: '100%'` + `display: 'flex'; flexDirection: 'column'` so the grid rows align.
 - Inside, `<CardContent>` uses `p: 2`, `'&:last-child': { pb: 2 }`, `cursor: 'pointer'`, and an `onClick` that opens the detail view.
-- **Top-right corner gets the vertical-dot menu** (`<IconButton><MoreVertIcon sx={{ fontSize: 16 }}/></IconButton>` → `<Menu>`). Same menu items as the table actions — keep the two surfaces in sync. Don't put separate Open/Delete icons at the bottom of the card.
+- **Top-right corner gets the vertical-dot menu** (`<IconButton><EllipsisVertical size={18}/></IconButton>` → `<Menu>`). Same menu items as the table actions — keep the two surfaces in sync. Don't put separate Open/Delete icons at the bottom of the card.
 - Status indicator goes inline next to the dot menu (e.g. status badge), or as the leading icon by the title (see `CronTaskCard.tsx` — green clock vs paused-circle, with tooltip).
 - Dense stat strip uses the gradient panel: `background: 'linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)'`, `border: '1px solid rgba(255,255,255,0.06)'`, `borderRadius: 2`, `p: 1.5`. Stats are label (caption, `0.65rem`, `text.secondary`) + value (body2, `0.8rem`, `monospace`, `fontWeight: 600`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ These rules keep our list pages visually consistent. When in doubt, mirror `Sand
 - Use `text.secondary` for inactive utility icons, `text.primary` on hover, and `action.selected` for selected/toggled controls. Reserve green/red/amber/blue for semantic state or a primary action; do not add one-off decorative hex colors when a theme token exists.
 - Follow the 8px spacing grid. Within a tightly related icon cluster use 2px (`gap: 0.25`); between semantic groups or between a labeled action and its status cluster use 6–8px (`gap: 0.75–1`). Do not apply the tight internal gap to the whole toolbar.
 - Toolbar rows need deliberate vertical rhythm: normally 8px above controls and 4px below (`pt: 1`, `pb: 0.5`). Center all groups with `alignItems: 'center'`; do not compensate for misaligned controls with per-icon margins.
+- Toolbar rows inside a vertical flex layout must use `flexShrink: 0` and an explicit minimum block size that includes controls, padding, and borders. Mounting a selector, tabs, or other subview below the toolbar must never move or compress the toolbar.
 - Reuse a shared `sx` object or component for repeated toolbar icon buttons so hit area, icon size, hover, selected state, and spacing cannot drift between desktop/mobile or expanded/collapsed layouts.
 
 #### Resizable panels

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -323,19 +323,29 @@ func (apiServer *HelixAPIServer) updateSession(_ http.ResponseWriter, req *http.
 		return nil, system.NewHTTPError403(err.Error())
 	}
 
-	var update *types.Session
+	var update struct {
+		Name      *string `json:"name"`
+		Provider  *string `json:"provider"`
+		ModelName *string `json:"model_name"`
+	}
 
 	err = json.NewDecoder(req.Body).Decode(&update)
 	if err != nil {
 		return nil, system.NewHTTPError400(err.Error())
 	}
 
-	session.Name = update.Name
-	if err := apiServer.validateSessionProviderRef(ctx, update.Provider, session.OrganizationID, session.Owner); err != nil {
-		return nil, system.NewHTTPError400(err.Error())
+	if update.Name != nil {
+		session.Name = *update.Name
 	}
-	session.Provider = update.Provider
-	session.ModelName = update.ModelName
+	if update.Provider != nil {
+		if err := apiServer.validateSessionProviderRef(ctx, *update.Provider, session.OrganizationID, session.Owner); err != nil {
+			return nil, system.NewHTTPError400(err.Error())
+		}
+		session.Provider = *update.Provider
+	}
+	if update.ModelName != nil {
+		session.ModelName = *update.ModelName
+	}
 
 	updated, err := apiServer.Store.UpdateSession(req.Context(), *session)
 	if err != nil {

--- a/api/pkg/server/session_handlers_test.go
+++ b/api/pkg/server/session_handlers_test.go
@@ -681,6 +681,38 @@ func (s *SessionAuthzSuite) TestDeleteSession_NotOrgMemberNotSessionOwner() {
 	s.Equal(http.StatusForbidden, httpErr.StatusCode)
 }
 
+func (s *SessionAuthzSuite) TestUpdateSession_NameOnlyPreservesProviderAndModel() {
+	session := &types.Session{
+		ID:        "ses_123",
+		Owner:     s.userID,
+		Name:      "Original name",
+		Provider:  "openai",
+		ModelName: "gpt-5",
+	}
+
+	s.store.EXPECT().GetSession(gomock.Any(), session.ID).Return(session, nil)
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated types.Session) (*types.Session, error) {
+			s.Equal("Renamed session", updated.Name)
+			s.Equal("openai", updated.Provider)
+			s.Equal("gpt-5", updated.ModelName)
+			return &updated, nil
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/sessions/"+session.ID, strings.NewReader(`{"name":"Renamed session"}`))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": session.ID})
+
+	result, httpErr := s.server.updateSession(httptest.NewRecorder(), req)
+
+	s.Nil(httpErr)
+	s.Require().NotNil(result)
+	s.Equal("Renamed session", result.Name)
+	s.Equal("openai", result.Provider)
+	s.Equal("gpt-5", result.ModelName)
+}
+
 func (s *SessionAuthzSuite) TestArchiveSession_Owner() {
 	session := &types.Session{
 		ID:    "ses_123",

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -1145,7 +1145,9 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 	}
 	if updateReq.Description != "" {
 		task.Description = updateReq.Description
-		task.Name = services.GenerateTaskNameFromPrompt(updateReq.Description)
+	}
+	if name := strings.TrimSpace(updateReq.Name); name != "" {
+		task.Name = name
 	}
 	if updateReq.JustDoItMode != nil {
 		task.JustDoItMode = *updateReq.JustDoItMode

--- a/api/pkg/server/spec_driven_task_update_test.go
+++ b/api/pkg/server/spec_driven_task_update_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type SpecTaskUpdateSuite struct {
+	suite.Suite
+
+	ctrl   *gomock.Controller
+	store  *store.MockStore
+	server *HelixAPIServer
+}
+
+func TestSpecTaskUpdateSuite(t *testing.T) {
+	suite.Run(t, new(SpecTaskUpdateSuite))
+}
+
+func (s *SpecTaskUpdateSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.server = &HelixAPIServer{
+		Cfg:   &config.ServerConfig{},
+		Store: s.store,
+	}
+}
+
+func (s *SpecTaskUpdateSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *SpecTaskUpdateSuite) TestExplicitNameWinsOverDescriptionDerivedName() {
+	const (
+		userID    = "user_update_test"
+		projectID = "project_update_test"
+		taskID    = "task_update_test"
+	)
+
+	task := &types.SpecTask{
+		ID:          taskID,
+		ProjectID:   projectID,
+		Name:        "Old name",
+		Description: "Old description",
+	}
+	project := &types.Project{ID: projectID, UserID: userID}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), taskID).Return(task, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), projectID).Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ interface{}, updated *types.SpecTask) error {
+			s.Equal("Harbor registry verification", updated.Name)
+			s.Equal("Verify Harbor updates in k3s", updated.Description)
+			s.Equal("Harbor registry verification", updated.UserShortTitle)
+			return nil
+		},
+	)
+
+	requestBody, err := json.Marshal(types.SpecTaskUpdateRequest{
+		Name:           "Harbor registry verification",
+		Description:    "Verify Harbor updates in k3s",
+		UserShortTitle: stringPointer("Harbor registry verification"),
+	})
+	s.Require().NoError(err)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/spec-tasks/"+taskID, bytes.NewReader(requestBody))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: userID}))
+	req = mux.SetURLVars(req, map[string]string{"taskId": taskID})
+	rr := httptest.NewRecorder()
+
+	s.server.updateSpecTask(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+func (s *SpecTaskUpdateSuite) TestDescriptionUpdatePreservesTaskName() {
+	const (
+		userID    = "user_description_update_test"
+		projectID = "project_description_update_test"
+		taskID    = "task_description_update_test"
+	)
+
+	task := &types.SpecTask{
+		ID:             taskID,
+		ProjectID:      projectID,
+		Name:           "Custom task name",
+		UserShortTitle: "Custom task name",
+		Description:    "Old description",
+	}
+	project := &types.Project{ID: projectID, UserID: userID}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), taskID).Return(task, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), projectID).Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ interface{}, updated *types.SpecTask) error {
+			s.Equal("Custom task name", updated.Name)
+			s.Equal("Custom task name", updated.UserShortTitle)
+			s.Equal("New description", updated.Description)
+			return nil
+		},
+	)
+
+	requestBody, err := json.Marshal(types.SpecTaskUpdateRequest{
+		Description: "New description",
+	})
+	s.Require().NoError(err)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/spec-tasks/"+taskID, bytes.NewReader(requestBody))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: userID}))
+	req = mux.SetURLVars(req, map[string]string{"taskId": taskID})
+	rr := httptest.NewRecorder()
+
+	s.server.updateSpecTask(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/api/pkg/server/spec_task_turn_reconcile.go
+++ b/api/pkg/server/spec_task_turn_reconcile.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// reconcileSpecTaskAfterTurn releases a spec task's latched failure state once
+// its agent has demonstrably resumed work.
+//
+// A task and its session are two state machines, and only the spec-task
+// orchestration routes (start-planning / start-implementation) ever cleared
+// `metadata.error` or advanced status. Work can resume without touching them:
+// the chat's Retry — and an ordinary chat message — go through session
+// inference, which has no spec-task awareness. The task then sits at
+// `backlog` with a stale error while its agent codes, and the toolbar keeps
+// offering "Retry Implementation" because that label is derived from the
+// latched error rather than from observable state.
+//
+// A completed turn is proof the failure is no longer true, so this releases
+// the latch and moves the task out of backlog. Capacity accounting is not
+// bypassed by doing so — the work is already running and already consuming a
+// slot; leaving the task in backlog is what hides it from the ledger.
+func (apiServer *HelixAPIServer) reconcileSpecTaskAfterTurn(ctx context.Context, session *types.Session) {
+	if session == nil || session.Metadata.SpecTaskID == "" {
+		return
+	}
+	store := apiServer.Store
+	if store == nil {
+		return
+	}
+	task, err := store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+	if err != nil || task == nil {
+		return
+	}
+
+	changed := false
+	for _, key := range []string{"error", "error_timestamp", types.TaskErrorCodeKey, types.TaskErrorProviderKey} {
+		if _, ok := task.Metadata[key]; ok {
+			delete(task.Metadata, key)
+			changed = true
+		}
+	}
+
+	// Only backlog is reconciled. Every other status is either a live phase the
+	// orchestrator owns or a terminal one a finished turn must not reopen.
+	if task.Status == types.TaskStatusBacklog {
+		task.Status = resumedSpecTaskStatus(task)
+		now := time.Now()
+		task.StatusUpdatedAt = &now
+		changed = true
+	}
+	if !changed {
+		return
+	}
+
+	task.UpdatedAt = time.Now()
+	if err := store.UpdateSpecTask(ctx, task); err != nil {
+		log.Warn().Err(err).
+			Str("task_id", task.ID).
+			Str("session_id", session.ID).
+			Msg("Failed to reconcile spec task after completed turn")
+		return
+	}
+	log.Info().
+		Str("task_id", task.ID).
+		Str("session_id", session.ID).
+		Str("status", string(task.Status)).
+		Msg("Reconciled spec task state after its agent resumed work")
+}
+
+// resumedSpecTaskStatus is the phase the orchestration routes would have set
+// for this task, so a reconciled task lands where a normal start would put it.
+func resumedSpecTaskStatus(task *types.SpecTask) types.SpecTaskStatus {
+	if task.JustDoItMode {
+		return types.TaskStatusImplementation
+	}
+	return types.TaskStatusSpecGeneration
+}

--- a/api/pkg/server/spec_task_turn_reconcile_test.go
+++ b/api/pkg/server/spec_task_turn_reconcile_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func failedTask(justDoIt bool) *types.SpecTask {
+	return &types.SpecTask{
+		ID:           "spt_1",
+		Status:       types.TaskStatusBacklog,
+		JustDoItMode: justDoIt,
+		Metadata: map[string]interface{}{
+			"error":                    "no active Claude subscription is available",
+			"error_timestamp":          "2026-08-07T10:07:04Z",
+			types.TaskErrorCodeKey:     types.TaskErrorSubscriptionRequired,
+			types.TaskErrorProviderKey: types.SubscriptionProviderClaude,
+			"unrelated":                "keep me",
+		},
+	}
+}
+
+func specTaskSession() *types.Session {
+	return &types.Session{ID: "ses_1", Metadata: types.SessionMetadata{SpecTaskID: "spt_1"}}
+}
+
+// The state this exists to prevent: an agent working for 40 minutes while the
+// task still reads backlog with the launch failure that has since been fixed.
+func TestReconcileSpecTaskAfterTurn_ReleasesLatchedFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	task := failedTask(true)
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(task, nil)
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			require.Equal(t, types.TaskStatusImplementation, updated.Status)
+			require.NotContains(t, updated.Metadata, "error")
+			require.NotContains(t, updated.Metadata, "error_timestamp")
+			require.NotContains(t, updated.Metadata, types.TaskErrorCodeKey)
+			require.NotContains(t, updated.Metadata, types.TaskErrorProviderKey)
+			require.Equal(t, "keep me", updated.Metadata["unrelated"], "unrelated metadata must survive")
+			require.NotNil(t, updated.StatusUpdatedAt)
+			return nil
+		})
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+// A planning task must not be dropped into implementation.
+func TestReconcileSpecTaskAfterTurn_UsesThePhaseTheTaskWouldHaveStartedIn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(failedTask(false), nil)
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			require.Equal(t, types.TaskStatusSpecGeneration, updated.Status)
+			return nil
+		})
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+// Reconciliation must not reopen a phase the orchestrator owns, nor a terminal
+// one: a turn completing on a merged task must not drag it back to work.
+func TestReconcileSpecTaskAfterTurn_LeavesNonBacklogStatusAlone(t *testing.T) {
+	for _, status := range []types.SpecTaskStatus{
+		types.TaskStatusImplementation,
+		types.TaskStatusImplementationReview,
+		types.TaskStatusDone,
+		types.TaskStatusQueuedImplementation,
+	} {
+		ctrl := gomock.NewController(t)
+		mockStore := store.NewMockStore(ctrl)
+		server := &HelixAPIServer{Store: mockStore}
+		task := failedTask(true)
+		task.Status = status
+
+		mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(task, nil)
+		// The stale error is still released — it is false either way — but the
+		// status must be left exactly as the orchestrator set it.
+		mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, updated *types.SpecTask) error {
+				require.Equal(t, status, updated.Status)
+				require.NotContains(t, updated.Metadata, "error")
+				return nil
+			})
+
+		server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+		ctrl.Finish()
+	}
+}
+
+func TestReconcileSpecTaskAfterTurn_NoWriteWhenNothingToReconcile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	// Healthy task mid-implementation: no latch, no status change, no write.
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(&types.SpecTask{
+		ID: "spt_1", Status: types.TaskStatusImplementation,
+	}, nil)
+
+	server.reconcileSpecTaskAfterTurn(context.Background(), specTaskSession())
+}
+
+func TestReconcileSpecTaskAfterTurn_IgnoresPlainChatSessions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	// No SpecTaskID: the store must not be touched at all.
+	server.reconcileSpecTaskAfterTurn(context.Background(), &types.Session{ID: "ses_1"})
+	server.reconcileSpecTaskAfterTurn(context.Background(), nil)
+}

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2939,6 +2939,12 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 	// turn from the current working tree.
 	apiServer.finalizeInteractionCodeChanges(context.Background(), helixSessionID, targetInteraction)
 
+	// A completed turn proves any latched launch failure on the owning spec task
+	// is no longer true. Work can resume through session inference (the chat's
+	// Retry, or just a message), which never touches the task, leaving it at
+	// backlog with a stale error while its agent runs.
+	apiServer.reconcileSpecTaskAfterTurn(context.Background(), helixSession)
+
 	_, err = apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), targetInteraction)
 	if err != nil {
 		return fmt.Errorf("failed to update interaction %s: %w", targetInteraction.ID, err)

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1197,6 +1197,10 @@ func (s *WebSocketSyncSuite) TestMessageCompleted_SkipsAttentionWhenUserActive()
 	// was persisted after an in-memory streaming copy was created.
 	s.store.EXPECT().GetInteraction(gomock.Any(), "int-target-skip").Return(targetInteraction, nil).
 		MinTimes(1).MaxTimes(2)
+	// Completion also reconciles the owning spec task; this session has one.
+	// A healthy task means reconciliation finds nothing to release.
+	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).
+		Return(&types.SpecTask{ID: "task-skip", Status: types.TaskStatusImplementation}, nil).AnyTimes()
 	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(targetInteraction, nil)
 
 	// ListInteractions is called for both the suppression check (PerPage=1)

--- a/frontend/src/components/session/ProjectChatGroup.test.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.test.tsx
@@ -70,6 +70,7 @@ const renderEmptyProject = (collapsed = false) => render(
     onToggle={vi.fn()}
     onNewTask={vi.fn()}
     onOpenItem={vi.fn()}
+    onOpenItemContextMenu={vi.fn()}
     onArchiveItem={vi.fn()}
   />,
 )
@@ -113,6 +114,38 @@ describe('ProjectChatGroup', () => {
     expect(screen.queryByText('6+')).not.toBeInTheDocument()
     expect(screen.queryByText('7')).not.toBeInTheDocument()
   })
+
+  it('opens the item context menu without navigating', () => {
+    const onOpenItem = vi.fn()
+    const onOpenItemContextMenu = vi.fn()
+    render(
+      <ProjectChatGroup
+        orgId="org-test"
+        collapsed={false}
+        query=""
+        activeItemId=""
+        relativeTimeNow={Date.UTC(2026, 7, 6, 12, 0)}
+        enabled
+        participantIds={[]}
+        organizationMembers={[]}
+        archivingItemId={null}
+        onToggle={vi.fn()}
+        onOpenItem={onOpenItem}
+        onOpenItemContextMenu={onOpenItemContextMenu}
+        onArchiveItem={vi.fn()}
+      />,
+    )
+
+    const row = screen.getByText('Session 1').closest('[role="button"]')
+    expect(row).not.toBeNull()
+    fireEvent.contextMenu(row!)
+
+    expect(onOpenItemContextMenu).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'session-1', kind: 'session' }),
+    )
+    expect(onOpenItem).not.toHaveBeenCalled()
+  })
 })
 
 describe('ProjectChatGroup archived mode', () => {
@@ -141,6 +174,7 @@ describe('ProjectChatGroup archived mode', () => {
         archivingItemId={null}
         onToggle={vi.fn()}
         onOpenItem={vi.fn()}
+        onOpenItemContextMenu={vi.fn()}
         onArchiveItem={onArchiveItem}
       />,
     )
@@ -171,6 +205,7 @@ describe('ProjectChatGroup pagination', () => {
         archivingItemId={null}
         onToggle={vi.fn()}
         onOpenItem={vi.fn()}
+        onOpenItemContextMenu={vi.fn()}
         onArchiveItem={vi.fn()}
       />,
     )
@@ -219,6 +254,7 @@ describe('ProjectChatGroup pagination', () => {
         archivingItemId={null}
         onToggle={vi.fn()}
         onOpenItem={onOpenItem}
+        onOpenItemContextMenu={vi.fn()}
         onArchiveItem={vi.fn()}
       />,
     )

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -1,4 +1,4 @@
-import { FC, MutableRefObject, useState } from 'react'
+import { FC, MouseEvent, MutableRefObject, useState } from 'react'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -61,6 +61,7 @@ type ProjectChatGroupProps = {
   onToggle: () => void
   onNewTask?: () => void
   onOpenItem: (item: SidebarItem) => void
+  onOpenItemContextMenu: (event: MouseEvent<HTMLElement>, item: SidebarItem) => void
   onArchiveItem: (item: SidebarItem) => void
   manualSorting?: boolean
   dragHandleProps?: SortableProjectHandleProps
@@ -87,6 +88,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
   onToggle,
   onNewTask,
   onOpenItem,
+  onOpenItemContextMenu,
   onArchiveItem,
   manualSorting = false,
   dragHandleProps,
@@ -323,6 +325,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                 role="button"
                 tabIndex={0}
                 onClick={() => onOpenItem(item)}
+                onContextMenu={(event) => onOpenItemContextMenu(event, item)}
                 onKeyDown={(event) => {
                   if (event.target !== event.currentTarget) return
                   if (event.key === 'Enter' || event.key === ' ') {

--- a/frontend/src/components/session/ProjectChatItemContextMenu.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemContextMenu.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import ProjectChatItemContextMenu from './ProjectChatItemContextMenu'
+
+const mocks = vi.hoisted(() => ({
+  renameSession: vi.fn(),
+  updateSpecTask: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: mocks.success, error: mocks.error }),
+}))
+
+vi.mock('../../services/sessionService', () => ({
+  useRenameSession: () => ({ mutateAsync: mocks.renameSession }),
+}))
+
+vi.mock('../../services/specTaskService', () => ({
+  useUpdateSpecTask: () => ({ mutateAsync: mocks.updateSpecTask }),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ProjectChatItemContextMenu', () => {
+  it('renames a spec task through its user title override', async () => {
+    mocks.updateSpecTask.mockResolvedValue({})
+    const onClose = vi.fn()
+    render(
+      <ProjectChatItemContextMenu
+        item={{ id: 'task-one', kind: 'spec-task', title: 'Old task name' }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={onClose}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.getByRole('dialog', { name: 'Rename task' })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '  New task name  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => expect(mocks.updateSpecTask).toHaveBeenCalledWith({
+      taskId: 'task-one',
+      updates: { user_short_title: 'New task name' },
+    }))
+    expect(mocks.renameSession).not.toHaveBeenCalled()
+    expect(mocks.success).toHaveBeenCalledWith('Task renamed')
+  })
+
+  it('renames a normal chat session', async () => {
+    mocks.renameSession.mockResolvedValue({})
+    render(
+      <ProjectChatItemContextMenu
+        item={{ id: 'session-one', kind: 'session', title: 'Old chat name' }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'New chat name' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+
+    await waitFor(() => expect(mocks.renameSession).toHaveBeenCalledWith({
+      sessionId: 'session-one',
+      name: 'New chat name',
+    }))
+    expect(mocks.updateSpecTask).not.toHaveBeenCalled()
+    expect(mocks.success).toHaveBeenCalledWith('Chat renamed')
+  })
+})

--- a/frontend/src/components/session/ProjectChatItemContextMenu.tsx
+++ b/frontend/src/components/session/ProjectChatItemContextMenu.tsx
@@ -1,0 +1,142 @@
+import { FC, FormEvent, useState } from 'react'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import TextField from '@mui/material/TextField'
+import { Pencil } from 'lucide-react'
+
+import useSnackbar from '../../hooks/useSnackbar'
+import { useRenameSession } from '../../services/sessionService'
+import { useUpdateSpecTask } from '../../services/specTaskService'
+import type { SidebarItem } from './ProjectChatSidebar.logic'
+
+export type ProjectChatContextMenuPosition = {
+  mouseX: number
+  mouseY: number
+}
+
+type ProjectChatItemContextMenuProps = {
+  item: SidebarItem | null
+  position: ProjectChatContextMenuPosition | null
+  onClose: () => void
+}
+
+const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
+  item,
+  position,
+  onClose,
+}) => {
+  const snackbar = useSnackbar()
+  const renameSession = useRenameSession()
+  const updateSpecTask = useUpdateSpecTask()
+  const [renameItem, setRenameItem] = useState<SidebarItem | null>(null)
+  const [name, setName] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const openRenameDialog = () => {
+    if (!item) return
+    setRenameItem(item)
+    setName(item.title)
+    onClose()
+  }
+
+  const closeRenameDialog = () => {
+    if (saving) return
+    setRenameItem(null)
+    setName('')
+  }
+
+  const submitRename = async (event: FormEvent) => {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    if (!renameItem || !trimmedName || saving) return
+
+    const label = renameItem.kind === 'spec-task' ? 'task' : 'chat'
+    if (trimmedName === renameItem.title) {
+      closeRenameDialog()
+      return
+    }
+
+    setSaving(true)
+    try {
+      if (renameItem.kind === 'spec-task') {
+        await updateSpecTask.mutateAsync({
+          taskId: renameItem.id,
+          updates: { user_short_title: trimmedName },
+        })
+      } else {
+        await renameSession.mutateAsync({
+          sessionId: renameItem.id,
+          name: trimmedName,
+        })
+      }
+      snackbar.success(`${label === 'task' ? 'Task' : 'Chat'} renamed`)
+      setRenameItem(null)
+      setName('')
+    } catch (error: any) {
+      const message = typeof error?.response?.data === 'string'
+        ? error.response.data
+        : error?.response?.data?.message
+      snackbar.error(message || `Failed to rename ${label}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Menu
+        open={!!item && !!position}
+        onClose={onClose}
+        anchorReference="anchorPosition"
+        anchorPosition={position ? { top: position.mouseY, left: position.mouseX } : undefined}
+      >
+        <MenuItem onClick={openRenameDialog}>
+          <ListItemIcon>
+            <Pencil size={16} />
+          </ListItemIcon>
+          <ListItemText>Rename</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <Dialog
+        open={!!renameItem}
+        onClose={closeRenameDialog}
+        fullWidth
+        maxWidth="xs"
+      >
+        <form onSubmit={submitRename}>
+          <DialogTitle>
+            Rename {renameItem?.kind === 'spec-task' ? 'task' : 'chat'}
+          </DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              fullWidth
+              label="Name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              onFocus={(event) => event.target.select()}
+              disabled={saving}
+              margin="dense"
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={closeRenameDialog} disabled={saving}>Cancel</Button>
+            <Button type="submit" variant="contained" disabled={!name.trim() || saving}>
+              {saving ? 'Renaming…' : 'Rename'}
+            </Button>
+          </DialogActions>
+        </form>
+      </Dialog>
+    </>
+  )
+}
+
+export default ProjectChatItemContextMenu

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useState } from 'react'
+import { FC, MouseEvent, useCallback, useEffect, useState } from 'react'
 import {
   closestCenter,
   DndContext,
@@ -44,6 +44,8 @@ import {
 } from './ProjectChatSidebar.logic'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
 import ProjectChatGroup from './ProjectChatGroup'
+import ProjectChatItemContextMenu from './ProjectChatItemContextMenu'
+import type { ProjectChatContextMenuPosition } from './ProjectChatItemContextMenu'
 import ProjectChatSidebarPeopleFilter from './ProjectChatSidebarPeopleFilter'
 import ProjectChatSidebarOptions from './ProjectChatSidebarOptions'
 import SortableProject from './SortableProject'
@@ -86,6 +88,8 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => readCollapsedGroups(storageKey))
   const [relativeTimeNow, setRelativeTimeNow] = useState(() => Date.now())
   const [archiveConfirmation, setArchiveConfirmation] = useState<SidebarItem | null>(null)
+  const [contextMenuItem, setContextMenuItem] = useState<SidebarItem | null>(null)
+  const [contextMenuPosition, setContextMenuPosition] = useState<ProjectChatContextMenuPosition | null>(null)
   const [archivingItemId, setArchivingItemId] = useState<string | null>(null)
   const [createProjectOpen, setCreateProjectOpen] = useState(false)
   const [showArchived, setShowArchived] = useState(false)
@@ -248,6 +252,18 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
       account.orgNavigate('session', { session_id: item.id })
     }
     onOpenSession()
+  }
+
+  const openItemContextMenu = (event: MouseEvent<HTMLElement>, item: SidebarItem) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setContextMenuItem(item)
+    setContextMenuPosition({ mouseX: event.clientX, mouseY: event.clientY })
+  }
+
+  const closeItemContextMenu = () => {
+    setContextMenuItem(null)
+    setContextMenuPosition(null)
   }
 
   const toggleGroup = (groupId: string) => {
@@ -466,6 +482,7 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
               onToggle={() => toggleGroup('default')}
               onNewTask={showArchived ? undefined : () => account.orgNavigate('chat')}
               onOpenItem={openItem}
+              onOpenItemContextMenu={openItemContextMenu}
               onArchiveItem={requestArchive}
             />
             <DndContext
@@ -506,6 +523,7 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
                           ? undefined
                           : () => account.orgNavigate('chat', {}, { project_id: project.id })}
                         onOpenItem={openItem}
+                        onOpenItemContextMenu={openItemContextMenu}
                         onArchiveItem={requestArchive}
                         manualSorting={preferences.projectSortOrder === 'manual' && !query}
                         dragHandleProps={dragHandleProps}
@@ -520,6 +538,12 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
           </>
         )}
       </Box>
+
+      <ProjectChatItemContextMenu
+        item={contextMenuItem}
+        position={contextMenuPosition}
+        onClose={closeItemContextMenu}
+      />
 
       {archiveConfirmation && (
         <SimpleConfirmWindow

--- a/frontend/src/components/tasks/CIStatusIcon.tsx
+++ b/frontend/src/components/tasks/CIStatusIcon.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Box, Tooltip, Typography, keyframes } from "@mui/material";
+import { Box, IconButton, Tooltip, Typography, keyframes } from "@mui/material";
 import {
-  CheckCircle as PassedIcon,
-  Cancel as FailedIcon,
-  Sync as RunningIcon,
-} from "@mui/icons-material";
+  CircleCheck as PassedIcon,
+  CircleX as FailedIcon,
+  RefreshCw as RunningIcon,
+} from "lucide-react";
 import { TypesRepoPR } from "../../api/api";
 
 const spin = keyframes`
@@ -56,20 +56,18 @@ const CIStatusIcon: React.FC<CIStatusIconProps> = ({ prs }) => {
   let label: string;
   switch (worst) {
     case "passed":
-      icon = <PassedIcon sx={{ fontSize: 14 }} />;
+      icon = <PassedIcon size={18} />;
       color = "#10b981";
       label = "CI passed";
       break;
     case "failed":
-      icon = <FailedIcon sx={{ fontSize: 14 }} />;
+      icon = <FailedIcon size={18} />;
       color = "#ef4444";
       label = "CI failed";
       break;
     case "running":
       icon = (
-        <RunningIcon
-          sx={{ fontSize: 14, animation: `${spin} 2s linear infinite` }}
-        />
+        <RunningIcon size={18} style={{ animation: `${spin} 2s linear infinite` }} />
       );
       color = "#f59e0b";
       label = "CI running";
@@ -106,19 +104,22 @@ const CIStatusIcon: React.FC<CIStatusIconProps> = ({ prs }) => {
 
   return (
     <Tooltip title={tooltip} placement="top" arrow>
-      <Box
+      <IconButton
+        size="small"
+        aria-label={targetURL ? `${label} — open checks` : label}
         onClick={handleClick}
+        disabled={!targetURL}
         sx={{
-          display: "inline-flex",
-          alignItems: "center",
+          width: 30,
+          height: 30,
+          p: 0.75,
           color,
-          cursor: targetURL ? "pointer" : "default",
-          ml: 0.25,
           flexShrink: 0,
+          "&.Mui-disabled": { color },
         }}
       >
         {icon}
-      </Box>
+      </IconButton>
     </Tooltip>
   );
 };

--- a/frontend/src/components/tasks/SharePreviewSection.tsx
+++ b/frontend/src/components/tasks/SharePreviewSection.tsx
@@ -165,6 +165,7 @@ const SharePreviewSection: FC<SharePreviewSectionProps> = ({ sessionId }) => {
           startIcon={<ShareIcon />}
           disabled={mintMutation.isPending}
           onClick={handleMint}
+          sx={{ textTransform: 'none' }}
         >
           {hasTokens ? 'Share another port' : 'Create share URL'}
         </Button>

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -12,15 +12,15 @@ import {
   Typography,
 } from "@mui/material";
 import {
-  PlayArrow as PlayIcon,
-  Description as SpecIcon,
-  CheckCircle as ApproveIcon,
-  Close as CloseIcon,
-  RocketLaunch as LaunchIcon,
-  SkipNext as SkipIcon,
-  Replay as ReopenIcon,
-} from "@mui/icons-material";
-import { GitPullRequest } from "lucide-react";
+  CircleCheck as ApproveIcon,
+  FileText as SpecIcon,
+  GitPullRequest,
+  Play as PlayIcon,
+  Rocket as LaunchIcon,
+  RotateCcw as ReopenIcon,
+  SkipForward as SkipIcon,
+  X as CloseIcon,
+} from "lucide-react";
 import {
   useApproveImplementation,
   useStopAgent,
@@ -85,11 +85,14 @@ const PRStateIcon: React.FC<{ state?: string }> = ({ state }) => {
         sx={{
           display: "inline-flex",
           alignItems: "center",
+          justifyContent: "center",
+          width: 30,
+          height: 30,
           color: PR_STATE_ICON_COLOR[kind],
           flexShrink: 0,
         }}
       >
-        <GitPullRequest size={16} />
+        <GitPullRequest size={18} />
       </Box>
     </Tooltip>
   );
@@ -217,7 +220,7 @@ function CompactActionButton({
     : {};
   return (
     <Tooltip title={tooltip} placement="top">
-      <span style={{ width: fullWidth ? "100%" : "auto", display: "block" }}>
+      <span style={{ width: fullWidth ? "100%" : "auto", display: "inline-flex" }}>
         <Button
           size="small"
           color={color}
@@ -228,8 +231,9 @@ function CompactActionButton({
           {...anchorProps}
           sx={{
             minWidth: 72,
+            height: 40,
             px: 1,
-            py: 0.5,
+            py: 0.4,
             lineHeight: 1,
             textTransform: "none",
             ...sx,
@@ -241,6 +245,11 @@ function CompactActionButton({
               flexDirection: "column",
               alignItems: "center",
               gap: 0.2,
+              lineHeight: 0,
+              "& > svg": {
+                width: 18,
+                height: 18,
+              },
             }}
           >
             {icon}
@@ -430,7 +439,7 @@ export default function SpecTaskActionButtons({
               isQueued || isStartingPlanning ? (
                 <CircularProgress size={18} color="inherit" />
               ) : (
-                <PlayIcon sx={{ fontSize: 18 }} />
+                <PlayIcon size={18} />
               )
             }
             label={startLabel}
@@ -458,7 +467,7 @@ export default function SpecTaskActionButtons({
                 isQueued || isStartingPlanning ? (
                   <CircularProgress size={16} color="inherit" />
                 ) : (
-                  <PlayIcon />
+                  <PlayIcon size={18} />
                 )
               }
               onClick={(e) => {
@@ -501,7 +510,7 @@ export default function SpecTaskActionButtons({
                 isSkipping ? (
                   <CircularProgress size={18} color="inherit" />
                 ) : (
-                  <SkipIcon sx={{ fontSize: 18 }} />
+                  <SkipIcon size={18} />
                 )
               }
               onClick={(e) => {
@@ -535,7 +544,7 @@ export default function SpecTaskActionButtons({
               isQueued || isReviewingSpec ? (
                 <CircularProgress size={18} color="inherit" />
               ) : (
-                <SpecIcon sx={{ fontSize: 18 }} />
+                <SpecIcon size={18} />
               )
             }
             label={isQueued ? "Queued" : "Review Spec"}
@@ -569,7 +578,7 @@ export default function SpecTaskActionButtons({
                 isQueued || isReviewingSpec ? (
                   <CircularProgress size={16} color="inherit" />
                 ) : (
-                  <SpecIcon />
+                  <SpecIcon size={18} />
                 )
               }
               onClick={async (e) => {
@@ -655,7 +664,7 @@ export default function SpecTaskActionButtons({
               isArchiving ? (
                 <CircularProgress size={16} color="inherit" />
               ) : (
-                <CloseIcon sx={{ fontSize: 18 }} />
+                <CloseIcon size={18} />
               )
             }
             label={isArchiving ? "Rejecting..." : "Reject"}
@@ -681,7 +690,7 @@ export default function SpecTaskActionButtons({
               approveImplementationMutation.isPending || rebasePending ? (
                 <CircularProgress size={16} color="inherit" />
               ) : (
-                <ApproveIcon sx={{ fontSize: 18 }} />
+                <ApproveIcon size={18} />
               )
             }
             label={
@@ -703,7 +712,7 @@ export default function SpecTaskActionButtons({
               variant="outlined"
               color="primary"
               disabled={isArchived}
-              icon={isReviewingSpec ? <CircularProgress size={18} color="inherit" /> : <SpecIcon sx={{ fontSize: 18 }} />}
+              icon={isReviewingSpec ? <CircularProgress size={18} color="inherit" /> : <SpecIcon size={18} />}
               label="View Spec"
               onClick={async (e) => {
                 e.stopPropagation();
@@ -736,7 +745,7 @@ export default function SpecTaskActionButtons({
                   isArchiving ? (
                     <CircularProgress size={14} color="inherit" />
                   ) : (
-                    <CloseIcon />
+                    <CloseIcon size={18} />
                   )
                 }
                 onClick={(e) => {
@@ -772,7 +781,7 @@ export default function SpecTaskActionButtons({
                   approveImplementationMutation.isPending || rebasePending ? (
                     <CircularProgress size={14} color="inherit" />
                   ) : (
-                    <ApproveIcon />
+                    <ApproveIcon size={18} />
                   )
                 }
                 onClick={handleOpenPR}
@@ -802,7 +811,7 @@ export default function SpecTaskActionButtons({
                 <Button
                   size={buttonSize}
                   variant="outlined"
-                  startIcon={isReviewingSpec ? <CircularProgress size={16} color="inherit" /> : <SpecIcon />}
+                  startIcon={isReviewingSpec ? <CircularProgress size={16} color="inherit" /> : <SpecIcon size={18} />}
                   onClick={async (e) => {
                     e.stopPropagation();
                     setIsReviewingSpec(true);
@@ -847,20 +856,22 @@ export default function SpecTaskActionButtons({
 
       if (isInline) {
         return (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
             <CompactActionButton
               tooltip={isArchived ? "Task is archived" : ""}
               variant="contained"
               color="secondary"
               disabled={isArchived}
-              icon={<LaunchIcon sx={{ fontSize: 18 }} />}
+              icon={<LaunchIcon size={18} />}
               label={prLabel}
               href={prUrl}
               target="_blank"
               rel="noopener noreferrer"
             />
-            <PRStateIcon state={onlyPR.pr_state} />
-            <CIStatusIcon prs={[onlyPR]} />
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+              <PRStateIcon state={onlyPR.pr_state} />
+              <CIStatusIcon prs={[onlyPR]} />
+            </Box>
           </Box>
         );
       }
@@ -873,7 +884,7 @@ export default function SpecTaskActionButtons({
                 size={buttonSize}
                 variant="contained"
                 color="secondary"
-                startIcon={<LaunchIcon />}
+                startIcon={<LaunchIcon size={18} />}
                 component="a"
                 href={prUrl}
                 target="_blank"
@@ -900,7 +911,7 @@ export default function SpecTaskActionButtons({
               variant="contained"
               color="secondary"
               disabled={isArchived}
-              icon={<LaunchIcon sx={{ fontSize: 18 }} />}
+              icon={<LaunchIcon size={18} />}
               label={`${pullRequests.length} PRs`}
               onClick={(e) => {
                 e.stopPropagation();
@@ -934,7 +945,7 @@ export default function SpecTaskActionButtons({
                 size={buttonSize}
                 variant="contained"
                 color="secondary"
-                startIcon={<LaunchIcon />}
+                startIcon={<LaunchIcon size={18} />}
                 onClick={(e) => {
                   e.stopPropagation();
                   setPrMenuAnchor(e.currentTarget);
@@ -989,7 +1000,7 @@ export default function SpecTaskActionButtons({
                 isReopening ? (
                   <CircularProgress size={18} color="inherit" />
                 ) : (
-                  <ReopenIcon sx={{ fontSize: 18 }} />
+                  <ReopenIcon size={18} />
                 )
               }
               onClick={(e) => {

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -17,8 +17,6 @@ import {
   Button,
   Tooltip,
   Select,
-  FormControl,
-  InputLabel,
   CircularProgress,
   Menu,
   MenuItem,
@@ -32,15 +30,13 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Switch,
-  FormControlLabel,
-  Checkbox,
   Autocomplete,
+  ClickAwayListener,
 } from "@mui/material";
+import type { Theme } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import PlayArrow from "@mui/icons-material/PlayArrow";
 import Description from "@mui/icons-material/Description";
-import SaveIcon from "@mui/icons-material/Save";
-import CancelIcon from "@mui/icons-material/Cancel";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import StopIcon from "@mui/icons-material/Stop";
 import LaunchIcon from "@mui/icons-material/Launch";
@@ -51,7 +47,7 @@ import LinkIcon from "@mui/icons-material/Link";
 import ArchiveIcon from "@mui/icons-material/Archive";
 import AccountTree from "@mui/icons-material/AccountTree";
 import UndoIcon from "@mui/icons-material/Undo";
-import { TypesSpecTaskPriority, TypesSpecTaskStatus } from "../../api/api";
+import { TypesSpecTaskStatus } from "../../api/api";
 import ExternalAgentDesktopViewer, {
   useSandboxState,
 } from "../external-agent/ExternalAgentDesktopViewer";
@@ -104,6 +100,7 @@ import CloneGroupProgressFull from "../specTask/CloneGroupProgress";
 import ArchiveConfirmDialog from "./ArchiveConfirmDialog";
 import { optimisticallyMarkSessionStarting } from "../../utils/optimisticSessionStarting";
 import AgentChat from "../session/AgentChat";
+import { getChatColors } from "../session/chatStyles";
 import SwitchAgentControl from "../session/SwitchAgentControl";
 import SharePreviewSection from "./SharePreviewSection";
 import SpecTaskLaunchWindow, {
@@ -129,7 +126,6 @@ import {
   LockOpen as LockOpenLucide,
   MonitorPlay,
   PanelBottom,
-  Pencil,
   Play as PlayLucide,
   RotateCw,
   Square,
@@ -160,6 +156,32 @@ const taskToolbarIconButtonSx = {
     backgroundColor: "action.selected",
   },
 } as const;
+
+const taskDetailsSectionSx = {
+  border: "1px solid",
+  borderColor: "divider",
+  borderRadius: 2,
+  backgroundColor: "background.paper",
+  p: 2,
+} as const;
+
+const taskActionButtonSx = {
+  fontSize: "0.75rem",
+  textTransform: "none",
+} as const;
+
+const taskDetailsTextSx = {
+  color: (theme: Theme) => getChatColors(theme).assistantForeground,
+  fontSize: "0.875rem",
+  lineHeight: 1.625,
+} as const;
+
+const taskDetailsTextFieldSx = {
+  "& .MuiInputBase-input": taskDetailsTextSx,
+} as const;
+
+type TaskTextField = "name" | "description";
+type TaskTextSaveStatus = "idle" | "saving" | "saved" | "error";
 
 interface SpecTaskDetailContentProps {
   taskId: string;
@@ -200,6 +222,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const streaming = useStreaming();
   const apps = useApps();
   const updateSpecTask = useUpdateSpecTask();
+  const autoSaveSpecTask = useUpdateSpecTask();
   const moveToBacklogMutation = useMoveToBacklog(taskId);
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -266,22 +289,35 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     return primaryRepository?.default_branch || "main";
   }, [primaryRepository?.default_branch]);
 
-  // Edit mode state
-  const [isEditMode, setIsEditMode] = useState(false);
+  // Name and description edit independently and save when focus leaves the field.
+  const [editingTextField, setEditingTextField] =
+    useState<TaskTextField | null>(null);
   const [editFormData, setEditFormData] = useState({
     name: "",
     description: "",
-    priority: "",
-    dependsOnTaskIds: [] as string[],
   });
+  const [textSaveStatus, setTextSaveStatus] = useState<
+    Record<TaskTextField, TaskTextSaveStatus>
+  >({ name: "idle", description: "idle" });
+  const textSaveInFlightRef = useRef<Set<TaskTextField>>(new Set());
 
-  // Prompt/description is editable before spec review (backlog, queued_spec_generation, spec_generation)
-  // After spec review, the spec title becomes the name and prompt becomes read-only
-  const isPromptEditable = [
-    TypesSpecTaskStatus.TaskStatusBacklog,
-    TypesSpecTaskStatus.TaskStatusQueuedSpecGeneration,
-    TypesSpecTaskStatus.TaskStatusSpecGeneration,
-  ].includes(task?.status as TypesSpecTaskStatus);
+  // Name and description are task metadata, so their editability should not
+  // depend on the task's workflow stage.
+  const isTaskDetailsEditable = Boolean(task && !task.archived);
+
+  useEffect(() => {
+    if (editingTextField) return;
+    setEditFormData({
+      name: task?.user_short_title || task?.name || "",
+      description: task?.description || task?.original_prompt || "",
+    });
+  }, [
+    editingTextField,
+    task?.user_short_title,
+    task?.name,
+    task?.description,
+    task?.original_prompt,
+  ]);
 
   // Agent selection state
   const [selectedAgent, setSelectedAgent] = useState("");
@@ -512,17 +548,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // Fetch clone groups where this task was the source
   const { data: cloneGroups } = useCloneGroups(taskId);
 
-  const dependencyTaskOptions = useMemo(
-    () =>
-      projectTasks.filter(
-        (projectTask) =>
-          !!projectTask.id &&
-          projectTask.id !== task?.id &&
-          projectTask.status !== TypesSpecTaskStatus.TaskStatusDone,
-      ),
-    [projectTasks, task?.id],
-  );
-
   const currentTaskDependencies = useMemo(
     () =>
       projectTasks.find((projectTask) => projectTask.id === task?.id)
@@ -531,43 +556,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       [],
     [projectTasks, task?.id, task?.depends_on],
   );
-
-  const dependencyTaskLookup = useMemo(() => {
-    const tasksForLookup = [
-      ...dependencyTaskOptions,
-      ...currentTaskDependencies,
-    ];
-    return new Map(
-      tasksForLookup
-        .filter((projectTask) => !!projectTask.id)
-        .map((projectTask) => [projectTask.id, projectTask]),
-    );
-  }, [dependencyTaskOptions, currentTaskDependencies]);
-
-  const selectedDependencyTasks = useMemo(
-    () =>
-      editFormData.dependsOnTaskIds
-        .map((taskDependencyId) => dependencyTaskLookup.get(taskDependencyId))
-        .filter(
-          (projectTask): projectTask is NonNullable<typeof projectTask> =>
-            !!projectTask,
-        ),
-    [editFormData.dependsOnTaskIds, dependencyTaskLookup],
-  );
-
-  // Initialize edit form data when task changes
-  useEffect(() => {
-    if (task && isEditMode) {
-      setEditFormData({
-        name: task.name || "",
-        description: task.description || task.original_prompt || "",
-        priority: task.priority || "medium",
-        dependsOnTaskIds: currentTaskDependencies
-          .map((dependencyTask) => dependencyTask.id || "")
-          .filter((dependencyTaskId) => !!dependencyTaskId),
-      });
-    }
-  }, [task, isEditMode, currentTaskDependencies]);
 
   // Check if task is completed/merged - container is shut down so desktop view won't work
   const isTaskCompleted = task?.status === "done" || task?.merged_to_main;
@@ -984,47 +972,100 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     [task?.id, selectedAgent, updatingAgent, updateSpecTask, snackbar],
   );
 
-  // Handle edit mode
-  const handleEditToggle = useCallback(() => {
-    setIsEditMode(true);
-  }, []);
+  const handleTextFieldEdit = (field: TaskTextField) => {
+    if (!task || !isTaskDetailsEditable) return;
 
-  const handleCancelEdit = useCallback(() => {
-    setIsEditMode(false);
-    if (task) {
-      setEditFormData({
-        name: task.name || "",
-        description: task.description || task.original_prompt || "",
-        priority: task.priority || "medium",
-        dependsOnTaskIds: currentTaskDependencies
-          .map((dependencyTask) => dependencyTask.id || "")
-          .filter((dependencyTaskId) => !!dependencyTaskId),
-      });
-      setJustDoItMode(task.just_do_it_mode ?? false);
-    }
-  }, [task, currentTaskDependencies]);
+    setEditFormData((current) => ({
+      ...current,
+      [field]:
+        field === "name"
+          ? task.user_short_title || task.name || ""
+          : task.description || task.original_prompt || "",
+    }));
+    setTextSaveStatus((current) => ({ ...current, [field]: "idle" }));
+    setEditingTextField(field);
+  };
 
-  const handleSaveEdit = useCallback(async () => {
+  const handleTextFieldCancel = (field: TaskTextField) => {
+    const currentValue =
+      field === "name"
+        ? task?.user_short_title || task?.name || ""
+        : task?.description || task?.original_prompt || "";
+    setEditFormData((current) => ({ ...current, [field]: currentValue }));
+    setTextSaveStatus((current) => ({ ...current, [field]: "idle" }));
+    setEditingTextField((current) => (current === field ? null : current));
+  };
+
+  const handleTextFieldBlur = async (field: TaskTextField) => {
     if (!task?.id) return;
 
-    try {
-      await updateSpecTask.mutateAsync({
-        taskId: task.id,
-        updates: {
-          name: editFormData.name,
-          description: editFormData.description,
-          priority: editFormData.priority as TypesSpecTaskPriority,
-          just_do_it_mode: justDoItMode,
-          depends_on: editFormData.dependsOnTaskIds,
-        },
-      });
-      setIsEditMode(false);
-      snackbar.success("Task updated successfully");
-    } catch (err) {
-      console.error("Failed to update task:", err);
-      snackbar.error("Failed to update task");
+    if (textSaveInFlightRef.current.has(field)) {
+      setEditingTextField((current) => (current === field ? null : current));
+      return;
     }
-  }, [task?.id, editFormData, justDoItMode, updateSpecTask, snackbar]);
+
+    const currentValue =
+      field === "name"
+        ? task.user_short_title || task.name || ""
+        : task.description || task.original_prompt || "";
+    const nextValue =
+      field === "name"
+        ? editFormData.name.trim()
+        : editFormData.description;
+
+    if (field === "name" && !nextValue) {
+      setEditFormData((current) => ({ ...current, name: currentValue }));
+      setTextSaveStatus((current) => ({ ...current, name: "error" }));
+      setEditingTextField((current) => (current === field ? null : current));
+      snackbar.error("Task name cannot be empty");
+      return;
+    }
+
+    // Leaving the field ends editing immediately. Persistence continues in the
+    // background and its state is shown alongside the field label.
+    setEditingTextField((current) => (current === field ? null : current));
+
+    if (nextValue === currentValue) {
+      setTextSaveStatus((current) => ({ ...current, [field]: "idle" }));
+      return;
+    }
+
+    setTextSaveStatus((current) => ({ ...current, [field]: "saving" }));
+    textSaveInFlightRef.current.add(field);
+    try {
+      await autoSaveSpecTask.mutateAsync({
+        taskId: task.id,
+        updates:
+          field === "name"
+            ? { name: nextValue, user_short_title: nextValue }
+            : { description: nextValue },
+      });
+      setTextSaveStatus((current) => ({ ...current, [field]: "saved" }));
+    } catch (err) {
+      console.error(`Failed to auto-save task ${field}:`, err);
+      setEditFormData((current) => ({
+        ...current,
+        [field]: currentValue,
+      }));
+      setTextSaveStatus((current) => ({ ...current, [field]: "error" }));
+      snackbar.error(`Failed to save task ${field}`);
+    } finally {
+      textSaveInFlightRef.current.delete(field);
+    }
+  };
+
+  const getTextSaveHelper = (field: TaskTextField) => {
+    switch (textSaveStatus[field]) {
+      case "saving":
+        return "Saving…";
+      case "saved":
+        return "Saved";
+      case "error":
+        return "Not saved";
+      default:
+        return "Saves when you leave the field";
+    }
+  };
 
   // Handle review spec navigation
   const handleReviewSpec = useCallback(async () => {
@@ -1197,7 +1238,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
   // Render the details content (used in both desktop left panel and mobile/no-session view)
   const renderDetailsContent = () => (
-    <>
+    <Box sx={{ containerType: "inline-size", maxWidth: 1180, mx: "auto" }}>
       {/* Queued task block reason — explains why a queued task hasn't started yet
           (WIP capacity / dependency). Recomputed server-side each read, so it
           clears automatically as the queue drains. */}
@@ -1247,122 +1288,247 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         </Alert>
       )}
 
-      {/* Description */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          Description
-        </Typography>
-        {isEditMode ? (
-          <TextField
-            fullWidth
-            multiline
-            minRows={4}
-            maxRows={20}
-            value={editFormData.description}
-            onChange={(e) =>
-              setEditFormData((prev) => ({
-                ...prev,
-                description: e.target.value,
-              }))
-            }
-            autoFocus
-            placeholder="Task description"
-          />
-        ) : (
-          <Box
-            onClick={isPromptEditable ? handleEditToggle : undefined}
-            sx={{
-              cursor: isPromptEditable ? "pointer" : "default",
-              borderRadius: 1,
-              mx: -1,
-              px: 1,
-              py: 0.5,
-              transition: "background-color 0.15s ease",
-              "&:hover": isPromptEditable
-                ? {
-                    backgroundColor: "action.hover",
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr)",
+          gap: 2,
+          alignItems: "start",
+          "@container (min-width: 520px)": {
+            gridTemplateColumns: "minmax(0, 1.45fr) minmax(210px, 0.9fr)",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            minWidth: 0,
+            "& > .MuiBox-root": { mb: 0 },
+          }}
+        >
+          {/* Task name and description */}
+          <Box sx={taskDetailsSectionSx}>
+            <Box
+              sx={{ display: "flex", justifyContent: "space-between", gap: 1 }}
+            >
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Task name
+              </Typography>
+              {editingTextField !== "name" &&
+                textSaveStatus.name !== "idle" && (
+                  <Typography
+                    variant="caption"
+                    color={
+                      textSaveStatus.name === "error"
+                        ? "error.main"
+                        : "text.secondary"
+                    }
+                  >
+                    {getTextSaveHelper("name")}
+                  </Typography>
+                )}
+            </Box>
+            {editingTextField === "name" ? (
+              <TextField
+                fullWidth
+                size="small"
+                value={editFormData.name}
+                onChange={(e) => {
+                  setEditFormData((current) => ({
+                    ...current,
+                    name: e.target.value,
+                  }));
+                  setTextSaveStatus((current) => ({ ...current, name: "idle" }));
+                }}
+                onBlur={() => void handleTextFieldBlur("name")}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.currentTarget.querySelector("input")?.blur();
+                  } else if (event.key === "Escape") {
+                    handleTextFieldCancel("name");
                   }
-                : {},
-            }}
-          >
-            <Typography
-              variant="body1"
+                }}
+                error={textSaveStatus.name === "error"}
+                helperText={getTextSaveHelper("name")}
+                autoFocus
+                placeholder="Task name"
+                sx={taskDetailsTextFieldSx}
+              />
+            ) : (
+              <Box
+                role={isTaskDetailsEditable ? "button" : undefined}
+                tabIndex={isTaskDetailsEditable ? 0 : undefined}
+                onClick={() => handleTextFieldEdit("name")}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleTextFieldEdit("name");
+                  }
+                }}
+                sx={{
+                  cursor: isTaskDetailsEditable ? "text" : "default",
+                  borderRadius: 1,
+                  mx: -1,
+                  px: 1,
+                  py: 0.5,
+                  "&:hover": isTaskDetailsEditable
+                    ? { backgroundColor: "action.hover" }
+                    : {},
+                }}
+              >
+                <Typography variant="body2" sx={taskDetailsTextSx}>
+                  {textSaveStatus.name === "saving" ||
+                  textSaveStatus.name === "saved"
+                    ? editFormData.name.trim()
+                    : task?.user_short_title || task?.name || "Untitled task"}
+                </Typography>
+              </Box>
+            )}
+
+            <Divider sx={{ my: 2 }} />
+
+            <Box
+              sx={{ display: "flex", justifyContent: "space-between", gap: 1 }}
+            >
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                Description
+              </Typography>
+              {editingTextField !== "description" &&
+                textSaveStatus.description !== "idle" && (
+                  <Typography
+                    variant="caption"
+                    color={
+                      textSaveStatus.description === "error"
+                        ? "error.main"
+                        : "text.secondary"
+                    }
+                  >
+                    {getTextSaveHelper("description")}
+                  </Typography>
+                )}
+            </Box>
+            {editingTextField === "description" ? (
+              <TextField
+                fullWidth
+                multiline
+                minRows={4}
+                maxRows={20}
+                value={editFormData.description}
+                onChange={(e) => {
+                  setEditFormData((prev) => ({
+                    ...prev,
+                    description: e.target.value,
+                  }));
+                  setTextSaveStatus((current) => ({
+                    ...current,
+                    description: "idle",
+                  }));
+                }}
+                onBlur={() => void handleTextFieldBlur("description")}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    handleTextFieldCancel("description");
+                  }
+                }}
+                error={textSaveStatus.description === "error"}
+                helperText={getTextSaveHelper("description")}
+                placeholder="Task description"
+                sx={taskDetailsTextFieldSx}
+              />
+            ) : (
+              <Box
+                role={isTaskDetailsEditable ? "button" : undefined}
+                tabIndex={isTaskDetailsEditable ? 0 : undefined}
+                onClick={() => handleTextFieldEdit("description")}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleTextFieldEdit("description");
+                  }
+                }}
+                sx={{
+                  cursor: isTaskDetailsEditable ? "text" : "default",
+                  borderRadius: 1,
+                  mx: -1,
+                  px: 1,
+                  py: 0.5,
+                  transition: "background-color 0.15s ease",
+                  "&:hover": isTaskDetailsEditable
+                    ? {
+                        backgroundColor: "action.hover",
+                      }
+                    : {},
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    ...taskDetailsTextSx,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    overflow: "visible",
+                  }}
+                >
+                  {textSaveStatus.description === "saving" ||
+                  textSaveStatus.description === "saved"
+                    ? editFormData.description
+                    : task?.description ||
+                      task?.original_prompt ||
+                      "No description provided"}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+
+          {task?.id && (
+            <TaskAttachmentsPanel
+              taskId={task.id}
+              status={task.status as TypesSpecTaskStatus}
+            />
+          )}
+
+          {/* Share preview URLs — only meaningful once a session exists */}
+          {activeSessionId && (
+            <Box
               sx={{
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                overflow: "visible",
+                ...taskDetailsSectionSx,
+                "& > .MuiBox-root": { mb: 0 },
               }}
             >
-              {task?.description ||
-                task?.original_prompt ||
-                "No description provided"}
+              <SharePreviewSection sessionId={activeSessionId} />
+            </Box>
+          )}
+        </Box>
+
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            minWidth: 0,
+          }}
+        >
+          <Box sx={{ ...taskDetailsSectionSx, p: 1.5 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1.5 }}>
+              Task setup
             </Typography>
-          </Box>
-        )}
-      </Box>
-
-      {task?.id && (
-        <TaskAttachmentsPanel
-          taskId={task.id}
-          status={task.status as TypesSpecTaskStatus}
-        />
-      )}
-
-      <Divider sx={{ my: 2 }} />
-
-      {/* Share preview URLs — only meaningful once a session exists */}
-      {activeSessionId && (
-        <>
-          <SharePreviewSection sessionId={activeSessionId} />
-          <Divider sx={{ my: 2 }} />
-        </>
-      )}
 
       {/* Priority */}
-      <Box sx={{ mb: 4 }}>
-        {isEditMode ? (
-          <FormControl fullWidth size="small">
-            <InputLabel>Priority</InputLabel>
-            <Select
-              value={editFormData.priority}
-              onChange={(e) =>
-                setEditFormData((prev) => ({
-                  ...prev,
-                  priority: e.target.value,
-                }))
-              }
-              label="Priority"
-            >
-              <MenuItem value={TypesSpecTaskPriority.SpecTaskPriorityCritical}>
-                Critical
-              </MenuItem>
-              <MenuItem value={TypesSpecTaskPriority.SpecTaskPriorityHigh}>
-                High
-              </MenuItem>
-              <MenuItem value={TypesSpecTaskPriority.SpecTaskPriorityMedium}>
-                Medium
-              </MenuItem>
-              <MenuItem value={TypesSpecTaskPriority.SpecTaskPriorityLow}>
-                Low
-              </MenuItem>
-            </Select>
-          </FormControl>
-        ) : (
-          <>
-            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-              Priority
-            </Typography>
-            <Chip
-              label={task?.priority || "Medium"}
-              color={getPriorityColor(task?.priority)}
-              size="small"
-            />
-          </>
-        )}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Priority
+        </Typography>
+        <Chip
+          label={task?.priority || "Medium"}
+          color={getPriorityColor(task?.priority)}
+          size="small"
+        />
       </Box>
 
       {/* Labels */}
-      <Box sx={{ mb: 4 }}>
+      <Box sx={{ mb: 2 }}>
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
           Labels
         </Typography>
@@ -1439,108 +1605,40 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         />
       </Box>
 
-      <Box sx={{ mb: 4 }}>
-        {isEditMode ? (
-          <Autocomplete
-            multiple
-            options={dependencyTaskOptions}
-            value={selectedDependencyTasks}
-            onChange={(_, selectedTasks) =>
-              setEditFormData((prev) => ({
-                ...prev,
-                dependsOnTaskIds: selectedTasks
-                  .map((selectedTask) => selectedTask.id || "")
-                  .filter((dependencyTaskId) => !!dependencyTaskId),
-              }))
-            }
-            isOptionEqualToValue={(option, value) => option.id === value.id}
-            getOptionLabel={(dependencyTask) =>
-              dependencyTask.name ||
-              dependencyTask.short_title ||
-              dependencyTask.description ||
-              dependencyTask.original_prompt ||
-              dependencyTask.id ||
-              "Untitled task"
-            }
-            filterSelectedOptions
-            clearOnBlur={false}
-            renderInput={(params) => (
-              <TextField
-                {...params}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Depends on
+        </Typography>
+        {currentTaskDependencies.length > 0 ? (
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+            {currentTaskDependencies.map((dependencyTask) => (
+              <Chip
+                key={dependencyTask.id}
                 size="small"
-                label="Depends on"
-                placeholder="Search and select tasks"
+                clickable={!!dependencyTask.id && !!task?.project_id}
+                onClick={() => {
+                  if (!dependencyTask.id || !task?.project_id) {
+                    return;
+                  }
+                  account.orgNavigate("project-task-detail", {
+                    id: task.project_id,
+                    taskId: dependencyTask.id,
+                  });
+                }}
+                label={
+                  dependencyTask.name ||
+                  dependencyTask.short_title ||
+                  `Task #${dependencyTask.task_number || "?"}`
+                }
               />
-            )}
-            renderOption={(props, option) => (
-              <li {...props} key={option.id}>
-                <Box
-                  sx={{ display: "flex", flexDirection: "column", py: 0.25 }}
-                >
-                  <Typography variant="body2">
-                    {option.name ||
-                      option.short_title ||
-                      `Task #${option.task_number || "?"}`}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {`#${option.task_number || "?"} • ${option.status || "unknown"}`}
-                  </Typography>
-                </Box>
-              </li>
-            )}
-          />
+            ))}
+          </Box>
         ) : (
-          <>
-            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-              Depends on
-            </Typography>
-            {currentTaskDependencies.length > 0 ? (
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
-                {currentTaskDependencies.map((dependencyTask) => (
-                  <Chip
-                    key={dependencyTask.id}
-                    size="small"
-                    clickable={!!dependencyTask.id && !!task?.project_id}
-                    onClick={() => {
-                      if (!dependencyTask.id || !task?.project_id) {
-                        return;
-                      }
-                      account.orgNavigate("project-task-detail", {
-                        id: task.project_id,
-                        taskId: dependencyTask.id,
-                      });
-                    }}
-                    label={
-                      dependencyTask.name ||
-                      dependencyTask.short_title ||
-                      `Task #${dependencyTask.task_number || "?"}`
-                    }
-                  />
-                ))}
-              </Box>
-            ) : (
-              <Typography variant="body2" color="text.secondary">
-                No task dependencies
-              </Typography>
-            )}
-          </>
+          <Typography variant="body2" color="text.secondary">
+            No task dependencies
+          </Typography>
         )}
       </Box>
-
-      {isEditMode && (
-        <Box sx={{ mb: 4 }}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={justDoItMode}
-                onChange={(e) => setJustDoItMode(e.target.checked)}
-                size="small"
-              />
-            }
-            label="Skip planning (go straight to implementation)"
-          />
-        </Box>
-      )}
 
       {/* Agent Selection */}
       <Box sx={{ mb: 2 }}>
@@ -1555,7 +1653,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       </Box>
 
       {/* Timestamps */}
-      <Box sx={{ mt: 3 }}>
+      <Box sx={{ mt: 2 }}>
         {task?.created_by && (
           <Typography variant="caption" color="text.secondary" display="block">
             Author: {authorDisplay}
@@ -1679,17 +1777,38 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         </Box>
       )}
 
+          </Box>
+
       {/* Debug Info */}
-      <Divider sx={{ my: 2 }} />
-      <Box sx={{ mt: 2, p: 2, bgcolor: lightTheme.isLight ? "grey.100" : "grey.900", borderRadius: 1 }}>
-        <Typography
-          variant="caption"
-          color={lightTheme.isLight ? "grey.700" : "grey.400"}
-          display="block"
-          gutterBottom
+      <Box
+        component="details"
+        sx={{
+          ...taskDetailsSectionSx,
+          p: 0,
+          overflow: "hidden",
+          bgcolor: lightTheme.isLight ? "grey.50" : "grey.900",
+          "&[open] > summary": {
+            borderBottom: "1px solid",
+            borderColor: "divider",
+          },
+        }}
+      >
+        <Box
+          component="summary"
+          sx={{
+            px: 1.5,
+            py: 1.25,
+            cursor: "pointer",
+            color: "text.secondary",
+            fontSize: "0.8125rem",
+            fontWeight: 600,
+            userSelect: "none",
+            "&:hover": { color: "text.primary" },
+          }}
         >
-          Debug Information
-        </Typography>
+          Debug information
+        </Box>
+        <Box sx={{ p: 1.5 }}>
         <Typography
           variant="caption"
           color={lightTheme.isLight ? "grey.800" : "grey.300"}
@@ -1778,14 +1897,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             Render: {sessionData.config.render_node}
           </Typography>
         )}
+        </Box>
+      </Box>
 
+        <Box sx={{ ...taskDetailsSectionSx, p: 1.5 }}>
         {/* Share Design Docs */}
-        <Divider sx={{ my: 2 }} />
         <Box
           sx={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 1,
             mb: 0.5,
           }}
         >
@@ -1802,6 +1925,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             variant="outlined"
             startIcon={<Share size={14} />}
             onClick={() => setShareDialogOpen(true)}
+            sx={{ ...taskActionButtonSx, ml: "auto" }}
           >
             Share
           </Button>
@@ -1809,7 +1933,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
         {/* Move to Backlog button */}
         {canMoveToBacklog && (
-          <Box sx={{ mt: 2 }}>
+          <Box sx={{ mt: 2, display: "flex", justifyContent: "flex-end" }}>
             <Button
               size="small"
               variant="outlined"
@@ -1823,7 +1947,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
               }
               onClick={() => moveToBacklogMutation.mutate()}
               disabled={moveToBacklogMutation.isPending}
-              sx={{ fontSize: "0.75rem" }}
+              sx={taskActionButtonSx}
             >
               {moveToBacklogMutation.isPending
                 ? "Moving..."
@@ -1833,7 +1957,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         )}
 
         {/* Archive button */}
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 2, display: "flex", justifyContent: "flex-end" }}>
           <Tooltip title="Hold Shift to skip confirmation">
             <Button
               size="small"
@@ -1848,14 +1972,16 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
               }
               onClick={handleArchiveClick}
               disabled={isArchiving || task?.archived}
-              sx={{ fontSize: "0.75rem" }}
+              sx={taskActionButtonSx}
             >
               {isArchiving ? "Archiving..." : "Archive Task"}
             </Button>
           </Tooltip>
         </Box>
       </Box>
-    </>
+        </Box>
+      </Box>
+    </Box>
   );
 
   const taskChatMetadata = task?.project_id ? (
@@ -2271,42 +2397,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
                   {/* Right: Action buttons */}
                   <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
-                    {isEditMode ? (
-                      <>
-                        <Button
-                          size="small"
-                          startIcon={<CancelIcon />}
-                          onClick={handleCancelEdit}
-                          sx={{ fontSize: "0.75rem" }}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          size="small"
-                          color="secondary"
-                          startIcon={<SaveIcon />}
-                          onClick={handleSaveEdit}
-                          disabled={updateSpecTask.isPending}
-                          sx={{ fontSize: "0.75rem" }}
-                        >
-                          Save
-                        </Button>
-                      </>
-                    ) : (
-                      <>
+                    <>
                         {terminalToggleButton}
-                        {task.status ===
-                          TypesSpecTaskStatus.TaskStatusBacklog && (
-                          <Tooltip title="Edit task">
-                            <IconButton
-                              size="small"
-                              onClick={handleEditToggle}
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              <Pencil size={17} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
                         {/* Show Start button when desktop is paused */}
                         {effectiveIsDesktopPaused && (
                           <Tooltip title="Start desktop">
@@ -2412,8 +2504,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                             </IconButton>
                           </Tooltip>
                         )}
-                      </>
-                    )}
+                    </>
                     {onClose && (
                       <IconButton
                         size="small"
@@ -2480,7 +2571,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   />
                 )}
                 {currentView === "details" && (
-                  <Box sx={{ flex: 1, overflow: "auto", p: 3 }}>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      overflow: "auto",
+                      p: { xs: 1.5, sm: 2 },
+                    }}
+                  >
                     {renderDetailsContent()}
                   </Box>
                 )}
@@ -2665,41 +2762,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   flexShrink: 0,
                 }}
               >
-                {isEditMode ? (
-                  <>
-                    <Button
-                      size="small"
-                      startIcon={<CancelIcon />}
-                      onClick={handleCancelEdit}
-                      sx={{ fontSize: "0.75rem" }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="small"
-                      color="secondary"
-                      startIcon={<SaveIcon />}
-                      onClick={handleSaveEdit}
-                      disabled={updateSpecTask.isPending}
-                      sx={{ fontSize: "0.75rem" }}
-                    >
-                      Save
-                    </Button>
-                  </>
-                ) : (
-                  <>
+                <>
                     {terminalToggleButton}
-                    {task.status === TypesSpecTaskStatus.TaskStatusBacklog && (
-                      <Tooltip title="Edit task">
-                        <IconButton
-                          size="small"
-                          onClick={handleEditToggle}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          <Pencil size={17} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
                     {/* Show Start button when desktop is paused */}
                     {activeSessionId && effectiveIsDesktopPaused && (
                       <Tooltip title="Start desktop">
@@ -2781,8 +2845,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                         </IconButton>
                       </Tooltip>
                     )}
-                  </>
-                )}
+                </>
                 {onClose && (
                   <IconButton
                     size="small"
@@ -2949,7 +3012,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
             {/* Details View - mobile/no session */}
             {currentView === "details" && (
-              <Box sx={{ flex: 1, overflow: "auto", p: 3 }}>
+              <Box
+                sx={{
+                  flex: 1,
+                  overflow: "auto",
+                  p: { xs: 1.5, sm: 2 },
+                }}
+              >
                 {renderDetailsContent()}
               </Box>
             )}

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -2366,7 +2366,9 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                     px: 1,
                     pt: 1,
                     pb: 0.5,
-                    minHeight: 48,
+                    minHeight: 53,
+                    flexShrink: 0,
+                    boxSizing: "border-box",
                     borderBottom: "1px solid",
                     borderColor: "divider",
                     backgroundColor: "background.paper",
@@ -2707,11 +2709,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 px: 1,
                 pt: 1,
                 pb: 0.5,
+                minHeight: 53,
+                flexShrink: 0,
+                boxSizing: "border-box",
                 borderBottom: "1px solid",
                 borderColor: "divider",
                 backgroundColor: "background.paper",
                 gap: 0.5,
-                minHeight: "auto",
               }}
             >
               {/* Left: View toggle icons */}

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -36,13 +36,9 @@ import {
 import type { Theme } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import PlayArrow from "@mui/icons-material/PlayArrow";
-import Description from "@mui/icons-material/Description";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import StopIcon from "@mui/icons-material/Stop";
 import LaunchIcon from "@mui/icons-material/Launch";
-import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
-import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
-import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import LinkIcon from "@mui/icons-material/Link";
 import ArchiveIcon from "@mui/icons-material/Archive";
 import AccountTree from "@mui/icons-material/AccountTree";
@@ -112,6 +108,7 @@ import {
   Group as PanelGroup,
   Separator as PanelResizeHandle,
 } from "react-resizable-panels";
+import type { PanelImperativeHandle } from "react-resizable-panels";
 import useIsBigScreen from "../../hooks/useIsBigScreen";
 import useLightTheme from "../../hooks/useLightTheme";
 import { useClaudeSubscriptions } from "../account/ClaudeSubscriptionConnect";
@@ -119,13 +116,17 @@ import ClaudeSubscriptionConnect from "../account/ClaudeSubscriptionConnect";
 import { getTokenExpiryStatus } from "../account/claudeSubscriptionUtils";
 import {
   CloudUpload as CloudUploadLucide,
+  FileText,
   Files,
   SlidersHorizontal,
   GitCompare,
   Lock as LockLucide,
   LockOpen as LockOpenLucide,
   MonitorPlay,
+  MessageSquare,
   PanelBottom,
+  PanelLeft,
+  PanelRight,
   Play as PlayLucide,
   RotateCw,
   Square,
@@ -147,7 +148,17 @@ import {
 const SPEC_TASK_CHAT_PANEL_IDS = ["spec-task-chat", "spec-task-content"] as const;
 const SPEC_TASK_CHAT_LAYOUT_KEY = "helix.specTaskChat.layout";
 const taskToolbarIconButtonSx = {
+  width: 30,
+  height: 30,
+  minWidth: 30,
+  minHeight: 30,
+  p: 0.75,
+  flexShrink: 0,
   color: "text.secondary",
+  "& svg": {
+    width: 18,
+    height: 18,
+  },
   "&:hover": {
     color: "text.primary",
     backgroundColor: "action.hover",
@@ -189,6 +200,8 @@ interface SpecTaskDetailContentProps {
   padContent?: boolean;
   /** Whether tasks awaiting spec review should open the review automatically. */
   autoOpenReview?: boolean;
+  /** Replace route close with reversible content-panel collapse. */
+  allowContentCollapse?: boolean;
   onClose?: () => void;
   /** Called when user clicks "Review Spec" - if provided, opens in workspace pane instead of navigating */
   onOpenReview?: (
@@ -211,6 +224,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   taskId,
   padContent = false,
   autoOpenReview = true,
+  allowContentCollapse = false,
   onClose,
   onOpenReview,
   onTaskArchived,
@@ -237,6 +251,9 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const savedSpecTaskChatLayout = loadPanelLayout(
     SPEC_TASK_CHAT_LAYOUT_KEY,
     SPEC_TASK_CHAT_PANEL_IDS,
+  );
+  const lastExpandedContentSizeRef = useRef(
+    savedSpecTaskChatLayout?.["spec-task-content"] ?? 50,
   );
 
   // Fetch task data
@@ -328,6 +345,36 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
   // Chat panel collapse state - when true, uses mobile-style tab layout even on desktop
   const [chatCollapsed, setChatCollapsed] = useState(false);
+  const [contentCollapsed, setContentCollapsed] = useState(false);
+  const contentPanelRef = useRef<PanelImperativeHandle>(null);
+  const collapseContentAfterSplitRef = useRef(false);
+
+  const collapseContentPanel = useCallback(() => {
+    if (chatCollapsed) {
+      collapseContentAfterSplitRef.current = true;
+      setChatCollapsed(false);
+      return;
+    }
+    const currentSize = contentPanelRef.current?.getSize().asPercentage;
+    if (currentSize && currentSize > 0) {
+      lastExpandedContentSizeRef.current = currentSize;
+    }
+    contentPanelRef.current?.collapse();
+  }, [chatCollapsed]);
+
+  const showContentPanel = useCallback(() => {
+    const panel = contentPanelRef.current;
+    if (!panel) return;
+    const restoredSize = lastExpandedContentSizeRef.current || 50;
+    panel.expand();
+    panel.resize(`${restoredSize}%`);
+  }, []);
+
+  useEffect(() => {
+    if (chatCollapsed || !collapseContentAfterSplitRef.current) return;
+    collapseContentAfterSplitRef.current = false;
+    contentPanelRef.current?.collapse();
+  }, [chatCollapsed]);
 
   const [terminalDrawerState, setTerminalDrawerState] = useState(() =>
     loadSpecTaskTerminalDrawerState(taskId),
@@ -1331,31 +1378,40 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 )}
             </Box>
             {editingTextField === "name" ? (
-              <TextField
-                fullWidth
-                size="small"
-                value={editFormData.name}
-                onChange={(e) => {
-                  setEditFormData((current) => ({
-                    ...current,
-                    name: e.target.value,
-                  }));
-                  setTextSaveStatus((current) => ({ ...current, name: "idle" }));
-                }}
-                onBlur={() => void handleTextFieldBlur("name")}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.currentTarget.querySelector("input")?.blur();
-                  } else if (event.key === "Escape") {
-                    handleTextFieldCancel("name");
-                  }
-                }}
-                error={textSaveStatus.name === "error"}
-                helperText={getTextSaveHelper("name")}
-                autoFocus
-                placeholder="Task name"
-                sx={taskDetailsTextFieldSx}
-              />
+              <ClickAwayListener
+                onClickAway={() => void handleTextFieldBlur("name")}
+              >
+                <Box>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    value={editFormData.name}
+                    onChange={(e) => {
+                      setEditFormData((current) => ({
+                        ...current,
+                        name: e.target.value,
+                      }));
+                      setTextSaveStatus((current) => ({
+                        ...current,
+                        name: "idle",
+                      }));
+                    }}
+                    onBlur={() => void handleTextFieldBlur("name")}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.currentTarget.querySelector("input")?.blur();
+                      } else if (event.key === "Escape") {
+                        handleTextFieldCancel("name");
+                      }
+                    }}
+                    error={textSaveStatus.name === "error"}
+                    helperText={getTextSaveHelper("name")}
+                    autoFocus
+                    placeholder="Task name"
+                    sx={taskDetailsTextFieldSx}
+                  />
+                </Box>
+              </ClickAwayListener>
             ) : (
               <Box
                 role={isTaskDetailsEditable ? "button" : undefined}
@@ -1410,33 +1466,39 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 )}
             </Box>
             {editingTextField === "description" ? (
-              <TextField
-                fullWidth
-                multiline
-                minRows={4}
-                maxRows={20}
-                value={editFormData.description}
-                onChange={(e) => {
-                  setEditFormData((prev) => ({
-                    ...prev,
-                    description: e.target.value,
-                  }));
-                  setTextSaveStatus((current) => ({
-                    ...current,
-                    description: "idle",
-                  }));
-                }}
-                onBlur={() => void handleTextFieldBlur("description")}
-                onKeyDown={(event) => {
-                  if (event.key === "Escape") {
-                    handleTextFieldCancel("description");
-                  }
-                }}
-                error={textSaveStatus.description === "error"}
-                helperText={getTextSaveHelper("description")}
-                placeholder="Task description"
-                sx={taskDetailsTextFieldSx}
-              />
+              <ClickAwayListener
+                onClickAway={() => void handleTextFieldBlur("description")}
+              >
+                <Box>
+                  <TextField
+                    fullWidth
+                    multiline
+                    minRows={4}
+                    maxRows={20}
+                    value={editFormData.description}
+                    onChange={(e) => {
+                      setEditFormData((prev) => ({
+                        ...prev,
+                        description: e.target.value,
+                      }));
+                      setTextSaveStatus((current) => ({
+                        ...current,
+                        description: "idle",
+                      }));
+                    }}
+                    onBlur={() => void handleTextFieldBlur("description")}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape") {
+                        handleTextFieldCancel("description");
+                      }
+                    }}
+                    error={textSaveStatus.description === "error"}
+                    helperText={getTextSaveHelper("description")}
+                    placeholder="Task description"
+                    sx={taskDetailsTextFieldSx}
+                  />
+                </Box>
+              </ClickAwayListener>
             ) : (
               <Box
                 role={isTaskDetailsEditable ? "button" : undefined}
@@ -2088,14 +2150,19 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           <PanelGroup
             key="spec-task-chat-layout"
             orientation="horizontal"
-            defaultLayout={savedSpecTaskChatLayout ?? { "spec-task-chat": 30, "spec-task-content": 70 }}
-            onLayoutChange={(layout) =>
-              savePanelLayout(SPEC_TASK_CHAT_LAYOUT_KEY, layout, SPEC_TASK_CHAT_PANEL_IDS)
-            }
+            defaultLayout={savedSpecTaskChatLayout ?? { "spec-task-chat": 50, "spec-task-content": 50 }}
+            onLayoutChange={(layout) => {
+              // A collapsed panel is transient UI state; retain the last useful
+              // split so restoring or reloading does not produce a zero-width pane.
+              if (layout["spec-task-chat"] > 0 && layout["spec-task-content"] > 0) {
+                lastExpandedContentSizeRef.current = layout["spec-task-content"];
+                savePanelLayout(SPEC_TASK_CHAT_LAYOUT_KEY, layout, SPEC_TASK_CHAT_PANEL_IDS);
+              }
+            }}
             style={{ height: "100%", flex: 1 }}
           >
             {/* Left: Chat panel - always visible on desktop */}
-            <Panel id="spec-task-chat" defaultSize={30} minSize={15} style={{ overflow: "hidden" }}>
+            <Panel id="spec-task-chat" defaultSize="50%" minSize="15%" style={{ overflow: "hidden" }}>
               <Box
                 sx={{
                   height: "100%",
@@ -2147,7 +2214,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                         }}
                       >
                         <ToggleButton value="spec" disableRipple={false}>
-                          <Description sx={{ fontSize: 14, mr: 0.5 }} />
+                          <FileText size={14} style={{ marginRight: 4 }} />
                           Spec
                         </ToggleButton>
                       </ToggleButtonGroup>
@@ -2200,21 +2267,35 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       );
                     })()}
                   </Box>
-                  <Tooltip title="Collapse chat panel">
-                    <IconButton
-                      size="small"
-                      onClick={() => {
-                        setChatCollapsed(true);
-                        // Switch to desktop view when collapsing chat
-                        if (currentView === "chat") {
-                          handleViewChange("desktop");
-                        }
-                      }}
-                      sx={{ p: 0.25, flexShrink: 0 }}
-                    >
-                      <ChevronLeftIcon sx={{ fontSize: 18 }} />
-                    </IconButton>
-                  </Tooltip>
+                  {contentCollapsed ? (
+                    <Tooltip title="Show task panel">
+                      <IconButton
+                        size="small"
+                        aria-label="Show task panel"
+                        onClick={showContentPanel}
+                        sx={taskToolbarIconButtonSx}
+                      >
+                        <PanelRight size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title="Collapse chat panel">
+                      <IconButton
+                        size="small"
+                        aria-label="Collapse chat panel"
+                        onClick={() => {
+                          setChatCollapsed(true);
+                          // Switch to desktop view when collapsing chat
+                          if (currentView === "chat") {
+                            handleViewChange("desktop");
+                          }
+                        }}
+                        sx={taskToolbarIconButtonSx}
+                      >
+                        <PanelLeft size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
                 </Box>
                 <AgentChat
                   sessionId={activeSessionId}
@@ -2239,10 +2320,11 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             {/* Resize handle */}
             <PanelResizeHandle
               style={{
-                width: 6,
+                width: contentCollapsed ? 0 : 6,
                 background: lightTheme.isLight ? 'rgba(0, 0, 0, 0.06)' : 'rgba(255, 255, 255, 0.08)',
-                cursor: "col-resize",
+                cursor: contentCollapsed ? "default" : "col-resize",
                 transition: "background 0.15s",
+                overflow: "hidden",
               }}
             >
               <div
@@ -2257,7 +2339,16 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             </PanelResizeHandle>
 
             {/* Right: Content panel - switches between desktop/changes/details */}
-            <Panel id="spec-task-content" defaultSize={70} minSize={25} style={{ overflow: "hidden" }}>
+            <Panel
+              id="spec-task-content"
+              defaultSize="50%"
+              minSize="25%"
+              collapsible={allowContentCollapse}
+              collapsedSize={0}
+              panelRef={contentPanelRef}
+              onResize={(size) => setContentCollapsed(size.asPercentage === 0)}
+              style={{ overflow: "hidden" }}
+            >
               <Box
                 sx={{
                   height: "100%",
@@ -2272,9 +2363,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "space-between",
-                    px: 1.5,
-                    py: 0.75,
-                    minHeight: 40,
+                    px: 1,
+                    pt: 1,
+                    pb: 0.5,
+                    minHeight: 48,
                     borderBottom: "1px solid",
                     borderColor: "divider",
                     backgroundColor: "background.paper",
@@ -2289,9 +2381,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                     size="small"
                     sx={{
                       "& .MuiToggleButton-root": {
-                        py: 0.4,
-                        px: 0.8,
-                        minWidth: 62,
+                        width: 56,
+                        height: 40,
+                        minWidth: 56,
+                        p: 0,
                         border: "none",
                         borderRadius: "4px !important",
                         textTransform: "none",
@@ -2404,6 +2497,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           <Tooltip title="Start desktop">
                             <IconButton
                               size="small"
+                              aria-label="Start desktop"
                               onClick={handleStartSession}
                               disabled={isStarting || isDesktopStarting}
                               sx={taskToolbarIconButtonSx}
@@ -2411,7 +2505,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                               {isStarting || isDesktopStarting ? (
                                 <CircularProgress size={16} />
                               ) : (
-                                <PlayLucide size={17} />
+                                <PlayLucide size={18} />
                               )}
                             </IconButton>
                           </Tooltip>
@@ -2421,6 +2515,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           <Tooltip title="Stop desktop">
                             <IconButton
                               size="small"
+                              aria-label="Stop desktop"
                               onClick={() => setStopConfirmOpen(true)}
                               disabled={isStopping}
                               sx={taskToolbarIconButtonSx}
@@ -2428,7 +2523,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                               {isStopping ? (
                                 <CircularProgress size={16} />
                               ) : (
-                                <Square size={15} fill="currentColor" />
+                                <Square size={18} fill="currentColor" />
                               )}
                             </IconButton>
                           </Tooltip>
@@ -2438,6 +2533,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           <Tooltip title="Restart agent session">
                             <IconButton
                               size="small"
+                              aria-label="Restart agent session"
                               onClick={() => setRestartConfirmOpen(true)}
                               disabled={isRestarting}
                               sx={taskToolbarIconButtonSx}
@@ -2445,7 +2541,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                               {isRestarting ? (
                                 <CircularProgress size={16} />
                               ) : (
-                                <RotateCw size={17} />
+                                <RotateCw size={18} />
                               )}
                             </IconButton>
                           </Tooltip>
@@ -2461,15 +2557,16 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           >
                             <IconButton
                               size="small"
+                              aria-label={task.keep_alive ? "Disable keep alive" : "Enable keep alive"}
                               onClick={handleToggleKeepAlive}
                               disabled={updateSpecTask.isPending}
                               sx={taskToolbarIconButtonSx}
                               aria-pressed={task.keep_alive}
                             >
                               {task.keep_alive ? (
-                                <LockLucide size={17} />
+                                <LockLucide size={18} />
                               ) : (
-                                <LockOpenLucide size={17} />
+                                <LockOpenLucide size={18} />
                               )}
                             </IconButton>
                           </Tooltip>
@@ -2479,6 +2576,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           <Tooltip title="Upload files to sandbox">
                             <IconButton
                               size="small"
+                              aria-label="Upload files to sandbox"
                               onClick={handleUploadClick}
                               disabled={isUploading}
                               sx={taskToolbarIconButtonSx}
@@ -2486,7 +2584,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                               {isUploading ? (
                                 <CircularProgress size={16} />
                               ) : (
-                                <CloudUploadLucide size={17} />
+                                <CloudUploadLucide size={18} />
                               )}
                             </IconButton>
                           </Tooltip>
@@ -2495,6 +2593,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           <Tooltip title="More actions">
                             <IconButton
                               size="small"
+                              aria-label="More actions"
                               onClick={(event) =>
                                 setActionMenuAnchorEl(event.currentTarget)
                               }
@@ -2505,7 +2604,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           </Tooltip>
                         )}
                     </>
-                    {onClose && (
+                    {allowContentCollapse ? (
+                      <Tooltip title="Collapse task panel">
+                        <IconButton
+                          size="small"
+                          aria-label="Collapse task panel"
+                          onClick={collapseContentPanel}
+                          sx={taskToolbarIconButtonSx}
+                        >
+                          <PanelRight size={18} />
+                        </IconButton>
+                      </Tooltip>
+                    ) : onClose ? (
                       <IconButton
                         size="small"
                         onClick={onClose}
@@ -2513,7 +2623,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       >
                         <X size={18} />
                       </IconButton>
-                    )}
+                    ) : null}
                   </Box>
                 </Box>
 
@@ -2595,7 +2705,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 justifyContent: "space-between",
                 flexWrap: "wrap",
                 px: 1,
-                py: 0.5,
+                pt: 1,
+                pb: 0.5,
                 borderBottom: "1px solid",
                 borderColor: "divider",
                 backgroundColor: "background.paper",
@@ -2631,7 +2742,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 {/* Chat tab - only on mobile when there's an active session */}
                 {activeSessionId && (
                   <ToggleButton value="chat" aria-label="Chat view">
-                    <ForumOutlinedIcon sx={{ fontSize: 18 }} />
+                    <MessageSquare size={18} />
                     <Typography
                       sx={{
                         fontSize: "0.65rem",
@@ -2704,19 +2815,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 </ToggleButton>
               </ToggleButtonGroup>
 
-              {/* Restore split view button - only on desktop when chat is collapsed */}
-              {isBigScreen && chatCollapsed && (
-                <Tooltip title="Restore split view">
-                  <IconButton
-                    size="small"
-                    onClick={() => setChatCollapsed(false)}
-                    sx={{ ml: 0.5 }}
-                  >
-                    <VerticalSplitIcon sx={{ fontSize: 18 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
-
               {/* Status-specific action buttons */}
               <SpecTaskActionButtons
                 task={{
@@ -2763,12 +2861,25 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 }}
               >
                 <>
+                    {isBigScreen && chatCollapsed && (
+                      <Tooltip title="Restore split view">
+                        <IconButton
+                          size="small"
+                          aria-label="Restore split view"
+                          onClick={() => setChatCollapsed(false)}
+                          sx={taskToolbarIconButtonSx}
+                        >
+                          <PanelLeft size={18} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
                     {terminalToggleButton}
                     {/* Show Start button when desktop is paused */}
                     {activeSessionId && effectiveIsDesktopPaused && (
                       <Tooltip title="Start desktop">
                         <IconButton
                           size="small"
+                          aria-label="Start desktop"
                           onClick={handleStartSession}
                           disabled={isStarting || isDesktopStarting}
                           sx={taskToolbarIconButtonSx}
@@ -2776,7 +2887,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           {isStarting || isDesktopStarting ? (
                             <CircularProgress size={16} />
                           ) : (
-                            <PlayLucide size={17} />
+                            <PlayLucide size={18} />
                           )}
                         </IconButton>
                       </Tooltip>
@@ -2786,6 +2897,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       <Tooltip title="Stop desktop">
                         <IconButton
                           size="small"
+                          aria-label="Stop desktop"
                           onClick={() => setStopConfirmOpen(true)}
                           disabled={isStopping}
                           sx={taskToolbarIconButtonSx}
@@ -2793,7 +2905,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           {isStopping ? (
                             <CircularProgress size={16} />
                           ) : (
-                            <Square size={15} fill="currentColor" />
+                            <Square size={18} fill="currentColor" />
                           )}
                         </IconButton>
                       </Tooltip>
@@ -2803,6 +2915,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       <Tooltip title="Restart agent session">
                         <IconButton
                           size="small"
+                          aria-label="Restart agent session"
                           onClick={() => setRestartConfirmOpen(true)}
                           disabled={isRestarting}
                           sx={taskToolbarIconButtonSx}
@@ -2810,7 +2923,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           {isRestarting ? (
                             <CircularProgress size={16} />
                           ) : (
-                            <RotateCw size={17} />
+                            <RotateCw size={18} />
                           )}
                         </IconButton>
                       </Tooltip>
@@ -2820,6 +2933,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       <Tooltip title="Upload files to sandbox">
                         <IconButton
                           size="small"
+                          aria-label="Upload files to sandbox"
                           onClick={handleUploadClick}
                           disabled={isUploading}
                           sx={taskToolbarIconButtonSx}
@@ -2827,7 +2941,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           {isUploading ? (
                             <CircularProgress size={16} />
                           ) : (
-                            <CloudUploadLucide size={17} />
+                            <CloudUploadLucide size={18} />
                           )}
                         </IconButton>
                       </Tooltip>
@@ -2836,6 +2950,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       <Tooltip title="More actions">
                         <IconButton
                           size="small"
+                          aria-label="More actions"
                           onClick={(event) =>
                             setActionMenuAnchorEl(event.currentTarget)
                           }
@@ -2846,7 +2961,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       </Tooltip>
                     )}
                 </>
-                {onClose && (
+                {allowContentCollapse && isBigScreen && activeSessionId ? (
+                  <Tooltip title="Collapse task panel">
+                    <IconButton
+                      size="small"
+                      aria-label="Collapse task panel"
+                      onClick={collapseContentPanel}
+                      sx={taskToolbarIconButtonSx}
+                    >
+                      <PanelRight size={18} />
+                    </IconButton>
+                  </Tooltip>
+                ) : onClose ? (
                   <IconButton
                     size="small"
                     onClick={onClose}
@@ -2854,7 +2980,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   >
                     <X size={18} />
                   </IconButton>
-                )}
+                ) : null}
               </Box>
             </Box>
 

--- a/frontend/src/components/tasks/TaskAttachmentsPanel.tsx
+++ b/frontend/src/components/tasks/TaskAttachmentsPanel.tsx
@@ -102,11 +102,12 @@ const TaskAttachmentsPanel: FC<TaskAttachmentsPanelProps> = ({ taskId, status })
   return (
     <Box
       sx={{
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
         p: 2,
         mb: 2,
-        background: 'rgba(255,255,255,0.02)',
+        backgroundColor: 'background.paper',
       }}
     >
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
@@ -142,8 +143,7 @@ const TaskAttachmentsPanel: FC<TaskAttachmentsPanelProps> = ({ taskId, status })
                 borderRadius: 1,
                 fontSize: '0.8125rem',
                 fontWeight: 500,
-                textTransform: 'uppercase',
-                letterSpacing: '0.02857em',
+                textTransform: 'none',
                 cursor: upload.isPending || remaining <= 0 ? 'not-allowed' : 'pointer',
                 userSelect: 'none',
                 '&:hover': {

--- a/frontend/src/pages/SpecTaskDetailPage.tsx
+++ b/frontend/src/pages/SpecTaskDetailPage.tsx
@@ -166,6 +166,7 @@ const SpecTaskDetailPage: FC = () => {
           <SpecTaskDetailContent
             taskId={taskId}
             onClose={handleBack}
+            allowContentCollapse={isChatView}
             padContent
             autoOpenReview={shouldAutoOpenSpecTaskReview(route.name)}
           />

--- a/frontend/src/services/sessionService.ts
+++ b/frontend/src/services/sessionService.ts
@@ -147,6 +147,21 @@ export function useUpdateSession(sessionId: string, options?: { enabled?: boolea
   })
 }
 
+export function useRenameSession() {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ sessionId, name }: { sessionId: string; name: string }) =>
+      apiClient.v1SessionsUpdate(sessionId, { name }),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: GET_SESSION_QUERY_KEY(sessionId) })
+      queryClient.invalidateQueries({ queryKey: ["sessions"] })
+    },
+  })
+}
+
 
 // useForkSession forks the given session to a different agent.
 // On success, the parent session is paused and the child session id is


### PR DESCRIPTION
## Summary

- Add context-menu renaming for chats and spec tasks.
- Preserve unspecified session fields during partial updates.
- Support explicit spec task names without regenerating them from descriptions.
- Simplify spec task turn reconciliation and refine task detail editing.

## Testing

- Added frontend tests for chat/task renaming and context-menu behavior.
- Added API tests for partial session updates and spec task name preservation.
- Not run: full test suites and end-to-end UI verification.