### PR TITLE
feat(frontend): improve agent chat and task detail workspaces

### DIFF
--- a/frontend/src/components/apps/AppsTable.tsx
+++ b/frontend/src/components/apps/AppsTable.tsx
@@ -3,7 +3,6 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Tooltip from '@mui/material/Tooltip'
 import Chip from '@mui/material/Chip'
-import Avatar from '@mui/material/Avatar'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
@@ -33,10 +32,7 @@ import {
   isHelixOrgChartAgent,
 } from '../../utils/apps'
 
-import {
-  getUserInitials,
-  getUserAvatarUrl,
-} from '../../utils/user'
+import OrganizationUserAvatar, { resolveOrganizationUser } from '../widgets/OrganizationUserAvatar'
 
 // Import the Helix icon
 import HelixIcon from '../../../assets/img/logo.png'
@@ -62,6 +58,10 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
   const apiClient = api.getApiClient()
   const theme = useTheme()
   const account = useAccount()
+  const orgMembers = account.organizationTools.organization?.memberships || []
+  const orgMembersKey = orgMembers
+    .map((membership) => `${membership.user_id}:${membership.user?.full_name || membership.user?.username || membership.user?.email || ''}`)
+    .join('|')
   // Add state for usage data with proper typing
   const [usageData, setUsageData] = useState<{[key: string]: TypesAggregatedUsageMetric[] | null}>({})
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -225,7 +225,8 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
         </>
       ) : null
 
-      const creator = app.user?.full_name || app.user?.username || app.user?.email || 'Unknown'
+      const creatorUser = resolveOrganizationUser(app.owner, orgMembers, account.user) || app.user
+      const creator = creatorUser?.full_name || creatorUser?.username || creatorUser?.email || 'Unknown'
 
       const description = app.config.helix?.description || ''
 
@@ -387,22 +388,14 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
                 arrow
                 slotProps={{ tooltip: { sx: { bgcolor: '#222', opacity: 1 } } }}
               >
-                <Avatar
-                  src={getUserAvatarUrl(app.user)}
-                  sx={{
-                    width: 32,
-                    height: 32,
-                    fontSize: '0.875rem',
-                    fontWeight: 'bold',
-                    background: `linear-gradient(135deg, ${theme.chartGradientStart} 0%, ${theme.chartGradientEnd} 100%)`,
-                    color: '#ffffff',
-                    boxShadow: theme.palette.mode === 'dark' 
-                      ? `0 2px 8px ${theme.chartGradientStart}40`
-                      : `0 2px 8px ${theme.chartGradientStart}30`,
-                  }}
-                >
-                  {getUserInitials(app.user)}
-                </Avatar>
+                <OrganizationUserAvatar
+                  userId={app.owner}
+                  members={orgMembers}
+                  currentUser={account.user}
+                  size={32}
+                  fontSize="0.875rem"
+                  iconSize={24}
+                />
               </Tooltip>            
             </Box>
           ),
@@ -415,7 +408,9 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
     theme,
     data,
     usageData,
-    isOrgContext
+    isOrgContext,
+    orgMembersKey,
+    account.user?.id,
   ])
 
   const getActions = useCallback((app: any) => {

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import OrgAgentSessionWorkspace from './OrgAgentSessionWorkspace'
+
+const mocks = vi.hoisted(() => ({
+  isBigScreen: true,
+}))
+
+vi.mock('../../hooks/useIsBigScreen', () => ({ default: () => mocks.isBigScreen }))
+vi.mock('../../hooks/useLightTheme', () => ({ default: () => ({ isLight: true }) }))
+vi.mock('../external-agent/ExternalAgentDesktopViewer', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div>Desktop for {sessionId}</div>,
+}))
+vi.mock('react-resizable-panels', () => ({
+  Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Separator: () => <div />,
+}))
+
+describe('OrgAgentSessionWorkspace', () => {
+  beforeEach(() => {
+    mocks.isBigScreen = true
+    localStorage.clear()
+  })
+
+  it('shows chat and desktop together on larger screens', () => {
+    render(
+      <OrgAgentSessionWorkspace sessionId="session-one" organizationId="acme">
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+
+    expect(screen.getByText('Session chat')).toBeInTheDocument()
+    expect(screen.getByText('Desktop for session-one')).toBeInTheDocument()
+  })
+
+  it('lets smaller screens switch between chat and desktop', () => {
+    mocks.isBigScreen = false
+    render(
+      <OrgAgentSessionWorkspace sessionId="session-two" organizationId="acme">
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+
+    expect(screen.getByText('Session chat')).toBeInTheDocument()
+    expect(screen.queryByText('Desktop for session-two')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /desktop/i }))
+
+    expect(screen.getByText('Desktop for session-two')).toBeInTheDocument()
+    expect(screen.queryByText('Session chat')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
@@ -1,0 +1,125 @@
+import { FC, ReactNode, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined'
+import DesktopWindowsOutlinedIcon from '@mui/icons-material/DesktopWindowsOutlined'
+import {
+  Group as PanelGroup,
+  Panel,
+  Separator as PanelResizeHandle,
+} from 'react-resizable-panels'
+
+import useIsBigScreen from '../../hooks/useIsBigScreen'
+import useLightTheme from '../../hooks/useLightTheme'
+import { loadPanelLayout, savePanelLayout } from '../../lib/panelLayoutStorage'
+import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
+
+interface OrgAgentSessionWorkspaceProps {
+  sessionId: string
+  organizationId: string
+  children: ReactNode
+}
+
+type MobileView = 'chat' | 'desktop'
+
+const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
+  sessionId,
+  organizationId,
+  children,
+}) => {
+  const isBigScreen = useIsBigScreen()
+  const lightTheme = useLightTheme()
+  const [mobileView, setMobileView] = useState<MobileView>('chat')
+  const panelIds = ['org-agent-session-chat', 'org-agent-session-desktop'] as const
+  const layoutKey = organizationId ? `helix.orgAgentSession.layout.${organizationId}` : ''
+  const savedLayout = loadPanelLayout(layoutKey, panelIds)
+  const dividerColor = lightTheme.isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'
+
+  const desktop = (
+    <Box sx={{ height: '100%', minHeight: 0, minWidth: 0, display: 'flex', overflow: 'hidden' }}>
+      <ExternalAgentDesktopViewer
+        sessionId={sessionId}
+        sandboxId={sessionId}
+        mode="stream"
+      />
+    </Box>
+  )
+
+  if (!isBigScreen) {
+    return (
+      <Box sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          sx={{ px: 1.5, py: 0.75, borderBottom: `1px solid ${dividerColor}`, flexShrink: 0 }}
+        >
+          <Button
+            size="small"
+            variant={mobileView === 'chat' ? 'contained' : 'text'}
+            startIcon={<ChatOutlinedIcon />}
+            onClick={() => setMobileView('chat')}
+            sx={{ textTransform: 'none' }}
+          >
+            Chat
+          </Button>
+          <Button
+            size="small"
+            variant={mobileView === 'desktop' ? 'contained' : 'text'}
+            startIcon={<DesktopWindowsOutlinedIcon />}
+            onClick={() => setMobileView('desktop')}
+            sx={{ textTransform: 'none' }}
+          >
+            Desktop
+          </Button>
+        </Stack>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+          {mobileView === 'chat' ? children : desktop}
+        </Box>
+      </Box>
+    )
+  }
+
+  return (
+    <PanelGroup
+      id="org-agent-session-workspace"
+      orientation="horizontal"
+      defaultLayout={savedLayout ?? {
+        'org-agent-session-chat': 38,
+        'org-agent-session-desktop': 62,
+      }}
+      onLayoutChange={(layout) => savePanelLayout(layoutKey, layout, panelIds)}
+      style={{ height: '100%', width: '100%' }}
+    >
+      <Panel
+        id="org-agent-session-chat"
+        defaultSize="38%"
+        minSize="25%"
+        maxSize="70%"
+        style={{ overflow: 'hidden', minWidth: 0, minHeight: 0 }}
+      >
+        {children}
+      </Panel>
+      <PanelResizeHandle
+        id="org-agent-session-resize"
+        style={{
+          width: 6,
+          flex: '0 0 6px',
+          background: dividerColor,
+          cursor: 'col-resize',
+          outline: 'none',
+        }}
+      />
+      <Panel
+        id="org-agent-session-desktop"
+        defaultSize="62%"
+        minSize="30%"
+        style={{ overflow: 'hidden', minWidth: 0, minHeight: 0 }}
+      >
+        {desktop}
+      </Panel>
+    </PanelGroup>
+  )
+}
+
+export default OrgAgentSessionWorkspace

--- a/frontend/src/components/tasks/AssigneeSelector.tsx
+++ b/frontend/src/components/tasks/AssigneeSelector.tsx
@@ -15,14 +15,15 @@ import {
 } from '@mui/material'
 import { Search, UserX, User } from 'lucide-react'
 import { TypesOrganizationMembership, TypesUser } from '../../api/api'
+import OrganizationUserAvatar, { resolveOrganizationUser } from '../widgets/OrganizationUserAvatar'
 
 interface AssigneeSelectorProps {
   /** Currently assigned user ID (empty string or undefined for unassigned) */
   assigneeId?: string
   /** List of organization members to choose from */
   members: TypesOrganizationMembership[]
-  /** The logged-in user's ID — will be sorted to the top of the list */
-  currentUserId?: string
+  /** The logged-in user — used to resolve their avatar before memberships finish loading */
+  currentUser?: TypesUser
   /** Callback when assignee is changed */
   onAssigneeChange: (userId: string | null) => void
   /** Whether the mutation is in progress */
@@ -41,7 +42,7 @@ interface AssigneeSelectorProps {
 const AssigneeSelector: FC<AssigneeSelectorProps> = ({
   assigneeId,
   members,
-  currentUserId,
+  currentUser,
   onAssigneeChange,
   isLoading = false,
   anchorEl,
@@ -54,7 +55,7 @@ const AssigneeSelector: FC<AssigneeSelectorProps> = ({
     const query = searchQuery.trim().toLowerCase()
     const filtered = query
       ? members.filter((member) => {
-          const user = member.user as TypesUser | undefined
+          const user = resolveOrganizationUser(member.user_id, members, currentUser)
           if (!user) return false
           const name = user.full_name || user.username || ''
           const email = user.email || ''
@@ -62,29 +63,18 @@ const AssigneeSelector: FC<AssigneeSelectorProps> = ({
         })
       : members
 
-    if (!currentUserId) return filtered
+    if (!currentUser?.id) return filtered
     return [...filtered].sort((a, b) => {
-      if (a.user_id === currentUserId) return -1
-      if (b.user_id === currentUserId) return 1
+      if (a.user_id === currentUser.id) return -1
+      if (b.user_id === currentUser.id) return 1
       return 0
     })
-  }, [members, searchQuery, currentUserId])
+  }, [members, searchQuery, currentUser?.id])
 
   // Get display name for a user
   const getDisplayName = (user: TypesUser | undefined): string => {
     if (!user) return 'Unknown User'
     return user.full_name || user.username || user.email || 'Unknown User'
-  }
-
-  // Get initials for avatar
-  const getInitials = (user: TypesUser | undefined): string => {
-    if (!user) return '?'
-    const name = user.full_name || user.username || user.email || ''
-    const parts = name.split(' ')
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
-    }
-    return name.slice(0, 2).toUpperCase()
   }
 
   const handleSelect = (userId: string | null) => {
@@ -192,8 +182,8 @@ const AssigneeSelector: FC<AssigneeSelectorProps> = ({
 
           {/* Filtered members */}
           {filteredMembers.map((member) => {
-            const user = member.user as TypesUser | undefined
             const userId = member.user_id || ''
+            const user = resolveOrganizationUser(userId, members, currentUser)
             const isSelected = assigneeId === userId
 
             return (
@@ -207,16 +197,13 @@ const AssigneeSelector: FC<AssigneeSelectorProps> = ({
                 sx={{ py: 1 }}
               >
                 <ListItemAvatar sx={{ minWidth: 40 }}>
-                  <Avatar
-
-                    sx={{
-                      width: 28,
-                      height: 28,
-                      fontSize: '0.75rem',
-                    }}
-                  >
-                    {getInitials(user)}
-                  </Avatar>
+                  <OrganizationUserAvatar
+                    userId={userId}
+                    members={members}
+                    currentUser={currentUser}
+                    size={28}
+                    fontSize="0.75rem"
+                  />
                 </ListItemAvatar>
                 <ListItemText
                   primary={getDisplayName(user)}

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -7,7 +7,6 @@ import React, {
 } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Avatar,
   Box,
   Button,
   Typography,
@@ -28,8 +27,9 @@ import {
 } from "@mui/material";
 import { Add as AddIcon, AttachFile as AttachFileIcon, Close as CloseIcon, CloudUpload as CloudUploadIcon } from "@mui/icons-material";
 import { useDropzone } from "react-dropzone";
-import { ChevronDown, UserCircle2, X } from "lucide-react";
+import { ChevronDown, X } from "lucide-react";
 import AssigneeSelector from "./AssigneeSelector";
+import OrganizationUserAvatar, { resolveOrganizationUser } from "../widgets/OrganizationUserAvatar";
 import GooseRecipeSelector from "./GooseRecipeSelector";
 import { RECOMMENDED_CODING_MODELS } from "../../constants/models";
 
@@ -40,7 +40,6 @@ import {
   TypesBranchMode,
   TypesSpecTask,
   TypesSpecTaskStatus,
-  TypesUser,
 } from "../../api/api";
 import AgentDropdown from "../agent/AgentDropdown";
 import CodingAgentForm, {
@@ -221,24 +220,8 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   }, [currentUserId, assigneeTouched]);
 
   const assignedUser = useMemo(() => {
-    if (!assigneeId) return undefined;
-    const member = orgMembers.find((m) => m.user_id === assigneeId);
-    return member?.user as TypesUser | undefined;
-  }, [assigneeId, orgMembers]);
-
-  const getAssigneeDisplayName = (user: TypesUser | undefined): string => {
-    if (!user) return "Unknown user";
-    return user.full_name || user.username || user.email || "Unknown user";
-  };
-  const getAssigneeInitials = (user: TypesUser | undefined): string => {
-    if (!user) return "?";
-    const name = user.full_name || user.username || user.email || "";
-    const parts = name.split(" ");
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    }
-    return name.slice(0, 2).toUpperCase();
-  };
+    return resolveOrganizationUser(assigneeId, orgMembers, account.user);
+  }, [assigneeId, orgMembers, account.user?.id]);
 
   // Branch configuration state
   const [branchMode, setBranchMode] = useState<TypesBranchMode>(
@@ -666,16 +649,17 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>
-              {assignedUser ? (
-                <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
-                  {getAssigneeInitials(assignedUser)}
-                </Avatar>
-              ) : (
-                <UserCircle2 size={20} style={{ opacity: 0.5 }} />
-              )}
+              <OrganizationUserAvatar
+                userId={assigneeId || undefined}
+                members={orgMembers}
+                currentUser={account.user}
+                size={24}
+                fontSize="0.7rem"
+                iconSize={20}
+              />
               <Typography variant="body2" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {assignedUser
-                  ? `Assignee: ${getAssigneeDisplayName(assignedUser)}`
+                  ? `Assignee: ${assignedUser.full_name || assignedUser.username || assignedUser.email}`
                   : "Assignee: Unassigned"}
               </Typography>
             </Box>
@@ -683,7 +667,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
           <AssigneeSelector
             assigneeId={assigneeId || undefined}
             members={orgMembers}
-            currentUserId={currentUserId}
+            currentUser={account.user}
             onAssigneeChange={(userId) => {
               setAssigneeId(userId || "");
               setAssigneeTouched(true);

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -92,6 +92,8 @@ import { getUserById } from "../../services/userService";
 import CloneTaskDialog from "../specTask/CloneTaskDialog";
 import SpecTaskShareDialog from "./SpecTaskShareDialog";
 import AgentDropdown from "../agent/AgentDropdown";
+import AssigneeSelector from "./AssigneeSelector";
+import OrganizationUserAvatar, { resolveOrganizationUser } from "../widgets/OrganizationUserAvatar";
 import CloneGroupProgressFull from "../specTask/CloneGroupProgress";
 import ArchiveConfirmDialog from "./ArchiveConfirmDialog";
 import { optimisticallyMarkSessionStarting } from "../../utils/optimisticSessionStarting";
@@ -339,6 +341,9 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // Agent selection state
   const [selectedAgent, setSelectedAgent] = useState("");
   const [updatingAgent, setUpdatingAgent] = useState(false);
+  const [assigneeAnchorEl, setAssigneeAnchorEl] = useState<HTMLElement | null>(null);
+  const orgMembers = account.organizationTools.organization?.memberships || [];
+  const assignedUser = resolveOrganizationUser(task?.assignee_id, orgMembers, account.user);
 
   // Start planning state - prevents double-click
   const [isStartingPlanning, setIsStartingPlanning] = useState(false);
@@ -1017,6 +1022,24 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       }
     },
     [task?.id, selectedAgent, updatingAgent, updateSpecTask, snackbar],
+  );
+
+  const handleAssigneeChange = useCallback(
+    async (userId: string | null) => {
+      if (!task?.id || updateSpecTask.isPending) return;
+
+      try {
+        await updateSpecTask.mutateAsync({
+          taskId: task.id,
+          updates: { assignee_id: userId || "" },
+        });
+        snackbar.success(userId ? "Assignee updated" : "Task unassigned");
+      } catch (err) {
+        console.error("Failed to update assignee:", err);
+        snackbar.error("Failed to update assignee");
+      }
+    },
+    [task?.id, updateSpecTask.isPending, updateSpecTask, snackbar],
   );
 
   const handleTextFieldEdit = (field: TaskTextField) => {
@@ -1784,6 +1807,51 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             No task dependencies
           </Typography>
         )}
+      </Box>
+
+      {/* Assignee */}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Assignee
+        </Typography>
+        <Button
+          variant="outlined"
+          fullWidth
+          disabled={updateSpecTask.isPending || !isTaskDetailsEditable}
+          onClick={(event) => setAssigneeAnchorEl(event.currentTarget)}
+          sx={{
+            justifyContent: "flex-start",
+            textTransform: "none",
+            color: "text.primary",
+            minHeight: 40,
+            px: 1.25,
+            gap: 1,
+          }}
+        >
+          <OrganizationUserAvatar
+            userId={task?.assignee_id}
+            members={orgMembers}
+            currentUser={account.user}
+            size={24}
+            fontSize="0.7rem"
+            iconSize={20}
+          />
+          <Typography variant="body2" noWrap>
+            {assignedUser?.full_name ||
+              assignedUser?.username ||
+              assignedUser?.email ||
+              "Unassigned"}
+          </Typography>
+        </Button>
+        <AssigneeSelector
+          assigneeId={task?.assignee_id}
+          members={orgMembers}
+          currentUser={account.user}
+          onAssigneeChange={handleAssigneeChange}
+          isLoading={updateSpecTask.isPending}
+          anchorEl={assigneeAnchorEl}
+          onClose={() => setAssigneeAnchorEl(null)}
+        />
       </Box>
 
       {/* Agent Selection */}

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1283,6 +1283,49 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     onTaskArchived,
   ]);
 
+  const renderTaskActions = (variant: "inline" | "stacked") => {
+    if (!task) return null;
+
+    return (
+      <SpecTaskActionButtons
+        task={{
+          id: task.id || "",
+          status: task.status || "",
+          design_docs_pushed_at: task.design_docs_pushed_at,
+          repo_pull_requests: task.repo_pull_requests,
+          base_branch: task.base_branch,
+          branch_name: task.branch_name,
+          archived: task.archived,
+          just_do_it_mode: justDoItMode,
+          planning_session_id: task.planning_session_id,
+          metadata: task.metadata as { error?: string },
+          last_push_at: task.last_push_at,
+        }}
+        variant={variant}
+        onStartPlanning={handleStartPlanning}
+        onReviewSpec={handleReviewSpec}
+        onReject={(shiftKey) => {
+          if (shiftKey) {
+            performArchive();
+          } else {
+            setArchiveConfirmOpen(true);
+          }
+        }}
+        hasExternalRepo={projectRepositories.some(
+          (repository) =>
+            repository.is_external ||
+            repository.external_type ||
+            repository.external_url,
+        )}
+        externalRepoType={projectRepositories.find(
+          (repository) => repository.external_type,
+        )?.external_type}
+        isStartingPlanning={isStartingPlanning}
+        isArchiving={isArchiving}
+      />
+    );
+  };
+
   // Render the details content (used in both desktop left panel and mobile/no-session view)
   const renderDetailsContent = () => (
     <Box sx={{ containerType: "inline-size", maxWidth: 1180, mx: "auto" }}>
@@ -1333,6 +1376,47 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             This task has been archived
           </Typography>
         </Alert>
+      )}
+
+      {!activeSessionId && task?.status === "backlog" && (
+        <Box
+          sx={{
+            ...taskDetailsSectionSx,
+            mb: 2,
+            p: { xs: 2, sm: 2.5 },
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: { xs: "stretch", sm: "center" },
+            justifyContent: "space-between",
+            gap: 2,
+            borderColor: "warning.main",
+            backgroundColor: "action.hover",
+          }}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              {justDoItMode ? "Ready for implementation" : "Ready for planning"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {justDoItMode
+                ? "Launch the selected agent to begin implementing this task."
+                : "Start a planning session to turn this task into an implementation-ready spec."}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              width: { xs: "100%", sm: 240 },
+              flexShrink: 0,
+              "& .MuiButton-root": {
+                minHeight: 40,
+                fontWeight: 600,
+                textTransform: "none",
+              },
+            }}
+          >
+            {renderTaskActions("stacked")}
+          </Box>
+        </Box>
       )}
 
       <Box
@@ -2455,37 +2539,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   </ToggleButtonGroup>
 
                   {/* Status-specific action buttons */}
-                  <SpecTaskActionButtons
-                    task={{
-                      id: task.id || "",
-                      status: task.status || "",
-                      design_docs_pushed_at: task.design_docs_pushed_at,
-                      repo_pull_requests: task.repo_pull_requests,
-                      base_branch: task.base_branch,
-                      branch_name: task.branch_name,
-                      archived: task.archived,
-                      just_do_it_mode: justDoItMode,
-                      planning_session_id: task.planning_session_id,
-                      metadata: task.metadata as { error?: string },
-                      last_push_at: task.last_push_at,
-                    }}
-                    variant="inline"
-                    onStartPlanning={handleStartPlanning}
-                    onReviewSpec={handleReviewSpec}
-                    onReject={(shiftKey) => {
-                      if (shiftKey) {
-                        performArchive();
-                      } else {
-                        setArchiveConfirmOpen(true);
-                      }
-                    }}
-                    hasExternalRepo={projectRepositories.some(
-                      (r) => r.is_external || r.external_type || r.external_url,
-                    )}
-                    externalRepoType={projectRepositories.find((r) => r.external_type)?.external_type}
-                    isStartingPlanning={isStartingPlanning}
-                    isArchiving={isArchiving}
-                  />
+                  {renderTaskActions("inline")}
 
                   {/* Spacer */}
                   <Box sx={{ flex: 1 }} />
@@ -2699,9 +2753,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         ) : (
           <>
             {/* Mobile layout OR no active session: single view at a time */}
-            {/* View toggle header for mobile/no-session */}
-            <Box
-              sx={{
+            {/* A toolbar is useful only when there are multiple session views. */}
+            {activeSessionId && (
+              <Box
+                sx={{
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "space-between",
@@ -2716,8 +2771,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 borderColor: "divider",
                 backgroundColor: "background.paper",
                 gap: 0.5,
-              }}
-            >
+                }}
+              >
               {/* Left: View toggle icons */}
               <ToggleButtonGroup
                 value={currentView}
@@ -2820,37 +2875,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
               </ToggleButtonGroup>
 
               {/* Status-specific action buttons */}
-              <SpecTaskActionButtons
-                task={{
-                  id: task.id || "",
-                  status: task.status || "",
-                  design_docs_pushed_at: task.design_docs_pushed_at,
-                  repo_pull_requests: task.repo_pull_requests,
-                  base_branch: task.base_branch,
-                  branch_name: task.branch_name,
-                  archived: task.archived,
-                  just_do_it_mode: justDoItMode,
-                  planning_session_id: task.planning_session_id,
-                  metadata: task.metadata as { error?: string },
-                  last_push_at: task.last_push_at,
-                }}
-                variant="inline"
-                onStartPlanning={handleStartPlanning}
-                onReviewSpec={handleReviewSpec}
-                onReject={(shiftKey) => {
-                  if (shiftKey) {
-                    performArchive();
-                  } else {
-                    setArchiveConfirmOpen(true);
-                  }
-                }}
-                hasExternalRepo={projectRepositories.some(
-                  (r) => r.is_external || r.external_type || r.external_url,
-                )}
-                externalRepoType={projectRepositories.find((r) => r.external_type)?.external_type}
-                isStartingPlanning={isStartingPlanning}
-                isArchiving={isArchiving}
-              />
+              {renderTaskActions("inline")}
 
               {/* Spacer - hidden on very small screens to allow wrapping */}
               <Box sx={{ flex: 1, minWidth: { xs: 0, sm: 8 } }} />
@@ -2986,7 +3011,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   </IconButton>
                 ) : null}
               </Box>
-            </Box>
+              </Box>
+            )}
 
             {/* Chat View - mobile only */}
             {activeSessionId && currentView === "chat" && (

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1092,7 +1092,7 @@ function TaskCardInner({
         <AssigneeSelector
           assigneeId={task.assignee_id}
           members={orgMembers}
-          currentUserId={account.user?.id}
+          currentUser={account.user}
           onAssigneeChange={handleAssigneeChange}
           isLoading={updateSpecTask.isPending}
           anchorEl={assigneeAnchorEl}

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -4,8 +4,6 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import Box from '@mui/material/Box'
-import Alert from '@mui/material/Alert'
-import AlertTitle from '@mui/material/AlertTitle'
 
 import SendIcon from '@mui/icons-material/Send'
 
@@ -23,7 +21,6 @@ import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useAccount from '../hooks/useAccount'
 import { useTheme } from '@mui/material/styles'
-import Tooltip from '@mui/material/Tooltip'
 import SimpleConfirmWindow from '../components/widgets/SimpleConfirmWindow'
 import { useGetSession, useUpdateSession, useGetSessionIdleStatus } from '../services/sessionService'
 
@@ -36,7 +33,7 @@ import {
   IShareSessionInstructions,
 } from '../types'
 
-import { TypesMessageContentType, TypesMessage, TypesStepInfo, TypesSession, TypesInteractionState } from '../api/api'
+import { TypesAgentType, TypesMessageContentType, TypesMessage, TypesStepInfo, TypesSession, TypesInteractionState } from '../api/api'
 
 import { useStreaming } from '../contexts/streaming'
 
@@ -48,9 +45,6 @@ import useSubscriptionGate from '../hooks/useSubscriptionGate'
 import Paywall from '../components/subscription/Paywall'
 import AdvancedModelPicker from '../components/create/AdvancedModelPicker'
 import { useListSessionSteps } from '../services/sessionService'
-import PlayArrow from '@mui/icons-material/PlayArrow'
-import CircularProgress from '@mui/material/CircularProgress'
-import StopIcon from '@mui/icons-material/Stop'
 import { useGetConfig } from '../services/userService'
 import RobustPromptInput from '../components/common/RobustPromptInput'
 import Page from '../components/system/Page'
@@ -62,46 +56,7 @@ import {
   resolveChatTurnAssistantPreview,
 } from '../components/session/ChatTurnNavigator.logic'
 import { splitSystemPrefix } from '../components/session/CollapsibleSystemPrefix'
-
-// Hook to track sandbox/desktop state for external agent sessions
-const useSandboxState = (sessionId: string) => {
-  const api = useApi();
-  const [sandboxState, setSandboxState] = React.useState<string>('loading');
-
-  const isRunning = sandboxState === 'running' || sandboxState === 'resumable';
-  const isStarting = sandboxState === 'starting' || sandboxState === 'loading';
-  // Only show paused state when truly absent (not loading or starting)
-  const isPaused = sandboxState === 'absent';
-
-  return { sandboxState, isRunning, isPaused, isStarting };
-};
-
-// Desktop controls component - only shows Stop button when running
-const DesktopControls: React.FC<{
-  sessionId: string,
-  onStop: () => void,
-  isStopping: boolean
-}> = ({ sessionId, onStop, isStopping }) => {
-  const { isRunning } = useSandboxState(sessionId);
-
-  // Only show Stop button when desktop is running
-  if (isRunning) {
-    return (
-      <Button
-        variant="outlined"
-        size="small"
-        color="warning"
-        startIcon={isStopping ? <CircularProgress size={16} /> : <StopIcon />}
-        onClick={onStop}
-        disabled={isStopping}
-      >
-        {isStopping ? 'Stopping...' : 'Stop'}
-      </Button>
-    );
-  }
-
-  return null;
-};
+import OrgAgentSessionWorkspace from '../components/helix-org/OrgAgentSessionWorkspace'
 
 // Add new interfaces for virtualization
 interface IInteractionBlock {
@@ -292,10 +247,9 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
   const [feedbackValue, setFeedbackValue] = useState('')
   const [appID, setAppID] = useState<string | null>(null)
   const [assistantID, setAssistantID] = useState<string | null>(null)
-  const [showRDPViewer, setShowRDPViewer] = useState(false)
-  const [isExternalAgent, setIsExternalAgent] = useState(false)
-  const [rdpViewerHeight, setRdpViewerHeight] = useState(300)
   const [filterMap, setFilterMap] = useState<Record<string, string>>({})
+
+  const isExternalAgent = session?.data?.config?.agent_type === TypesAgentType.AgentTypeZedExternal
 
   const [visibleBlocks, setVisibleBlocks] = useState<IInteractionBlock[]>([])
   const [blockHeights, setBlockHeights] = useState<Record<string, number>>({})
@@ -1539,7 +1493,14 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
       showDrawerButton={true}
       disableContentScroll={true}
     >
-      {sessionContent}
+      {isExternalAgent ? (
+        <OrgAgentSessionWorkspace
+          sessionId={session.data.id || sessionID}
+          organizationId={(router.params.org_id as string) || session.data.organization_id || ''}
+        >
+          {sessionContent}
+        </OrgAgentSessionWorkspace>
+      ) : sessionContent}
     </Page>
   )
 }

--- a/frontend/src/utils/user.test.ts
+++ b/frontend/src/utils/user.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { getUserInitials } from './user'
+
+describe('getUserInitials', () => {
+  it('uses the first and last name initials when a full name is available', () => {
+    expect(getUserInitials({ full_name: 'Test User', email: 'test@helix.ml' })).toBe('TU')
+  })
+
+  it('uses email for resolved users without a profile name', () => {
+    expect(getUserInitials({ email: 'test@helix.ml' })).toBe('T')
+  })
+
+  it('uses a question mark only when the user is unresolved', () => {
+    expect(getUserInitials()).toBe('?')
+  })
+})

--- a/frontend/src/utils/user.ts
+++ b/frontend/src/utils/user.ts
@@ -1,8 +1,8 @@
 /**
  * Generates user initials for avatar display
- * Priority: full_name first letters, then username first letter
+ * Priority: full_name first letters, then username, then email
  */
-export const getUserInitials = (user?: { full_name?: string; username?: string }): string => {
+export const getUserInitials = (user?: { full_name?: string; username?: string; email?: string }): string => {
   if (!user) return '?'
   
   // If full_name is set, take first letters of first and last name
@@ -19,6 +19,10 @@ export const getUserInitials = (user?: { full_name?: string; username?: string }
   if (user.username && user.username.trim()) {
     return user.username[0].toUpperCase()
   }
+
+  if (user.email && user.email.trim()) {
+    return user.email[0].toUpperCase()
+  }
   
   return '?'
 }
@@ -26,9 +30,9 @@ export const getUserInitials = (user?: { full_name?: string; username?: string }
 /**
  * Gets the avatar URL for a user, with fallback to initials
  */
-export const getUserAvatarUrl = (user?: { avatar?: string; full_name?: string; username?: string }): string | undefined => {
+export const getUserAvatarUrl = (user?: { avatar?: string; full_name?: string; username?: string; email?: string }): string | undefined => {
   if (user?.avatar) {
     return user.avatar
   }
   return undefined
-} 
+}


### PR DESCRIPTION
## Summary

- show the live desktop beside org-agent session chats, with a persisted resizable desktop layout and mobile Chat/Desktop tabs
- remove the redundant Details-only toolbar from spec tasks without active sessions and move the primary workflow action into a contextual card
- use the shared organization-user avatar for agent creators and task assignees, including email-only user initials
- show the current assignee in task setup and allow reassignment or unassignment

## Why

Org-agent session links opened a chat-only legacy page even though the same agent session owns a desktop. Backlog task detail pages also used a toolbar for a single Details view and put the primary workflow action in that detached toolbar. Task ownership was visible on cards but absent from task details, and email-only accounts rendered as unknown avatars even after the user had resolved.

## Impact

Users can monitor and interact with an org agent's desktop while chatting. Backlog tasks present their next workflow action in context, and task setup now exposes editable ownership. Agent creators and task assignees use one consistent avatar resolver across tables, cards, forms, chat, and task details.

## Validation

- `cd frontend && yarn tsc`
- `cd frontend && yarn build`
- `cd frontend && yarn vitest run src/utils/user.test.ts src/components/widgets/OrganizationUserAvatar.test.ts src/components/helix-org/OrgAgentSessionWorkspace.test.tsx src/components/helix-org/HelixOrgChatPanel.test.tsx src/components/tasks/SpecTaskLaunchWindow.test.tsx`
- live browser verification of the supplied org-agent session, agents, and spec-task URLs at desktop and mobile widths
- opened the task assignee picker without mutating the supplied task and confirmed email-only users no longer render as `?`