### PR TITLE
fix(frontend): show GitHub topic events

### DIFF
--- a/api/pkg/org/domain/streaming/inbound.go
+++ b/api/pkg/org/domain/streaming/inbound.go
@@ -42,6 +42,7 @@ type InboundState struct {
 	WebhookID      int64
 	WebhookHTMLURL string
 	Active         bool
+	Events         []string
 	PayloadURL     string
 	Detail         string
 }

--- a/api/pkg/org/infrastructure/transports/github/webhook_provisioner.go
+++ b/api/pkg/org/infrastructure/transports/github/webhook_provisioner.go
@@ -150,6 +150,7 @@ func (p *WebhookProvisioner) Status(ctx context.Context, orgID string, topic str
 		WebhookID:      hook.ID,
 		WebhookHTMLURL: githubclient.WebhookSettingsURL(owner, repoName, hook.ID),
 		Active:         hook.Active,
+		Events:         hook.Events,
 		PayloadURL:     payloadURL,
 	}, nil
 }

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -143,6 +143,18 @@ func decode(t *testing.T, rec *httptest.ResponseRecorder, dst any) {
 	}
 }
 
+type fakeInbound struct {
+	state streaming.InboundState
+}
+
+func (f fakeInbound) Install(context.Context, string, streaming.Topic) (streaming.InstallResult, error) {
+	return streaming.InstallResult{}, nil
+}
+
+func (f fakeInbound) Status(context.Context, string, streaming.Topic) (streaming.InboundState, error) {
+	return f.state, nil
+}
+
 // seedBot creates a Bot row directly in the store with the given id +
 // content. Mirrors what a create would persist, without the lifecycle
 // cascade — tests that just need a row to read/edit use this.
@@ -466,6 +478,40 @@ func TestPostGitHubWebhook_RoutesToInboundHandler(t *testing.T) {
 	}
 	if rec.Code < 200 || rec.Code >= 300 {
 		t.Fatalf("status: got %d, want 2xx; body=%s", rec.Code, rec.Body)
+	}
+}
+
+func TestGetGitHubWebhookStatus_IncludesLiveEvents(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	topic, err := streaming.NewTopic(
+		"s-gh-events", "github events", "", "b-owner", time.Now().UTC(),
+		transport.Transport{Kind: transport.KindGitHub, Config: json.RawMessage(`{"repo":"helixml/helix","events":["issues"]}`)},
+		"org-test",
+	)
+	if err != nil {
+		t.Fatalf("new topic: %v", err)
+	}
+	if err := st.Topics.Create(ctx, topic); err != nil {
+		t.Fatalf("seed topic: %v", err)
+	}
+	deps.Topics = topics.New(topics.Deps{
+		Topics: st.Topics,
+		Provisioners: map[transport.Kind]streaming.Inbound{
+			transport.KindGitHub: fakeInbound{state: streaming.InboundState{
+				State: "installed", Events: []string{"pull_request"},
+			}},
+		},
+	})
+
+	rec := do(t, orgapi.Handler(deps), http.MethodGet, "/topics/s-gh-events/github/webhook-status", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	var got orgapi.GitHubWebhookStatusResponse
+	decode(t, rec, &got)
+	if len(got.Events) != 1 || got.Events[0] != "pull_request" {
+		t.Fatalf("events = %v, want live [pull_request]", got.Events)
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/github.go
+++ b/api/pkg/org/interfaces/server/api/github.go
@@ -268,11 +268,12 @@ type GitHubWebhookStatusResponse struct {
 	//   "missing"   — GitHub was reachable and has no such webhook (needs install)
 	//   "unknown"   — couldn't determine (no repo / no public URL / no creds /
 	//                 GitHub error); see Detail. The UI falls back to stored state.
-	State          string `json:"state"`
-	WebhookID      int64  `json:"webhook_id,omitempty"`
-	WebhookHTMLURL string `json:"webhook_html_url,omitempty"`
-	Active         bool   `json:"active,omitempty"`
-	PayloadURL     string `json:"payload_url,omitempty"`
+	State          string   `json:"state"`
+	WebhookID      int64    `json:"webhook_id,omitempty"`
+	WebhookHTMLURL string   `json:"webhook_html_url,omitempty"`
+	Active         bool     `json:"active,omitempty"`
+	Events         []string `json:"events,omitempty"`
+	PayloadURL     string   `json:"payload_url,omitempty"`
 	// Detail explains a "unknown" state (and is empty otherwise).
 	Detail string `json:"detail,omitempty"`
 }
@@ -395,6 +396,7 @@ func (a *apiHandler) getGitHubWebhookStatus(w http.ResponseWriter, r *http.Reque
 		WebhookID:      res.WebhookID,
 		WebhookHTMLURL: res.WebhookHTMLURL,
 		Active:         res.Active,
+		Events:         res.Events,
 		PayloadURL:     res.PayloadURL,
 		Detail:         res.Detail,
 	})

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -23964,6 +23964,12 @@ const docTemplate = `{
                     "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
                     "type": "string"
                 },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "payload_url": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -23960,6 +23960,12 @@
                     "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
                     "type": "string"
                 },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "payload_url": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -463,6 +463,10 @@ definitions:
       detail:
         description: Detail explains a "unknown" state (and is empty otherwise).
         type: string
+      events:
+        items:
+          type: string
+        type: array
       payload_url:
         type: string
       state:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -322,6 +322,7 @@ export interface ApiGitHubWebhookStatusResponse {
   active?: boolean;
   /** Detail explains a "unknown" state (and is empty otherwise). */
   detail?: string;
+  events?: string[];
   payload_url?: string;
   /**
    * State is one of:

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -10,7 +10,7 @@ import useSnackbar from '../../hooks/useSnackbar'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
 import { useHelixOrgTopic, useUpdateHelixOrgTopic } from '../../services/helixOrgService'
-import { ClearTopicMessagesButton, TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
+import { ClearTopicMessagesButton, GitHubWebhookStatus, TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
 import HelixOrgOverviewCard from './HelixOrgOverviewCard'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 
@@ -77,6 +77,12 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
             }}
             onCancel={onClose}
           />
+          {topic.kind === 'github' && (
+            <GitHubWebhookStatus
+              topic={topic}
+              orgSlug={router.params.org_id as string | undefined}
+            />
+          )}
           <Stack direction="row" justifyContent="flex-end">
             <ClearTopicMessagesButton topic={topic} />
           </Stack>

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -534,7 +534,7 @@ const SettingsLink: FC<{ orgSlug?: string }> = ({ orgSlug }) => {
   )
 }
 
-const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ topic, orgSlug }) => {
+export const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ topic, orgSlug }) => {
   const snackbar = useSnackbar()
   const install = useInstallGitHubWebhook()
   // Live truth from GitHub: does a webhook for this topic's payload URL
@@ -640,6 +640,14 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ topic, orgSlug }) =
             Webhook registered on <strong>{cfg.repo}</strong>{webhookId ? <> (id <code>{webhookId}</code>)</> : null}.
             {active ? ' Deliveries flow into this topic automatically.' : ' ⚠ It is currently disabled on GitHub, so no deliveries arrive — re-install to re-enable.'}
           </Typography>
+          {live?.state === 'installed' && live.events && live.events.length > 0 && (
+            <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Typography variant="caption" color="text.secondary">GitHub events:</Typography>
+              {live.events.map((event) => (
+                <Chip key={event} label={event} size="small" variant="outlined" sx={{ fontFamily: 'monospace' }} />
+              ))}
+            </Stack>
+          )}
           <Stack direction="row" spacing={1} alignItems="center">
             {webhookHtmlUrl && (
               <Button

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -463,6 +463,10 @@ definitions:
       detail:
         description: Detail explains a "unknown" state (and is empty otherwise).
         type: string
+      events:
+        items:
+          type: string
+        type: array
       payload_url:
         type: string
       state:

--- a/openapi.json
+++ b/openapi.json
@@ -28666,6 +28666,12 @@
                         "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
                         "type": "string"
                     },
+                    "events": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "payload_url": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -23960,6 +23960,12 @@
                     "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
                     "type": "string"
                 },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "payload_url": {
                     "type": "string"
                 },


### PR DESCRIPTION
## Summary
- carry live GitHub webhook events through the topic status API
- show subscribed events on the topic detail page and chart drawer
- avoid presenting stale stored topic config as live GitHub state

## Tests
- `cd api && go test ./pkg/org/infrastructure/transports/github ./pkg/org/interfaces/server/api -count=1`
- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `./stack update_openapi`
- `cd frontend && yarn build`
- standalone Playwright verification of full detail and chart drawer