### PR TITLE
feat(org): add durable agent activation delivery

### DIFF
--- a/api/pkg/org/application/dispatch/dispatcher.go
+++ b/api/pkg/org/application/dispatch/dispatcher.go
@@ -46,10 +46,14 @@ import (
 // embedded Queue and focuses on the event-side fan-out.
 type Dispatcher struct {
 	store           *store.Store
-	queue           *activation.Queue
+	queue           ActivationQueue
 	logger          *slog.Logger
 	outbound        map[transport.Kind]streaming.Outbound
 	processorRunner ProcessorRunner
+}
+
+type ActivationQueue interface {
+	Enqueue(orgID string, agentID orgchart.NodeID, trigger activation.Trigger)
 }
 
 // ProcessorRunner is the late-bound execution arm that turns an Event
@@ -93,6 +97,14 @@ func (d *Dispatcher) RegisterOutbound(kind transport.Kind, e streaming.Outbound)
 // processor fan-out no-ops.
 func (d *Dispatcher) RegisterProcessorRunner(r ProcessorRunner) {
 	d.processorRunner = r
+}
+
+// RegisterActivationQueue replaces the in-memory activation queue. Production
+// uses this to install restart-safe delivery without changing dispatch callers.
+func (d *Dispatcher) RegisterActivationQueue(q ActivationQueue) {
+	if q != nil {
+		d.queue = q
+	}
 }
 
 // DispatchHire fires a hire-time activation for a freshly-created AI

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -60,6 +60,8 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	t.Parallel()
 	st := memory.New()
 	svc := newHireService(st)
+	cleaner := &recordingAgentDeliveryCleaner{}
+	svc.AgentDelivery = cleaner
 	ctx := context.Background()
 
 	boss, _ := orgchart.NewNode("w-boss", "# Eng", nil, hireClock(), "org-test")
@@ -78,6 +80,9 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	}
 	if res.Node.AgentID != "app-agent" {
 		t.Fatalf("agent app id = %q, want app-agent", res.Node.AgentID)
+	}
+	if !cleaner.restored || cleaner.orgID != "org-test" || cleaner.agentID != "w-new" {
+		t.Fatalf("agent delivery was not restored for recreated worker")
 	}
 	if _, err := st.Nodes.Get(ctx, "org-test", "w-new"); err != nil {
 		t.Fatalf("bot not persisted: %v", err)

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -97,14 +97,20 @@ type OrgReconciler interface {
 	Reconcile(ctx context.Context, orgID string) error
 }
 
+type AgentDeliveryLifecycle interface {
+	CleanupAgent(ctx context.Context, orgID string, agentID orgchart.NodeID) error
+	RestoreAgent(orgID string, agentID orgchart.NodeID)
+}
+
 // Service composes the node-lifecycle operations the REST/MCP layers
 // drive. All fields are required; pass nil HelixRuntime only in tests
 // that don't need the Helix-side teardown.
 type Service struct {
-	Store  *store.Store
-	Helix  HelixRuntime
-	Agents AgentCreator
-	Logger *slog.Logger
+	Store         *store.Store
+	Helix         HelixRuntime
+	Agents        AgentCreator
+	Logger        *slog.Logger
+	AgentDelivery AgentDeliveryLifecycle
 
 	// Nodes is the node-mutation service Create delegates the row creation
 	// to, so the base-tool union and id minting are shared with the
@@ -305,6 +311,9 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		}
 	}
 
+	if s.AgentDelivery != nil {
+		s.AgentDelivery.RestoreAgent(orgID, id)
+	}
 	if p.DeferActivation {
 		return CreateResult{Node: node}, nil
 	}
@@ -392,7 +401,7 @@ func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
 // events themselves are intentionally left behind as an audit trail; only
 // the Topic row is dropped. A configured Helix project is not node-owned and
 // survives deletion; only its reference to the deleted default agent is unset.
-func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) error {
+func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) (err error) {
 	if id == "" {
 		return errors.New("node id is empty")
 	}
@@ -402,6 +411,16 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 	node, err := s.Store.Nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return fmt.Errorf("get node %q: %w", id, err)
+	}
+	if s.AgentDelivery != nil {
+		if err := s.AgentDelivery.CleanupAgent(ctx, orgID, id); err != nil {
+			return fmt.Errorf("cleanup agent delivery %q: %w", id, err)
+		}
+		defer func() {
+			if err != nil {
+				s.AgentDelivery.RestoreAgent(orgID, id)
+			}
+		}()
 	}
 
 	// Capture the deleted Node's managers AND reports BEFORE deletion: the

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -2,6 +2,7 @@ package lifecycle_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -15,6 +16,24 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/transport"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 )
+
+type recordingAgentDeliveryCleaner struct {
+	orgID    string
+	agentID  orgchart.NodeID
+	restored bool
+}
+
+func (c *recordingAgentDeliveryCleaner) CleanupAgent(_ context.Context, orgID string, agentID orgchart.NodeID) error {
+	c.orgID = orgID
+	c.agentID = agentID
+	return nil
+}
+
+func (c *recordingAgentDeliveryCleaner) RestoreAgent(orgID string, agentID orgchart.NodeID) {
+	c.orgID = orgID
+	c.agentID = agentID
+	c.restored = true
+}
 
 // TestDelete_RemovesBotsTranscript pins the regression behind "we still
 // see s-transcript-w-ai-1 and s-transcript-w-test-ai even though those
@@ -312,6 +331,49 @@ func TestDelete_Guards(t *testing.T) {
 	}
 	if err := (&lifecycle.Service{}).Delete(ctx, "org", "b-x"); err == nil {
 		t.Fatal("nil store should error")
+	}
+}
+
+func TestDelete_CleansUpAgentDelivery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orggorm.GetOrgTestDB(t)
+	const orgID = "org-delete-delivery"
+	seedBot(t, st, orgID, "w-delete")
+
+	cleaner := &recordingAgentDeliveryCleaner{}
+	if err := (&lifecycle.Service{Store: st, AgentDelivery: cleaner}).Delete(ctx, orgID, "w-delete"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if cleaner.orgID != orgID || cleaner.agentID != "w-delete" {
+		t.Fatalf("cleaned delivery for (%q, %q), want (%q, %q)", cleaner.orgID, cleaner.agentID, orgID, "w-delete")
+	}
+}
+
+func TestDelete_RestoresAgentDeliveryWhenRuntimeDeleteFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orggorm.GetOrgTestDB(t)
+	const orgID = "org-delete-delivery-failure"
+	bot, err := orgchart.NewNode("w-delete", "# w-delete", nil, time.Now().UTC(), orgID)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+	bot.AgentID = "app-delete"
+	if err := st.Nodes.Create(ctx, bot); err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
+
+	cleaner := &recordingAgentDeliveryCleaner{}
+	svc := &lifecycle.Service{Store: st, Helix: &lifecycleRuntime{linkedErr: errors.New("delete failed")}, AgentDelivery: cleaner}
+	if err := svc.Delete(ctx, orgID, bot.ID); err == nil {
+		t.Fatal("Delete should fail")
+	}
+	if !cleaner.restored {
+		t.Fatal("agent delivery was not restored after failed deletion")
+	}
+	if _, err := st.Nodes.Get(ctx, orgID, bot.ID); err != nil {
+		t.Fatalf("bot should survive failed deletion: %v", err)
 	}
 }
 

--- a/api/pkg/org/infrastructure/agentdelivery/queue.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue.go
@@ -37,6 +37,7 @@ type Queue struct {
 	logger  *slog.Logger
 	mu      sync.Mutex
 	active  map[string]struct{}
+	removed map[string]struct{}
 	publish map[string]*sync.Mutex
 }
 
@@ -48,7 +49,7 @@ func New(ctx context.Context, provider pubsub.DurablePubSub, spawn activation.Sp
 		return nil, err
 	}
 	queueCtx, cancel := context.WithCancel(ctx)
-	return &Queue{ctx: queueCtx, cancel: cancel, pubsub: provider, spawn: spawn, logger: logger, active: map[string]struct{}{}, publish: map[string]*sync.Mutex{}}, nil
+	return &Queue{ctx: queueCtx, cancel: cancel, pubsub: provider, spawn: spawn, logger: logger, active: map[string]struct{}{}, removed: map[string]struct{}{}, publish: map[string]*sync.Mutex{}}, nil
 }
 
 func (q *Queue) Close() { q.cancel() }
@@ -76,6 +77,12 @@ func (q *Queue) Enqueue(orgID string, agentID orgchart.NodeID, trigger activatio
 	lock := q.publishLock(name)
 	lock.Lock()
 	defer lock.Unlock()
+	q.mu.Lock()
+	_, removed := q.removed[name]
+	q.mu.Unlock()
+	if removed {
+		return
+	}
 	if err := q.consume(name, subject); err != nil {
 		q.logger.Error("agent delivery: consume", "agent", agentID, "err", err)
 		return
@@ -88,6 +95,43 @@ func (q *Queue) Enqueue(orgID string, agentID orgchart.NodeID, trigger activatio
 	if err := q.pubsub.PublishDurable(q.ctx, streamName, subject, payload); err != nil {
 		q.logger.Error("agent delivery: publish", "agent", agentID, "err", err)
 	}
+}
+
+func (q *Queue) CleanupAgent(ctx context.Context, orgID string, agentID orgchart.NodeID) error {
+	name := consumerName(orgID, agentID)
+	lock := q.publishLock(name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	q.mu.Lock()
+	q.removed[name] = struct{}{}
+	q.mu.Unlock()
+	if err := q.pubsub.DeleteDurableConsumer(ctx, streamName, name); err != nil {
+		q.mu.Lock()
+		delete(q.removed, name)
+		q.mu.Unlock()
+		return err
+	}
+	q.mu.Lock()
+	delete(q.active, name)
+	q.mu.Unlock()
+	if err := q.pubsub.PurgeDurableSubject(ctx, streamName, subjectFor(orgID, agentID)); err != nil {
+		q.mu.Lock()
+		delete(q.removed, name)
+		q.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (q *Queue) RestoreAgent(orgID string, agentID orgchart.NodeID) {
+	name := consumerName(orgID, agentID)
+	lock := q.publishLock(name)
+	lock.Lock()
+	defer lock.Unlock()
+	q.mu.Lock()
+	delete(q.removed, name)
+	q.mu.Unlock()
 }
 
 func (q *Queue) publishLock(name string) *sync.Mutex {

--- a/api/pkg/org/infrastructure/agentdelivery/queue.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue.go
@@ -1,0 +1,166 @@
+package agentdelivery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/pubsub"
+)
+
+const (
+	streamName    = "HELIX_ORG_AGENT_ACTIVATIONS"
+	subjectPrefix = "helix-org.agent-activations"
+)
+
+type envelope struct {
+	OrganizationID string             `json:"organization_id"`
+	AgentID        orgchart.NodeID    `json:"agent_id"`
+	Trigger        activation.Trigger `json:"trigger"`
+}
+
+// Queue persists one message per agent activation. Each agent has a durable
+// pull consumer with one outstanding message, preserving FIFO independently
+// of every other agent.
+type Queue struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	pubsub  pubsub.DurablePubSub
+	spawn   activation.Spawn
+	logger  *slog.Logger
+	mu      sync.Mutex
+	active  map[string]struct{}
+	publish map[string]*sync.Mutex
+}
+
+func New(ctx context.Context, provider pubsub.DurablePubSub, spawn activation.Spawn, logger *slog.Logger) (*Queue, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := provider.EnsurePersistentStream(ctx, streamName, []string{subjectPrefix + ".>"}); err != nil {
+		return nil, err
+	}
+	queueCtx, cancel := context.WithCancel(ctx)
+	return &Queue{ctx: queueCtx, cancel: cancel, pubsub: provider, spawn: spawn, logger: logger, active: map[string]struct{}{}, publish: map[string]*sync.Mutex{}}, nil
+}
+
+func (q *Queue) Close() { q.cancel() }
+
+// Start resumes every durable agent consumer left by an earlier API process.
+func (q *Queue) Start() error {
+	consumers, err := q.pubsub.ListDurableConsumers(q.ctx, streamName)
+	if err != nil {
+		return err
+	}
+	for _, consumer := range consumers {
+		if err := q.consume(consumer.Name, consumer.Subject); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (q *Queue) Enqueue(orgID string, agentID orgchart.NodeID, trigger activation.Trigger) {
+	if q.spawn == nil {
+		return
+	}
+	subject := subjectFor(orgID, agentID)
+	name := consumerName(orgID, agentID)
+	lock := q.publishLock(name)
+	lock.Lock()
+	defer lock.Unlock()
+	if err := q.consume(name, subject); err != nil {
+		q.logger.Error("agent delivery: consume", "agent", agentID, "err", err)
+		return
+	}
+	payload, err := json.Marshal(envelope{OrganizationID: orgID, AgentID: agentID, Trigger: trigger})
+	if err != nil {
+		q.logger.Error("agent delivery: marshal", "agent", agentID, "err", err)
+		return
+	}
+	if err := q.pubsub.PublishDurable(q.ctx, streamName, subject, payload); err != nil {
+		q.logger.Error("agent delivery: publish", "agent", agentID, "err", err)
+	}
+}
+
+func (q *Queue) publishLock(name string) *sync.Mutex {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if lock, ok := q.publish[name]; ok {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	q.publish[name] = lock
+	return lock
+}
+
+func (q *Queue) consume(name, subject string) error {
+	q.mu.Lock()
+	if _, ok := q.active[name]; ok {
+		q.mu.Unlock()
+		return nil
+	}
+	q.active[name] = struct{}{}
+	q.mu.Unlock()
+
+	_, err := q.pubsub.ConsumeDurable(q.ctx, streamName, name, subject, 30*time.Minute, func(msg *pubsub.Message) error {
+		q.handle(msg)
+		return nil
+	})
+	if err != nil {
+		q.mu.Lock()
+		delete(q.active, name)
+		q.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (q *Queue) handle(msg *pubsub.Message) {
+	var delivery envelope
+	if err := json.Unmarshal(msg.Data, &delivery); err != nil {
+		q.logger.Error("agent delivery: decode", "err", err)
+		_ = msg.NakWithDelay(time.Second)
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				_ = msg.InProgress()
+			case <-done:
+				return
+			}
+		}
+	}()
+	err := q.spawn(context.Background(), delivery.OrganizationID, delivery.AgentID, []activation.Trigger{delivery.Trigger})
+	close(done)
+	if err != nil {
+		q.logger.Warn("agent delivery: activation failed", "agent", delivery.AgentID, "err", err)
+		_ = msg.NakWithDelay(time.Second)
+		return
+	}
+	if err := msg.Ack(); err != nil {
+		q.logger.Error("agent delivery: ack", "agent", delivery.AgentID, "err", err)
+	}
+}
+
+func subjectFor(orgID string, agentID orgchart.NodeID) string {
+	encode := base64.RawURLEncoding.EncodeToString
+	return subjectPrefix + "." + encode([]byte(orgID)) + "." + encode([]byte(agentID))
+}
+
+func consumerName(orgID string, agentID orgchart.NodeID) string {
+	sum := sha256.Sum256([]byte(orgID + "\x00" + string(agentID)))
+	return "helix-org-agent-" + hex.EncodeToString(sum[:16])
+}

--- a/api/pkg/org/infrastructure/agentdelivery/queue_test.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue_test.go
@@ -74,3 +74,46 @@ func TestQueueFansOutPerAgent(t *testing.T) {
 	}
 	require.Equal(t, map[string]bool{"agent-a": true, "agent-b": true}, got)
 }
+
+func TestQueueCleanupAgentRemovesConsumerAndPendingMessages(t *testing.T) {
+	n, err := pubsub.NewInMemoryNats()
+	require.NoError(t, err)
+	defer n.Close()
+
+	seen := make(chan string, 1)
+	q, err := New(context.Background(), n, func(_ context.Context, _ string, _ orgchart.NodeID, triggers []activation.Trigger) error {
+		seen <- triggers[0].EventID
+		return errors.New("retry")
+	}, nil)
+	require.NoError(t, err)
+	defer q.Close()
+
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "old"})
+	require.Equal(t, "old", <-seen)
+	require.NoError(t, q.CleanupAgent(context.Background(), "org-test", "agent-a"))
+
+	consumers, err := n.ListDurableConsumers(context.Background(), streamName)
+	require.NoError(t, err)
+	require.Empty(t, consumers)
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "ignored"})
+	consumers, err = n.ListDurableConsumers(context.Background(), streamName)
+	require.NoError(t, err)
+	require.Empty(t, consumers)
+
+	received := make(chan string, 1)
+	sub, err := n.ConsumeDurable(context.Background(), streamName, "probe", subjectFor("org-test", "agent-a"), time.Second, func(msg *pubsub.Message) error {
+		received <- string(msg.Data)
+		return msg.Ack()
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+	require.NoError(t, n.PublishDurable(context.Background(), streamName, subjectFor("org-test", "agent-a"), []byte("new")))
+	require.Equal(t, "new", <-received)
+	require.NoError(t, sub.Unsubscribe())
+	require.NoError(t, n.DeleteDurableConsumer(context.Background(), streamName, "probe"))
+	require.NoError(t, n.PurgeDurableSubject(context.Background(), streamName, subjectFor("org-test", "agent-a")))
+
+	q.RestoreAgent("org-test", "agent-a")
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerHire, EventID: "recreated"})
+	require.Equal(t, "recreated", <-seen)
+}

--- a/api/pkg/org/infrastructure/agentdelivery/queue_test.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue_test.go
@@ -1,0 +1,76 @@
+package agentdelivery
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueRetriesFailedActivation(t *testing.T) {
+	n, err := pubsub.NewInMemoryNats()
+	require.NoError(t, err)
+	defer n.Close()
+
+	var mu sync.Mutex
+	attempts := 0
+	completed := make(chan struct{})
+	q, err := New(context.Background(), n, func(context.Context, string, orgchart.NodeID, []activation.Trigger) error {
+		mu.Lock()
+		defer mu.Unlock()
+		attempts++
+		if attempts == 1 {
+			return errors.New("transient")
+		}
+		close(completed)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	defer q.Close()
+
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "e-1"})
+	select {
+	case <-completed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("activation was not retried")
+	}
+
+	mu.Lock()
+	require.Equal(t, 2, attempts)
+	mu.Unlock()
+}
+
+func TestQueueFansOutPerAgent(t *testing.T) {
+	n, err := pubsub.NewInMemoryNats()
+	require.NoError(t, err)
+	defer n.Close()
+
+	seen := make(chan string, 2)
+	q, err := New(context.Background(), n, func(_ context.Context, _ string, agentID orgchart.NodeID, _ []activation.Trigger) error {
+		seen <- string(agentID)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	defer q.Close()
+
+	trigger := activation.Trigger{Kind: activation.TriggerEvent, EventID: "e-1"}
+	q.Enqueue("org-test", "agent-a", trigger)
+	q.Enqueue("org-test", "agent-b", trigger)
+
+	got := map[string]bool{}
+	for range 2 {
+		select {
+		case id := <-seen:
+			got[id] = true
+		case <-time.After(5 * time.Second):
+			t.Fatal("one of the subscribed agents did not activate")
+		}
+	}
+	require.Equal(t, map[string]bool{"agent-a": true, "agent-b": true}, got)
+}

--- a/api/pkg/pubsub/durable.go
+++ b/api/pkg/pubsub/durable.go
@@ -1,0 +1,109 @@
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/rs/zerolog/log"
+)
+
+func (n *Nats) EnsurePersistentStream(ctx context.Context, name string, subjects []string) error {
+	_, err := n.js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      name,
+		Subjects:  subjects,
+		Retention: jetstream.WorkQueuePolicy,
+		Discard:   jetstream.DiscardOld,
+		Storage:   jetstream.FileStorage,
+	})
+	if err != nil {
+		return fmt.Errorf("ensure persistent stream %q: %w", name, err)
+	}
+	return nil
+}
+
+func (n *Nats) PublishDurable(ctx context.Context, stream, subject string, payload []byte) error {
+	if _, err := n.js.Publish(ctx, subject, payload, jetstream.WithExpectStream(stream)); err != nil {
+		return fmt.Errorf("publish to persistent stream %q: %w", stream, err)
+	}
+	return nil
+}
+
+func (n *Nats) ConsumeDurable(ctx context.Context, streamName, consumerName, subject string, ackWait time.Duration, handler func(msg *Message) error) (Subscription, error) {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		return nil, fmt.Errorf("get persistent stream %q: %w", streamName, err)
+	}
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Name:          consumerName,
+		Durable:       consumerName,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       ackWait,
+		MaxAckPending: 1,
+		FilterSubject: subject,
+		ReplayPolicy:  jetstream.ReplayInstantPolicy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ensure durable consumer %q: %w", consumerName, err)
+	}
+	messages, err := consumer.Messages(jetstream.PullMaxMessages(1))
+	if err != nil {
+		return nil, fmt.Errorf("open durable consumer %q: %w", consumerName, err)
+	}
+	sub := &durableSubscription{messages: messages, done: make(chan struct{})}
+	go func() {
+		select {
+		case <-ctx.Done():
+			sub.Unsubscribe()
+		case <-sub.done:
+		}
+	}()
+	go func() {
+		defer sub.Unsubscribe()
+		for {
+			msg, err := messages.Next()
+			if err != nil {
+				if ctx.Err() == nil {
+					log.Error().Err(err).Str("consumer", consumerName).Msg("durable consumer stopped")
+				}
+				return
+			}
+			if err := handler(&Message{Data: msg.Data(), Header: msg.Headers(), msg: msg}); err != nil {
+				log.Error().Err(err).Str("consumer", consumerName).Msg("durable consumer handler failed")
+			}
+		}
+	}()
+	return sub, nil
+}
+
+func (n *Nats) ListDurableConsumers(ctx context.Context, streamName string) ([]DurableConsumer, error) {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		return nil, fmt.Errorf("get persistent stream %q: %w", streamName, err)
+	}
+	list := stream.ListConsumers(ctx)
+	consumers := make([]DurableConsumer, 0)
+	for info := range list.Info() {
+		consumers = append(consumers, DurableConsumer{Name: info.Name, Subject: info.Config.FilterSubject})
+	}
+	if err := list.Err(); err != nil {
+		return nil, fmt.Errorf("list durable consumers for %q: %w", streamName, err)
+	}
+	return consumers, nil
+}
+
+type durableSubscription struct {
+	messages jetstream.MessagesContext
+	done     chan struct{}
+	once     sync.Once
+}
+
+func (s *durableSubscription) Unsubscribe() error {
+	s.once.Do(func() {
+		close(s.done)
+		s.messages.Stop()
+	})
+	return nil
+}

--- a/api/pkg/pubsub/durable.go
+++ b/api/pkg/pubsub/durable.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -92,6 +93,28 @@ func (n *Nats) ListDurableConsumers(ctx context.Context, streamName string) ([]D
 		return nil, fmt.Errorf("list durable consumers for %q: %w", streamName, err)
 	}
 	return consumers, nil
+}
+
+func (n *Nats) DeleteDurableConsumer(ctx context.Context, streamName, consumerName string) error {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		return fmt.Errorf("get persistent stream %q: %w", streamName, err)
+	}
+	if err := stream.DeleteConsumer(ctx, consumerName); err != nil && !errors.Is(err, jetstream.ErrConsumerNotFound) {
+		return fmt.Errorf("delete durable consumer %q: %w", consumerName, err)
+	}
+	return nil
+}
+
+func (n *Nats) PurgeDurableSubject(ctx context.Context, streamName, subject string) error {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		return fmt.Errorf("get persistent stream %q: %w", streamName, err)
+	}
+	if err := stream.Purge(ctx, jetstream.WithPurgeSubject(subject)); err != nil {
+		return fmt.Errorf("purge durable subject %q: %w", subject, err)
+	}
+	return nil
 }
 
 type durableSubscription struct {

--- a/api/pkg/pubsub/durable_test.go
+++ b/api/pkg/pubsub/durable_test.go
@@ -1,0 +1,102 @@
+package pubsub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurableConsumerRedeliversNak(t *testing.T) {
+	n, cleanup := setupTestNats(t)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, n.EnsurePersistentStream(ctx, "DURABLE_REDELIVERY", []string{"durable.redelivery.*"}))
+	deliveries := make(chan []byte, 2)
+	attempts := 0
+	sub, err := n.ConsumeDurable(ctx, "DURABLE_REDELIVERY", "worker-one", "durable.redelivery.one", time.Second, func(msg *Message) error {
+		attempts++
+		deliveries <- msg.Data
+		if attempts == 1 {
+			return msg.Nak()
+		}
+		return msg.Ack()
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+	require.NoError(t, n.PublishDurable(ctx, "DURABLE_REDELIVERY", "durable.redelivery.one", []byte("hello")))
+
+	require.Equal(t, []byte("hello"), <-deliveries)
+	require.Equal(t, []byte("hello"), <-deliveries)
+
+	stream, err := n.js.Stream(ctx, "DURABLE_REDELIVERY")
+	require.NoError(t, err)
+	streamInfo, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.Equal(t, jetstream.FileStorage, streamInfo.Config.Storage)
+	require.Zero(t, streamInfo.Config.MaxAge)
+	consumer, err := stream.Consumer(ctx, "worker-one")
+	require.NoError(t, err)
+	consumerInfo, err := consumer.Info(ctx)
+	require.NoError(t, err)
+	require.Equal(t, jetstream.AckExplicitPolicy, consumerInfo.Config.AckPolicy)
+	require.Equal(t, "durable.redelivery.one", consumerInfo.Config.FilterSubject)
+	require.Equal(t, 1, consumerInfo.Config.MaxAckPending)
+	require.Zero(t, consumerInfo.Config.InactiveThreshold)
+}
+
+func TestDurableConsumerSurvivesServerRestart(t *testing.T) {
+	storeDir := t.TempDir()
+	serverPort, websocketPort, err := getRandomPorts()
+	require.NoError(t, err)
+	cfg := durableTestConfig(storeDir, serverPort, websocketPort)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	first, err := NewNats(cfg)
+	require.NoError(t, err)
+	require.NoError(t, first.EnsurePersistentStream(ctx, "DURABLE_RESTART", []string{"durable.restart.*"}))
+	sub, err := first.ConsumeDurable(ctx, "DURABLE_RESTART", "worker-one", "durable.restart.one", time.Second, func(*Message) error { return nil })
+	require.NoError(t, err)
+	require.NoError(t, sub.Unsubscribe())
+	require.NoError(t, first.PublishDurable(ctx, "DURABLE_RESTART", "durable.restart.one", []byte("persisted")))
+	stopTestNats(first)
+
+	second, err := NewNats(cfg)
+	require.NoError(t, err)
+	defer stopTestNats(second)
+	consumers, err := second.ListDurableConsumers(ctx, "DURABLE_RESTART")
+	require.NoError(t, err)
+	require.Equal(t, []DurableConsumer{{Name: "worker-one", Subject: "durable.restart.one"}}, consumers)
+	received := make(chan []byte, 1)
+	sub, err = second.ConsumeDurable(ctx, "DURABLE_RESTART", "worker-one", "durable.restart.one", time.Second, func(msg *Message) error {
+		received <- msg.Data
+		return msg.Ack()
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+	require.Equal(t, []byte("persisted"), <-received)
+}
+
+func durableTestConfig(storeDir string, serverPort, websocketPort int) *config.ServerConfig {
+	cfg := &config.ServerConfig{}
+	cfg.PubSub.StoreDir = storeDir
+	cfg.PubSub.Server.Host = "127.0.0.1"
+	cfg.PubSub.Server.Port = serverPort
+	cfg.PubSub.Server.WebsocketPort = websocketPort
+	cfg.PubSub.Server.JetStream = true
+	cfg.PubSub.Server.MaxPayload = 32 * 1024 * 1024
+	cfg.PubSub.Server.EmbeddedNatsServerEnabled = true
+	return cfg
+}
+
+func stopTestNats(n *Nats) {
+	n.conn.Close()
+	n.embeddedServer.Shutdown()
+	n.embeddedServer.WaitForShutdown()
+}

--- a/api/pkg/pubsub/pubsub.go
+++ b/api/pkg/pubsub/pubsub.go
@@ -32,6 +32,8 @@ type DurablePubSub interface {
 	PublishDurable(ctx context.Context, stream, subject string, payload []byte) error
 	ConsumeDurable(ctx context.Context, stream, consumer, subject string, ackWait time.Duration, handler func(msg *Message) error) (Subscription, error)
 	ListDurableConsumers(ctx context.Context, stream string) ([]DurableConsumer, error)
+	DeleteDurableConsumer(ctx context.Context, stream, consumer string) error
+	PurgeDurableSubject(ctx context.Context, stream, subject string) error
 }
 
 type DurableConsumer struct {

--- a/api/pkg/pubsub/pubsub.go
+++ b/api/pkg/pubsub/pubsub.go
@@ -27,6 +27,18 @@ type PubSub interface {
 	OnConnectionStatus(handler ConnectionStatusHandler)
 }
 
+type DurablePubSub interface {
+	EnsurePersistentStream(ctx context.Context, name string, subjects []string) error
+	PublishDurable(ctx context.Context, stream, subject string, payload []byte) error
+	ConsumeDurable(ctx context.Context, stream, consumer, subject string, ackWait time.Duration, handler func(msg *Message) error) (Subscription, error)
+	ListDurableConsumers(ctx context.Context, stream string) ([]DurableConsumer, error)
+}
+
+type DurableConsumer struct {
+	Name    string
+	Subject string
+}
+
 type Message struct {
 	Type   string
 	Reply  string
@@ -39,6 +51,8 @@ type Message struct {
 type acker interface {
 	Ack() error
 	Nak() error
+	NakWithDelay(time.Duration) error
+	InProgress() error
 }
 
 // natsMsgWrapper is used to wrap nats msg to ensure
@@ -55,6 +69,14 @@ func (a *natsMsgWrapper) Nak() error {
 	return a.msg.Nak()
 }
 
+func (a *natsMsgWrapper) NakWithDelay(delay time.Duration) error {
+	return a.msg.NakWithDelay(delay)
+}
+
+func (a *natsMsgWrapper) InProgress() error {
+	return a.msg.InProgress()
+}
+
 // Ack acknowledges a message
 // This tells the server that the message was successfully processed and it can move on to the next message
 func (m *Message) Ack() error {
@@ -65,6 +87,14 @@ func (m *Message) Ack() error {
 // This tells the server to redeliver the message
 func (m *Message) Nak() error {
 	return m.msg.Nak()
+}
+
+func (m *Message) NakWithDelay(delay time.Duration) error {
+	return m.msg.NakWithDelay(delay)
+}
+
+func (m *Message) InProgress() error {
+	return m.msg.InProgress()
 }
 
 type Subscription interface {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -684,6 +684,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 		Now:           deps.Now,
 	})
 	dispatcher := dispatch.New(st, spawnerFn, logger)
+	var agentDelivery lifecycle.AgentDeliveryLifecycle
 	if provider, ok := cfg.APIServer.pubsub.(pubsub.DurablePubSub); ok {
 		durableQueue, err := agentdelivery.New(ctx, provider, activation.Spawn(spawnerFn), logger)
 		if err != nil {
@@ -693,6 +694,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 			return nil, fmt.Errorf("start durable agent delivery: %w", err)
 		}
 		dispatcher.RegisterActivationQueue(durableQueue)
+		agentDelivery = durableQueue
 	}
 	// Outbound webhook delivery is a transport concern, not the
 	// dispatcher's: register the webhook emitter so KindWebhook topics
@@ -757,10 +759,11 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	// runtime port is satisfied by the same in-process adapter every
 	// other Helix call goes through.
 	lifecycleSvc := &lifecycle.Service{
-		Store:  st,
-		Helix:  inProcClient,
-		Agents: inProcClient,
-		Logger: logger,
+		Store:         st,
+		Helix:         inProcClient,
+		Agents:        inProcClient,
+		Logger:        logger,
+		AgentDelivery: agentDelivery,
 		// Node-scoped reconcilers: the single topology reconciler (one owner
 		// of activation/team Topic lifecycle across create, reparent, and delete).
 		NodeReconcilers: []lifecycle.NodeReconciler{deps.Reconciler},

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -40,6 +40,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/credential"
 	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/agentdelivery"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/assetssh"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
@@ -305,7 +306,7 @@ func buildOrgServices(st *helixorgstore.Store, deps *mcptools.Config, bc *wakebu
 // plus the long-lived stream-cron and Socket Mode goroutines. Every
 // org-shaped route + lifecycle hook lives here.
 func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRouter, authRouter *mux.Router) error {
-	orgHandlers, err := initHelixOrgHandler(helixOrgConfig{
+	orgHandlers, err := initHelixOrgHandler(ctx, helixOrgConfig{
 		LocalFSPath: s.Cfg.FileStore.LocalFSPath,
 		APIServer:   s,
 	}, s.Store)
@@ -432,7 +433,7 @@ func (s *HelixAPIServer) registerHelixOrgAuthenticatedRoutes(authRouter *mux.Rou
 	)
 }
 
-func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*helixOrgHandlers, error) {
+func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore helixstore.Store) (*helixOrgHandlers, error) {
 	if cfg.APIServer == nil {
 		log.Warn().Msg("helix-org disabled: no HelixAPIServer threaded into helixOrgConfig")
 		return nil, nil
@@ -683,6 +684,16 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Now:           deps.Now,
 	})
 	dispatcher := dispatch.New(st, spawnerFn, logger)
+	if provider, ok := cfg.APIServer.pubsub.(pubsub.DurablePubSub); ok {
+		durableQueue, err := agentdelivery.New(ctx, provider, activation.Spawn(spawnerFn), logger)
+		if err != nil {
+			return nil, fmt.Errorf("init durable agent delivery: %w", err)
+		}
+		if err := durableQueue.Start(); err != nil {
+			return nil, fmt.Errorf("start durable agent delivery: %w", err)
+		}
+		dispatcher.RegisterActivationQueue(durableQueue)
+	}
 	// Outbound webhook delivery is a transport concern, not the
 	// dispatcher's: register the webhook emitter so KindWebhook topics
 	// POST their events. Slack/email emitters register the same way.


### PR DESCRIPTION
## Summary

- Add a durable JetStream stream for org agent activations.
- Use one explicit-ack durable consumer per subscribed agent with one in-flight message, preserving per-agent FIFO and fan-out semantics.
- Retry failed activations with NAK and refresh long-running leases with InProgress.
- Restore durable consumers after API restart and stop them with the server lifecycle context.
- Add JetStream redelivery/restart tests and agent fan-out/retry tests.

## Verification

- `go test ./pkg/org/...`
- `go test ./pkg/org/infrastructure/agentdelivery ./pkg/org/application/dispatch ./pkg/pubsub ./pkg/server`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`

## Known follow-up

This PR does not close the Postgres event append -> JetStream publish crash window. `Publishing` still appends the event before dispatch; a JetStream outage after append can leave a persisted event without a durable activation record. A transactional outbox or reconciliation worker is required before claiming complete end-to-end reliable delivery.
