### PR TITLE
fix(api): surface agent inference errors instead of returning empty 200

### DIFF
--- a/api/pkg/controller/inference_agent.go
+++ b/api/pkg/controller/inference_agent.go
@@ -341,22 +341,51 @@ func (c *Controller) getLLMModelConfig(ctx context.Context, owner, provider, mod
 	}, nil
 }
 
+// collectAgentResponse drains an agent session, accumulating its text until the
+// agent signals End.
+//
+// An Error response is returned as an error rather than dropped. Dropping it
+// meant a failed inference produced HTTP 200 with an empty assistant message —
+// so a provider outage read as "the model said nothing", and a 429 surfaced as
+// an integration test asserting on an empty string instead of a legible error.
+//
+// The drain continues to End even after an error, because the agent still emits
+// it; abandoning the channel early would leave the producer blocked on a send
+// nobody reads.
+func collectAgentResponse(next func() agent.Response) (string, error) {
+	var (
+		response strings.Builder
+		agentErr error
+	)
+
+	for {
+		out := next()
+
+		switch out.Type {
+		case agent.ResponseTypePartialText:
+			response.WriteString(out.Content)
+		case agent.ResponseTypeError:
+			if agentErr == nil {
+				agentErr = fmt.Errorf("agent error: %s", out.Content)
+			}
+		case agent.ResponseTypeEnd:
+			if agentErr != nil {
+				return "", agentErr
+			}
+			return response.String(), nil
+		}
+	}
+}
+
 func (c *Controller) runAgentBlocking(ctx context.Context, req *runAgentRequest) (*openai.ChatCompletionResponse, error) {
 	session, ragAccumulator, err := c.runAgent(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	var response string
-	for {
-		out := session.Out()
-
-		if out.Type == agent.ResponseTypePartialText {
-			response += out.Content
-		}
-		if out.Type == agent.ResponseTypeEnd {
-			break
-		}
+	response, err := collectAgentResponse(session.Out)
+	if err != nil {
+		return nil, err
 	}
 
 	// Update session metadata with accumulated RAG results for citation rendering

--- a/api/pkg/controller/inference_agent_collect_test.go
+++ b/api/pkg/controller/inference_agent_collect_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/agent"
+)
+
+// responder replays a fixed sequence of agent responses, then blocks the way a
+// real session would if the drain loop asked for more than the agent sent.
+func responder(t *testing.T, responses ...agent.Response) func() agent.Response {
+	t.Helper()
+
+	i := 0
+	return func() agent.Response {
+		if i >= len(responses) {
+			t.Fatalf("drain loop read past the end of the agent's output (%d responses)", len(responses))
+		}
+		r := responses[i]
+		i++
+		return r
+	}
+}
+
+func TestCollectAgentResponse_AccumulatesText(t *testing.T) {
+	got, err := collectAgentResponse(responder(t,
+		agent.Response{Type: agent.ResponseTypePartialText, Content: "The Porsche "},
+		agent.Response{Type: agent.ResponseTypePartialText, Content: "is black"},
+		agent.Response{Type: agent.ResponseTypeEnd},
+	))
+
+	require.NoError(t, err)
+	assert.Equal(t, "The Porsche is black", got)
+}
+
+// The regression: an agent error was dropped on the floor, so a failed
+// inference returned an empty string and no error. Callers turned that into
+// HTTP 200 with an empty assistant message, which is how a provider 429 reached
+// CI as `"" does not contain "black"` instead of the actual cause.
+func TestCollectAgentResponse_SurfacesAgentError(t *testing.T) {
+	_, err := collectAgentResponse(responder(t,
+		agent.Response{Type: agent.ResponseTypeError, Content: "429 Too Many Requests: You have no credits remaining"},
+		agent.Response{Type: agent.ResponseTypeEnd},
+	))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no credits remaining")
+}
+
+// Partial output before a failure must not be passed off as a complete answer.
+func TestCollectAgentResponse_DiscardsPartialTextOnError(t *testing.T) {
+	got, err := collectAgentResponse(responder(t,
+		agent.Response{Type: agent.ResponseTypePartialText, Content: "The Porsche is "},
+		agent.Response{Type: agent.ResponseTypeError, Content: "upstream exploded"},
+		agent.Response{Type: agent.ResponseTypeEnd},
+	))
+
+	require.Error(t, err)
+	assert.Empty(t, got, "a truncated answer must not be returned as if it were complete")
+}
+
+// The first error is the useful one; later ones are usually fallout.
+func TestCollectAgentResponse_ReportsFirstError(t *testing.T) {
+	_, err := collectAgentResponse(responder(t,
+		agent.Response{Type: agent.ResponseTypeError, Content: "first failure"},
+		agent.Response{Type: agent.ResponseTypeError, Content: "second failure"},
+		agent.Response{Type: agent.ResponseTypeEnd},
+	))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "first failure")
+	assert.NotContains(t, err.Error(), "second failure")
+}
+
+// The loop must keep reading to End even after an error, or the agent goroutine
+// is left blocked on a send nobody receives.
+func TestCollectAgentResponse_DrainsToEndAfterError(t *testing.T) {
+	drained := 0
+	next := func() agent.Response {
+		drained++
+		switch drained {
+		case 1:
+			return agent.Response{Type: agent.ResponseTypeError, Content: "boom"}
+		case 2:
+			return agent.Response{Type: agent.ResponseTypePartialText, Content: "trailing chunk"}
+		default:
+			return agent.Response{Type: agent.ResponseTypeEnd}
+		}
+	}
+
+	_, err := collectAgentResponse(next)
+
+	require.Error(t, err)
+	assert.Equal(t, 3, drained, "must consume everything up to and including End")
+}
+
+// Response types the loop does not care about (thinking, step info) must not
+// end the drain or leak into the answer.
+func TestCollectAgentResponse_IgnoresOtherResponseTypes(t *testing.T) {
+	got, err := collectAgentResponse(responder(t,
+		agent.Response{Type: agent.ResponseTypeThinking, Content: "considering"},
+		agent.Response{Type: agent.ResponseTypePartialText, Content: "answer"},
+		agent.Response{Type: agent.ResponseTypeEnd},
+	))
+
+	require.NoError(t, err)
+	assert.Equal(t, "answer", got)
+}

--- a/integration-test/api/integration_test.go
+++ b/integration-test/api/integration_test.go
@@ -48,6 +48,15 @@ func TestMain(m *testing.M) {
 	runTests := m.Run()
 
 	if startServer {
+		// The server's logs are the only place the cause of a failure is
+		// recorded — the test binary sees an HTTP response, not why the agent
+		// produced it. Dumping them only on startup failure meant a red CI run
+		// showed the assertion and nothing else, which is a long way to go to
+		// find out a provider was returning 429.
+		if runTests != 0 && buf != nil {
+			log.Printf("Tests failed. Server logs:\n%s", buf.String())
+		}
+
 		// Clean up the server process
 		if serverCmd != nil && serverCmd.Process != nil {
 			if err := serverCmd.Process.Kill(); err != nil {


### PR DESCRIPTION
## The bug

`runAgentBlocking` accumulated `ResponseTypePartialText` and broke on `ResponseTypeEnd`, **ignoring `ResponseTypeError` entirely**:

```go
for {
    out := session.Out()
    if out.Type == agent.ResponseTypePartialText { response += out.Content }
    if out.Type == agent.ResponseTypeEnd { break }
}
```

A failed inference therefore returned HTTP 200 with an empty assistant message and no error. A provider outage read as "the model said nothing".

The agent was doing its part correctly — `handleLLMError` emits `ResponseTypeError` with the message. The controller dropped it on the floor.

## This is why CI has been red

`api-integration-test` is the only failing step, and it has been failing on every branch since Aug 7. The chain:

1. The provider returns 429 — `You have no credits remaining`
2. The client retries with backoff, then gives up
3. The agent emits `ResponseTypeError` carrying that message
4. `runAgentBlocking` discards it and returns an empty string
5. The test asserts on the empty string:

```
agents_test.go:287   "" does not contain "black"
agents_test.go:216   strconv.ParseFloat: parsing "": invalid syntax
```

Neither says anything about a provider, which is why this took a while to find.

Reproduced locally against a 429ing provider — same failure, byte for byte. After the fix, the same run says what actually happened:

```
failed to run agent: agent error: error, status code: 429,
message: You have no credits remaining. Add credits to continue using the API
```

## The fix

The drain loop moves into `collectAgentResponse` so it can be tested without standing up a `Session`. Two details worth calling out:

- **It keeps reading to `End` after an error.** The agent still emits `End`, and returning early would leave the producer blocked on a send nobody receives — trading a wrong answer for a hang.
- **Partial text collected before a failure is discarded.** A truncated answer returned as if complete is worse than an error.

## Diagnosability

The spawned server's logs were only printed when the server *failed to start*. On a test failure they were discarded, so a red CI run showed the assertion and nothing about why the server produced it. They're now dumped when tests fail — that alone would have turned this investigation into a single log read.

## Tests

`collectAgentResponse` has six unit tests covering accumulation, error surfacing, discarding partial text on error, reporting the first error, draining to `End` after an error, and ignoring unrelated response types. Four of them fail against the previous behaviour:

```
--- FAIL: TestCollectAgentResponse_SurfacesAgentError          An error is expected but got nil.
--- FAIL: TestCollectAgentResponse_DiscardsPartialTextOnError  An error is expected but got nil.
--- FAIL: TestCollectAgentResponse_ReportsFirstError           An error is expected but got nil.
--- FAIL: TestCollectAgentResponse_DrainsToEndAfterError       An error is expected but got nil.
```

Green under `-race`; `go vet` and `gofmt` clean.

## What this does and does not fix

It does **not** make CI green. The underlying reason inference is failing is that the provider has no credits — no code change fixes that, and someone with access to the `openai_tools` secret needs to look at the account.

What it does is stop that being invisible. `api-integration-test` will now fail with the provider's actual message instead of an assertion about an empty string, and the server logs will be in the build output.

Related: https://github.com/helixml/helix/pull/2967 fixes a rate limiter deadlock that made the *same* 429 hang the whole suite for 8 minutes. With both, a provider 429 goes from "CI times out with no explanation" to "CI reports the provider said no credits remaining".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
