### PR TITLE
feat(frontend): add collapsible chat sidebar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@emotion/styled": "^11.6.0",
     "@fontsource-variable/dm-sans": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/sora": "^5.3.0",
     "@hookform/resolvers": "^3.10.0",
     "@inovua/reactdatagrid-community": "^5.10.2",
     "@mui/icons-material": "^5.3.1",

--- a/frontend/src/components/session/ChatSidebarBrandHeader.test.tsx
+++ b/frontend/src/components/session/ChatSidebarBrandHeader.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { describe, expect, it, vi } from 'vitest'
+
+import ChatSidebarBrandHeader from './ChatSidebarBrandHeader'
+
+describe('ChatSidebarBrandHeader', () => {
+  it('renders the Helix wordmark and collapses the chat panel', () => {
+    const onCollapse = vi.fn()
+
+    render(
+      <ThemeProvider theme={createTheme()}>
+        <ChatSidebarBrandHeader onCollapse={onCollapse} />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByText('Helix')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse chat panel' }))
+    expect(onCollapse).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/session/ChatSidebarBrandHeader.test.tsx
+++ b/frontend/src/components/session/ChatSidebarBrandHeader.test.tsx
@@ -14,7 +14,7 @@ describe('ChatSidebarBrandHeader', () => {
       </ThemeProvider>,
     )
 
-    expect(screen.getByText('Helix')).toBeInTheDocument()
+    expect(screen.getByText('helix')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Collapse chat panel' }))
     expect(onCollapse).toHaveBeenCalledOnce()
   })

--- a/frontend/src/components/session/ChatSidebarBrandHeader.tsx
+++ b/frontend/src/components/session/ChatSidebarBrandHeader.tsx
@@ -1,0 +1,151 @@
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { PanelLeft } from 'lucide-react'
+
+import { TOOLBAR_HEIGHT } from '../../config'
+import useLightTheme from '../../hooks/useLightTheme'
+import { APP_FONT_FAMILY } from '../../styles/typography'
+
+const ChatSidebarBrandHeader: FC<{ onCollapse: () => void }> = ({ onCollapse }) => {
+  const lightTheme = useLightTheme()
+
+  return (
+    <Box
+      data-chat-sidebar-brand-header
+      sx={{
+        position: 'relative',
+        isolation: 'isolate',
+        height: TOOLBAR_HEIGHT,
+        minHeight: TOOLBAR_HEIGHT,
+        px: 1.5,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        overflow: 'hidden',
+        borderBottom: lightTheme.isLight
+          ? '1px solid rgba(14, 116, 144, 0.18)'
+          : '1px solid rgba(103, 232, 249, 0.14)',
+        backgroundColor: lightTheme.isLight ? '#f7fbff' : '#070711',
+        backgroundImage: lightTheme.isLight
+          ? [
+              'radial-gradient(110% 140% at 8% 0%, rgba(34, 211, 238, 0.20) 0%, transparent 48%)',
+              'radial-gradient(95% 150% at 92% -15%, rgba(217, 70, 239, 0.15) 0%, transparent 52%)',
+              'linear-gradient(110deg, rgba(255,255,255,0.96) 0%, rgba(243,248,255,0.96) 55%, rgba(252,244,255,0.96) 100%)',
+            ].join(', ')
+          : [
+              'radial-gradient(100% 180% at 8% -25%, rgba(0, 213, 255, 0.32) 0%, transparent 52%)',
+              'radial-gradient(90% 190% at 90% -35%, rgba(239, 46, 198, 0.30) 0%, transparent 56%)',
+              'linear-gradient(112deg, #080916 0%, #111027 52%, #100817 100%)',
+            ].join(', '),
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          inset: 0,
+          zIndex: -1,
+          opacity: lightTheme.isLight ? 0.22 : 0.34,
+          backgroundImage: [
+            'radial-gradient(circle at 8px 9px, currentColor 0 0.65px, transparent 0.9px)',
+            'radial-gradient(circle at 19px 15px, currentColor 0 0.45px, transparent 0.75px)',
+          ].join(', '),
+          backgroundSize: '31px 27px, 47px 39px',
+          color: lightTheme.isLight ? '#0e7490' : '#dbeafe',
+          maskImage: 'linear-gradient(90deg, black 0%, transparent 74%)',
+          WebkitMaskImage: 'linear-gradient(90deg, black 0%, transparent 74%)',
+        },
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          left: 12,
+          right: 12,
+          bottom: 0,
+          height: '1px',
+          background: lightTheme.isLight
+            ? 'linear-gradient(90deg, transparent, rgba(14,116,144,0.40), rgba(192,38,211,0.24), transparent)'
+            : 'linear-gradient(90deg, transparent, rgba(34,211,238,0.46), rgba(232,121,249,0.34), transparent)',
+        },
+      }}
+    >
+      <Box
+        aria-hidden="true"
+        sx={{
+          width: 28,
+          height: 28,
+          flexShrink: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          border: lightTheme.isLight
+            ? '1px solid rgba(14,116,144,0.16)'
+            : '1px solid rgba(255,255,255,0.12)',
+          borderRadius: '9px',
+          backgroundColor: lightTheme.isLight
+            ? 'rgba(255,255,255,0.64)'
+            : 'rgba(255,255,255,0.055)',
+          boxShadow: lightTheme.isLight
+            ? '0 3px 12px rgba(14,116,144,0.10)'
+            : 'inset 0 1px rgba(255,255,255,0.08), 0 4px 16px rgba(0,0,0,0.28)',
+        }}
+      >
+        <Box
+          component="img"
+          src="/img/logo.png"
+          alt=""
+          sx={{ width: 22, height: 18, objectFit: 'contain' }}
+        />
+      </Box>
+
+      <Typography
+        component="span"
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: APP_FONT_FAMILY,
+          fontSize: '17px',
+          fontWeight: 720,
+          lineHeight: 1,
+          letterSpacing: '-0.045em',
+          background: lightTheme.isLight
+            ? 'linear-gradient(105deg, #111827 10%, #0e7490 62%, #86198f 100%)'
+            : 'linear-gradient(105deg, #ffffff 12%, #a5f3fc 62%, #f0abfc 100%)',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+          color: 'transparent',
+          WebkitTextFillColor: 'transparent',
+          textShadow: lightTheme.isLight ? 'none' : '0 0 18px rgba(103,232,249,0.12)',
+        }}
+      >
+        Helix
+      </Typography>
+
+      <Tooltip title="Collapse chat panel">
+        <IconButton
+          onClick={onCollapse}
+          aria-label="Collapse chat panel"
+          sx={{
+            width: 30,
+            height: 30,
+            flexShrink: 0,
+            color: lightTheme.isLight ? 'rgba(15,23,42,0.64)' : 'rgba(255,255,255,0.70)',
+            border: '1px solid transparent',
+            '&:hover': {
+              color: lightTheme.isLight ? '#0f172a' : '#ffffff',
+              borderColor: lightTheme.isLight
+                ? 'rgba(14,116,144,0.14)'
+                : 'rgba(255,255,255,0.10)',
+              backgroundColor: lightTheme.isLight
+                ? 'rgba(255,255,255,0.58)'
+                : 'rgba(255,255,255,0.07)',
+            },
+          }}
+        >
+          <PanelLeft size={18} strokeWidth={1.7} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  )
+}
+
+export default ChatSidebarBrandHeader

--- a/frontend/src/components/session/ChatSidebarBrandHeader.tsx
+++ b/frontend/src/components/session/ChatSidebarBrandHeader.tsx
@@ -7,7 +7,8 @@ import { PanelLeft } from 'lucide-react'
 
 import { TOOLBAR_HEIGHT } from '../../config'
 import useLightTheme from '../../hooks/useLightTheme'
-import { APP_FONT_FAMILY } from '../../styles/typography'
+
+const HELIX_WORDMARK_FONT_FAMILY = '"Sora Variable", "Sora", sans-serif'
 
 const ChatSidebarBrandHeader: FC<{ onCollapse: () => void }> = ({ onCollapse }) => {
   const lightTheme = useLightTheme()
@@ -102,11 +103,11 @@ const ChatSidebarBrandHeader: FC<{ onCollapse: () => void }> = ({ onCollapse }) 
         sx={{
           flex: 1,
           minWidth: 0,
-          fontFamily: APP_FONT_FAMILY,
-          fontSize: '17px',
-          fontWeight: 720,
+          fontFamily: HELIX_WORDMARK_FONT_FAMILY,
+          fontSize: '18px',
+          fontWeight: 680,
           lineHeight: 1,
-          letterSpacing: '-0.045em',
+          letterSpacing: '-0.055em',
           background: lightTheme.isLight
             ? 'linear-gradient(105deg, #111827 10%, #0e7490 62%, #86198f 100%)'
             : 'linear-gradient(105deg, #ffffff 12%, #a5f3fc 62%, #f0abfc 100%)',
@@ -117,7 +118,7 @@ const ChatSidebarBrandHeader: FC<{ onCollapse: () => void }> = ({ onCollapse }) 
           textShadow: lightTheme.isLight ? 'none' : '0 0 18px rgba(103,232,249,0.12)',
         }}
       >
-        Helix
+        helix
       </Typography>
 
       <Tooltip title="Collapse chat panel">

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -13,7 +13,7 @@ import IconButton from '@mui/material/IconButton'
 import InputBase from '@mui/material/InputBase'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { Archive, FolderPlus, Search, SquarePen } from 'lucide-react'
+import { Archive, FolderPlus, PanelLeft, Search, SquarePen } from 'lucide-react'
 
 import {
   TypesExternalRepositoryType,
@@ -54,6 +54,7 @@ import ProjectChatSidebarOptions from './ProjectChatSidebarOptions'
 import SortableProject from './SortableProject'
 import useProjectChatSidebarDrag from './useProjectChatSidebarDrag'
 import useProjectChatSidebarPreferences from './useProjectChatSidebarPreferences'
+import { TOOLBAR_HEIGHT } from '../../config'
 
 const RELATIVE_TIME_REFRESH_MS = 15000
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
@@ -74,7 +75,10 @@ const readParticipantIds = (storageKey: string): string[] | null => {
   }
 }
 
-const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }) => {
+const ProjectChatSidebar: FC<{
+  onCollapse: () => void
+  onOpenSession: () => void
+}> = ({ onCollapse, onOpenSession }) => {
   const account = useAccount()
   const router = useRouter()
   const lightTheme = useLightTheme()
@@ -439,6 +443,35 @@ const ProjectChatSidebar: FC<{ onOpenSession: () => void }> = ({ onOpenSession }
         },
       }}
     >
+      <Box
+        sx={{
+          height: TOOLBAR_HEIGHT,
+          minHeight: TOOLBAR_HEIGHT,
+          px: 1.5,
+          display: 'flex',
+          alignItems: 'center',
+          borderBottom: lightTheme.border,
+        }}
+      >
+        <Typography sx={{ flex: 1, fontSize: '16px', fontWeight: 600 }}>
+          Helix
+        </Typography>
+        <Tooltip title="Collapse chat panel">
+          <IconButton
+            onClick={onCollapse}
+            aria-label="Collapse chat panel"
+            sx={{
+              width: 30,
+              height: 30,
+              color: 'text.secondary',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            <PanelLeft size={18} strokeWidth={1.7} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
       <Box
         sx={{
           height: 60,

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -13,7 +13,7 @@ import IconButton from '@mui/material/IconButton'
 import InputBase from '@mui/material/InputBase'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { Archive, FolderPlus, PanelLeft, Search, SquarePen } from 'lucide-react'
+import { Archive, FolderPlus, Search, SquarePen } from 'lucide-react'
 
 import {
   TypesExternalRepositoryType,
@@ -54,7 +54,7 @@ import ProjectChatSidebarOptions from './ProjectChatSidebarOptions'
 import SortableProject from './SortableProject'
 import useProjectChatSidebarDrag from './useProjectChatSidebarDrag'
 import useProjectChatSidebarPreferences from './useProjectChatSidebarPreferences'
-import { TOOLBAR_HEIGHT } from '../../config'
+import ChatSidebarBrandHeader from './ChatSidebarBrandHeader'
 
 const RELATIVE_TIME_REFRESH_MS = 15000
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
@@ -443,34 +443,7 @@ const ProjectChatSidebar: FC<{
         },
       }}
     >
-      <Box
-        sx={{
-          height: TOOLBAR_HEIGHT,
-          minHeight: TOOLBAR_HEIGHT,
-          px: 1.5,
-          display: 'flex',
-          alignItems: 'center',
-          borderBottom: lightTheme.border,
-        }}
-      >
-        <Typography sx={{ flex: 1, fontSize: '16px', fontWeight: 600 }}>
-          Helix
-        </Typography>
-        <Tooltip title="Collapse chat panel">
-          <IconButton
-            onClick={onCollapse}
-            aria-label="Collapse chat panel"
-            sx={{
-              width: 30,
-              height: 30,
-              color: 'text.secondary',
-              '&:hover': { color: 'text.primary' },
-            }}
-          >
-            <PanelLeft size={18} strokeWidth={1.7} />
-          </IconButton>
-        </Tooltip>
-      </Box>
+      <ChatSidebarBrandHeader onCollapse={onCollapse} />
 
       <Box
         sx={{

--- a/frontend/src/components/session/chatSidebarVisibility.test.ts
+++ b/frontend/src/components/session/chatSidebarVisibility.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  chatSidebarCollapsedStorageKey,
+  parseChatSidebarCollapsed,
+} from './chatSidebarVisibility'
+
+describe('chat sidebar visibility storage', () => {
+  it('scopes the stored state to the organization', () => {
+    expect(chatSidebarCollapsedStorageKey('unmanned-org'))
+      .toBe('helix:project-chat-sidebar:hidden:unmanned-org')
+  })
+
+  it('only treats an explicit true value as collapsed', () => {
+    expect(parseChatSidebarCollapsed('true')).toBe(true)
+    expect(parseChatSidebarCollapsed('false')).toBe(false)
+    expect(parseChatSidebarCollapsed(null)).toBe(false)
+  })
+})

--- a/frontend/src/components/session/chatSidebarVisibility.ts
+++ b/frontend/src/components/session/chatSidebarVisibility.ts
@@ -1,0 +1,7 @@
+export const chatSidebarCollapsedStorageKey = (orgId: string): string => (
+  `helix:project-chat-sidebar:hidden:${orgId}`
+)
+
+export const parseChatSidebarCollapsed = (storedValue: string | null): boolean => (
+  storedValue === 'true'
+)

--- a/frontend/src/components/system/AppBar.tsx
+++ b/frontend/src/components/system/AppBar.tsx
@@ -20,6 +20,7 @@ const AppBar: React.FC<{
   height?: number,
   px?: number,
   title?: string | React.ReactNode,
+  leadingContent?: React.ReactNode,
   leftContent?: React.ReactNode,
   onOpenDrawer?: () => void,
   children?: React.ReactNode,
@@ -27,6 +28,7 @@ const AppBar: React.FC<{
   height = TOOLBAR_HEIGHT,
   px = 3,
   title,
+  leadingContent,
   leftContent,
   onOpenDrawer,
   children,
@@ -78,6 +80,13 @@ const AppBar: React.FC<{
                 >
                   <Menu size={24} />
                 </IconButton>
+              </Cell>
+            )
+          }
+          {
+            leadingContent && (
+              <Cell sx={{ flexShrink: 0, mr: 1 }}>
+                { leadingContent }
               </Cell>
             )
           }

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -9,6 +9,7 @@ import { SxProps } from '@mui/system'
 import SearchIcon from '@mui/icons-material/Search'
 import LightModeIcon from '@mui/icons-material/LightMode'
 import DarkModeIcon from '@mui/icons-material/DarkMode'
+import { PanelLeft } from 'lucide-react'
 
 import AppBar from './AppBar'
 import GlobalSearchDialog from './GlobalSearchDialog'
@@ -20,6 +21,7 @@ import useAccount from '../../hooks/useAccount'
 import useLightTheme from '../../hooks/useLightTheme'
 import useDocumentTitle from '../../hooks/useDocumentTitle'
 import { ThemeContext } from '../../contexts/theme'
+import { useChatSidebar } from '../../contexts/chatSidebar'
 
 import {
   IPageBreadcrumb,
@@ -77,7 +79,14 @@ const Page: React.FC<{
   const account = useAccount()
   const lightTheme = useLightTheme()
   const { mode, toggleMode } = useContext(ThemeContext)
+  const chatSidebar = useChatSidebar()
   const [searchDialogOpen, setSearchDialogOpen] = useState(false)
+  const showChatSidebarButton = chatSidebar.collapsed && [
+    'org_chat',
+    'org_chat-task',
+    'org_session',
+    'org_new',
+  ].includes(router.name)
 
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -248,6 +257,22 @@ const Page: React.FC<{
           >
             <AppBar
               title={ useTopbarTitle }
+              leadingContent={showChatSidebarButton ? (
+                <Tooltip title="Open chat panel">
+                  <IconButton
+                    onClick={chatSidebar.expand}
+                    aria-label="Open chat panel"
+                    sx={{
+                      width: 30,
+                      height: 30,
+                      color: 'text.secondary',
+                      '&:hover': { color: 'text.primary' },
+                    }}
+                  >
+                    <PanelLeft size={18} strokeWidth={1.7} />
+                  </IconButton>
+                </Tooltip>
+              ) : null}
               leftContent={ topbarLeftContent }
               px={ px }
               onOpenDrawer={ showDrawerButton ? () => account.setMobileMenuOpen(true) : undefined }

--- a/frontend/src/contexts/chatSidebar.tsx
+++ b/frontend/src/contexts/chatSidebar.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, FC, ReactNode, useContext } from 'react'
+
+type ChatSidebarContextValue = {
+  collapsed: boolean
+  collapse: () => void
+  expand: () => void
+}
+
+const ChatSidebarContext = createContext<ChatSidebarContextValue>({
+  collapsed: false,
+  collapse: () => undefined,
+  expand: () => undefined,
+})
+
+export const ChatSidebarProvider: FC<ChatSidebarContextValue & { children: ReactNode }> = ({
+  collapsed,
+  collapse,
+  expand,
+  children,
+}) => (
+  <ChatSidebarContext.Provider value={{ collapsed, collapse, expand }}>
+    {children}
+  </ChatSidebarContext.Provider>
+)
+
+export const useChatSidebar = (): ChatSidebarContextValue => useContext(ChatSidebarContext)

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import '@fontsource-variable/dm-sans'
 import '@fontsource-variable/jetbrains-mono'
+import '@fontsource-variable/sora'
 import App from './App'
 import ErrorBoundary from './components/system/ErrorBoundary'
 import { isMobileOrTablet } from './utils/isMobileOrTablet'

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -62,6 +62,11 @@ import useUserMenuHeight from "../hooks/useUserMenuHeight";
 import { LIGHT_SIDEBAR_COLORS } from "../styles/themeTokens";
 import { TOOLBAR_HEIGHT } from "../config";
 import { usesFocusedAgentDetails } from "../utils/apps";
+import { ChatSidebarProvider } from "../contexts/chatSidebar";
+import {
+  chatSidebarCollapsedStorageKey,
+  parseChatSidebarCollapsed,
+} from "../components/session/chatSidebarVisibility";
 
 // Admin and Connected Services are rendered as full-screen dialog overlays
 // so the user stays within their current org-scoped URL
@@ -270,6 +275,7 @@ const Layout: FC<{
   const floatingModal = useFloatingModal();
   const orgId = router.params.org_id || "";
   const sidebarWidthStorageKey = chatSidebarWidthStorageKey(orgId);
+  const sidebarCollapsedStorageKey = chatSidebarCollapsedStorageKey(orgId);
   const defaultChatSidebarWidth = themeConfig.drawerWidth || CHAT_SIDEBAR_DEFAULT_WIDTH;
   const [chatSidebarWidth, setChatSidebarWidth] = useState(() => {
     try {
@@ -282,6 +288,13 @@ const Layout: FC<{
     }
   });
   const [isResizingChatSidebar, setIsResizingChatSidebar] = useState(false);
+  const [chatSidebarCollapsed, setChatSidebarCollapsed] = useState(() => {
+    try {
+      return parseChatSidebarCollapsed(window.localStorage.getItem(sidebarCollapsedStorageKey));
+    } catch {
+      return false;
+    }
+  });
   const chatSidebarWidthRef = useRef(chatSidebarWidth);
   const [showVersionBanner, setShowVersionBanner] = useState(true);
   const [showLocalProviderBanner, setShowLocalProviderBanner] = useState(true);
@@ -297,6 +310,25 @@ const Layout: FC<{
     useState(false);
   const licenseTimerRef = useRef<NodeJS.Timeout | null>(null);
   const userMenuHeight = useUserMenuHeight();
+
+  useEffect(() => {
+    try {
+      setChatSidebarCollapsed(parseChatSidebarCollapsed(
+        window.localStorage.getItem(sidebarCollapsedStorageKey),
+      ));
+    } catch {
+      setChatSidebarCollapsed(false);
+    }
+  }, [sidebarCollapsedStorageKey]);
+
+  const setChatSidebarCollapsedAndPersist = (collapsed: boolean) => {
+    setChatSidebarCollapsed(collapsed);
+    try {
+      window.localStorage.setItem(sidebarCollapsedStorageKey, String(collapsed));
+    } catch {
+      // Persistence is optional when browser storage is unavailable.
+    }
+  };
 
   useEffect(() => {
     try {
@@ -578,7 +610,15 @@ const Layout: FC<{
         return <FilesSidebar onOpenFile={() => {}} />;
 
       default:
-        return <ProjectChatSidebar onOpenSession={onOpenSession} />;
+        return (
+          <ProjectChatSidebar
+            onCollapse={() => {
+              if (isBigScreen) setChatSidebarCollapsedAndPersist(true);
+              else account.setMobileMenuOpen(false);
+            }}
+            onOpenSession={onOpenSession}
+          />
+        );
     }
   }
 
@@ -600,8 +640,15 @@ const Layout: FC<{
     );
   }
 
+  const desktopChatSidebarCollapsed = isBigScreen && isConversationRoute && chatSidebarCollapsed;
+  const visibleChatSidebarWidth = desktopChatSidebarCollapsed ? 64 : chatSidebarWidth;
+
   return (
-    <>
+    <ChatSidebarProvider
+      collapsed={desktopChatSidebarCollapsed}
+      collapse={() => setChatSidebarCollapsedAndPersist(true)}
+      expand={() => setChatSidebarCollapsedAndPersist(false)}
+    >
       <MuiSnackbar
         open={showVersionBanner && hasNewVersion}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
@@ -683,7 +730,7 @@ const Layout: FC<{
               width: shouldShowSidebar
                 ? isBigScreen
                   ? isConversationRoute
-                    ? chatSidebarWidth
+                    ? visibleChatSidebarWidth
                     : themeConfig.drawerWidth
                   : themeConfig.smallDrawerWidth
                 : 64,
@@ -747,7 +794,7 @@ const Layout: FC<{
                 sidebarVisible={shouldShowSidebar && !isConversationRoute}
               />
             </Box>
-            {shouldShowSidebar && (
+            {shouldShowSidebar && !desktopChatSidebarCollapsed && (
               <Box
                 sx={{
                   flex: 1,
@@ -763,7 +810,7 @@ const Layout: FC<{
               </Box>
             )}
           </Box>
-          {isBigScreen && shouldShowSidebar && isConversationRoute && (
+          {isBigScreen && shouldShowSidebar && isConversationRoute && !desktopChatSidebarCollapsed && (
             <Box
               data-chat-sidebar-resize-handle
               role="separator"
@@ -843,7 +890,7 @@ const Layout: FC<{
               },
               "& [data-page-toolbar] > .MuiAppBar-root": {
                 position: "fixed",
-                left: isConversationRoute ? chatSidebarWidth : 64,
+                left: isConversationRoute ? visibleChatSidebarWidth : 64,
                 right: 0,
                 width: "auto",
                 zIndex: (theme) => theme.zIndex.drawer + 1,
@@ -944,7 +991,7 @@ const Layout: FC<{
       {licenseRequired && (
         <LicenseKeyPrompt gracePeriodExpired={licenseGracePeriodExpired} />
       )}
-    </>
+    </ChatSidebarProvider>
   );
 };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -401,6 +401,11 @@
   resolved "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz"
   integrity sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==
 
+"@fontsource-variable/sora@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.3.0.tgz"
+  integrity sha512-h8kHta4Z8SkfUGeI82TUy1n3rbrKpBRGwuk4t4qCwto5oEHxlbOFD2yGP+Df5fbmTXwKGn+o667vYp0E4K8Whw==
+
 "@hookform/resolvers@^3.10.0":
   version "3.10.0"
   resolved "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz"


### PR DESCRIPTION
## Summary
- add a toolbar-height Helix brand header and collapse control to the chat sessions rail
- give the product wordmark a Helix-specific cyan-magenta aurora treatment, subtle particle texture, and the existing Helix mark
- collapse the rail to the primary navigation while preserving the chat workspace and right panel
- add a toolbar control to reopen the chat rail and persist visibility per organization

## Testing
- `cd frontend && yarn tsc`
- `cd frontend && yarn test src/components/session/ChatSidebarBrandHeader.test.tsx src/components/session/chatSidebarVisibility.test.ts src/components/session/chatSidebarWidth.test.ts`
- `cd frontend && yarn build`

## Browser verification
- Local stack is healthy and Vite hot-reloaded the changed modules without errors. The collaborative preview browser rejected the local proxy, Vite, and directly exposed preview ports, so the final visual interaction was not verified through browser automation.