### PR TITLE
fix(frontend): restore spec task agent selector

### DIFF
--- a/frontend/src/components/session/SwitchAgentControl.test.tsx
+++ b/frontend/src/components/session/SwitchAgentControl.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import SwitchAgentControl from "./SwitchAgentControl";
+
+vi.mock("../../hooks/useApps", () => ({
+  default: () => ({
+    apps: [
+      {
+        id: "app_claude",
+        config: {
+          helix: {
+            name: "Claude Code",
+            assistants: [{ code_agent_runtime: "claude_code" }],
+          },
+        },
+      },
+      {
+        id: "app_codex",
+        config: {
+          helix: {
+            name: "Codex",
+            assistants: [{ code_agent_runtime: "codex_cli" }],
+          },
+        },
+      },
+    ],
+  }),
+}));
+
+vi.mock("../../hooks/useSnackbar", () => ({
+  default: () => ({ success: vi.fn() }),
+}));
+
+vi.mock("../../services/projectService", () => ({
+  useListProjectSpecTaskAgents: () => ({
+    data: [
+      { id: "app_claude", name: "Claude Code" },
+      { id: "app_codex", name: "Codex" },
+    ],
+  }),
+}));
+
+vi.mock("../../services/sessionService", () => ({
+  useGetSession: () => ({
+    data: { data: { parent_app: "app_claude", config: {} } },
+  }),
+  useSwitchAgent: () => ({ mutateAsync: vi.fn() }),
+}));
+
+describe("SwitchAgentControl", () => {
+  it("uses the project allow-list when legacy app records omit agent_kind", () => {
+    render(
+      <SwitchAgentControl
+        sessionId="session-one"
+        projectId="project-one"
+        displayMode="compact"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Switch agent" });
+    expect(button).toBeEnabled();
+    expect(within(button).getByText("Claude Code")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.getByRole("menuitem", { name: /Claude Code/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Codex/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/session/SwitchAgentControl.tsx
+++ b/frontend/src/components/session/SwitchAgentControl.tsx
@@ -17,8 +17,9 @@ import AgentDropdown from "../agent/AgentDropdown";
 import AgentHarness, { getAgentHarnessRuntime } from "../agent/AgentHarness";
 import useApps from "../../hooks/useApps";
 import useSnackbar from "../../hooks/useSnackbar";
+import { useListProjectSpecTaskAgents } from "../../services/projectService";
 import { useGetSession, useSwitchAgent } from "../../services/sessionService";
-import { selectCodingAgents } from "../../utils/apps";
+import { AGENT_KIND_CODING, IApp } from "../../types";
 import { getChatColors } from "./chatStyles";
 
 interface SwitchAgentControlProps {
@@ -26,6 +27,8 @@ interface SwitchAgentControlProps {
    *  reflects this session's parent_app; picking a different agent switches
    *  the agent IN PLACE on this same session (no fork, no new container). */
   sessionId: string;
+  /** Project whose access-controlled coding agents can run this spec task. */
+  projectId: string;
   /** Optional callback after a successful switch. The session id is
    *  unchanged, so this is just a hook for the parent to refresh/react —
    *  there is nothing to navigate to. */
@@ -49,6 +52,7 @@ interface SwitchAgentControlProps {
  */
 const SwitchAgentControl: FC<SwitchAgentControlProps> = ({
   sessionId,
+  projectId,
   onSwitched,
   size = "small",
   displayMode = "field",
@@ -69,19 +73,41 @@ const SwitchAgentControl: FC<SwitchAgentControlProps> = ({
   });
   const session = sessionResponse?.data;
   const switchMutation = useSwitchAgent(sessionId);
+  const { data: projectAgents = [] } = useListProjectSpecTaskAgents(projectId, !!projectId);
 
   // The dropdown value reflects the session's parent_app (the helix app the
   // agent was launched from). For sessions without parent_app the dropdown
   // shows "Select Agent" and any selection becomes a switch.
   const currentAppId = session?.parent_app || "";
 
-  // Switching only makes sense between external-agent frameworks that run
-  // inside Zed, and never to a Helix org-chart Worker agent — those belong to
-  // the org chart, not to spec tasks.
+  // The project endpoint is the authoritative, access-controlled allow-list.
+  // Hydrate its minimal records from AppsContext for richer harness metadata.
+  // Do not filter AppsContext by agent_kind here: older API deployments omit
+  // that field even though the project endpoint correctly identifies coding
+  // agents, which previously made this selector empty and disabled.
   const eligibleAgents = useMemo(() => {
-    if (!apps.apps) return [];
-    return selectCodingAgents(apps.apps);
-  }, [apps.apps]);
+    return projectAgents.flatMap((agent): IApp[] => {
+      if (!agent.id) return [];
+      const fullAgent = apps.apps?.find((app) => app.id === agent.id);
+      if (fullAgent) {
+        return [{ ...fullAgent, agent_kind: AGENT_KIND_CODING }];
+      }
+      return [{
+        id: agent.id,
+        agent_kind: AGENT_KIND_CODING,
+        config: {
+          helix: {
+            name: agent.name || "Unnamed agent",
+            description: "",
+            external_url: "",
+            assistants: [{ code_agent_runtime: agent.code_agent_runtime || "zed_agent" }],
+          },
+          secrets: {},
+          allowed_domains: [],
+        },
+      } as unknown as IApp];
+    });
+  }, [apps.apps, projectAgents]);
 
   const handleSelect = (newAppId: string) => {
     setMenuAnchor(null);

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -2451,7 +2451,11 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   enableInteractionDebugCopy
                   onWillSend={handleWillSend}
                   leadingActions={(
-                    <SwitchAgentControl sessionId={activeSessionId} displayMode="compact" />
+                    <SwitchAgentControl
+                      sessionId={activeSessionId}
+                      projectId={task.project_id || ""}
+                      displayMode="compact"
+                    />
                   )}
                   footerContent={taskChatMetadata}
                   placeholder={
@@ -3200,7 +3204,11 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   enableInteractionDebugCopy
                   onWillSend={handleWillSend}
                   leadingActions={(
-                    <SwitchAgentControl sessionId={activeSessionId} displayMode="compact" />
+                    <SwitchAgentControl
+                      sessionId={activeSessionId}
+                      projectId={task.project_id || ""}
+                      displayMode="compact"
+                    />
                   )}
                   footerContent={taskChatMetadata}
                   placeholder={


### PR DESCRIPTION
## Summary

- Populate the spec-task switcher from the project-scoped agent allow-list.
- Hydrate allowed agents with full app metadata for names and harness icons.
- Preserve compatibility with agent responses that omit `agent_kind`.
- Add a regression test for the legacy response shape.

## Root cause

The switcher filtered the organization app list by `agent_kind`. The affected deployment omits that field from full agent responses, so every coding agent was filtered out even though the project-specific spec-task agent endpoint returned Claude Code and Codex correctly.

## Validation

- `yarn test SwitchAgentControl.test.tsx`
- `yarn tsc`
- `yarn build`
- Live browser verification on the reported spec task: selector enabled, current agent displayed as Claude Code, and menu listed Claude Code, Codex, and zed-codex.
