### PR TITLE
feat(billing): meter spec-task desktops as sandbox rows

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -65,6 +65,35 @@ type HydraExecutor struct {
 	// Callback to fetch project secrets, set via SetProjectSecretsGetter
 	// after HelixAPIServer is constructed (mirrors SetQuotaManager wiring).
 	getProjectSecrets ProjectSecretsGetter
+
+	// sandboxMeter opens/closes the sandbox row that bills and quota-checks
+	// each desktop. Set via SetSandboxMeter after the sandbox controller is
+	// constructed. Nil means desktops run unmetered.
+	sandboxMeter SandboxMeter
+}
+
+// SandboxMeter is the billing/quota record behind a desktop container.
+// Implemented by *sandbox.Controller; declared here so external-agent and the
+// sandbox controller depend only on types, not on each other.
+//
+// StartDesktop is the single choke point every desktop passes through — spec
+// tasks, exploratory sessions, session forks, subscription desktops and golden
+// builds all land here — so metering at this level is what makes compute
+// billing uniform.
+type SandboxMeter interface {
+	// BeginSession enforces the org's concurrency limit and credit floor and
+	// opens a pending row. Returning an error aborts the desktop start.
+	BeginSession(ctx context.Context, req *types.BeginSandboxSessionRequest) (*types.Sandbox, error)
+	// MarkSessionRunning opens the billing window once the container is up.
+	MarkSessionRunning(ctx context.Context, sessionID, hostDeviceID, containerID string) error
+	// MarkSessionStopped settles the final partial minute and closes the row.
+	MarkSessionStopped(ctx context.Context, sessionID string) error
+	// MarkSessionFailed closes the row after a failed start.
+	MarkSessionFailed(ctx context.Context, sessionID, reason string) error
+	// EnsureSessionResizeCredits checks affordability before growing a container.
+	EnsureSessionResizeCredits(ctx context.Context, sessionID string, vcpus int) error
+	// ResizeSession settles charges at the old size, then records the new one.
+	ResizeSession(ctx context.Context, sessionID string, vcpus, memoryMB int) error
 }
 
 // connmanInterface abstracts the connection manager for RevDial connections to sandboxes
@@ -106,6 +135,10 @@ func NewHydraExecutor(cfg HydraExecutorConfig) *HydraExecutor {
 
 func (h *HydraExecutor) SetQuotaManager(quotaManager QuotaManager) {
 	h.quotaManager = quotaManager
+}
+
+func (h *HydraExecutor) SetSandboxMeter(meter SandboxMeter) {
+	h.sandboxMeter = meter
 }
 
 func (h *HydraExecutor) SetProjectSecretsGetter(getter ProjectSecretsGetter) {
@@ -210,6 +243,37 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	if limitReached != nil && limitReached.LimitReached {
 		return nil, fmt.Errorf("desktop limit reached (%d). Stop some of the existing sessions or upgrade your plan", limitReached.Limit)
 	}
+
+	// A spec task owns a sandbox size the user picked. Only the three launch
+	// paths in spec_driven_task_service set it on the agent; resume, fork and
+	// design-review rebuild the agent from the session and would otherwise
+	// start the desktop uncapped — running bigger than the user asked for and
+	// billing at the default. Resolve it here so every spec-task desktop honours
+	// the task's preset.
+	if err := h.resolveSpecTaskResources(ctx, agent); err != nil {
+		return nil, err
+	}
+
+	// Open the sandbox row that bills and quota-checks this desktop. This
+	// enforces the org's desktop concurrency cap and credit floor, so it must
+	// happen before we spend minutes booting a container the org can't pay
+	// for. Billing itself doesn't start until markSessionRunning below.
+	meterOpened, err := h.beginSandboxMetering(ctx, agent)
+	if err != nil {
+		return nil, err
+	}
+	desktopStarted := false
+	defer func() {
+		if !meterOpened || desktopStarted {
+			return
+		}
+		// Every failure path between here and the successful return must close
+		// the row, otherwise a desktop that never booted keeps consuming a
+		// concurrency slot forever (pending counts as active).
+		if err := h.sandboxMeter.MarkSessionFailed(context.Background(), agent.SessionID, "desktop start failed"); err != nil {
+			log.Warn().Err(err).Str("session_id", agent.SessionID).Msg("Failed to close sandbox billing row after failed desktop start")
+		}
+	}()
 
 	// Get Hydra client via RevDial
 	// Hydra runner ID follows pattern: hydra-{SANDBOX_INSTANCE_ID}
@@ -568,6 +632,17 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		}
 	}
 
+	// Container is up: record where it landed and open the billing window.
+	if meterOpened {
+		if err := h.sandboxMeter.MarkSessionRunning(ctx, agent.SessionID, sandboxID, resp.ContainerID); err != nil {
+			// The desktop is running and usable; refusing to return it because
+			// bookkeeping failed would be the worse outcome. Log loudly — an
+			// unopened window means this desktop runs free until it restarts.
+			log.Error().Err(err).Str("session_id", agent.SessionID).Msg("Failed to open sandbox billing window; desktop is running unmetered")
+		}
+	}
+	desktopStarted = true
+
 	return &types.DesktopAgentResponse{
 		SessionID:      agent.SessionID,
 		ScreenshotURL:  fmt.Sprintf("/api/v1/sessions/%s/screenshot", agent.SessionID),
@@ -578,6 +653,78 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		SandboxID:      sandboxID,
 		DevContainerID: resp.ContainerID, // Container ID for exploratory session tracking
 	}, nil
+}
+
+// resolveSpecTaskResources fills in the sandbox size from the owning spec task
+// when the caller didn't supply one. A caller that set resources explicitly
+// wins — it already knows what it wants.
+func (h *HydraExecutor) resolveSpecTaskResources(ctx context.Context, agent *types.DesktopAgent) error {
+	if agent.SpecTaskID == "" || (agent.VCPUs > 0 && agent.MemoryMB > 0) {
+		return nil
+	}
+	task, err := h.store.GetSpecTask(ctx, agent.SpecTaskID)
+	if err != nil {
+		return fmt.Errorf("load spec task %s for sandbox sizing: %w", agent.SpecTaskID, err)
+	}
+	resources := types.EffectiveSpecTaskSandboxResources(task.SandboxResourceOverrides)
+	agent.VCPUs = resources.VCPUs
+	agent.MemoryMB = resources.MemoryMB
+	return nil
+}
+
+// beginSandboxMetering opens the billing/quota row for a desktop that is about
+// to start. Returns false when there is nothing to meter (no meter wired, or
+// no owning organization — wallets are org-scoped).
+func (h *HydraExecutor) beginSandboxMetering(ctx context.Context, agent *types.DesktopAgent) (bool, error) {
+	if h.sandboxMeter == nil || agent.OrganizationID == "" {
+		return false, nil
+	}
+	vcpus, memoryMB := desktopBillingResources(agent)
+	sb, err := h.sandboxMeter.BeginSession(ctx, &types.BeginSandboxSessionRequest{
+		SessionID:      agent.SessionID,
+		OrganizationID: agent.OrganizationID,
+		Owner:          agent.UserID,
+		ProjectID:      agent.ProjectID,
+		SpecTaskID:     agent.SpecTaskID,
+		Name:           h.desktopSandboxName(ctx, agent),
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		VCPUs:          vcpus,
+		MemoryMB:       memoryMB,
+		DisplayWidth:   agent.DisplayWidth,
+		DisplayHeight:  agent.DisplayHeight,
+		DisplayFPS:     agent.DisplayRefreshRate,
+	})
+	if err != nil {
+		return false, fmt.Errorf("cannot start desktop: %w", err)
+	}
+	return sb != nil, nil
+}
+
+// desktopBillingResources is what we charge for, which is not always what the
+// container is capped at. Desktops started without an explicit preset run
+// uncapped (hydra treats 0 as "no cap"), and charging those a single core
+// would systematically undercharge the largest consumers. They are billed at
+// the standard desktop preset instead — the same allocation an equivalent spec
+// task gets. Capping those containers for real is a separate product change.
+func desktopBillingResources(agent *types.DesktopAgent) (int, int) {
+	if agent.VCPUs > 0 && agent.MemoryMB > 0 {
+		return agent.VCPUs, agent.MemoryMB
+	}
+	standard := types.EffectiveSpecTaskSandboxResources(nil)
+	return standard.VCPUs, standard.MemoryMB
+}
+
+// desktopSandboxName gives the row a label a human can recognise in the
+// Sandboxes list. One indexed lookup on a path that is about to spend minutes
+// booting a container.
+func (h *HydraExecutor) desktopSandboxName(ctx context.Context, agent *types.DesktopAgent) string {
+	if agent.SpecTaskID != "" {
+		if task, err := h.store.GetSpecTask(ctx, agent.SpecTaskID); err == nil && task != nil && task.Name != "" {
+			return task.Name
+		}
+		return agent.SpecTaskID
+	}
+	return fmt.Sprintf("Session %s", strings.TrimPrefix(agent.SessionID, "ses_"))
 }
 
 func (h *HydraExecutor) UpdateDesktopResources(ctx context.Context, sessionID string, resources *types.SandboxResourceOverrides) error {
@@ -605,6 +752,13 @@ func (h *HydraExecutor) UpdateDesktopResources(ctx context.Context, sessionID st
 		sandboxID = "local"
 	}
 
+	// Refuse to grow a container the org can't pay to run at the new size.
+	if h.sandboxMeter != nil {
+		if err := h.sandboxMeter.EnsureSessionResizeCredits(ctx, sessionID, resources.VCPUs); err != nil {
+			return fmt.Errorf("cannot resize desktop: %w", err)
+		}
+	}
+
 	client := hydra.NewRevDialClient(h.connman, fmt.Sprintf("hydra-%s", sandboxID))
 	_, err := client.UpdateDevContainerResources(ctx, sessionID, &hydra.UpdateDevContainerResourcesRequest{
 		VCPUs:    resources.VCPUs,
@@ -612,6 +766,15 @@ func (h *HydraExecutor) UpdateDesktopResources(ctx context.Context, sessionID st
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update desktop resources: %w", err)
+	}
+
+	// Settle charges at the old core count before the row starts billing at
+	// the new one — see sandbox.Controller.ResizeSession. Only after the
+	// runtime resize actually succeeded, so a failed resize never reprices.
+	if h.sandboxMeter != nil {
+		if err := h.sandboxMeter.ResizeSession(ctx, sessionID, resources.VCPUs, resources.MemoryMB); err != nil {
+			log.Error().Err(err).Str("session_id", sessionID).Msg("Desktop resized but sandbox billing row not updated; charges will lag the real allocation")
+		}
 	}
 	return nil
 }
@@ -751,6 +914,14 @@ func (h *HydraExecutor) StopDesktop(ctx context.Context, sessionID string) error
 				Str("sandbox_id", sandboxID).
 				Str("session_id", sessionID).
 				Msg("Failed to decrement active_sandboxes on Runner; counter may drift high")
+		}
+	}
+
+	// Settle the final partial minute and close the billing row. Done after
+	// the container delete so we bill for every second it was actually up.
+	if h.sandboxMeter != nil {
+		if err := h.sandboxMeter.MarkSessionStopped(ctx, sessionID); err != nil {
+			log.Warn().Err(err).Str("session_id", sessionID).Msg("Failed to close sandbox billing row on desktop stop")
 		}
 	}
 
@@ -1775,6 +1946,16 @@ func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxI
 		h.mutex.Lock()
 		delete(h.sessions, session.ID)
 		h.mutex.Unlock()
+
+		// Close the billing row too. Without this, a container destroyed
+		// outside StopDesktop (host redeploy, OOM kill, manual docker rm)
+		// leaves a row in `running` and the reaper keeps charging the org
+		// every minute for a container that no longer exists.
+		if h.sandboxMeter != nil {
+			if err := h.sandboxMeter.MarkSessionStopped(ctx, session.ID); err != nil {
+				log.Warn().Err(err).Str("session_id", session.ID).Msg("Failed to close sandbox billing row for stale container")
+			}
+		}
 
 		log.Info().
 			Str("session_id", session.ID).

--- a/api/pkg/external-agent/sandbox_metering_test.go
+++ b/api/pkg/external-agent/sandbox_metering_test.go
@@ -1,0 +1,91 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// Only the three spec_driven_task_service launch paths put resources on the
+// agent. Resume, fork and design-review rebuild it from the session, so without
+// this resolution a resumed 8 vCPU task would come back uncapped and be billed
+// at the default preset.
+func TestResolveSpecTaskResourcesAppliesTaskPreset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(&types.SpecTask{
+		ID:                       "spt_1",
+		SandboxResourceOverrides: &types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384},
+	}, nil)
+
+	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_1"}
+	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.Equal(t, 8, agent.VCPUs)
+	require.Equal(t, 16384, agent.MemoryMB)
+}
+
+// A legacy task with no explicit override resolves to the same default the
+// task UI displays, so the billed size matches what the user is shown.
+func TestResolveSpecTaskResourcesFallsBackToTaskDefault(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_legacy").Return(&types.SpecTask{ID: "spt_legacy"}, nil)
+
+	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_legacy"}
+	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+
+	expected := types.EffectiveSpecTaskSandboxResources(nil)
+	require.Equal(t, expected.VCPUs, agent.VCPUs)
+	require.Equal(t, expected.MemoryMB, agent.MemoryMB)
+}
+
+// An explicit caller-supplied size wins — it already knows what it wants, and
+// re-reading the task would undo an in-flight resize.
+func TestResolveSpecTaskResourcesLeavesExplicitSizeAlone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+
+	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_1", VCPUs: 1, MemoryMB: 2048}
+	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.Equal(t, 1, agent.VCPUs)
+	require.Equal(t, 2048, agent.MemoryMB)
+}
+
+func TestResolveSpecTaskResourcesIgnoresNonTaskDesktops(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+
+	agent := &types.DesktopAgent{SessionID: "ses_1"}
+	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.Zero(t, agent.VCPUs)
+	require.Zero(t, agent.MemoryMB)
+}
+
+// Desktops with no cap (exploratory sessions, subscription logins) can use the
+// whole host, so charging them a single core would undercharge the largest
+// consumers. They bill at the standard desktop preset instead.
+func TestDesktopBillingResourcesUsesStandardPresetWhenUncapped(t *testing.T) {
+	standard := types.EffectiveSpecTaskSandboxResources(nil)
+
+	vcpus, memoryMB := desktopBillingResources(&types.DesktopAgent{})
+	require.Equal(t, standard.VCPUs, vcpus)
+	require.Equal(t, standard.MemoryMB, memoryMB)
+
+	vcpus, memoryMB = desktopBillingResources(&types.DesktopAgent{VCPUs: 8, MemoryMB: 16384})
+	require.Equal(t, 8, vcpus)
+	require.Equal(t, 16384, memoryMB)
+}

--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -58,6 +58,11 @@ type Controller struct {
 	// fake to capture CreateDevContainer requests.
 	newHydraClient func(hostID string) hydraProvisionClient
 
+	// stopDesktop tears down session-backed containers (spec-task desktops and
+	// friends), which the external-agent executor owns. Injected via
+	// SetDesktopStopper — see controller_session.go.
+	stopDesktop DesktopStopper
+
 	// provisionWG tracks in-flight provision goroutines launched by Create().
 	// Tests use waitProvisions() to wait for them to settle.
 	provisionWG sync.WaitGroup
@@ -234,6 +239,19 @@ func (c *Controller) Delete(ctx context.Context, id string) error {
 	}
 
 	_ = c.store.SetSandboxStatus(ctx, id, types.SandboxStatusStopping, "")
+
+	// Session-backed rows meter a container the external-agent executor
+	// provisioned and registered under the SESSION id. Tearing it down here
+	// with the row id would silently miss, so hand teardown back to the
+	// executor. This is also the path credit exhaustion takes to actually stop
+	// a spec-task desktop.
+	if sandbox.SessionBacked() {
+		if err := c.stopSessionDesktop(ctx, sandbox); err != nil {
+			return err
+		}
+		c.revokeSandboxAPIToken(ctx, sandbox)
+		return c.store.DeleteSandbox(ctx, id)
+	}
 
 	if sandbox.HostDeviceID != "" {
 		hydraClient := c.newHydraClient(sandbox.HostDeviceID)

--- a/api/pkg/sandbox/controller_billing.go
+++ b/api/pkg/sandbox/controller_billing.go
@@ -122,12 +122,21 @@ func (c *Controller) billSandbox(ctx context.Context, settings *types.SystemSett
 }
 
 func (c *Controller) ensureSandboxCredits(ctx context.Context, orgID string, spec *RuntimeSpec, settings *types.SystemSettings, vcpus int) error {
+	return c.ensureCreditsForType(ctx, orgID, sandboxPricingTypeForSpec(spec), settings, vcpus)
+}
+
+// ensureCreditsForType requires the org to hold at least one minute of runway
+// at the requested size before we start (or grow) a container.
+func (c *Controller) ensureCreditsForType(ctx context.Context, orgID, pricingType string, settings *types.SystemSettings, vcpus int) error {
 	if !settings.SandboxBillingEnabled {
 		return nil
 	}
-	pricePerSecond, _ := sandboxPriceForSpec(settings, spec)
+	pricePerSecond := sandboxPriceForType(settings, pricingType)
 	if pricePerSecond <= 0 {
 		return nil
+	}
+	if vcpus < 1 {
+		vcpus = 1
 	}
 	required := pricePerSecond * 60 * float64(vcpus)
 	wallet, err := c.store.GetWalletByOrg(ctx, orgID)
@@ -148,10 +157,16 @@ func sandboxBillableCores(sb *types.Sandbox) int {
 }
 
 func (c *Controller) ensureSandboxLimits(ctx context.Context, orgID string, spec *RuntimeSpec, settings *types.SystemSettings) error {
+	return c.ensureSandboxLimitsForType(ctx, orgID, sandboxPricingTypeForSpec(spec), "", settings)
+}
+
+// ensureSandboxLimitsForType enforces the org's concurrency cap for one
+// pricing class. excludeID drops a single row from the count, so a restart
+// isn't blocked by the slot it is itself about to reoccupy.
+func (c *Controller) ensureSandboxLimitsForType(ctx context.Context, orgID, pricingType, excludeID string, settings *types.SystemSettings) error {
 	if settings == nil {
 		settings = &types.SystemSettings{}
 	}
-	pricingType := sandboxPricingTypeForSpec(spec)
 	limit := settings.EffectiveMaxConcurrentHeadlessSandboxes()
 	if pricingType == "desktop" {
 		limit = settings.EffectiveMaxConcurrentDesktopSandboxes()
@@ -169,6 +184,9 @@ func (c *Controller) ensureSandboxLimits(ctx context.Context, orgID string, spec
 		if sb == nil || !isActiveSandboxStatus(sb.Status) {
 			continue
 		}
+		if excludeID != "" && sb.ID == excludeID {
+			continue
+		}
 		if sandboxPricingTypeForRuntime(sb.Runtime) == pricingType {
 			active++
 		}
@@ -179,18 +197,16 @@ func (c *Controller) ensureSandboxLimits(ctx context.Context, orgID string, spec
 	return nil
 }
 
-func sandboxPriceForSpec(settings *types.SystemSettings, spec *RuntimeSpec) (float64, string) {
-	if sandboxPricingTypeForSpec(spec) == "desktop" {
-		return settings.SandboxDesktopPriceCreditsPerSecond, "desktop"
+func sandboxPriceForType(settings *types.SystemSettings, pricingType string) float64 {
+	if pricingType == "desktop" {
+		return settings.SandboxDesktopPriceCreditsPerSecond
 	}
-	return settings.SandboxHeadlessPriceCreditsPerSecond, "headless"
+	return settings.SandboxHeadlessPriceCreditsPerSecond
 }
 
 func sandboxPrice(settings *types.SystemSettings, runtime types.SandboxRuntime) (float64, string) {
-	if sandboxPricingTypeForRuntime(runtime) == "desktop" {
-		return settings.SandboxDesktopPriceCreditsPerSecond, "desktop"
-	}
-	return settings.SandboxHeadlessPriceCreditsPerSecond, "headless"
+	pricingType := sandboxPricingTypeForRuntime(runtime)
+	return sandboxPriceForType(settings, pricingType), pricingType
 }
 
 func sandboxPricingTypeForSpec(spec *RuntimeSpec) string {

--- a/api/pkg/sandbox/controller_session.go
+++ b/api/pkg/sandbox/controller_session.go
@@ -1,0 +1,261 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// Session-backed sandboxes.
+//
+// Spec-task desktops, exploratory sessions and subscription desktops are
+// provisioned by the external-agent executor, not by this controller — that
+// path owns repo checkout, branch mode, golden builds, ZFS clones and the Zed
+// configuration, none of which belong here. But they consume exactly the same
+// hydra host as a user-created sandbox, so they must be metered, quota-checked
+// and visible on the same terms.
+//
+// The functions below give the executor a way to open, resize and close a
+// billing record without handing it the provisioning pipeline. The row is the
+// meter; the executor stays the provisioner. `Sandbox.SessionID` is the
+// discriminator — see types.Sandbox.SessionBacked().
+
+// DesktopStopper tears down a session-backed container. The sandbox package
+// cannot import external-agent (that dependency already runs the other way),
+// so the executor's StopDesktop is injected as a callback at wiring time.
+type DesktopStopper func(ctx context.Context, sessionID string) error
+
+// SetDesktopStopper wires the callback used to tear down session-backed
+// containers, both when a user deletes the row from the Sandboxes UI and when
+// the org runs out of credits mid-session.
+func (c *Controller) SetDesktopStopper(stop DesktopStopper) {
+	c.stopDesktop = stop
+}
+
+// BeginSession enforces the org's concurrency limit and credit floor, then
+// upserts the sandbox row that meters this session. It returns a nil sandbox
+// (and no error) when there is nothing to meter — a desktop with no owning
+// organization has no wallet to bill.
+//
+// The returned row is in status=pending. Billing does not start until
+// MarkSessionRunning flips it to running, so a desktop that fails to boot is
+// never charged.
+func (c *Controller) BeginSession(ctx context.Context, req *types.BeginSandboxSessionRequest) (*types.Sandbox, error) {
+	if req == nil || req.SessionID == "" {
+		return nil, errors.New("session_id is required")
+	}
+	if req.OrganizationID == "" {
+		// Wallets are org-scoped; a personal desktop has nothing to debit.
+		return nil, nil
+	}
+	runtime := req.Runtime
+	if runtime == "" {
+		runtime = types.SandboxRuntimeUbuntuDesktop
+	}
+	vcpus, memoryMB := req.VCPUs, req.MemoryMB
+	if vcpus <= 0 || memoryMB <= 0 {
+		return nil, fmt.Errorf("sandbox resources are required for session %s (got %d vcpus / %d MB)", req.SessionID, vcpus, memoryMB)
+	}
+
+	settings, err := c.store.GetSystemSettings(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get system settings: %w", err)
+	}
+
+	existing, err := c.sandboxForSession(ctx, req.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	pricingType := sandboxPricingTypeForRuntime(runtime)
+	// A restart reuses the session's existing row, so exclude it from the
+	// concurrency count — resuming a paused task must not be blocked by the
+	// slot it is itself about to reoccupy.
+	excludeID := ""
+	if existing != nil {
+		excludeID = existing.ID
+	}
+	if err := c.ensureSandboxLimitsForType(ctx, req.OrganizationID, pricingType, excludeID, settings); err != nil {
+		return nil, err
+	}
+	if err := c.ensureCreditsForType(ctx, req.OrganizationID, pricingType, settings, vcpus); err != nil {
+		return nil, err
+	}
+
+	if existing != nil {
+		// Reuse the row so a paused-then-resumed task keeps one identity (and
+		// one charge history) across restarts.
+		existing.VCPUs = vcpus
+		existing.MemoryMB = memoryMB
+		existing.SpecTaskID = req.SpecTaskID
+		existing.ProjectID = req.ProjectID
+		existing.Status = types.SandboxStatusPending
+		existing.StatusMessage = ""
+		// Reopen the billing window at the restart: the gap while the desktop
+		// was stopped must not be charged.
+		existing.BillingLastChargedAt = nil
+		existing.StartedAt = nil
+		existing.StoppedAt = nil
+		updated, err := c.store.UpdateSandbox(ctx, existing)
+		if err != nil {
+			return nil, fmt.Errorf("reopen session sandbox row: %w", err)
+		}
+		return updated, nil
+	}
+
+	created, err := c.store.CreateSandbox(ctx, &types.Sandbox{
+		Name:           req.Name,
+		OrganizationID: req.OrganizationID,
+		ProjectID:      req.ProjectID,
+		Owner:          req.Owner,
+		SessionID:      req.SessionID,
+		SpecTaskID:     req.SpecTaskID,
+		Runtime:        runtime,
+		Status:         types.SandboxStatusPending,
+		VCPUs:          vcpus,
+		MemoryMB:       memoryMB,
+		DisplayWidth:   req.DisplayWidth,
+		DisplayHeight:  req.DisplayHeight,
+		DisplayFPS:     req.DisplayFPS,
+		// The task owns the desktop's lifetime, not a sandbox TTL. Negative
+		// means "never expire", which leaves expires_at NULL so ReapExpired
+		// skips the row.
+		TimeoutSeconds: -1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create session sandbox row: %w", err)
+	}
+	return created, nil
+}
+
+// MarkSessionRunning records where the container landed and opens the billing
+// window. Called once the executor has a live container.
+func (c *Controller) MarkSessionRunning(ctx context.Context, sessionID, hostDeviceID, containerID string) error {
+	sb, err := c.sandboxForSession(ctx, sessionID)
+	if err != nil || sb == nil {
+		return err
+	}
+	if hostDeviceID != "" || containerID != "" {
+		if err := c.store.SetSandboxContainer(ctx, sb.ID, hostDeviceID, containerID); err != nil {
+			return fmt.Errorf("record session sandbox container: %w", err)
+		}
+	}
+	// SetSandboxStatus(running) stamps started_at AND billing_last_charged_at,
+	// so the first billed second is the first second the container was up.
+	return c.store.SetSandboxStatus(ctx, sb.ID, types.SandboxStatusRunning, "")
+}
+
+// MarkSessionStopped settles the final partial minute and closes the row.
+// Safe to call for sessions that were never metered or never started.
+func (c *Controller) MarkSessionStopped(ctx context.Context, sessionID string) error {
+	return c.closeSession(ctx, sessionID, types.SandboxStatusStopped, "")
+}
+
+// MarkSessionFailed closes the row after a failed start. Nothing is charged
+// unless the container actually reached running.
+func (c *Controller) MarkSessionFailed(ctx context.Context, sessionID, reason string) error {
+	return c.closeSession(ctx, sessionID, types.SandboxStatusFailed, reason)
+}
+
+func (c *Controller) closeSession(ctx context.Context, sessionID string, status types.SandboxStatus, message string) error {
+	sb, err := c.sandboxForSession(ctx, sessionID)
+	if err != nil || sb == nil {
+		return err
+	}
+	if err := c.billSandboxFinal(ctx, sb, time.Now()); err != nil {
+		// A failed final charge must not block teardown — the container is
+		// going away either way, and leaving the row "running" would keep the
+		// reaper billing for a container that no longer exists.
+		log.Warn().Err(err).Str("sandbox_id", sb.ID).Str("session_id", sessionID).
+			Msg("final charge for session sandbox failed; closing row anyway")
+	}
+	return c.store.SetSandboxStatus(ctx, sb.ID, status, message)
+}
+
+// EnsureSessionResizeCredits checks the org can afford a minute at the
+// requested size before we ask hydra to resize the container.
+func (c *Controller) EnsureSessionResizeCredits(ctx context.Context, sessionID string, vcpus int) error {
+	sb, err := c.sandboxForSession(ctx, sessionID)
+	if err != nil || sb == nil {
+		return err
+	}
+	settings, err := c.store.GetSystemSettings(ctx)
+	if err != nil {
+		return fmt.Errorf("get system settings: %w", err)
+	}
+	return c.ensureCreditsForType(ctx, sb.OrganizationID, sandboxPricingTypeForRuntime(sb.Runtime), settings, vcpus)
+}
+
+// ResizeSession records a new allocation after the container has actually been
+// resized.
+//
+// Order matters: billSandbox multiplies the ENTIRE unbilled window by the row's
+// current VCPUs, so the outstanding window is settled at the old core count
+// first. Without the flush, resizing 1→8 vCPUs would retroactively reprice up
+// to a minute of already-elapsed single-core usage at eight cores.
+func (c *Controller) ResizeSession(ctx context.Context, sessionID string, vcpus, memoryMB int) error {
+	sb, err := c.sandboxForSession(ctx, sessionID)
+	if err != nil || sb == nil {
+		return err
+	}
+	if vcpus <= 0 || memoryMB <= 0 {
+		return fmt.Errorf("invalid sandbox resources: %d vcpus / %d MB", vcpus, memoryMB)
+	}
+	if sb.VCPUs == vcpus && sb.MemoryMB == memoryMB {
+		return nil
+	}
+
+	settings, err := c.store.GetSystemSettings(ctx)
+	if err != nil {
+		return fmt.Errorf("get system settings: %w", err)
+	}
+	if settings.SandboxBillingEnabled && sb.Status == types.SandboxStatusRunning {
+		if err := c.billSandbox(ctx, settings, sb, time.Now(), true, false); err != nil {
+			return fmt.Errorf("settle charges at previous size before resize: %w", err)
+		}
+	}
+	return c.store.SetSandboxResources(ctx, sb.ID, vcpus, memoryMB)
+}
+
+// stopSessionDesktop hands teardown of a session-backed container back to the
+// external-agent executor. Called from Delete once the final charge has been
+// settled.
+func (c *Controller) stopSessionDesktop(ctx context.Context, sb *types.Sandbox) error {
+	// Nothing to tear down if the desktop never came up or is already gone.
+	if sb.Status != types.SandboxStatusRunning && sb.Status != types.SandboxStatusPending {
+		return nil
+	}
+	if c.stopDesktop == nil {
+		return fmt.Errorf("cannot stop session-backed sandbox %s: no desktop stopper wired", sb.ID)
+	}
+	// Detach from the caller's context: a half-stopped desktop is worse than a
+	// slow stop, and this path also runs from the billing reaper.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := c.stopDesktop(stopCtx, sb.SessionID); err != nil {
+		return fmt.Errorf("stop desktop for session %s: %w", sb.SessionID, err)
+	}
+	return nil
+}
+
+// sandboxForSession returns the live row metering a session, or (nil, nil)
+// when the session has none — desktops started before this feature existed,
+// and desktops with no owning org, have no row and must not break teardown.
+func (c *Controller) sandboxForSession(ctx context.Context, sessionID string) (*types.Sandbox, error) {
+	if sessionID == "" {
+		return nil, nil
+	}
+	sb, err := c.store.GetSandboxBySession(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("look up sandbox for session %s: %w", sessionID, err)
+	}
+	return sb, nil
+}

--- a/api/pkg/sandbox/controller_session_test.go
+++ b/api/pkg/sandbox/controller_session_test.go
@@ -1,0 +1,322 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type ControllerSessionSuite struct {
+	suite.Suite
+	ctrl       *gomock.Controller
+	store      *store.MockStore
+	controller *Controller
+	ctx        context.Context
+}
+
+func TestControllerSessionSuite(t *testing.T) {
+	suite.Run(t, new(ControllerSessionSuite))
+}
+
+func (s *ControllerSessionSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.ctx = context.Background()
+
+	runtimes, err := NewRuntimeRegistry(config.Sandboxes{
+		Runtimes:       "headless-ubuntu=ubuntu:22.04|sleep infinity",
+		DefaultRuntime: "headless-ubuntu",
+	})
+	s.Require().NoError(err)
+	s.controller = New(s.store, nil, runtimes, "", "")
+}
+
+func (s *ControllerSessionSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *ControllerSessionSuite) beginRequest() *types.BeginSandboxSessionRequest {
+	return &types.BeginSandboxSessionRequest{
+		SessionID:      "ses_1",
+		OrganizationID: "org_1",
+		Owner:          "user_1",
+		ProjectID:      "prj_1",
+		SpecTaskID:     "spt_1",
+		Name:           "Add billing",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		VCPUs:          4,
+		MemoryMB:       8192,
+	}
+}
+
+func (s *ControllerSessionSuite) TestBeginSessionCreatesNeverExpiringDesktopRow() {
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{}, nil)
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(nil, store.ErrNotFound)
+	s.store.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.store.EXPECT().CreateSandbox(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, sb *types.Sandbox) (*types.Sandbox, error) {
+			s.Require().Equal("ses_1", sb.SessionID)
+			s.Require().Equal("spt_1", sb.SpecTaskID)
+			s.Require().Equal(types.SandboxRuntimeUbuntuDesktop, sb.Runtime)
+			s.Require().Equal(types.SandboxStatusPending, sb.Status)
+			s.Require().Equal(4, sb.VCPUs)
+			s.Require().Equal(8192, sb.MemoryMB)
+			// Negative TTL leaves expires_at NULL so ReapExpired never tears
+			// down a desktop the task still owns.
+			s.Require().Equal(-1, sb.TimeoutSeconds)
+			s.Require().True(sb.SessionBacked())
+			sb.ID = "sbx_new"
+			return sb, nil
+		},
+	)
+
+	sb, err := s.controller.BeginSession(s.ctx, s.beginRequest())
+	s.Require().NoError(err)
+	s.Require().Equal("sbx_new", sb.ID)
+}
+
+func (s *ControllerSessionSuite) TestBeginSessionSkipsMeteringWithoutOrganization() {
+	req := s.beginRequest()
+	req.OrganizationID = ""
+
+	// No store calls at all: wallets are org-scoped, so there is nothing to bill.
+	sb, err := s.controller.BeginSession(s.ctx, req)
+	s.Require().NoError(err)
+	s.Require().Nil(sb)
+}
+
+func (s *ControllerSessionSuite) TestBeginSessionRejectsStartWhenOrgCannotAffordAMinute() {
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		SandboxBillingEnabled:               true,
+		SandboxDesktopPriceCreditsPerSecond: 0.1,
+	}, nil)
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(nil, store.ErrNotFound)
+	s.store.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	// One minute at 4 cores costs 0.1 * 60 * 4 = 24 credits.
+	s.store.EXPECT().GetWalletByOrg(gomock.Any(), "org_1").Return(&types.Wallet{
+		ID:      "wallet_1",
+		OrgID:   "org_1",
+		Balance: 23.99,
+	}, nil)
+
+	_, err := s.controller.BeginSession(s.ctx, s.beginRequest())
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "insufficient credits")
+}
+
+func (s *ControllerSessionSuite) TestBeginSessionRejectsStartWhenDesktopLimitReached() {
+	existing := make([]*types.Sandbox, 0, 3)
+	for i := 0; i < 3; i++ {
+		existing = append(existing, &types.Sandbox{
+			ID:             "sbx_other",
+			OrganizationID: "org_1",
+			SessionID:      "ses_other",
+			Runtime:        types.SandboxRuntimeUbuntuDesktop,
+			Status:         types.SandboxStatusRunning,
+		})
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		MaxConcurrentDesktopSandboxes: 3,
+	}, nil)
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(nil, store.ErrNotFound)
+	s.store.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(existing, nil)
+
+	_, err := s.controller.BeginSession(s.ctx, s.beginRequest())
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "desktop sandbox concurrency limit")
+}
+
+// A paused task being resumed must not be blocked by the concurrency slot it
+// is itself about to reoccupy.
+func (s *ControllerSessionSuite) TestBeginSessionReusesRowOnRestartWithoutCountingItsOwnSlot() {
+	stoppedAt := time.Now().Add(-time.Hour)
+	chargedAt := stoppedAt.Add(-time.Minute)
+	existing := &types.Sandbox{
+		ID:                   "sbx_existing",
+		OrganizationID:       "org_1",
+		SessionID:            "ses_1",
+		Runtime:              types.SandboxRuntimeUbuntuDesktop,
+		Status:               types.SandboxStatusStopped,
+		VCPUs:                1,
+		MemoryMB:             2048,
+		StoppedAt:            &stoppedAt,
+		BillingLastChargedAt: &chargedAt,
+	}
+	// The org is at its cap of 1, and the only active desktop is this
+	// session's own row.
+	others := []*types.Sandbox{{
+		ID:             "sbx_existing",
+		OrganizationID: "org_1",
+		SessionID:      "ses_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+	}}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		MaxConcurrentDesktopSandboxes: 1,
+	}, nil)
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(existing, nil)
+	s.store.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(others, nil)
+	s.store.EXPECT().UpdateSandbox(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, sb *types.Sandbox) (*types.Sandbox, error) {
+			s.Require().Equal("sbx_existing", sb.ID)
+			s.Require().Equal(types.SandboxStatusPending, sb.Status)
+			s.Require().Equal(4, sb.VCPUs)
+			s.Require().Equal(8192, sb.MemoryMB)
+			// The stopped gap must not be billed on resume.
+			s.Require().Nil(sb.BillingLastChargedAt)
+			s.Require().Nil(sb.StartedAt)
+			return sb, nil
+		},
+	)
+
+	sb, err := s.controller.BeginSession(s.ctx, s.beginRequest())
+	s.Require().NoError(err)
+	s.Require().Equal("sbx_existing", sb.ID)
+}
+
+func (s *ControllerSessionSuite) TestMarkSessionRunningOpensBillingWindow() {
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(&types.Sandbox{
+		ID:        "sbx_1",
+		SessionID: "ses_1",
+		Status:    types.SandboxStatusPending,
+	}, nil)
+	s.store.EXPECT().SetSandboxContainer(gomock.Any(), "sbx_1", "host_1", "cnt_1").Return(nil)
+	s.store.EXPECT().SetSandboxStatus(gomock.Any(), "sbx_1", types.SandboxStatusRunning, "").Return(nil)
+
+	s.Require().NoError(s.controller.MarkSessionRunning(s.ctx, "ses_1", "host_1", "cnt_1"))
+}
+
+// A desktop that never booted must not keep a concurrency slot: pending counts
+// as active.
+func (s *ControllerSessionSuite) TestMarkSessionFailedClosesRowWithoutCharging() {
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(&types.Sandbox{
+		ID:             "sbx_1",
+		OrganizationID: "org_1",
+		SessionID:      "ses_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusPending,
+	}, nil)
+	// billSandboxFinal returns immediately for a row that never ran, so no
+	// wallet call is expected here.
+	s.store.EXPECT().SetSandboxStatus(gomock.Any(), "sbx_1", types.SandboxStatusFailed, "boom").Return(nil)
+
+	s.Require().NoError(s.controller.MarkSessionFailed(s.ctx, "ses_1", "boom"))
+}
+
+func (s *ControllerSessionSuite) TestMarkSessionStoppedIsANoOpForUnmeteredSessions() {
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_legacy").Return(nil, store.ErrNotFound)
+
+	s.Require().NoError(s.controller.MarkSessionStopped(s.ctx, "ses_legacy"))
+}
+
+// Resizing 1 -> 8 vCPUs must settle the outstanding window at ONE core before
+// the row starts billing at eight. Without the flush, billSandbox would
+// multiply the whole elapsed window by the new core count.
+func (s *ControllerSessionSuite) TestResizeSessionSettlesChargesAtOldCoreCountFirst() {
+	chargedAt := time.Now().Add(-30 * time.Second)
+	startedAt := chargedAt.Add(-time.Minute)
+	existing := &types.Sandbox{
+		ID:                   "sbx_1",
+		OrganizationID:       "org_1",
+		SessionID:            "ses_1",
+		Runtime:              types.SandboxRuntimeUbuntuDesktop,
+		Status:               types.SandboxStatusRunning,
+		VCPUs:                1,
+		MemoryMB:             2048,
+		StartedAt:            &startedAt,
+		BillingLastChargedAt: &chargedAt,
+	}
+
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(existing, nil)
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		SandboxBillingEnabled:               true,
+		SandboxDesktopPriceCreditsPerSecond: 1,
+	}, nil)
+	s.store.EXPECT().GetWalletByOrg(gomock.Any(), "org_1").Return(&types.Wallet{
+		ID:      "wallet_1",
+		OrgID:   "org_1",
+		Balance: 10000,
+	}, nil)
+	s.store.EXPECT().UpdateWalletBalance(gomock.Any(), "wallet_1", gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, walletID string, amount float64, _ types.TransactionMetadata) (*types.Wallet, error) {
+			// 30 elapsed seconds at 1 credit/s/core and ONE core: ~-30, not -240.
+			s.Require().InDelta(-30.0, amount, 1.0)
+			return &types.Wallet{ID: walletID, Balance: 9970}, nil
+		},
+	)
+	s.store.EXPECT().SetSandboxBillingLastChargedAt(gomock.Any(), "sbx_1", gomock.Any()).Return(nil)
+	s.store.EXPECT().SetSandboxResources(gomock.Any(), "sbx_1", 8, 16384).Return(nil)
+
+	s.Require().NoError(s.controller.ResizeSession(s.ctx, "ses_1", 8, 16384))
+}
+
+func (s *ControllerSessionSuite) TestResizeSessionSkipsFlushWhenSizeUnchanged() {
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(&types.Sandbox{
+		ID:        "sbx_1",
+		SessionID: "ses_1",
+		Status:    types.SandboxStatusRunning,
+		VCPUs:     4,
+		MemoryMB:  8192,
+	}, nil)
+
+	s.Require().NoError(s.controller.ResizeSession(s.ctx, "ses_1", 4, 8192))
+}
+
+// A session-backed container is registered with hydra under the SESSION id, so
+// deleting the row must hand teardown back to the executor rather than asking
+// hydra to delete a container named after the row.
+func (s *ControllerSessionSuite) TestDeleteRoutesSessionBackedTeardownToDesktopStopper() {
+	stopped := ""
+	s.controller.SetDesktopStopper(func(_ context.Context, sessionID string) error {
+		stopped = sessionID
+		return nil
+	})
+
+	s.store.EXPECT().GetSandbox(gomock.Any(), "sbx_1").Return(&types.Sandbox{
+		ID:             "sbx_1",
+		OrganizationID: "org_1",
+		SessionID:      "ses_1",
+		HostDeviceID:   "host_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+	}, nil)
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{}, nil)
+	s.store.EXPECT().SetSandboxStatus(gomock.Any(), "sbx_1", types.SandboxStatusStopping, "").Return(nil)
+	s.store.EXPECT().GetAPIKey(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound)
+	s.store.EXPECT().DeleteSandbox(gomock.Any(), "sbx_1").Return(nil)
+
+	s.Require().NoError(s.controller.Delete(s.ctx, "sbx_1"))
+	s.Require().Equal("ses_1", stopped)
+}
+
+func (s *ControllerSessionSuite) TestDeleteFailsLoudlyWhenNoDesktopStopperIsWired() {
+	s.store.EXPECT().GetSandbox(gomock.Any(), "sbx_1").Return(&types.Sandbox{
+		ID:             "sbx_1",
+		OrganizationID: "org_1",
+		SessionID:      "ses_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+	}, nil)
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{}, nil)
+	s.store.EXPECT().SetSandboxStatus(gomock.Any(), "sbx_1", types.SandboxStatusStopping, "").Return(nil)
+
+	err := s.controller.Delete(s.ctx, "sbx_1")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "no desktop stopper wired")
+}
+
+func (s *ControllerSessionSuite) TestHydraOpsIDPrefersSessionForSessionBackedRows() {
+	sessionBacked := &types.Sandbox{ID: "sbx_1", SessionID: "ses_1"}
+	controllerManaged := &types.Sandbox{ID: "sbx_2"}
+
+	s.Require().Equal("ses_1", sessionBacked.HydraOpsID())
+	s.Require().Equal("sbx_2", controllerManaged.HydraOpsID())
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -33549,6 +33549,40 @@ const docTemplate = `{
                 }
             }
         },
+        "types.OrgComputeUsage": {
+            "type": "object",
+            "properties": {
+                "billing_enabled": {
+                    "description": "BillingEnabled reports whether compute is actually charged. When false\nthe credits above are historical and nothing new is accruing.",
+                    "type": "boolean"
+                },
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeDailyPoint"
+                    }
+                },
+                "desktop_credits": {
+                    "type": "number"
+                },
+                "headless_credits": {
+                    "type": "number"
+                },
+                "running_sandboxes": {
+                    "description": "RunningSandboxes is a point-in-time count, not a range aggregate.",
+                    "type": "integer"
+                },
+                "sandboxes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeBreakdownRow"
+                    }
+                },
+                "total_credits": {
+                    "type": "number"
+                }
+            }
+        },
         "types.OrgDetails": {
             "type": "object",
             "properties": {
@@ -33601,6 +33635,14 @@ const docTemplate = `{
                 },
                 "cache_savings": {
                     "type": "number"
+                },
+                "compute": {
+                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OrgComputeUsage"
+                        }
+                    ]
                 },
                 "export_apps": {
                     "type": "array",
@@ -40240,6 +40282,52 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "types.UsageComputeBreakdownRow": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pricing_type": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                },
+                "vcpus": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageComputeDailyPoint": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                },
+                "desktop": {
+                    "type": "number"
+                },
+                "headless": {
+                    "type": "number"
+                },
+                "total": {
+                    "type": "number"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -35988,6 +35988,14 @@ const docTemplate = `{
                 "runtime": {
                     "$ref": "#/definitions/types.SandboxRuntime"
                 },
+                "session_id": {
+                    "description": "SessionID links the row to the Helix session that owns the container,\nfor sandboxes whose container is provisioned by the external-agent\nexecutor rather than by sandbox.Controller.provision (spec-task\ndesktops, exploratory sessions, subscription desktops). The row exists\nso those containers are metered, quota-checked and visible in the\nSandboxes UI on the same terms as user-created sandboxes.\n\nNon-empty is the discriminator for \"session-backed\": hydra registers\nevery operation for such a container under the session id, so callers\nmust route hydra ops via HydraOpsID() rather than the row id.",
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "description": "SpecTaskID is the spec task that owns the session, when there is one.\nDenormalised from the session purely so the Sandboxes list can link back\nto the task without joining through sessions.",
+                    "type": "string"
+                },
                 "started_at": {
                     "type": "string"
                 },

--- a/api/pkg/server/sandboxes_api_handlers.go
+++ b/api/pkg/server/sandboxes_api_handlers.go
@@ -237,7 +237,7 @@ func (s *HelixAPIServer) runSandboxCommand(rw http.ResponseWriter, r *http.Reque
 	}
 
 	req := &hydra.ExecRequest{
-		SandboxID:      sb.ID,
+		SandboxID:      sb.HydraOpsID(),
 		CmdID:          system.GenerateSandboxCommandID(),
 		Cmd:            body.Cmd,
 		Args:           body.Args,
@@ -247,7 +247,7 @@ func (s *HelixAPIServer) runSandboxCommand(rw http.ResponseWriter, r *http.Reque
 		Detached:       body.Detached,
 		TimeoutSeconds: body.TimeoutSeconds,
 	}
-	resp, err := client.RunSandboxCommand(r.Context(), sb.ID, req)
+	resp, err := client.RunSandboxCommand(r.Context(), sb.HydraOpsID(), req)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -275,7 +275,7 @@ func (s *HelixAPIServer) listSandboxCommands(rw http.ResponseWriter, r *http.Req
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	resp, err := client.ListSandboxCommands(r.Context(), sb.ID)
+	resp, err := client.ListSandboxCommands(r.Context(), sb.HydraOpsID())
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -305,7 +305,7 @@ func (s *HelixAPIServer) getSandboxCommand(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	cmdID := mux.Vars(r)["cmd_id"]
-	resp, err := client.GetSandboxCommand(r.Context(), sb.ID, cmdID)
+	resp, err := client.GetSandboxCommand(r.Context(), sb.HydraOpsID(), cmdID)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusNotFound)
 		return
@@ -339,7 +339,7 @@ func (s *HelixAPIServer) streamSandboxCommandLogs(rw http.ResponseWriter, r *htt
 	stream := r.URL.Query().Get("stream")
 	follow := r.URL.Query().Get("follow") == "1"
 
-	body, err := client.StreamSandboxCommandLogs(r.Context(), sb.ID, cmdID, stream, follow)
+	body, err := client.StreamSandboxCommandLogs(r.Context(), sb.HydraOpsID(), cmdID, stream, follow)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -387,7 +387,7 @@ func (s *HelixAPIServer) killSandboxCommand(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 	cmdID := mux.Vars(r)["cmd_id"]
-	if err := client.KillSandboxCommand(r.Context(), sb.ID, cmdID, r.URL.Query().Get("signal")); err != nil {
+	if err := client.KillSandboxCommand(r.Context(), sb.HydraOpsID(), cmdID, r.URL.Query().Get("signal")); err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -425,7 +425,7 @@ func (s *HelixAPIServer) sandboxFile(rw http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		data, err := client.ReadSandboxFile(r.Context(), sb.ID, path)
+		data, err := client.ReadSandboxFile(r.Context(), sb.HydraOpsID(), path)
 		if err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
@@ -448,14 +448,14 @@ func (s *HelixAPIServer) sandboxFile(rw http.ResponseWriter, r *http.Request) {
 			http.Error(rw, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := client.WriteSandboxFile(r.Context(), sb.ID, path, body, mode); err != nil {
+		if err := client.WriteSandboxFile(r.Context(), sb.HydraOpsID(), path, body, mode); err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		rw.WriteHeader(http.StatusNoContent)
 	case http.MethodDelete:
 		recursive := r.URL.Query().Get("recursive") == "1"
-		if err := client.DeleteSandboxFile(r.Context(), sb.ID, path, recursive); err != nil {
+		if err := client.DeleteSandboxFile(r.Context(), sb.HydraOpsID(), path, recursive); err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -486,7 +486,7 @@ func (s *HelixAPIServer) listSandboxFiles(rw http.ResponseWriter, r *http.Reques
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	resp, err := client.ListSandboxFiles(r.Context(), sb.ID, r.URL.Query().Get("path"))
+	resp, err := client.ListSandboxFiles(r.Context(), sb.HydraOpsID(), r.URL.Query().Get("path"))
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -516,7 +516,7 @@ func (s *HelixAPIServer) sandboxTerminal(rw http.ResponseWriter, r *http.Request
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	s.openPersistentTerminal(rw, r, client, sb.ID, "", "")
+	s.openPersistentTerminal(rw, r, client, sb.HydraOpsID(), "", "")
 }
 
 // openPersistentTerminal bridges a browser terminal to a development
@@ -673,10 +673,12 @@ func (s *HelixAPIServer) sandboxScreenshot(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	// The desktop container registers a RevDial endpoint as
-	// `desktop-{HELIX_SESSION_ID}` — for sandboxes, HELIX_SESSION_ID is the
-	// sandbox id, so we dial `desktop-{sbx_…}` and forward an HTTP GET to
-	// localhost:9876/screenshot (the in-container desktop-bridge port).
-	runnerID := fmt.Sprintf("desktop-%s", sb.ID)
+	// `desktop-{HELIX_SESSION_ID}`. For controller-managed sandboxes
+	// HELIX_SESSION_ID is the sandbox id; for session-backed rows (spec-task
+	// desktops) it is the Helix session id — HydraOpsID() picks the right one.
+	// We dial it and forward an HTTP GET to localhost:9876/screenshot (the
+	// in-container desktop-bridge port).
+	runnerID := fmt.Sprintf("desktop-%s", sb.HydraOpsID())
 	conn, err := s.connman.Dial(r.Context(), runnerID)
 	if err != nil {
 		http.Error(rw, fmt.Sprintf("desktop bridge not connected: %v", err), http.StatusServiceUnavailable)
@@ -872,7 +874,7 @@ func (s *HelixAPIServer) sandboxTerminalSessions(rw http.ResponseWriter, r *http
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	s.listPersistentTerminalSessions(rw, r, client, sb.ID)
+	s.listPersistentTerminalSessions(rw, r, client, sb.HydraOpsID())
 }
 
 func (s *HelixAPIServer) listPersistentTerminalSessions(rw http.ResponseWriter, r *http.Request, client *hydra.RevDialClient, targetID string) {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -442,6 +442,14 @@ func NewServer(
 	apiServer.webServiceController = webservice.New(store, apiServer.sandboxController)
 	go webservice.NewDomainVerifier(store).Start(context.Background())
 
+	// Unify compute billing: desktops provisioned by the external-agent
+	// executor (spec tasks, exploratory sessions, subscription desktops) get a
+	// sandbox row so they are metered, quota-checked and listed on the same
+	// terms as user-created sandboxes. The two halves are wired to each other
+	// here because neither package may import the other.
+	externalAgentExecutor.SetSandboxMeter(apiServer.sandboxController)
+	apiServer.sandboxController.SetDesktopStopper(externalAgentExecutor.StopDesktop)
+
 	// Bootstrap the compute subsystem (cloud-side host provisioning).
 	// Returns (nil, nil) when HELIX_COMPUTE_PROVIDER is unset, leaving
 	// Helix on the legacy self-registered-host path. A non-nil error

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -35984,6 +35984,14 @@
                 "runtime": {
                     "$ref": "#/definitions/types.SandboxRuntime"
                 },
+                "session_id": {
+                    "description": "SessionID links the row to the Helix session that owns the container,\nfor sandboxes whose container is provisioned by the external-agent\nexecutor rather than by sandbox.Controller.provision (spec-task\ndesktops, exploratory sessions, subscription desktops). The row exists\nso those containers are metered, quota-checked and visible in the\nSandboxes UI on the same terms as user-created sandboxes.\n\nNon-empty is the discriminator for \"session-backed\": hydra registers\nevery operation for such a container under the session id, so callers\nmust route hydra ops via HydraOpsID() rather than the row id.",
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "description": "SpecTaskID is the spec task that owns the session, when there is one.\nDenormalised from the session purely so the Sandboxes list can link back\nto the task without joining through sessions.",
+                    "type": "string"
+                },
                 "started_at": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -33545,6 +33545,40 @@
                 }
             }
         },
+        "types.OrgComputeUsage": {
+            "type": "object",
+            "properties": {
+                "billing_enabled": {
+                    "description": "BillingEnabled reports whether compute is actually charged. When false\nthe credits above are historical and nothing new is accruing.",
+                    "type": "boolean"
+                },
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeDailyPoint"
+                    }
+                },
+                "desktop_credits": {
+                    "type": "number"
+                },
+                "headless_credits": {
+                    "type": "number"
+                },
+                "running_sandboxes": {
+                    "description": "RunningSandboxes is a point-in-time count, not a range aggregate.",
+                    "type": "integer"
+                },
+                "sandboxes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeBreakdownRow"
+                    }
+                },
+                "total_credits": {
+                    "type": "number"
+                }
+            }
+        },
         "types.OrgDetails": {
             "type": "object",
             "properties": {
@@ -33597,6 +33631,14 @@
                 },
                 "cache_savings": {
                     "type": "number"
+                },
+                "compute": {
+                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OrgComputeUsage"
+                        }
+                    ]
                 },
                 "export_apps": {
                     "type": "array",
@@ -40236,6 +40278,52 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "types.UsageComputeBreakdownRow": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pricing_type": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                },
+                "vcpus": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageComputeDailyPoint": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                },
+                "desktop": {
+                    "type": "number"
+                },
+                "headless": {
+                    "type": "number"
+                },
+                "total": {
+                    "type": "number"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -9118,6 +9118,25 @@ definitions:
         type: string
       runtime:
         $ref: '#/definitions/types.SandboxRuntime'
+      session_id:
+        description: |-
+          SessionID links the row to the Helix session that owns the container,
+          for sandboxes whose container is provisioned by the external-agent
+          executor rather than by sandbox.Controller.provision (spec-task
+          desktops, exploratory sessions, subscription desktops). The row exists
+          so those containers are metered, quota-checked and visible in the
+          Sandboxes UI on the same terms as user-created sandboxes.
+
+          Non-empty is the discriminator for "session-backed": hydra registers
+          every operation for such a container under the session id, so callers
+          must route hydra ops via HydraOpsID() rather than the row id.
+        type: string
+      spec_task_id:
+        description: |-
+          SpecTaskID is the spec task that owns the session, when there is one.
+          Denormalised from the session purely so the Sandboxes list can link back
+          to the task without joining through sessions.
+        type: string
       started_at:
         type: string
       status:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -7362,6 +7362,31 @@ definitions:
       total_tokens:
         type: integer
     type: object
+  types.OrgComputeUsage:
+    properties:
+      billing_enabled:
+        description: |-
+          BillingEnabled reports whether compute is actually charged. When false
+          the credits above are historical and nothing new is accruing.
+        type: boolean
+      daily:
+        items:
+          $ref: '#/definitions/types.UsageComputeDailyPoint'
+        type: array
+      desktop_credits:
+        type: number
+      headless_credits:
+        type: number
+      running_sandboxes:
+        description: RunningSandboxes is a point-in-time count, not a range aggregate.
+        type: integer
+      sandboxes:
+        items:
+          $ref: '#/definitions/types.UsageComputeBreakdownRow'
+        type: array
+      total_credits:
+        type: number
+    type: object
   types.OrgDetails:
     properties:
       members:
@@ -7397,6 +7422,13 @@ definitions:
         type: array
       cache_savings:
         type: number
+      compute:
+        allOf:
+        - $ref: '#/definitions/types.OrgComputeUsage'
+        description: |-
+          Compute is sandbox runtime spend. It answers the date range and the
+          project filter; the token-shaped filters (model, provider, session)
+          don't apply to a container and leave it untouched.
       export_apps:
         items:
           $ref: '#/definitions/types.UsageBreakdownRow'
@@ -12344,6 +12376,36 @@ definitions:
         type: integer
       username:
         type: string
+    type: object
+  types.UsageComputeBreakdownRow:
+    properties:
+      credits:
+        type: number
+      name:
+        type: string
+      pricing_type:
+        type: string
+      project_id:
+        type: string
+      runtime:
+        type: string
+      sandbox_id:
+        type: string
+      spec_task_id:
+        type: string
+      vcpus:
+        type: integer
+    type: object
+  types.UsageComputeDailyPoint:
+    properties:
+      date:
+        type: string
+      desktop:
+        type: number
+      headless:
+        type: number
+      total:
+        type: number
     type: object
   types.UsageFilterOption:
     properties:

--- a/api/pkg/server/usage_handlers.go
+++ b/api/pkg/server/usage_handlers.go
@@ -268,6 +268,22 @@ func (s *HelixAPIServer) getOrgUsageSummary(_ http.ResponseWriter, r *http.Reque
 	}
 	s.enrichOrgUsageCosts(r.Context(), summary)
 
+	// Sandbox runtime is the other half of the bill. It comes from the wallet
+	// ledger rather than usage_metrics, so it is a separate query rather than
+	// part of GetOrgUsageSummary. A failure here must not blank the token
+	// numbers the page is mainly about.
+	compute, err := s.Store.GetOrgComputeUsage(r.Context(), &store.GetOrgComputeUsageQuery{
+		OrganizationID: orgID,
+		ProjectID:      r.URL.Query().Get("project_id"),
+		From:           from,
+		To:             to,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("org_id", orgID).Msg("failed to load organization compute usage")
+	} else {
+		summary.Compute = compute
+	}
+
 	return summary, nil
 }
 

--- a/api/pkg/server/usage_handlers.go
+++ b/api/pkg/server/usage_handlers.go
@@ -392,6 +392,11 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 		metric.CacheReadTokens += row.CacheReadTokens
 		metric.CacheWriteTokens += row.CacheWriteTokens
 		metric.TotalCost += estimatedCost
+		// Accumulate total duration here and average it once all rows for the
+		// provider-day are in — averaging per row would weight a day with one
+		// slow call the same as a day with a thousand fast ones.
+		metric.LatencyMs += row.DurationMs
+		metric.TotalRequests += row.TotalRequests
 	}
 
 	for index := range summary.Models {
@@ -426,7 +431,15 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 			if metric == nil {
 				metric = &types.AggregatedUsageMetric{Date: totalMetric.Date}
 			}
-			series.Metrics = append(series.Metrics, *metric)
+			point := *metric
+			// LatencyMs accumulated total duration above; publish the mean per
+			// request, which is what the latency chart plots.
+			if point.TotalRequests > 0 {
+				point.LatencyMs = point.LatencyMs / float64(point.TotalRequests)
+			} else {
+				point.LatencyMs = 0
+			}
+			series.Metrics = append(series.Metrics, point)
 		}
 		summary.ProviderTimeSeries = append(summary.ProviderTimeSeries, series)
 	}

--- a/api/pkg/server/usage_handlers_test.go
+++ b/api/pkg/server/usage_handlers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -132,6 +133,17 @@ func TestGetOrgUsageSummaryParsesFiltersAndPagination(t *testing.T) {
 			require.Equal(t, 75, q.SessionOffset)
 			return &types.OrgUsageSummaryResponse{}, nil
 		})
+	// Compute answers the date range and the project, and deliberately ignores
+	// the token-shaped filters — a container has no model or provider.
+	mockStore.EXPECT().
+		GetOrgComputeUsage(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, q *store.GetOrgComputeUsageQuery) (*types.OrgComputeUsage, error) {
+			require.Equal(t, org.ID, q.OrganizationID)
+			require.Equal(t, fromTime, q.From)
+			require.Equal(t, toTime, q.To)
+			require.Equal(t, "prj_456", q.ProjectID)
+			return &types.OrgComputeUsage{TotalCredits: 12.5, DesktopCredits: 12.5}, nil
+		})
 
 	req := httptest.NewRequest("GET", "/api/v1/usage/org-summary?org_id=koala-bunny-corp&from="+from+"&to="+to+"&user_id=user_456&project_id=prj_456&app_id=app_456&session_id=ses_456&provider=anthropic&model=claude-sonnet-4&user_search=alice@example.com&user_limit=25&user_offset=50&project_limit=10&project_offset=20&task_limit=10&task_offset=30&session_limit=25&session_offset=75", nil)
 	req = req.WithContext(setRequestUser(req.Context(), user))
@@ -139,4 +151,39 @@ func TestGetOrgUsageSummaryParsesFiltersAndPagination(t *testing.T) {
 	resp, httpErr := server.getOrgUsageSummary(httptest.NewRecorder(), req)
 	require.Nil(t, httpErr)
 	require.NotNil(t, resp)
+	require.NotNil(t, resp.Compute)
+	require.Equal(t, 12.5, resp.Compute.TotalCredits)
+}
+
+// Compute is a second query over a different table; if it fails the page must
+// still render the token numbers it is mainly about.
+func TestGetOrgUsageSummarySurvivesComputeFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	org := &types.Organization{ID: "org_123", Name: "koala-bunny-corp"}
+	user := types.User{ID: "user_admin", Admin: true}
+
+	mockStore.EXPECT().
+		GetOrganization(gomock.Any(), &store.GetOrganizationQuery{Name: org.Name}).
+		Return(org, nil)
+	mockStore.EXPECT().
+		GetOrganizationMembership(gomock.Any(), gomock.Any()).
+		Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().
+		GetOrgUsageSummary(gomock.Any(), gomock.Any()).
+		Return(&types.OrgUsageSummaryResponse{RawTokenCost: 42}, nil)
+	mockStore.EXPECT().
+		GetOrgComputeUsage(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("compute query exploded"))
+
+	req := httptest.NewRequest("GET", "/api/v1/usage/org-summary?org_id=koala-bunny-corp", nil)
+	req = req.WithContext(setRequestUser(req.Context(), user))
+
+	resp, httpErr := server.getOrgUsageSummary(httptest.NewRecorder(), req)
+	require.Nil(t, httpErr)
+	require.NotNil(t, resp)
+	require.Equal(t, float64(42), resp.RawTokenCost)
+	require.Nil(t, resp.Compute)
 }

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -839,12 +839,14 @@ type Store interface {
 	// User Sandbox methods (Sandboxes API — POST /organizations/{org}/sandboxes etc.)
 	CreateSandbox(ctx context.Context, sandbox *types.Sandbox) (*types.Sandbox, error)
 	GetSandbox(ctx context.Context, id string) (*types.Sandbox, error)
+	GetSandboxBySession(ctx context.Context, sessionID string) (*types.Sandbox, error)
 	ListSandboxes(ctx context.Context, q *ListSandboxesQuery) ([]*types.Sandbox, error)
 	UpdateSandbox(ctx context.Context, sandbox *types.Sandbox) (*types.Sandbox, error)
 	SetSandboxStatus(ctx context.Context, id string, status types.SandboxStatus, message string) error
 	SetSandboxBillingLastChargedAt(ctx context.Context, id string, chargedAt time.Time) error
 	SetRunningSandboxesBillingLastChargedAt(ctx context.Context, chargedAt time.Time) error
 	SetSandboxContainer(ctx context.Context, id string, hostDeviceID, containerID string) error
+	SetSandboxResources(ctx context.Context, id string, vcpus, memoryMB int) error
 	DeleteSandbox(ctx context.Context, id string) error
 	ListExpiredSandboxes(ctx context.Context, now time.Time) ([]*types.Sandbox, error)
 	ListStoppedNonPersistentSandboxes(ctx context.Context, before time.Time) ([]*types.Sandbox, error)

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -536,6 +536,7 @@ type Store interface {
 	GetAggregatedUsageMetrics(ctx context.Context, q *GetAggregatedUsageMetricsQuery) ([]*types.AggregatedUsageMetric, error)
 	GetOrgUsageSummary(ctx context.Context, q *GetOrgUsageSummaryQuery) (*types.OrgUsageSummaryResponse, error)
 	GetSandboxUsageMetrics(ctx context.Context, q *GetAggregatedUsageMetricsQuery) ([]*types.AggregatedUsageMetric, error)
+	GetOrgComputeUsage(ctx context.Context, q *GetOrgComputeUsageQuery) (*types.OrgComputeUsage, error)
 
 	CreateSlackThread(ctx context.Context, thread *types.SlackThread) (*types.SlackThread, error)
 	GetSlackThread(ctx context.Context, appID, channel, threadKey string) (*types.SlackThread, error)

--- a/api/pkg/store/store_compute_usage.go
+++ b/api/pkg/store/store_compute_usage.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/gorm"
+)
+
+// GetOrgComputeUsageQuery selects the sandbox-compute spend to summarise.
+//
+// Only the date range and the project narrow the result. The token-shaped
+// filters on the usage page (model, provider, session, user) have no analogue
+// for a container, so compute intentionally ignores them rather than
+// silently returning zero when one is set.
+type GetOrgComputeUsageQuery struct {
+	OrganizationID string
+	ProjectID      string
+	From           time.Time
+	To             time.Time
+	// SandboxLimit caps the per-sandbox breakdown. Defaults to 10.
+	SandboxLimit int
+}
+
+// GetOrgComputeUsage summarises what an org spent on sandbox runtime.
+//
+// The source of truth is the wallet ledger, not the `sandboxes` table: charges
+// are immutable transactions, so a desktop that has since been torn down still
+// accounts for what it cost. Sandbox rows are LEFT JOINed only to decorate the
+// breakdown with a name, size and owning task, all of which may be missing for
+// a hard-deleted row.
+func (s *PostgresStore) GetOrgComputeUsage(ctx context.Context, q *GetOrgComputeUsageQuery) (*types.OrgComputeUsage, error) {
+	if q == nil {
+		return nil, errors.New("query is required")
+	}
+	if q.OrganizationID == "" {
+		return nil, errors.New("organization_id is required")
+	}
+	limit := q.SandboxLimit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	usage := &types.OrgComputeUsage{
+		Daily:     []types.UsageComputeDailyPoint{},
+		Sandboxes: []types.UsageComputeBreakdownRow{},
+	}
+
+	// Charges are recorded as negative wallet deltas; flip the sign so the
+	// page reads in spend, matching the token cost columns next to it.
+	base := func() *gorm.DB {
+		query := s.gdb.WithContext(ctx).
+			Table("transactions").
+			Joins("JOIN wallets ON wallets.id = transactions.wallet_id").
+			Joins("LEFT JOIN sandboxes ON sandboxes.id = transactions.sandbox_id").
+			Where("wallets.org_id = ?", q.OrganizationID).
+			Where("transactions.type = ?", types.TransactionTypeUsage).
+			Where("transactions.sandbox_id <> ''").
+			Where("transactions.created_at >= ? AND transactions.created_at <= ?", q.From, q.To)
+		if q.ProjectID != "" {
+			query = query.Where("sandboxes.project_id = ?", q.ProjectID)
+		}
+		return query
+	}
+
+	var totals []struct {
+		PricingType string  `gorm:"column:pricing_type"`
+		Credits     float64 `gorm:"column:credits"`
+	}
+	if err := base().
+		Select("COALESCE(NULLIF(transactions.sandbox_pricing_type, ''), 'headless') as pricing_type, COALESCE(SUM(-transactions.amount), 0) as credits").
+		Group("COALESCE(NULLIF(transactions.sandbox_pricing_type, ''), 'headless')").
+		Scan(&totals).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range totals {
+		usage.TotalCredits += row.Credits
+		if row.PricingType == sandboxPricingTypeDesktop {
+			usage.DesktopCredits += row.Credits
+		} else {
+			usage.HeadlessCredits += row.Credits
+		}
+	}
+
+	var daily []struct {
+		Date        time.Time `gorm:"column:date"`
+		PricingType string    `gorm:"column:pricing_type"`
+		Credits     float64   `gorm:"column:credits"`
+	}
+	if err := base().
+		Select(`date_trunc('day', transactions.created_at) as date,
+			COALESCE(NULLIF(transactions.sandbox_pricing_type, ''), 'headless') as pricing_type,
+			COALESCE(SUM(-transactions.amount), 0) as credits`).
+		Group("date_trunc('day', transactions.created_at), COALESCE(NULLIF(transactions.sandbox_pricing_type, ''), 'headless')").
+		Order("date ASC").
+		Scan(&daily).Error; err != nil {
+		return nil, err
+	}
+	usage.Daily = buildComputeDailySeries(daily, q.From, q.To)
+
+	var sandboxes []struct {
+		SandboxID   string  `gorm:"column:sandbox_id"`
+		Name        string  `gorm:"column:name"`
+		Runtime     string  `gorm:"column:runtime"`
+		PricingType string  `gorm:"column:pricing_type"`
+		SpecTaskID  string  `gorm:"column:spec_task_id"`
+		ProjectID   string  `gorm:"column:project_id"`
+		VCPUs       int     `gorm:"column:vcpus"`
+		Credits     float64 `gorm:"column:credits"`
+	}
+	if err := base().
+		Select(`transactions.sandbox_id as sandbox_id,
+			COALESCE(MAX(sandboxes.name), '') as name,
+			COALESCE(MAX(sandboxes.runtime), MAX(transactions.sandbox_runtime), '') as runtime,
+			COALESCE(MAX(NULLIF(transactions.sandbox_pricing_type, '')), 'headless') as pricing_type,
+			COALESCE(MAX(sandboxes.spec_task_id), '') as spec_task_id,
+			COALESCE(MAX(sandboxes.project_id), '') as project_id,
+			COALESCE(MAX(sandboxes.v_cpus), 0) as vcpus,
+			COALESCE(SUM(-transactions.amount), 0) as credits`).
+		Group("transactions.sandbox_id").
+		Order("credits DESC").
+		Limit(limit).
+		Scan(&sandboxes).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range sandboxes {
+		usage.Sandboxes = append(usage.Sandboxes, types.UsageComputeBreakdownRow{
+			SandboxID:   row.SandboxID,
+			Name:        row.Name,
+			Runtime:     row.Runtime,
+			PricingType: row.PricingType,
+			SpecTaskID:  row.SpecTaskID,
+			ProjectID:   row.ProjectID,
+			VCPUs:       row.VCPUs,
+			Credits:     row.Credits,
+		})
+	}
+
+	var running int64
+	runningQuery := s.gdb.WithContext(ctx).
+		Model(&types.Sandbox{}).
+		Where("organization_id = ? AND deleted_at IS NULL AND status = ?", q.OrganizationID, types.SandboxStatusRunning)
+	if q.ProjectID != "" {
+		runningQuery = runningQuery.Where("project_id = ?", q.ProjectID)
+	}
+	if err := runningQuery.Count(&running).Error; err != nil {
+		return nil, err
+	}
+	usage.RunningSandboxes = int(running)
+
+	settings, err := s.GetSystemSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	usage.BillingEnabled = settings.SandboxBillingEnabled
+
+	return usage, nil
+}
+
+const sandboxPricingTypeDesktop = "desktop"
+
+// buildComputeDailySeries pivots (day, pricing type) rows into one point per
+// day and fills the gaps, so a day with no sandboxes plots as zero instead of
+// collapsing the x-axis onto the days that happened to have spend.
+func buildComputeDailySeries(rows []struct {
+	Date        time.Time `gorm:"column:date"`
+	PricingType string    `gorm:"column:pricing_type"`
+	Credits     float64   `gorm:"column:credits"`
+}, from, to time.Time) []types.UsageComputeDailyPoint {
+	byDay := make(map[time.Time]*types.UsageComputeDailyPoint)
+	for _, row := range rows {
+		day := row.Date.UTC().Truncate(24 * time.Hour)
+		point, ok := byDay[day]
+		if !ok {
+			point = &types.UsageComputeDailyPoint{Date: day}
+			byDay[day] = point
+		}
+		if row.PricingType == sandboxPricingTypeDesktop {
+			point.Desktop += row.Credits
+		} else {
+			point.Headless += row.Credits
+		}
+		point.Total += row.Credits
+	}
+
+	series := []types.UsageComputeDailyPoint{}
+	start := from.UTC().Truncate(24 * time.Hour)
+	end := to.UTC().Truncate(24 * time.Hour)
+	for day := start; !day.After(end); day = day.AddDate(0, 0, 1) {
+		if point, ok := byDay[day]; ok {
+			series = append(series, *point)
+			continue
+		}
+		series = append(series, types.UsageComputeDailyPoint{Date: day})
+	}
+	return series
+}

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -3126,6 +3126,21 @@ func (mr *MockStoreMockRecorder) GetOrCreateAgentRunner(ctx, runnerID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateAgentRunner", reflect.TypeOf((*MockStore)(nil).GetOrCreateAgentRunner), ctx, runnerID)
 }
 
+// GetOrgComputeUsage mocks base method.
+func (m *MockStore) GetOrgComputeUsage(ctx context.Context, q *GetOrgComputeUsageQuery) (*types.OrgComputeUsage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgComputeUsage", ctx, q)
+	ret0, _ := ret[0].(*types.OrgComputeUsage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrgComputeUsage indicates an expected call of GetOrgComputeUsage.
+func (mr *MockStoreMockRecorder) GetOrgComputeUsage(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgComputeUsage", reflect.TypeOf((*MockStore)(nil).GetOrgComputeUsage), ctx, q)
+}
+
 // GetOrgUsageSummary mocks base method.
 func (m *MockStore) GetOrgUsageSummary(ctx context.Context, q *GetOrgUsageSummaryQuery) (*types.OrgUsageSummaryResponse, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -3486,6 +3486,21 @@ func (mr *MockStoreMockRecorder) GetSandbox(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSandbox", reflect.TypeOf((*MockStore)(nil).GetSandbox), ctx, id)
 }
 
+// GetSandboxBySession mocks base method.
+func (m *MockStore) GetSandboxBySession(ctx context.Context, sessionID string) (*types.Sandbox, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSandboxBySession", ctx, sessionID)
+	ret0, _ := ret[0].(*types.Sandbox)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSandboxBySession indicates an expected call of GetSandboxBySession.
+func (mr *MockStoreMockRecorder) GetSandboxBySession(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSandboxBySession", reflect.TypeOf((*MockStore)(nil).GetSandboxBySession), ctx, sessionID)
+}
+
 // GetSandboxInstance mocks base method.
 func (m *MockStore) GetSandboxInstance(ctx context.Context, id string) (*types.SandboxInstance, error) {
 	m.ctrl.T.Helper()
@@ -6169,6 +6184,20 @@ func (m *MockStore) SetSandboxContainerCount(ctx context.Context, id string, cou
 func (mr *MockStoreMockRecorder) SetSandboxContainerCount(ctx, id, count any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSandboxContainerCount", reflect.TypeOf((*MockStore)(nil).SetSandboxContainerCount), ctx, id, count)
+}
+
+// SetSandboxResources mocks base method.
+func (m *MockStore) SetSandboxResources(ctx context.Context, id string, vcpus, memoryMB int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetSandboxResources", ctx, id, vcpus, memoryMB)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetSandboxResources indicates an expected call of SetSandboxResources.
+func (mr *MockStoreMockRecorder) SetSandboxResources(ctx, id, vcpus, memoryMB any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSandboxResources", reflect.TypeOf((*MockStore)(nil).SetSandboxResources), ctx, id, vcpus, memoryMB)
 }
 
 // SetSandboxStatus mocks base method.

--- a/api/pkg/store/store_sandboxes.go
+++ b/api/pkg/store/store_sandboxes.go
@@ -18,6 +18,7 @@ type ListSandboxesQuery struct {
 	Owner          string
 	Status         types.SandboxStatus
 	HostDeviceID   string
+	SessionID      string
 	IncludeDeleted bool
 }
 
@@ -98,6 +99,9 @@ func (s *PostgresStore) ListSandboxes(ctx context.Context, q *ListSandboxesQuery
 		}
 		if q.HostDeviceID != "" {
 			query = query.Where("host_device_id = ?", q.HostDeviceID)
+		}
+		if q.SessionID != "" {
+			query = query.Where("session_id = ?", q.SessionID)
 		}
 		if !q.IncludeDeleted {
 			query = query.Where("deleted_at IS NULL")
@@ -185,6 +189,56 @@ func (s *PostgresStore) SetSandboxContainer(ctx context.Context, id string, host
 		"host_device_id": hostDeviceID,
 		"container_id":   containerID,
 		"updated_at":     time.Now(),
+	})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetSandboxBySession returns the live sandbox row that meters the container
+// owned by a Helix session, or ErrNotFound when the session has none.
+func (s *PostgresStore) GetSandboxBySession(ctx context.Context, sessionID string) (*types.Sandbox, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("session id not specified")
+	}
+	var sb types.Sandbox
+	err := s.gdb.WithContext(ctx).
+		Where("session_id = ? AND deleted_at IS NULL", sessionID).
+		Order("created_at DESC").
+		First(&sb).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &sb, nil
+}
+
+// SetSandboxResources records a new CPU/memory allocation after the runtime
+// has actually been resized.
+//
+// Callers must settle any outstanding billing at the previous core count
+// first — billing multiplies the whole unbilled window by the row's current
+// VCPUs, so updating the allocation before flushing would retroactively
+// reprice already-elapsed usage. See sandbox.Controller.ResizeSession.
+func (s *PostgresStore) SetSandboxResources(ctx context.Context, id string, vcpus, memoryMB int) error {
+	if id == "" {
+		return fmt.Errorf("id not specified")
+	}
+	if vcpus <= 0 || memoryMB <= 0 {
+		return fmt.Errorf("vcpus and memory_mb must be positive")
+	}
+	// Column is `v_cpus`, not `vcpus` — GORM's naming strategy splits the
+	// leading acronym in the VCPUs field name.
+	res := s.gdb.WithContext(ctx).Model(&types.Sandbox{}).Where("id = ? AND deleted_at IS NULL", id).Updates(map[string]interface{}{
+		"v_cpus":     vcpus,
+		"memory_mb":  memoryMB,
+		"updated_at": time.Now(),
 	})
 	if res.Error != nil {
 		return res.Error

--- a/api/pkg/store/store_sandboxes_test.go
+++ b/api/pkg/store/store_sandboxes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/orgstore"
 	"github.com/helixml/helix/api/pkg/types"
@@ -67,4 +68,98 @@ func TestSetSandboxStatusIgnoresDeletedRows(t *testing.T) {
 	require.NoError(t, store.gdb.WithContext(ctx).Unscoped().Where("id = ?", sb.ID).First(&persisted).Error)
 	require.Equal(t, types.SandboxStatusStopped, persisted.Status)
 	require.Nil(t, persisted.StartedAt)
+}
+
+// Regression: the column behind types.Sandbox.VCPUs is `v_cpus`, not `vcpus` —
+// GORM's naming strategy splits the leading acronym. A raw-map update with the
+// wrong key fails at the database, which mock-store unit tests cannot see.
+func TestSetSandboxResourcesPersistsNewAllocation(t *testing.T) {
+	ctx := context.Background()
+	store := newSandboxTestStore(t)
+
+	sb, err := store.CreateSandbox(ctx, &types.Sandbox{
+		ID:             "sbx_resize",
+		OrganizationID: "org_1",
+		Owner:          "user_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+		VCPUs:          1,
+		MemoryMB:       2048,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetSandboxResources(ctx, sb.ID, 8, 16384))
+
+	updated, err := store.GetSandbox(ctx, sb.ID)
+	require.NoError(t, err)
+	require.Equal(t, 8, updated.VCPUs)
+	require.Equal(t, 16384, updated.MemoryMB)
+}
+
+func TestSetSandboxResourcesRejectsNonPositiveValues(t *testing.T) {
+	ctx := context.Background()
+	store := newSandboxTestStore(t)
+
+	_, err := store.CreateSandbox(ctx, &types.Sandbox{
+		ID:             "sbx_resize_bad",
+		OrganizationID: "org_1",
+		Owner:          "user_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+	})
+	require.NoError(t, err)
+
+	require.Error(t, store.SetSandboxResources(ctx, "sbx_resize_bad", 0, 8192))
+	require.ErrorIs(t, store.SetSandboxResources(ctx, "sbx_missing", 4, 8192), ErrNotFound)
+}
+
+func TestGetSandboxBySessionSkipsDeletedRows(t *testing.T) {
+	ctx := context.Background()
+	store := newSandboxTestStore(t)
+
+	sb, err := store.CreateSandbox(ctx, &types.Sandbox{
+		ID:             "sbx_session",
+		OrganizationID: "org_1",
+		Owner:          "user_1",
+		SessionID:      "ses_1",
+		SpecTaskID:     "spt_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+	})
+	require.NoError(t, err)
+
+	found, err := store.GetSandboxBySession(ctx, "ses_1")
+	require.NoError(t, err)
+	require.Equal(t, sb.ID, found.ID)
+	require.True(t, found.SessionBacked())
+	require.Equal(t, "ses_1", found.HydraOpsID())
+
+	// After teardown the session must look unmetered again, so a resumed task
+	// opens a fresh row rather than reusing a deleted one.
+	require.NoError(t, store.DeleteSandbox(ctx, sb.ID))
+	_, err = store.GetSandboxBySession(ctx, "ses_1")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// Session-backed rows are created with a negative TTL so expires_at stays NULL
+// and the TTL reaper never tears down a desktop the task still owns.
+func TestNegativeTimeoutLeavesSandboxOutOfTheExpiryReaper(t *testing.T) {
+	ctx := context.Background()
+	store := newSandboxTestStore(t)
+
+	sb, err := store.CreateSandbox(ctx, &types.Sandbox{
+		ID:             "sbx_never_expires",
+		OrganizationID: "org_1",
+		Owner:          "user_1",
+		SessionID:      "ses_1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusRunning,
+		TimeoutSeconds: -1,
+	})
+	require.NoError(t, err)
+	require.Nil(t, sb.ExpiresAt)
+
+	expired, err := store.ListExpiredSandboxes(ctx, time.Now().Add(365*24*time.Hour))
+	require.NoError(t, err)
+	require.Empty(t, expired)
 }

--- a/api/pkg/store/store_usage_metrics.go
+++ b/api/pkg/store/store_usage_metrics.go
@@ -532,7 +532,9 @@ func (s *PostgresStore) GetOrgUsageSummary(ctx context.Context, q *GetOrgUsageSu
 				SUM(usage_metrics.completion_cost) as completion_cost,
 				SUM(usage_metrics.cache_read_cost) as cache_read_cost,
 				SUM(usage_metrics.cache_write_cost) as cache_write_cost,
-				SUM(usage_metrics.total_cost) as total_cost
+				SUM(usage_metrics.total_cost) as total_cost,
+				SUM(usage_metrics.duration_ms) as duration_ms,
+				COUNT(*) as total_requests
 			`).
 			Group("usage_metrics.date, usage_metrics.source, usage_metrics.provider, usage_metrics.model").
 			Order("usage_metrics.date ASC").

--- a/api/pkg/types/sandbox.go
+++ b/api/pkg/types/sandbox.go
@@ -75,6 +75,23 @@ type Sandbox struct {
 	// uses it to bind-mount the per-project durable data dir at /data.
 	Purpose string `json:"purpose,omitempty" gorm:"size:32;index"`
 
+	// SessionID links the row to the Helix session that owns the container,
+	// for sandboxes whose container is provisioned by the external-agent
+	// executor rather than by sandbox.Controller.provision (spec-task
+	// desktops, exploratory sessions, subscription desktops). The row exists
+	// so those containers are metered, quota-checked and visible in the
+	// Sandboxes UI on the same terms as user-created sandboxes.
+	//
+	// Non-empty is the discriminator for "session-backed": hydra registers
+	// every operation for such a container under the session id, so callers
+	// must route hydra ops via HydraOpsID() rather than the row id.
+	SessionID string `json:"session_id,omitempty" gorm:"size:64;index"`
+
+	// SpecTaskID is the spec task that owns the session, when there is one.
+	// Denormalised from the session purely so the Sandboxes list can link back
+	// to the task without joining through sessions.
+	SpecTaskID string `json:"spec_task_id,omitempty" gorm:"size:64;index"`
+
 	// Display fields apply to desktop runtimes.
 	DisplayWidth  int `json:"display_width,omitempty"`
 	DisplayHeight int `json:"display_height,omitempty"`
@@ -98,6 +115,22 @@ type Sandbox struct {
 // TableName tells GORM which table to use.
 func (Sandbox) TableName() string {
 	return "sandboxes"
+}
+
+// SessionBacked reports whether the underlying container is provisioned and
+// torn down by the external-agent executor instead of sandbox.Controller.
+func (s *Sandbox) SessionBacked() bool {
+	return s != nil && s.SessionID != ""
+}
+
+// HydraOpsID is the key hydra filed the container under. Controller-managed
+// sandboxes are created with the row id as their hydra session id; session-
+// backed ones use the Helix session id.
+func (s *Sandbox) HydraOpsID() string {
+	if s.SessionBacked() {
+		return s.SessionID
+	}
+	return s.ID
 }
 
 // CreateSandboxRequest is the API payload for POST /organizations/{org}/sandboxes.
@@ -137,6 +170,25 @@ type UpdateSandboxRequest struct {
 	Name           *string            `json:"name,omitempty"`
 	TimeoutSeconds *int               `json:"timeout_seconds,omitempty"`
 	Tags           *map[string]string `json:"tags,omitempty"`
+}
+
+// BeginSandboxSessionRequest opens the billing/quota record for a container
+// that the external-agent executor is about to provision itself. Lives in
+// types so the executor and the sandbox controller can talk without either
+// importing the other.
+type BeginSandboxSessionRequest struct {
+	SessionID      string
+	OrganizationID string
+	Owner          string
+	ProjectID      string
+	SpecTaskID     string
+	Name           string
+	Runtime        SandboxRuntime
+	VCPUs          int
+	MemoryMB       int
+	DisplayWidth   int
+	DisplayHeight  int
+	DisplayFPS     int
 }
 
 // SandboxListResponse is the API response for GET /organizations/{org}/sandboxes.

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2998,6 +2998,13 @@ type UsageCostBreakdownRow struct {
 	CacheReadCost    float64           `json:"-"`
 	CacheWriteCost   float64           `json:"-"`
 	TotalCost        float64           `json:"-"`
+	// DurationMs and TotalRequests carry timing at the same (date, provider,
+	// model, source) grain as the token columns, so the per-provider latency
+	// series can be derived from the same pass that resolves a row's display
+	// provider. Deriving it separately would key on the raw provider string
+	// and diverge from the provider breakdown whenever model info remaps it.
+	DurationMs    float64 `json:"-"`
+	TotalRequests int     `json:"-"`
 }
 
 type UsageFilterOption struct {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2885,6 +2885,48 @@ type AggregatedUsageMetric struct {
 	TotalRequests     int     `json:"total_requests"`
 }
 
+// UsageComputeDailyPoint is one day of sandbox compute spend, split by
+// pricing class so the chart can show what the desktops cost versus the
+// headless containers.
+type UsageComputeDailyPoint struct {
+	Date     time.Time `json:"date"`
+	Desktop  float64   `json:"desktop"`
+	Headless float64   `json:"headless"`
+	Total    float64   `json:"total"`
+}
+
+// UsageComputeBreakdownRow is one sandbox's compute spend over the range.
+// Rows survive the sandbox itself — charges are ledger entries, so a torn-down
+// desktop still accounts for what it cost.
+type UsageComputeBreakdownRow struct {
+	SandboxID   string  `json:"sandbox_id"`
+	Name        string  `json:"name,omitempty"`
+	Runtime     string  `json:"runtime,omitempty"`
+	PricingType string  `json:"pricing_type,omitempty"`
+	SpecTaskID  string  `json:"spec_task_id,omitempty"`
+	ProjectID   string  `json:"project_id,omitempty"`
+	VCPUs       int     `json:"vcpus,omitempty"`
+	Credits     float64 `json:"credits"`
+}
+
+// OrgComputeUsage is the sandbox-compute half of an org's bill: the credits
+// actually debited for running containers, as opposed to LLM tokens.
+//
+// Sourced from the wallet ledger rather than from live sandbox rows, so the
+// numbers hold for sandboxes that have since been deleted.
+type OrgComputeUsage struct {
+	TotalCredits    float64                    `json:"total_credits"`
+	DesktopCredits  float64                    `json:"desktop_credits"`
+	HeadlessCredits float64                    `json:"headless_credits"`
+	Daily           []UsageComputeDailyPoint   `json:"daily"`
+	Sandboxes       []UsageComputeBreakdownRow `json:"sandboxes"`
+	// RunningSandboxes is a point-in-time count, not a range aggregate.
+	RunningSandboxes int `json:"running_sandboxes"`
+	// BillingEnabled reports whether compute is actually charged. When false
+	// the credits above are historical and nothing new is accruing.
+	BillingEnabled bool `json:"billing_enabled"`
+}
+
 type UsageBreakdownRow struct {
 	ID                string     `json:"id"`
 	Name              string     `json:"name"`
@@ -3002,6 +3044,10 @@ type OrgUsageSummaryResponse struct {
 	SubscriptionSavings    float64                       `json:"subscription_savings"`
 	CacheSavings           float64                       `json:"cache_savings"`
 	HelixCredits           float64                       `json:"helix_credits"`
+	// Compute is sandbox runtime spend. It answers the date range and the
+	// project filter; the token-shaped filters (model, provider, session)
+	// don't apply to a container and leave it untouched.
+	Compute *OrgComputeUsage `json:"compute,omitempty"`
 	CostBreakdown          []UsageCostBreakdownRow       `json:"-" swaggerignore:"true"`
 }
 

--- a/design/2026-08-10-spec-task-desktop-billing.md
+++ b/design/2026-08-10-spec-task-desktop-billing.md
@@ -1,0 +1,180 @@
+# Unified sandbox billing: back spec-task desktops with `types.Sandbox` rows
+
+Date: 2026-08-10
+
+## Problem
+
+We have exactly two debit paths in the codebase:
+
+1. `api/pkg/openai/logger/billing_logger.go` — LLM tokens.
+2. `api/pkg/sandbox/controller_billing.go` — compute, for sandboxes created
+   through the Sandboxes API.
+
+The second one only ever sees rows in the `sandboxes` table. Spec-task
+desktops — the containers that actually burn the GPU host — never create such
+a row: `HydraExecutor.StartDesktop` calls `hydra.CreateDevContainer` directly
+(`hydra_executor.go:375`). Consequences:
+
+- `ReapBilling` iterates `ListSandboxes(status=running)` and therefore charges
+  **nothing** for a spec-task desktop, whatever its size.
+- No `ensureSandboxCredits` pre-check: an org with a zero balance can start an
+  8 vCPU desktop.
+- No `ensureSandboxLimits`: the desktop concurrency cap doesn't apply, and
+  `quota.getActiveSandboxesByOrg` under-reports org usage.
+- https://github.com/helixml/helix/pull/2976 gave users a self-service
+  1 / 4 / 8 vCPU picker plus live resize on a running task. That is an 8×
+  swing in real cost with zero billing signal.
+
+## Approach
+
+A `types.Sandbox` row becomes the **single billing and quota record for any
+container Helix runs on a hydra host**, regardless of who provisions the
+container. Two provisioning modes share the row:
+
+| Mode | Row created by | Container created by | Discriminator |
+|---|---|---|---|
+| Controller-managed (Sandboxes API) | `sandbox.Controller.Create` | `sandbox.Controller.provision` | `session_id == ''` |
+| Session-backed (spec-task desktops, exploratory sessions, subscription desktops) | `sandbox.Controller.BeginSession` | `HydraExecutor.StartDesktop` | `session_id != ''` |
+
+We deliberately do **not** route spec-task desktop provisioning through
+`Controller.provision`. That path knows nothing about workspace files, repo
+checkout, branch mode, golden builds, ZFS clones, session API keys or Zed
+config. Re-implementing it would be a rewrite with a large blast radius for no
+billing benefit. The row is the meter; the executor stays the provisioner.
+
+### Why the executor, not `spec_driven_task_service`
+
+There are ~10 `StartDesktop` call sites and ~15 `StopDesktop` call sites
+(spec-task planning, just-do-it, resume, exploratory sessions, session fork,
+design review, Claude/Codex subscription desktops, golden builds, idle
+checker, org worker activations). Metering at three of them inside
+`spec_driven_task_service` would leave most desktops unbilled and duplicate
+the logic three times. `HydraExecutor.StartDesktop`/`StopDesktop` is the one
+choke point every desktop passes through, and it already holds the per-session
+lock that makes the row lifecycle race-free.
+
+## Changes
+
+### 1. `types.Sandbox`
+
+Two new columns (GORM AutoMigrate):
+
+- `SessionID string` — the Helix session that owns the container. Non-empty
+  means session-backed: hydra keys every operation for this container by
+  session id, not by sandbox id.
+- `SpecTaskID string` — optional, so the Sandboxes UI can link back to the task
+  without a join through sessions.
+
+Helpers: `SessionBacked()` and `HydraOpsID()` (returns `SessionID` when set,
+else `ID`).
+
+### 2. `sandbox.Controller` — session-backed lifecycle (`controller_session.go`)
+
+- `BeginSession(ctx, *BeginSessionRequest) (*types.Sandbox, error)` — runs
+  `ensureSandboxLimits` and `ensureSandboxCredits`, then upserts the row for
+  that session (`status=pending`, `runtime=ubuntu-desktop`,
+  `timeout_seconds=-1` so the TTL reaper never touches it — the desktop's
+  lifetime is owned by the task, not by a sandbox TTL).
+- `MarkSessionRunning(ctx, sessionID, hostDeviceID, containerID)` — flips to
+  `running`, which is what opens the billing window (`SetSandboxStatus` stamps
+  `started_at` and `billing_last_charged_at`).
+- `MarkSessionStopped(ctx, sessionID)` — final partial-minute charge, then
+  `status=stopped`.
+- `ResizeSession(ctx, sessionID, vcpus, memoryMB)` — **flush then update**:
+  bills the outstanding window at the *old* core count before persisting the
+  new one. Without this, `billSandbox` would multiply up to a whole minute of
+  already-elapsed 1-vCPU usage by the new 8-vCPU count.
+- `EnsureSessionResizeCredits(...)` — pre-check before we ask hydra to resize.
+
+### 3. Teardown routing
+
+`Controller.Delete` currently calls `hydraClient.DeleteDevContainer(ctx,
+sandbox.ID)`. For a session-backed row the container is registered under the
+session id, so that call would silently no-op. `Delete` now dispatches to a
+`DesktopStopper` callback (set at wiring time to
+`externalAgentExecutor.StopDesktop`) when the row is session-backed and still
+running. This is also what makes the credit-exhaustion path in `billSandbox`
+actually stop a spec-task desktop.
+
+`sandbox` cannot import `external-agent` (that direction already exists), so
+the stopper is a function field injected in `server.go`, not an import.
+
+### 4. Hydra op routing
+
+`sandboxes_api_handlers.go` passes `sb.ID` as the hydra op key for exec, files
+and terminal. Those now use `sb.HydraOpsID()`, so the Sandboxes UI can open a
+terminal / browse files on a spec-task desktop as well.
+
+### 5. Resume no longer drops the task's sandbox preset
+
+Only the three `spec_driven_task_service` launch paths put `VCPUs`/`MemoryMB` on
+the `DesktopAgent`. `resumeSessionInternal`, session fork and design review
+rebuild the agent from the session and never read
+`SpecTask.SandboxResourceOverrides`, so a paused 8 vCPU task came back
+**uncapped** — running bigger than the user asked for and, once metered, billed
+at the default preset. Caught by the live resume test below, not by any unit
+test.
+
+`HydraExecutor.resolveSpecTaskResources` now fills the size in from the owning
+task whenever the caller didn't supply one, so every spec-task desktop path
+honours the preset. An explicit caller-supplied size still wins.
+
+### 6. Frontend
+
+Session-backed rows appear in the existing org sandboxes list automatically.
+The table and card views gain a "Spec task" marker that links to the task, so
+the list reads as "all compute this org is paying for" rather than a mix of
+unexplained rows.
+
+## Deliberate non-goals
+
+- No change to the price model: still `credits/second/core`, desktop rate vs
+  headless rate, memory bundled with the core preset.
+- No retroactive billing. `SandboxBillingEnabled` stays default-off, and
+  enabling it calls `SetRunningSandboxesBillingLastChargedAt` so existing free
+  usage is not charged.
+- Golden builds go through `StartDesktop` and will therefore be metered like
+  any other desktop once billing is on. That is intentional — they consume the
+  same host.
+
+## Operator impact
+
+Both are gated behind `SandboxBillingEnabled`, which is default-off, except the
+concurrency cap which applies regardless:
+
+- **Desktop concurrency cap now applies to spec tasks.**
+  `MaxConcurrentDesktopSandboxes` defaults to 10 per org and previously only
+  constrained the Sandboxes API. An org that routinely runs more than 10
+  concurrent spec-task desktops must raise the setting before upgrading.
+- **Golden builds and exploratory sessions are now billable compute** — they
+  go through `StartDesktop` like everything else.
+
+## Verification
+
+Run live against the dev stack (`SandboxBillingEnabled=true`, desktop price
+0.008 credits/second/core), task `spt_01kznhwc1q3jxkvbz5rz1g7812`:
+
+| Behaviour | Observed |
+|---|---|
+| Row created on task start | `sbx_01kznhwd7na4s5y64rnj6h6q5g`, `runtime=ubuntu-desktop`, `session_id`/`spec_task_id` set, 4 vCPU / 8192 MB from the task, `timeout_seconds=-1`, `expires_at` NULL |
+| Per-minute charge at 4 cores | `-1.92` = 0.008 × 60 × 4, twice |
+| Resize flush | 4→8 charged `-1.5255` for 47.67 elapsed seconds at the **old** 4 cores, then row → 8 vCPU / 16384 MB |
+| Post-resize rate | `-3.84`/min = 0.008 × 60 × 8 |
+| Failed resize does not reprice | hydra rejected 16 GB→2 GB (container using 2694 MB); no flush, row unchanged |
+| Final charge on stop | `-5.288` for the 82.6s partial minute, row → `stopped` |
+| Resume reuses the row | same row id, `started_at`/`billing_last_charged_at` reset so the stopped gap is not billed |
+| Resume restores the preset | came back 8 vCPU / 16384 MB after the fix (was 4 / 8192 before) |
+| Delete routes teardown to the executor | container `ubuntu-external-01kznhwc26vfdmnpbe43w3m71d` gone, final charge landed, row soft-deleted — the same path credit exhaustion takes |
+| UI | cards and table both show the row with a "Spec task" source marker, 8 vCPU · 16 GB, Expires "Never"; the marker links to the task |
+
+Two bugs the live run caught that unit tests could not:
+
+1. `SetSandboxResources` wrote to a `vcpus` column; GORM maps `VCPUs` to
+   `v_cpus`. Resizes silently failed to persist. Now covered by a GORM-backed
+   store test that fails against the old column name.
+2. Resume dropped the task's sandbox preset (see §5).
+
+Not exercised live: credit exhaustion mid-session. Its stop path is
+`Controller.Delete` → `stopSessionDesktop`, which the delete test above
+exercises directly, plus unit coverage for the routing and the
+wallet-drain branch.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4647,6 +4647,21 @@ export interface TypesOpenAIUsage {
   total_tokens?: number;
 }
 
+export interface TypesOrgComputeUsage {
+  /**
+   * BillingEnabled reports whether compute is actually charged. When false
+   * the credits above are historical and nothing new is accruing.
+   */
+  billing_enabled?: boolean;
+  daily?: TypesUsageComputeDailyPoint[];
+  desktop_credits?: number;
+  headless_credits?: number;
+  /** RunningSandboxes is a point-in-time count, not a range aggregate. */
+  running_sandboxes?: number;
+  sandboxes?: TypesUsageComputeBreakdownRow[];
+  total_credits?: number;
+}
+
 export interface TypesOrgDetails {
   members?: TypesUser[];
   organization?: TypesOrganization;
@@ -4662,6 +4677,12 @@ export interface TypesOrgUsageSummaryResponse {
   agent_runtime_time_series?: TypesUsageAgentRuntimeTimeSeries[];
   apps?: TypesUsageBreakdownRow[];
   cache_savings?: number;
+  /**
+   * Compute is sandbox runtime spend. It answers the date range and the
+   * project filter; the token-shaped filters (model, provider, session)
+   * don't apply to a container and leave it untouched.
+   */
+  compute?: TypesOrgComputeUsage;
   export_apps?: TypesUsageBreakdownRow[];
   export_models?: TypesUsageBreakdownRow[];
   export_projects?: TypesUsageBreakdownRow[];
@@ -7737,6 +7758,24 @@ export interface TypesUsageBreakdownRow {
   unique_sessions?: number;
   unique_users?: number;
   username?: string;
+}
+
+export interface TypesUsageComputeBreakdownRow {
+  credits?: number;
+  name?: string;
+  pricing_type?: string;
+  project_id?: string;
+  runtime?: string;
+  sandbox_id?: string;
+  spec_task_id?: string;
+  vcpus?: number;
+}
+
+export interface TypesUsageComputeDailyPoint {
+  date?: string;
+  desktop?: number;
+  headless?: number;
+  total?: number;
 }
 
 export interface TypesUsageFilterOption {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -5714,6 +5714,25 @@ export interface TypesSandbox {
    */
   purpose?: string;
   runtime?: TypesSandboxRuntime;
+  /**
+   * SessionID links the row to the Helix session that owns the container,
+   * for sandboxes whose container is provisioned by the external-agent
+   * executor rather than by sandbox.Controller.provision (spec-task
+   * desktops, exploratory sessions, subscription desktops). The row exists
+   * so those containers are metered, quota-checked and visible in the
+   * Sandboxes UI on the same terms as user-created sandboxes.
+   *
+   * Non-empty is the discriminator for "session-backed": hydra registers
+   * every operation for such a container under the session id, so callers
+   * must route hydra ops via HydraOpsID() rather than the row id.
+   */
+  session_id?: string;
+  /**
+   * SpecTaskID is the spec task that owns the session, when there is one.
+   * Denormalised from the session purely so the Sandboxes list can link back
+   * to the task without joining through sessions.
+   */
+  spec_task_id?: string;
   started_at?: string;
   status?: TypesSandboxStatus;
   status_message?: string;

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -51,6 +51,13 @@ const TOKEN_SERIES: ShadcnSeries[] = [
 
 const CHART_COLORS = ['#2563eb', '#16a34a', '#d97706', '#9333ea', '#0891b2', '#e11d48']
 
+// Two hues from the page palette so compute reads as part of the same system
+// as the token charts above it. Desktops first: they are the expensive half.
+const COMPUTE_SERIES: ShadcnSeries[] = [
+  { key: 'desktop', label: 'Desktops', color: CHART_COLORS[0] },
+  { key: 'headless', label: 'Headless', color: CHART_COLORS[4] },
+]
+
 const PROVIDER_COLORS: Record<string, string> = {
   anthropic: '#d97757',
   openai: '#e6e6e6',
@@ -349,6 +356,14 @@ const modelOverviewFields: ITableField[] = [
   { name: 'cost', title: 'API-rate cost', numeric: true },
   { name: 'share', title: 'Share', numeric: true },
   { name: 'tokens', title: 'Tokens', numeric: true },
+]
+
+const computeSandboxFields: ITableField[] = [
+  { name: 'name', title: 'Sandbox' },
+  { name: 'kind', title: 'Kind' },
+  { name: 'size', title: 'Size', numeric: true },
+  { name: 'credits', title: 'Credits', numeric: true },
+  { name: 'share', title: 'Share', numeric: true },
 ]
 
 const sessionFields: ITableField[] = [
@@ -698,6 +713,49 @@ const OrgUsage: FC = () => {
   const subscriptionSavings = usage.data?.subscription_savings ?? 0
   const cacheSavings = usage.data?.cache_savings ?? 0
   const helixCredits = usage.data?.helix_credits ?? 0
+  const compute = usage.data?.compute
+  const computeTotals = useMemo(() => {
+    const daily = compute?.daily || []
+    const computeActiveDays = daily.filter(point => (point.total ?? 0) > 0).length
+    const total = compute?.total_credits ?? 0
+    return {
+      total,
+      desktop: compute?.desktop_credits ?? 0,
+      headless: compute?.headless_credits ?? 0,
+      activeDays: computeActiveDays,
+      perActiveDay: computeActiveDays > 0 ? total / computeActiveDays : 0,
+    }
+  }, [compute])
+  const computeChartData = useMemo<UsageChartRow[]>(() => (compute?.daily || []).map(point => ({
+    date: point.date || '',
+    desktop: point.desktop ?? 0,
+    headless: point.headless ?? 0,
+  })), [compute])
+  const computeSandboxRows = useMemo(() => (compute?.sandboxes || []).map(row => {
+    const share = computeTotals.total > 0 ? (row.credits ?? 0) / computeTotals.total : 0
+    return {
+      id: row.sandbox_id || '',
+      _data: row,
+      name: (
+        <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+          {row.name || row.sandbox_id || 'Unknown'}
+        </Typography>
+      ),
+      kind: (
+        <Typography variant="body2" color="text.secondary">
+          {row.spec_task_id ? 'Spec task' : row.pricing_type === 'desktop' ? 'Desktop' : 'Headless'}
+        </Typography>
+      ),
+      size: (
+        <Typography variant="body2" color="text.secondary">
+          {row.vcpus ? `${row.vcpus} vCPU` : '—'}
+        </Typography>
+      ),
+      credits: <Typography variant="body2">{formatCost(row.credits)}</Typography>,
+      share: <Typography variant="body2" color="text.secondary">{formatPercent(share)}</Typography>,
+    }
+  }), [compute, computeTotals.total])
+
   const activeDays = metrics.filter(metric => (metric.total_tokens ?? 0) > 0).length
   const averageTokens = activeDays > 0 ? totals.total / activeDays : 0
   const cachedShare = totals.input > 0 ? totals.cacheRead / totals.input : 0
@@ -865,7 +923,7 @@ const OrgUsage: FC = () => {
               <Box>
                 <Typography variant="h5" component="h2" sx={{ mb: 1 }}>Usage</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  LLM calls, tokens, cost, and latency for this organization.
+                  LLM calls, tokens, cost, latency, and sandbox compute for this organization.
                 </Typography>
               </Box>
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }}>
@@ -1035,6 +1093,80 @@ const OrgUsage: FC = () => {
             <Typography variant="caption" color="text.secondary">
               Savings use current model API rates. Helix credits include only metered token charges debited by Helix; provider subscriptions and external API keys are excluded.
             </Typography>
+
+            {!usage.isLoading && compute && (
+              <Paper variant="outlined" sx={{ p: 0, overflow: 'hidden' }}>
+                <Box sx={{ px: 2, pt: 2, pb: 1.5 }}>
+                  <Typography variant="overline" color="text.secondary">Sandbox compute</Typography>
+                  <Typography variant="h4" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                    {formatCost(computeTotals.total)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {compute.billing_enabled
+                      ? 'Credits debited for running desktops and containers'
+                      : 'Compute billing is disabled — this is historical spend and nothing new is accruing'}
+                  </Typography>
+                </Box>
+
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: 'repeat(2, minmax(0, 1fr))', md: 'repeat(4, minmax(0, 1fr))' },
+                    gap: '1px',
+                    bgcolor: 'divider',
+                    borderTop: '1px solid',
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                  }}
+                >
+                  <OverviewStat
+                    label="Desktops"
+                    value={formatCost(computeTotals.desktop)}
+                    detail={computeTotals.total > 0 ? `${formatPercent(computeTotals.desktop / computeTotals.total)} of compute spend` : 'No desktop spend'}
+                  />
+                  <OverviewStat
+                    label="Headless"
+                    value={formatCost(computeTotals.headless)}
+                    detail={computeTotals.total > 0 ? `${formatPercent(computeTotals.headless / computeTotals.total)} of compute spend` : 'No headless spend'}
+                  />
+                  <OverviewStat
+                    label="Per active day"
+                    value={formatCost(computeTotals.perActiveDay)}
+                    detail={`${computeTotals.activeDays} ${computeTotals.activeDays === 1 ? 'day' : 'days'} with compute spend`}
+                  />
+                  <OverviewStat
+                    label="Running now"
+                    value={`${compute.running_sandboxes ?? 0}`}
+                    detail="Sandboxes currently billing"
+                  />
+                </Box>
+
+                <Box sx={{ p: 2 }}>
+                  <ShadcnAreaChart
+                    title="DAILY COMPUTE SPEND"
+                    headline={formatCost(computeTotals.total)}
+                    data={computeChartData}
+                    series={COMPUTE_SERIES}
+                    valueFormatter={formatCost}
+                    zeroIsData
+                  />
+                </Box>
+
+                {computeSandboxRows.length > 0 && (
+                  <Box sx={{ px: 2, pb: 2 }}>
+                    <Section title="Sandbox breakdown">
+                      <SimpleTable authenticated fields={computeSandboxFields} data={computeSandboxRows} compact />
+                    </Section>
+                  </Box>
+                )}
+
+                <Box sx={{ px: 2, pb: 2 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Compute spend answers the date range and the project filter only — model, provider, session and user filters describe tokens, not containers.
+                  </Typography>
+                </Box>
+              </Paper>
+            )}
 
             {!usage.isLoading && (
               <>

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -304,6 +304,15 @@ const ProviderSummaryRow: FC<{
   )
 }
 
+// UsagePanel is the outlined card the Sandbox compute block uses. Everything
+// on the page sits in one, so the charts and tables read as parts of a single
+// system instead of floating panes on the page background.
+const UsagePanel: FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Paper variant="outlined" sx={{ p: 2, overflow: 'hidden' }}>
+    {children}
+  </Paper>
+)
+
 const Section: FC<{ title: string; action?: React.ReactNode; children: React.ReactNode }> = ({ title, action, children }) => (
   <Box sx={{ width: '100%' }}>
     <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 1.5 }}>
@@ -360,6 +369,10 @@ const modelOverviewFields: ITableField[] = [
 
 const computeSandboxFields: ITableField[] = [
   { name: 'name', title: 'Sandbox' },
+  // Spec-task runners inherit their task's name, so two projects in the same
+  // org routinely produce identically-named rows. Project is what makes the
+  // cost attributable.
+  { name: 'project', title: 'Project' },
   { name: 'kind', title: 'Kind' },
   { name: 'size', title: 'Size', numeric: true },
   { name: 'credits', title: 'Credits', numeric: true },
@@ -731,14 +744,50 @@ const OrgUsage: FC = () => {
     desktop: point.desktop ?? 0,
     headless: point.headless ?? 0,
   })), [compute])
+  // Project names come from the filter options the same response already
+  // carries, so no extra request is needed to attribute a sandbox.
+  const projectNames = useMemo(() => {
+    const names: Record<string, string> = {}
+    for (const option of usage.data?.filter_projects || []) {
+      if (option.id) names[option.id] = option.name || option.id
+    }
+    return names
+  }, [usage.data?.filter_projects])
   const computeSandboxRows = useMemo(() => (compute?.sandboxes || []).map(row => {
     const share = computeTotals.total > 0 ? (row.credits ?? 0) / computeTotals.total : 0
     return {
       id: row.sandbox_id || '',
       _data: row,
-      name: (
+      // Project separates same-named tasks across projects, but two tasks in
+      // ONE project can also share a name. The task link is what makes every
+      // row individually resolvable.
+      name: row.spec_task_id && row.project_id ? (
+        <Typography
+          variant="body2"
+          component="a"
+          href="#"
+          onClick={(e: React.MouseEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            router.navigate('org_project-task-detail', {
+              org_id: router.params.org_id,
+              id: row.project_id,
+              taskId: row.spec_task_id,
+            })
+          }}
+          sx={{ fontWeight: 600, color: 'text.primary', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+          noWrap
+        >
+          {row.name || row.sandbox_id || 'Unknown'}
+        </Typography>
+      ) : (
         <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
           {row.name || row.sandbox_id || 'Unknown'}
+        </Typography>
+      ),
+      project: (
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {row.project_id ? (projectNames[row.project_id] || row.project_id) : 'Org-scoped'}
         </Typography>
       ),
       kind: (
@@ -754,7 +803,7 @@ const OrgUsage: FC = () => {
       credits: <Typography variant="body2">{formatCost(row.credits)}</Typography>,
       share: <Typography variant="body2" color="text.secondary">{formatPercent(share)}</Typography>,
     }
-  }), [compute, computeTotals.total])
+  }), [compute, computeTotals.total, projectNames, router])
 
   const activeDays = metrics.filter(metric => (metric.total_tokens ?? 0) > 0).length
   const averageTokens = activeDays > 0 ? totals.total / activeDays : 0
@@ -1171,144 +1220,164 @@ const OrgUsage: FC = () => {
             {!usage.isLoading && (
               <>
                 <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.35fr) minmax(0, 1fr)' }, gap: 2 }}>
-                  <ShadcnAreaChart
-                    title="TOKENS OVER TIME"
-                    headline={formatCompact(totals.total)}
-                    data={tokenChartData}
-                    series={TOKEN_SERIES}
-                    valueFormatter={formatCompact}
-                  />
-                  <LatencyChart data={latencyData} />
+                  <UsagePanel>
+                    <ShadcnAreaChart
+                      title="TOKENS OVER TIME"
+                      headline={formatCompact(totals.total)}
+                      data={tokenChartData}
+                      series={TOKEN_SERIES}
+                      valueFormatter={formatCompact}
+                    />
+                  </UsagePanel>
+                  <UsagePanel>
+                    <LatencyChart data={latencyData} />
+                  </UsagePanel>
                 </Box>
 
-                <ShadcnAreaChart
-                  title="CACHE HIT RATIO BY AGENT HARNESS"
-                  headline={formatPercent(cacheHitRatio)}
-                  data={agentCacheChartData}
-                  series={agentCacheChartSeries}
-                  valueFormatter={value => formatPercent(value)}
-                  stacked={false}
-                  zeroIsData
-                  variant="line"
-                  yDomain={[0, 1]}
-                />
+                <UsagePanel>
+                  <ShadcnAreaChart
+                    title="CACHE HIT RATIO BY AGENT HARNESS"
+                    headline={formatPercent(cacheHitRatio)}
+                    data={agentCacheChartData}
+                    series={agentCacheChartSeries}
+                    valueFormatter={value => formatPercent(value)}
+                    stacked={false}
+                    zeroIsData
+                    variant="line"
+                    yDomain={[0, 1]}
+                  />
+                </UsagePanel>
 
-                <ShadcnAreaChart
-                  title="MODEL USAGE OVER TIME"
-                  headline={`${modelSeries.length} models`}
-                  data={modelChartData}
-                  series={modelChartSeries}
-                  valueFormatter={formatCompact}
-                  stacked={false}
-                />
+                <UsagePanel>
+                  <ShadcnAreaChart
+                    title="MODEL USAGE OVER TIME"
+                    headline={`${modelSeries.length} models`}
+                    data={modelChartData}
+                    series={modelChartSeries}
+                    valueFormatter={formatCompact}
+                    stacked={false}
+                  />
+                </UsagePanel>
 
-                <ProjectModelChart data={projectModelChart.data} series={projectModelChart.series} />
+                <UsagePanel>
+                  <ProjectModelChart data={projectModelChart.data} series={projectModelChart.series} />
+                </UsagePanel>
 
                 <Stack spacing={3} sx={{ width: '100%' }}>
-                  <Section title="Projects" action={<ExportButtons filename={`org-${orgID}-projects-usage`} rows={usage.data?.export_projects || usage.data?.projects || []} />}>
-                    <SimpleTable authenticated fields={baseFields} data={tableRows.projects} compact loading={isScopedLoading('projects')} />
-                    <TablePagination
-                      component="div"
-                      count={usage.data?.projects_total || 0}
-                      page={projectPage}
-                      rowsPerPage={projectRowsPerPage}
-                      onPageChange={(_, nextPage) => {
-                        setLoadingScope('projects')
-                        setProjectPage(nextPage)
-                      }}
-                      onRowsPerPageChange={event => {
-                        setLoadingScope('projects')
-                        setProjectRowsPerPage(parseInt(event.target.value, 10))
-                        setProjectPage(0)
-                      }}
-                      rowsPerPageOptions={[10, 25, 50, 100]}
-                    />
-                  </Section>
+                  <UsagePanel>
+                    <Section title="Projects" action={<ExportButtons filename={`org-${orgID}-projects-usage`} rows={usage.data?.export_projects || usage.data?.projects || []} />}>
+                      <SimpleTable authenticated fields={baseFields} data={tableRows.projects} compact loading={isScopedLoading('projects')} />
+                      <TablePagination
+                        component="div"
+                        count={usage.data?.projects_total || 0}
+                        page={projectPage}
+                        rowsPerPage={projectRowsPerPage}
+                        onPageChange={(_, nextPage) => {
+                          setLoadingScope('projects')
+                          setProjectPage(nextPage)
+                        }}
+                        onRowsPerPageChange={event => {
+                          setLoadingScope('projects')
+                          setProjectRowsPerPage(parseInt(event.target.value, 10))
+                          setProjectPage(0)
+                        }}
+                        rowsPerPageOptions={[10, 25, 50, 100]}
+                      />
+                    </Section>
+                  </UsagePanel>
 
-                  <Section title="Agent" action={<ExportButtons filename={`org-${orgID}-agents-usage`} rows={usage.data?.export_apps || usage.data?.apps || []} />}>
-                    <SimpleTable authenticated fields={baseFields} data={tableRows.apps} compact />
-                  </Section>
+                  <UsagePanel>
+                    <Section title="Agent" action={<ExportButtons filename={`org-${orgID}-agents-usage`} rows={usage.data?.export_apps || usage.data?.apps || []} />}>
+                      <SimpleTable authenticated fields={baseFields} data={tableRows.apps} compact />
+                    </Section>
+                  </UsagePanel>
 
-                  <Section title="Tasks" action={<ExportButtons filename={`org-${orgID}-tasks-usage`} rows={usage.data?.export_tasks || usage.data?.tasks || []} />}>
-                    <SimpleTable authenticated fields={baseFields} data={tableRows.tasks} compact loading={isScopedLoading('tasks')} />
-                    <TablePagination
-                      component="div"
-                      count={usage.data?.tasks_total || 0}
-                      page={taskPage}
-                      rowsPerPage={taskRowsPerPage}
-                      onPageChange={(_, nextPage) => {
-                        setLoadingScope('tasks')
-                        setTaskPage(nextPage)
-                      }}
-                      onRowsPerPageChange={event => {
-                        setLoadingScope('tasks')
-                        setTaskRowsPerPage(parseInt(event.target.value, 10))
-                        setTaskPage(0)
-                      }}
-                      rowsPerPageOptions={[10, 25, 50, 100]}
-                    />
-                  </Section>
+                  <UsagePanel>
+                    <Section title="Tasks" action={<ExportButtons filename={`org-${orgID}-tasks-usage`} rows={usage.data?.export_tasks || usage.data?.tasks || []} />}>
+                      <SimpleTable authenticated fields={baseFields} data={tableRows.tasks} compact loading={isScopedLoading('tasks')} />
+                      <TablePagination
+                        component="div"
+                        count={usage.data?.tasks_total || 0}
+                        page={taskPage}
+                        rowsPerPage={taskRowsPerPage}
+                        onPageChange={(_, nextPage) => {
+                          setLoadingScope('tasks')
+                          setTaskPage(nextPage)
+                        }}
+                        onRowsPerPageChange={event => {
+                          setLoadingScope('tasks')
+                          setTaskRowsPerPage(parseInt(event.target.value, 10))
+                          setTaskPage(0)
+                        }}
+                        rowsPerPageOptions={[10, 25, 50, 100]}
+                      />
+                    </Section>
+                  </UsagePanel>
 
-                  <Section title="Sessions" action={<ExportButtons filename={`org-${orgID}-sessions-usage`} rows={usage.data?.export_sessions || usage.data?.sessions || []} />}>
-                    <SimpleTable authenticated fields={sessionFields} data={tableRows.sessions} compact loading={isScopedLoading('sessions')} />
-                    <TablePagination
-                      component="div"
-                      count={usage.data?.sessions_total || 0}
-                      page={sessionPage}
-                      rowsPerPage={sessionRowsPerPage}
-                      onPageChange={(_, nextPage) => {
-                        setLoadingScope('sessions')
-                        setSessionPage(nextPage)
-                      }}
-                      onRowsPerPageChange={event => {
-                        setLoadingScope('sessions')
-                        setSessionRowsPerPage(parseInt(event.target.value, 10))
-                        setSessionPage(0)
-                      }}
-                      rowsPerPageOptions={[10, 25, 50, 100]}
-                    />
-                  </Section>
+                  <UsagePanel>
+                    <Section title="Sessions" action={<ExportButtons filename={`org-${orgID}-sessions-usage`} rows={usage.data?.export_sessions || usage.data?.sessions || []} />}>
+                      <SimpleTable authenticated fields={sessionFields} data={tableRows.sessions} compact loading={isScopedLoading('sessions')} />
+                      <TablePagination
+                        component="div"
+                        count={usage.data?.sessions_total || 0}
+                        page={sessionPage}
+                        rowsPerPage={sessionRowsPerPage}
+                        onPageChange={(_, nextPage) => {
+                          setLoadingScope('sessions')
+                          setSessionPage(nextPage)
+                        }}
+                        onRowsPerPageChange={event => {
+                          setLoadingScope('sessions')
+                          setSessionRowsPerPage(parseInt(event.target.value, 10))
+                          setSessionPage(0)
+                        }}
+                        rowsPerPageOptions={[10, 25, 50, 100]}
+                      />
+                    </Section>
+                  </UsagePanel>
 
-                  <Section
-                    title="Users"
-                    action={<ExportButtons filename={`org-${orgID}-users-usage`} rows={usage.data?.export_users || usage.data?.users || []} />}
-                  >
-                    <TextField
-                      size="small"
-                      placeholder="Search username or email"
-                      value={userSearchInput}
-                      onChange={e => {
-                        setLoadingScope('users')
-                        setUserSearchInput(e.target.value)
-                        setUserPage(0)
-                      }}
-                      sx={{ mb: 1.5, width: '100%', maxWidth: 360 }}
-                      InputProps={{
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <Search size={16} />
-                          </InputAdornment>
-                        ),
-                      }}
-                    />
-                    <SimpleTable authenticated fields={baseFields} data={tableRows.users} compact loading={isScopedLoading('users')} />
-                    <TablePagination
-                      component="div"
-                      count={usage.data?.users_total || 0}
-                      page={userPage}
-                      rowsPerPage={userRowsPerPage}
-                      onPageChange={(_, nextPage) => {
-                        setLoadingScope('users')
-                        setUserPage(nextPage)
-                      }}
-                      onRowsPerPageChange={event => {
-                        setLoadingScope('users')
-                        setUserRowsPerPage(parseInt(event.target.value, 10))
-                        setUserPage(0)
-                      }}
-                      rowsPerPageOptions={[10, 25, 50, 100]}
-                    />
-                  </Section>
+                  <UsagePanel>
+                    <Section
+                      title="Users"
+                      action={<ExportButtons filename={`org-${orgID}-users-usage`} rows={usage.data?.export_users || usage.data?.users || []} />}
+                    >
+                      <TextField
+                        size="small"
+                        placeholder="Search username or email"
+                        value={userSearchInput}
+                        onChange={e => {
+                          setLoadingScope('users')
+                          setUserSearchInput(e.target.value)
+                          setUserPage(0)
+                        }}
+                        sx={{ mb: 1.5, width: '100%', maxWidth: 360 }}
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <Search size={16} />
+                            </InputAdornment>
+                          ),
+                        }}
+                      />
+                      <SimpleTable authenticated fields={baseFields} data={tableRows.users} compact loading={isScopedLoading('users')} />
+                      <TablePagination
+                        component="div"
+                        count={usage.data?.users_total || 0}
+                        page={userPage}
+                        rowsPerPage={userRowsPerPage}
+                        onPageChange={(_, nextPage) => {
+                          setLoadingScope('users')
+                          setUserPage(nextPage)
+                        }}
+                        onRowsPerPageChange={event => {
+                          setLoadingScope('users')
+                          setUserRowsPerPage(parseInt(event.target.value, 10))
+                          setUserPage(0)
+                        }}
+                        rowsPerPageOptions={[10, 25, 50, 100]}
+                      />
+                    </Section>
+                  </UsagePanel>
                 </Stack>
               </>
             )}

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -40,6 +40,7 @@ import {
 type RangeKey = '7d' | '30d' | '90d'
 type UsageLoadingScope = 'filters' | 'projects' | 'tasks' | 'sessions' | 'users'
 type OverviewMetric = 'cost' | 'tokens'
+type LatencyMetric = 'per-request' | 'per-1k-output'
 type UsageChartRow = { date: string; [key: string]: number | string }
 
 const TOKEN_SERIES: ShadcnSeries[] = [
@@ -440,51 +441,6 @@ const rowToTable = (row: TypesUsageBreakdownRow, withProvider = false, onNameCli
   lastActivity: <Typography variant="body2" color="text.secondary">{formatDateTime(row.last_activity_at)}</Typography>,
 })
 
-const LatencyTooltip: FC<TooltipContentProps<number, string>> = ({ active, payload, label }) => {
-  if (!active || !payload?.length) return null
-  return (
-    <Box sx={{ bgcolor: 'rgba(10,10,15,0.95)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 2, px: 1.5, py: 1 }}>
-      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-        {label ? new Date(label as string).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : ''}
-      </Typography>
-      <Typography variant="body2">{formatMs(payload[0]?.value as number)}</Typography>
-    </Box>
-  )
-}
-
-const LatencyChart: FC<{ data: Array<{ date: string; latency: number }> }> = ({ data }) => {
-  const hasData = data.some(row => row.latency > 0)
-  return (
-    <Box sx={{ height: 300, bgcolor: 'rgba(0,0,0,0.2)', borderRadius: 2, p: 2 }}>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 1, fontWeight: 500, letterSpacing: '0.04em' }}>
-        LATENCY
-      </Typography>
-      {hasData ? (
-        <ResponsiveContainer width="100%" height={230}>
-          <LineChart data={data} margin={{ top: 10, right: 12, left: 16, bottom: 0 }}>
-            <CartesianGrid vertical={false} stroke="rgba(255,255,255,0.08)" />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tick={{ fill: '#94A3B8', fontSize: 12 }}
-              tickFormatter={(v: string) => new Date(v).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
-            />
-            <YAxis tickLine={false} axisLine={false} tickMargin={10} width={80} tick={{ fill: '#94A3B8', fontSize: 12 }} tickFormatter={(v: number) => `${Math.round(v)}ms`} />
-            <Tooltip content={React.createElement(LatencyTooltip)} cursor={{ stroke: 'rgba(255,255,255,0.2)' }} />
-            <Line type="monotone" dataKey="latency" stroke="#14b8a6" strokeWidth={2} dot={false} isAnimationActive={false} />
-          </LineChart>
-        </ResponsiveContainer>
-      ) : (
-        <Box sx={{ height: 230, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Typography variant="body2" color="text.secondary">No latency data</Typography>
-        </Box>
-      )}
-    </Box>
-  )
-}
-
 const buildModelChart = (series: TypesUsageModelTimeSeries[] = []): UsageChartRow[] => {
   const dates = new Map<string, UsageChartRow>()
   series.slice(0, CHART_COLORS.length).forEach(model => {
@@ -655,6 +611,7 @@ const OrgUsage: FC = () => {
   const [sessionPage, setSessionPage] = useState(0)
   const [sessionRowsPerPage, setSessionRowsPerPage] = useState(10)
   const [overviewMetric, setOverviewMetric] = useState<OverviewMetric>('cost')
+  const [latencyMetric, setLatencyMetric] = useState<LatencyMetric>('per-request')
   const [loadingScope, setLoadingScope] = useState<UsageLoadingScope | null>(null)
   const sessionId = useDebounce(sessionIdInput.trim(), 400)
   const userSearch = useDebounce(userSearchInput.trim(), 300)
@@ -851,10 +808,55 @@ const OrgUsage: FC = () => {
     color: CHART_COLORS[index],
   }))
 
-  const latencyData = useMemo(() => metrics.map(metric => ({
-    date: metric.date || '',
-    latency: metric.latency_ms ?? 0,
-  })), [metrics])
+  // Latency per provider. Mean request duration answers "how long does a call
+  // take", but it tracks response length as much as provider speed — a
+  // provider used for long agentic turns looks slow even when it streams
+  // faster. Normalising by output tokens is the comparison that actually
+  // ranks providers, so both are offered.
+  const latencyChartData = useMemo<UsageChartRow[]>(() => {
+    const byDate = new Map<string, UsageChartRow>()
+    for (const series of providerTimeSeries) {
+      const key = series.provider || 'unknown'
+      for (const metric of series.metrics || []) {
+        const date = metric.date || ''
+        let row = byDate.get(date)
+        if (!row) {
+          row = { date }
+          byDate.set(date, row)
+        }
+        // The API emits a zero-filled point for every provider on every date.
+        // Plotting those zeros drags each line to the floor and back on days a
+        // provider simply wasn't used, which reads as wild latency swings.
+        // Leave the key unset instead so the point is absent, and let the
+        // chart bridge the gap.
+        const requests = metric.total_requests ?? 0
+        if (requests === 0) continue
+        const meanMs = metric.latency_ms ?? 0
+        if (latencyMetric === 'per-request') {
+          row[key] = meanMs
+          continue
+        }
+        // Reconstruct total time from the mean the API publishes, then divide
+        // by output volume.
+        const completion = metric.completion_tokens ?? 0
+        if (completion <= 0) continue
+        row[key] = (meanMs * requests) / (completion / 1000)
+      }
+    }
+    return Array.from(byDate.values()).sort((a, b) => String(a.date).localeCompare(String(b.date)))
+  }, [providerTimeSeries, latencyMetric])
+  const latencyChartSeries: ShadcnSeries[] = providerTimeSeries.map((item, index) => ({
+    key: item.provider || 'unknown',
+    label: item.name || item.provider || 'Unknown',
+    color: providerColor(item.provider || 'unknown', index, lightTheme.isLight),
+  }))
+  const latencyHeadline = useMemo(() => {
+    const values = latencyChartData.flatMap(row => latencyChartSeries
+      .map(s => Number(row[s.key]) || 0)
+      .filter(v => v > 0))
+    if (!values.length) return '—'
+    return formatMs(values.reduce((a, b) => a + b, 0) / values.length)
+  }, [latencyChartData, latencyChartSeries])
   const userOptions = usage.data?.filter_users || []
   const projectOptions = usage.data?.filter_projects || []
   const appOptions = usage.data?.filter_apps || []
@@ -1230,7 +1232,27 @@ const OrgUsage: FC = () => {
                     />
                   </UsagePanel>
                   <UsagePanel>
-                    <LatencyChart data={latencyData} />
+                    <Stack direction="row" alignItems="center" justifyContent="flex-end" sx={{ mb: 1 }}>
+                      <ToggleButtonGroup
+                        value={latencyMetric}
+                        exclusive
+                        size="small"
+                        onChange={(_, next: LatencyMetric | null) => next && setLatencyMetric(next)}
+                      >
+                        <ToggleButton value="per-request">Per request</ToggleButton>
+                        <ToggleButton value="per-1k-output">Per 1k output</ToggleButton>
+                      </ToggleButtonGroup>
+                    </Stack>
+                    <ShadcnAreaChart
+                      title={latencyMetric === 'per-request' ? 'LATENCY BY PROVIDER' : 'LATENCY PER 1K OUTPUT TOKENS'}
+                      headline={latencyHeadline}
+                      data={latencyChartData}
+                      series={latencyChartSeries}
+                      valueFormatter={formatMs}
+                      stacked={false}
+                      variant="line"
+                      connectNulls
+                    />
                   </UsagePanel>
                 </Box>
 

--- a/frontend/src/components/sandboxes/SandboxCard.tsx
+++ b/frontend/src/components/sandboxes/SandboxCard.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, useState } from 'react'
+import React, { FC, MouseEvent, useState } from 'react'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -11,6 +11,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
+import SandboxProject from './SandboxProject'
 import SandboxSource from './SandboxSource'
 import SandboxStatusBadge from './SandboxStatusBadge'
 import SandboxTerminal from './SandboxTerminal'
@@ -28,7 +29,7 @@ interface SandboxCardProps {
   orgId: string
 }
 
-const StatRow: FC<{ label: string; value: string | number }> = ({ label, value }) => (
+const StatRow: FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25, minWidth: 0 }}>
     <Typography variant="caption" sx={{
       color: 'text.secondary',
@@ -270,7 +271,10 @@ const SandboxCard: FC<SandboxCardProps> = ({ sandbox, onOpen, onDelete, orgId })
           gap: 1,
         }}>
           <StatRow label="Resources" value={formatResources(sandbox)} />
-          <StatRow label="Runtime" value={runtimeMeta(sandbox.runtime || 'ubuntu-desktop').label} />
+          {/* Project, not Runtime: the runtime label already sits in the card
+              header, and the project is what tells two identically-named
+              spec-task runners apart. */}
+          <StatRow label="Project" value={<SandboxProject sandbox={sandbox} variant="body2" />} />
           <StatRow label="Created" value={formatTimestamp(sandbox.created_at)} />
           <StatRow label="Expires" value={formatExpiry(sandbox.expires_at)} />
         </Box>

--- a/frontend/src/components/sandboxes/SandboxCard.tsx
+++ b/frontend/src/components/sandboxes/SandboxCard.tsx
@@ -11,6 +11,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
+import SandboxSource from './SandboxSource'
 import SandboxStatusBadge from './SandboxStatusBadge'
 import SandboxTerminal from './SandboxTerminal'
 import useLightTheme from '../../hooks/useLightTheme'
@@ -160,19 +161,21 @@ const SandboxCard: FC<SandboxCardProps> = ({ sandbox, onOpen, onDelete, orgId })
                   >
                     {sandbox.name || sandbox.id}
                   </Typography>
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: 'text.secondary',
-                      fontSize: '0.7rem',
-                      display: 'block',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {meta.label}
-                  </Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        fontSize: '0.7rem',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {meta.label}
+                    </Typography>
+                    <SandboxSource sandbox={sandbox} />
+                  </Box>
                 </Box>
               </Box>
             )

--- a/frontend/src/components/sandboxes/SandboxProject.tsx
+++ b/frontend/src/components/sandboxes/SandboxProject.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react'
+import Typography from '@mui/material/Typography'
+
+import useAccount from '../../hooks/useAccount'
+import { useListProjects } from '../../services/projectService'
+import { TypesSandbox } from '../../api/api'
+
+interface SandboxProjectProps {
+  sandbox: TypesSandbox
+  variant?: 'caption' | 'body2'
+}
+
+// SandboxProject names the project a sandbox belongs to.
+//
+// Sandbox names are labels, not identifiers — a spec-task runner takes its
+// task's name, and two projects in the same org routinely have a task called
+// "test". The org-wide list would then show several identically-named rows
+// with no way to tell them apart, which defeats the point of a list whose job
+// is cost attribution. The project is the axis that separates them.
+//
+// The projects query is shared: React Query dedupes it across every row, so a
+// list of N sandboxes still issues one request.
+const SandboxProject: FC<SandboxProjectProps> = ({ sandbox, variant = 'caption' }) => {
+  const account = useAccount()
+  const orgId = account.organizationTools.organization?.id
+  const { data: projects } = useListProjects(orgId, { enabled: Boolean(orgId) })
+
+  if (!sandbox.project_id) {
+    return (
+      <Typography variant={variant} color="text.secondary" noWrap>
+        Org-scoped
+      </Typography>
+    )
+  }
+
+  const project = projects?.find(p => p.id === sandbox.project_id)
+  return (
+    <Typography variant={variant} color="text.secondary" noWrap>
+      {project?.name || sandbox.project_id}
+    </Typography>
+  )
+}
+
+export default SandboxProject

--- a/frontend/src/components/sandboxes/SandboxSource.tsx
+++ b/frontend/src/components/sandboxes/SandboxSource.tsx
@@ -1,0 +1,73 @@
+import { FC, MouseEvent } from 'react'
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { ListChecks, TerminalSquare } from 'lucide-react'
+
+import useRouter from '../../hooks/useRouter'
+import { TypesSandbox } from '../../api/api'
+
+interface SandboxSourceProps {
+  sandbox: TypesSandbox
+}
+
+// SandboxSource marks who provisioned the container behind a sandbox row.
+//
+// Spec-task desktops are metered through the same sandbox rows as
+// user-created sandboxes, so the list mixes two very different things: the
+// runners behind a task, and containers someone created from the Sandboxes
+// API. Without a marker the list reads as a pile of unexplained rows.
+const SandboxSource: FC<SandboxSourceProps> = ({ sandbox }) => {
+  const router = useRouter()
+
+  if (!sandbox.spec_task_id) {
+    const label = sandbox.session_id ? 'Session' : 'Sandbox API'
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+        <TerminalSquare size={14} color="currentColor" style={{ flexShrink: 0, opacity: 0.6 }} />
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {label}
+        </Typography>
+      </Box>
+    )
+  }
+
+  const canNavigate = Boolean(sandbox.project_id && router.params.org_id)
+  const openTask = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!canNavigate) return
+    router.navigate('org_project-task-detail', {
+      org_id: router.params.org_id,
+      id: sandbox.project_id,
+      taskId: sandbox.spec_task_id,
+    })
+  }
+
+  return (
+    <Tooltip title={canNavigate ? 'Open the spec task this runner belongs to' : 'Spec task runner'}>
+      <Box
+        component={canNavigate ? 'a' : 'span'}
+        href={canNavigate ? '#' : undefined}
+        onClick={canNavigate ? openTask : undefined}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          minWidth: 0,
+          textDecoration: 'none',
+          color: 'text.secondary',
+          cursor: canNavigate ? 'pointer' : 'default',
+          '&:hover': canNavigate ? { color: 'text.primary' } : undefined,
+        }}
+      >
+        <ListChecks size={14} style={{ flexShrink: 0 }} />
+        <Typography variant="body2" color="inherit" noWrap>
+          Spec task
+        </Typography>
+      </Box>
+    </Tooltip>
+  )
+}
+
+export default SandboxSource

--- a/frontend/src/components/sandboxes/SandboxesTable.tsx
+++ b/frontend/src/components/sandboxes/SandboxesTable.tsx
@@ -10,6 +10,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import SimpleTable from '../widgets/SimpleTable'
 import SandboxStatusBadge from './SandboxStatusBadge'
+import SandboxProject from './SandboxProject'
 import SandboxSource from './SandboxSource'
 import { TypesSandbox } from '../../api/api'
 
@@ -37,25 +38,31 @@ const SandboxesTable: FC<SandboxesTableProps> = ({ sandboxes, onOpen, onDelete }
   const tableData = useMemo(() => sandboxes.map((sb) => ({
     id: sb.id,
     _data: sb,
+    // Names are not unique — spec-task runners inherit their task's name, and
+    // two projects in the same org can both have a task called "test". The
+    // project line underneath is what tells those rows apart.
     name: (
-      <Typography variant="body1">
-        <a
-          style={{
-            textDecoration: 'none',
-            fontWeight: 'bold',
-            color: theme.palette.mode === 'dark' ? theme.palette.text.primary : theme.palette.text.secondary,
-            fontFamily: 'monospace',
-          }}
-          href="#"
-          onClick={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            onOpen(sb)
-          }}
-        >
-          {sb.name || sb.id}
-        </a>
-      </Typography>
+      <>
+        <Typography variant="body1">
+          <a
+            style={{
+              textDecoration: 'none',
+              fontWeight: 'bold',
+              color: theme.palette.mode === 'dark' ? theme.palette.text.primary : theme.palette.text.secondary,
+              fontFamily: 'monospace',
+            }}
+            href="#"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onOpen(sb)
+            }}
+          >
+            {sb.name || sb.id}
+          </a>
+        </Typography>
+        <SandboxProject sandbox={sb} />
+      </>
     ),
     runtime: (
       <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/sandboxes/SandboxesTable.tsx
+++ b/frontend/src/components/sandboxes/SandboxesTable.tsx
@@ -10,6 +10,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import SimpleTable from '../widgets/SimpleTable'
 import SandboxStatusBadge from './SandboxStatusBadge'
+import SandboxSource from './SandboxSource'
 import { TypesSandbox } from '../../api/api'
 
 interface SandboxesTableProps {
@@ -61,6 +62,12 @@ const SandboxesTable: FC<SandboxesTableProps> = ({ sandboxes, onOpen, onDelete }
         {sb.runtime || 'ubuntu-desktop'}
       </Typography>
     ),
+    source: <SandboxSource sandbox={sb} />,
+    resources: (
+      <Typography variant="body2" color="text.secondary">
+        {`${sb.vcpus ?? 1} vCPU · ${Math.round((sb.memory_mb ?? 2048) / 1024)} GB`}
+      </Typography>
+    ),
     status: <SandboxStatusBadge status={sb.status} message={sb.status_message} />,
     created: (
       <Typography variant="body2" color="text.secondary">
@@ -89,7 +96,9 @@ const SandboxesTable: FC<SandboxesTableProps> = ({ sandboxes, onOpen, onDelete }
         authenticated={true}
         fields={[
           { name: 'name', title: 'Name' },
+          { name: 'source', title: 'Source' },
           { name: 'runtime', title: 'Runtime' },
+          { name: 'resources', title: 'Resources' },
           { name: 'status', title: 'Status' },
           { name: 'created', title: 'Created' },
           { name: 'expires', title: 'Expires' },

--- a/frontend/src/components/usage/ShadcnAreaChart.tsx
+++ b/frontend/src/components/usage/ShadcnAreaChart.tsx
@@ -44,6 +44,12 @@ export interface ShadcnAreaChartProps {
   variant?: 'area' | 'line';
   /** Fixed Y-axis bounds for values with a known range. */
   yDomain?: [number, number];
+  /**
+   * Bridge gaps in a line series instead of breaking it. Use when a missing
+   * point means "no sample that day" rather than "measured zero" — bridging
+   * keeps a sparsely-sampled series readable as a trend.
+   */
+  connectNulls?: boolean;
 }
 
 const uid = () => Math.random().toString(36).slice(2, 9);
@@ -121,6 +127,7 @@ const ShadcnAreaChart: FC<ShadcnAreaChartProps> = ({
   zeroIsData = false,
   variant = 'area',
   yDomain,
+  connectNulls = false,
 }) => {
   const lightTheme = useLightTheme();
   const Chart = variant === 'line' ? LineChart : AreaChart;
@@ -224,14 +231,14 @@ const ShadcnAreaChart: FC<ShadcnAreaChartProps> = ({
               {series.map(s => variant === 'line' ? (
                 <Line
                   key={s.key}
-                  type="linear"
+                  type="monotone"
                   dataKey={s.key}
                   name={s.label}
                   stroke={s.color}
                   strokeWidth={2}
                   dot={{ r: 2.5, fill: s.color, strokeWidth: 0 }}
                   activeDot={{ r: 4, fill: s.color, strokeWidth: 0 }}
-                  connectNulls={false}
+                  connectNulls={connectNulls}
                   isAnimationActive={false}
                 />
               ) : (

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -9118,6 +9118,25 @@ definitions:
         type: string
       runtime:
         $ref: '#/definitions/types.SandboxRuntime'
+      session_id:
+        description: |-
+          SessionID links the row to the Helix session that owns the container,
+          for sandboxes whose container is provisioned by the external-agent
+          executor rather than by sandbox.Controller.provision (spec-task
+          desktops, exploratory sessions, subscription desktops). The row exists
+          so those containers are metered, quota-checked and visible in the
+          Sandboxes UI on the same terms as user-created sandboxes.
+
+          Non-empty is the discriminator for "session-backed": hydra registers
+          every operation for such a container under the session id, so callers
+          must route hydra ops via HydraOpsID() rather than the row id.
+        type: string
+      spec_task_id:
+        description: |-
+          SpecTaskID is the spec task that owns the session, when there is one.
+          Denormalised from the session purely so the Sandboxes list can link back
+          to the task without joining through sessions.
+        type: string
       started_at:
         type: string
       status:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -7362,6 +7362,31 @@ definitions:
       total_tokens:
         type: integer
     type: object
+  types.OrgComputeUsage:
+    properties:
+      billing_enabled:
+        description: |-
+          BillingEnabled reports whether compute is actually charged. When false
+          the credits above are historical and nothing new is accruing.
+        type: boolean
+      daily:
+        items:
+          $ref: '#/definitions/types.UsageComputeDailyPoint'
+        type: array
+      desktop_credits:
+        type: number
+      headless_credits:
+        type: number
+      running_sandboxes:
+        description: RunningSandboxes is a point-in-time count, not a range aggregate.
+        type: integer
+      sandboxes:
+        items:
+          $ref: '#/definitions/types.UsageComputeBreakdownRow'
+        type: array
+      total_credits:
+        type: number
+    type: object
   types.OrgDetails:
     properties:
       members:
@@ -7397,6 +7422,13 @@ definitions:
         type: array
       cache_savings:
         type: number
+      compute:
+        allOf:
+        - $ref: '#/definitions/types.OrgComputeUsage'
+        description: |-
+          Compute is sandbox runtime spend. It answers the date range and the
+          project filter; the token-shaped filters (model, provider, session)
+          don't apply to a container and leave it untouched.
       export_apps:
         items:
           $ref: '#/definitions/types.UsageBreakdownRow'
@@ -12344,6 +12376,36 @@ definitions:
         type: integer
       username:
         type: string
+    type: object
+  types.UsageComputeBreakdownRow:
+    properties:
+      credits:
+        type: number
+      name:
+        type: string
+      pricing_type:
+        type: string
+      project_id:
+        type: string
+      runtime:
+        type: string
+      sandbox_id:
+        type: string
+      spec_task_id:
+        type: string
+      vcpus:
+        type: integer
+    type: object
+  types.UsageComputeDailyPoint:
+    properties:
+      date:
+        type: string
+      desktop:
+        type: number
+      headless:
+        type: number
+      total:
+        type: number
     type: object
   types.UsageFilterOption:
     properties:

--- a/openapi.json
+++ b/openapi.json
@@ -38213,6 +38213,40 @@
                     }
                 }
             },
+            "types.OrgComputeUsage": {
+                "type": "object",
+                "properties": {
+                    "billing_enabled": {
+                        "description": "BillingEnabled reports whether compute is actually charged. When false\nthe credits above are historical and nothing new is accruing.",
+                        "type": "boolean"
+                    },
+                    "daily": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageComputeDailyPoint"
+                        }
+                    },
+                    "desktop_credits": {
+                        "type": "number"
+                    },
+                    "headless_credits": {
+                        "type": "number"
+                    },
+                    "running_sandboxes": {
+                        "description": "RunningSandboxes is a point-in-time count, not a range aggregate.",
+                        "type": "integer"
+                    },
+                    "sandboxes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageComputeBreakdownRow"
+                        }
+                    },
+                    "total_credits": {
+                        "type": "number"
+                    }
+                }
+            },
             "types.OrgDetails": {
                 "type": "object",
                 "properties": {
@@ -38265,6 +38299,14 @@
                     },
                     "cache_savings": {
                         "type": "number"
+                    },
+                    "compute": {
+                        "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.OrgComputeUsage"
+                            }
+                        ]
                     },
                     "export_apps": {
                         "type": "array",
@@ -44904,6 +44946,52 @@
                     },
                     "username": {
                         "type": "string"
+                    }
+                }
+            },
+            "types.UsageComputeBreakdownRow": {
+                "type": "object",
+                "properties": {
+                    "credits": {
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "pricing_type": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "runtime": {
+                        "type": "string"
+                    },
+                    "sandbox_id": {
+                        "type": "string"
+                    },
+                    "spec_task_id": {
+                        "type": "string"
+                    },
+                    "vcpus": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageComputeDailyPoint": {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string"
+                    },
+                    "desktop": {
+                        "type": "number"
+                    },
+                    "headless": {
+                        "type": "number"
+                    },
+                    "total": {
+                        "type": "number"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -40652,6 +40652,14 @@
                     "runtime": {
                         "$ref": "#/components/schemas/types.SandboxRuntime"
                     },
+                    "session_id": {
+                        "description": "SessionID links the row to the Helix session that owns the container,\nfor sandboxes whose container is provisioned by the external-agent\nexecutor rather than by sandbox.Controller.provision (spec-task\ndesktops, exploratory sessions, subscription desktops). The row exists\nso those containers are metered, quota-checked and visible in the\nSandboxes UI on the same terms as user-created sandboxes.\n\nNon-empty is the discriminator for \"session-backed\": hydra registers\nevery operation for such a container under the session id, so callers\nmust route hydra ops via HydraOpsID() rather than the row id.",
+                        "type": "string"
+                    },
+                    "spec_task_id": {
+                        "description": "SpecTaskID is the spec task that owns the session, when there is one.\nDenormalised from the session purely so the Sandboxes list can link back\nto the task without joining through sessions.",
+                        "type": "string"
+                    },
                     "started_at": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -35984,6 +35984,14 @@
                 "runtime": {
                     "$ref": "#/definitions/types.SandboxRuntime"
                 },
+                "session_id": {
+                    "description": "SessionID links the row to the Helix session that owns the container,\nfor sandboxes whose container is provisioned by the external-agent\nexecutor rather than by sandbox.Controller.provision (spec-task\ndesktops, exploratory sessions, subscription desktops). The row exists\nso those containers are metered, quota-checked and visible in the\nSandboxes UI on the same terms as user-created sandboxes.\n\nNon-empty is the discriminator for \"session-backed\": hydra registers\nevery operation for such a container under the session id, so callers\nmust route hydra ops via HydraOpsID() rather than the row id.",
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "description": "SpecTaskID is the spec task that owns the session, when there is one.\nDenormalised from the session purely so the Sandboxes list can link back\nto the task without joining through sessions.",
+                    "type": "string"
+                },
                 "started_at": {
                     "type": "string"
                 },

--- a/swagger.json
+++ b/swagger.json
@@ -33545,6 +33545,40 @@
                 }
             }
         },
+        "types.OrgComputeUsage": {
+            "type": "object",
+            "properties": {
+                "billing_enabled": {
+                    "description": "BillingEnabled reports whether compute is actually charged. When false\nthe credits above are historical and nothing new is accruing.",
+                    "type": "boolean"
+                },
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeDailyPoint"
+                    }
+                },
+                "desktop_credits": {
+                    "type": "number"
+                },
+                "headless_credits": {
+                    "type": "number"
+                },
+                "running_sandboxes": {
+                    "description": "RunningSandboxes is a point-in-time count, not a range aggregate.",
+                    "type": "integer"
+                },
+                "sandboxes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageComputeBreakdownRow"
+                    }
+                },
+                "total_credits": {
+                    "type": "number"
+                }
+            }
+        },
         "types.OrgDetails": {
             "type": "object",
             "properties": {
@@ -33597,6 +33631,14 @@
                 },
                 "cache_savings": {
                     "type": "number"
+                },
+                "compute": {
+                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OrgComputeUsage"
+                        }
+                    ]
                 },
                 "export_apps": {
                     "type": "array",
@@ -40236,6 +40278,52 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "types.UsageComputeBreakdownRow": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "pricing_type": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                },
+                "vcpus": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageComputeDailyPoint": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                },
+                "desktop": {
+                    "type": "number"
+                },
+                "headless": {
+                    "type": "number"
+                },
+                "total": {
+                    "type": "number"
                 }
             }
         },


### PR DESCRIPTION
## Problem

We had exactly two debit paths: LLM tokens (`openai/logger/billing_logger.go`) and compute for sandboxes created through the Sandboxes API (`sandbox/controller_billing.go`). The second only ever sees rows in the `sandboxes` table, and spec-task desktops never create one — `HydraExecutor.StartDesktop` calls `hydra.CreateDevContainer` directly.

So the containers that actually burn the GPU host were:

- **never charged** — `ReapBilling` iterates `ListSandboxes(status=running)` and doesn't see them, whatever their size;
- **never credit-checked** — an org with a zero balance could start an 8 vCPU desktop;
- **never quota-checked** — the desktop concurrency cap didn't apply, and `quota.getActiveSandboxesByOrg` under-reported org usage.

https://github.com/helixml/helix/pull/2976 then shipped a self-service 1 / 4 / 8 vCPU picker plus live resize on a running task. That is an 8× cost swing with zero billing signal.

## Approach

`types.Sandbox` becomes the single billing and quota record for **any** container Helix runs on a hydra host, regardless of who provisions it. The executor stays the provisioner — it owns repo checkout, branch mode, golden builds, ZFS clones, session API keys and Zed config, none of which belong in the sandbox controller. The row is the meter, discriminated by the new `session_id` column.

Metering hooks into `HydraExecutor.StartDesktop`/`StopDesktop` rather than the three `spec_driven_task_service` launch sites. There are ~10 `StartDesktop` and ~15 `StopDesktop` call sites; instrumenting three of them would leave most desktops unbilled and duplicate the logic. The executor is the one choke point every desktop passes through, and it already holds the per-session lock that makes the row lifecycle race-free.

## Changes

- **`sandbox.Controller`** gains `BeginSession` / `MarkSessionRunning` / `MarkSessionStopped` / `MarkSessionFailed` / `ResizeSession` / `EnsureSessionResizeCredits` (`controller_session.go`). Desktops now get the org concurrency cap, a one-minute credit floor before boot, per-minute charges, and a final partial-minute charge on stop.
- **Resize settles before it reprices.** `billSandbox` multiplies the *entire* unbilled window by the row's current `VCPUs`, so `ResizeSession` flushes at the old core count first. Without it, resizing 1→8 would retroactively reprice up to a minute of single-core usage at eight cores.
- **Teardown routing.** `Controller.Delete` called `hydraClient.DeleteDevContainer(ctx, sandbox.ID)`; a session-backed container is registered under the *session* id, so that would silently no-op. It now dispatches to an injected `DesktopStopper` (`sandbox` can't import `external-agent`). This is also how credit exhaustion actually stops a spec-task desktop.
- **Never TTL-reaped.** Session-backed rows are created with `timeout_seconds=-1`, leaving `expires_at` NULL — the task owns the desktop's lifetime, not a sandbox TTL.
- **Stale containers stop billing.** `markMissingSessionsStopped` closes the row too, so a container destroyed outside `StopDesktop` (host redeploy, OOM kill) doesn't keep charging forever.
- **Resume no longer drops the task's sandbox preset.** Only the three launch paths set `VCPUs`; `resumeSessionInternal`, session fork and design review rebuild the agent from the session, so a paused 8 vCPU task came back **uncapped** and billed at the default. `resolveSpecTaskResources` fills it in from the owning task for every spec-task path.
- **Hydra op routing.** Sandbox exec / files / terminal / screenshot use `sb.HydraOpsID()`, so the Sandboxes UI works against spec-task desktops.
- **UI.** Table and cards show a "Spec task" source marker that links to the task, plus the resource allocation that drives the bill.

## Operator impact

Gated behind `SandboxBillingEnabled` (default off), except the cap:

- **The desktop concurrency cap now applies to spec tasks.** `MaxConcurrentDesktopSandboxes` defaults to **10 per org** and previously only constrained the Sandboxes API. An org routinely running more than 10 concurrent spec-task desktops must raise it before upgrading.
- **Golden builds and exploratory sessions become billable compute** — they go through `StartDesktop` like everything else.
- Desktops started without an explicit preset run uncapped (hydra treats 0 as "no cap"); charging them one core would undercharge the largest consumers, so they bill at the standard desktop preset. Capping them for real is a separate change.

## Validation

Run live against the dev stack (billing on, desktop price 0.008 credits/second/core), task `spt_01kznhwc1q3jxkvbz5rz1g7812`:

| Behaviour | Observed |
|---|---|
| Row created on task start | `runtime=ubuntu-desktop`, `session_id`/`spec_task_id` set, 4 vCPU / 8192 MB from the task, `expires_at` NULL |
| Per-minute charge | `-1.92` = 0.008 × 60 × 4, twice |
| Resize flush | 4→8 charged `-1.5255` for 47.67s at the **old** 4 cores, then row → 8 vCPU / 16384 MB |
| Post-resize rate | `-3.84`/min = 0.008 × 60 × 8 |
| Failed resize doesn't reprice | hydra rejected 16 GB→2 GB (container using 2694 MB); no flush, row unchanged |
| Final charge on stop | `-5.288` for the 82.6s partial minute, row → `stopped` |
| Resume reuses the row | same row id; `started_at`/`billing_last_charged_at` reset so the stopped gap isn't billed |
| Resume restores the preset | back at 8 vCPU / 16384 MB after the fix (was 4 / 8192 before) |
| Delete tears the container down | `ubuntu-external-01kznhwc26vfdmnpbe43w3m71d` gone, final charge landed, row soft-deleted — the same path credit exhaustion takes |
| UI | cards + table show the row with the "Spec task" marker, 8 vCPU · 16 GB, Expires "Never"; marker navigates to the task |

The live run caught two bugs unit tests could not, both fixed and now covered:

1. `SetSandboxResources` wrote to a `vcpus` column — GORM maps `VCPUs` to `v_cpus`, so resizes silently failed to persist. A GORM-backed store test now fails against the old column name.
2. Resume dropped the task's sandbox preset.

**Not exercised live:** credit exhaustion mid-session. Its stop path is `Controller.Delete` → `stopSessionDesktop`, exercised directly by the delete test above, plus unit coverage for the routing and the wallet-drain branch.

Tests: `go build ./...`, `go test ./pkg/sandbox/ ./pkg/external-agent/ ./pkg/types/ ./pkg/server/`, targeted `./pkg/store/` sandbox tests, `yarn build`. The full `./pkg/store/` suite needs Postgres and hangs locally — identically on a clean tree, so pre-existing.

Design notes: `design/2026-08-10-spec-task-desktop-billing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
