### PR TITLE
fix(org): refresh stale MCP service credentials

### DIFF
--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -1078,7 +1079,10 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Int("json_api_routes", len(extras)).
 		Msg("helix-org mounted at /api/v1/orgs/{org}/helix-org/")
 	scope := newHelixOrgScope(configReg, st, helixStore, mirror, slackRouteReconciler, helixEventsReconciler)
-	scope.botRepair = func(ctx context.Context, orgID string) error {
+	scope.botRepair = func(ctx context.Context, orgID, serviceKey string) error {
+		if err := repairHelixOrgMCPServiceKeys(ctx, orgID, serviceKey, configReg, st, inProcClient); err != nil {
+			return err
+		}
 		return repairNeverActivatedBots(ctx, orgID, st, dispatcher, configReg, inProcClient)
 	}
 
@@ -1241,8 +1245,8 @@ type dynamicProjectApplier struct {
 	cfg        *configregistry.Registry
 	projectSvc runtimehelix.ProjectService
 	Store      *helixorgstore.Store
-	// helixStore is the main Helix store, used only to resolve the org's
-	// display name for the `<Bot> @ <Org>` project label.
+	// helixStore is the main Helix store, used to validate the service API
+	// key and resolve the org's display name for the `<Bot> @ <Org>` label.
 	helixStore helixstore.Store
 	logger     *slog.Logger
 }
@@ -1259,7 +1263,7 @@ type dynamicProjectApplier struct {
 // The Spawner does the same on its own activations; owner-chat goes
 // through this path only.
 func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, workerID orgchart.NodeID) (projectID, agentAppID, repoID string, err error) {
-	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.logger)
+	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.helixStore, d.projectSvc, d.Store, d.logger)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -1317,13 +1321,14 @@ func buildHelixOrgProjectApplier(
 	ctx context.Context,
 	orgID string,
 	cfg *configregistry.Registry,
+	helixStore helixstore.Store,
 	projectSvc runtimehelix.ProjectService,
 	orgStore *helixorgstore.Store,
 	logger *slog.Logger,
 ) (*runtimehelix.WorkerProject, string, error) {
-	apiKey, _ := cfg.GetString(ctx, orgID, "helix.api_key")
-	if apiKey == "" {
-		return nil, "", fmt.Errorf("helix.api_key not set")
+	apiKey, err := helixorg.NewHelixAPIKeys(helixStore, cfg).Service(ctx, orgID)
+	if err != nil {
+		return nil, "", fmt.Errorf("provision helix-org service api key: %w", err)
 	}
 	baseURL, err := cfg.GetString(ctx, orgID, "helix.url")
 	if err != nil {
@@ -1388,6 +1393,33 @@ func workerRuntimeSupportsSubscription(runtime string) bool {
 	return runtime == "claude_code" || runtime == "codex_cli"
 }
 
+func repairHelixOrgMCPServiceKeys(ctx context.Context, orgID, serviceKey string, cfg *configregistry.Registry, st *helixorgstore.Store, projectSvc runtimehelix.ProjectService) error {
+	baseURL, err := cfg.GetString(ctx, orgID, "helix.url")
+	if err != nil {
+		return fmt.Errorf("read helix.url: %w", err)
+	}
+	workers, err := st.Nodes.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("list bots for MCP service-key repair: %w", err)
+	}
+	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
+	var repairErrors []error
+	for _, worker := range workers {
+		if worker.AgentID == "" {
+			continue
+		}
+		if err := runtimehelix.AttachHelixOrgMCP(ctx, projectSvc, worker.AgentID, helixOrgURL, worker.ID, serviceKey); err != nil {
+			if errors.Is(err, helixstore.ErrNotFound) {
+				log.Warn().Str("org_id", orgID).Str("bot_id", worker.ID).Str("app_id", worker.AgentID).Msg("repair helix-org MCP service key skipped missing app")
+				continue
+			}
+			log.Warn().Err(err).Str("org_id", orgID).Str("bot_id", worker.ID).Str("app_id", worker.AgentID).Msg("repair helix-org MCP service key failed")
+			repairErrors = append(repairErrors, fmt.Errorf("repair helix-org MCP for bot %s: %w", worker.ID, err))
+		}
+	}
+	return errors.Join(repairErrors...)
+}
+
 // buildHelixOrgSpawnerConfig assembles the SpawnerConfig for
 // helix-org's production zed_external Spawner. The embedded SaaS
 // runs Workers on the `claude_code` runtime with subscription
@@ -1440,9 +1472,9 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 	if d.ProjectSvc == nil {
 		return runtimehelix.SpawnerConfig{}, fmt.Errorf("helix-org spawner: ProjectService is required")
 	}
-	apiKey, _ := d.Cfg.GetString(ctx, orgID, "helix.api_key")
-	if apiKey == "" {
-		return runtimehelix.SpawnerConfig{}, fmt.Errorf("helix.api_key not set")
+	apiKey, err := helixorg.NewHelixAPIKeys(d.HelixStore, d.Cfg).Service(ctx, orgID)
+	if err != nil {
+		return runtimehelix.SpawnerConfig{}, fmt.Errorf("provision helix-org service api key: %w", err)
 	}
 	baseURL, err := d.Cfg.GetString(ctx, orgID, "helix.url")
 	if err != nil {

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -707,6 +707,9 @@ func (c *inProcHelixClient) GetAppConfig(ctx context.Context, id string) (types.
 	}
 	app, herr := c.server.getAgent(nil, r)
 	if herr != nil {
+		if herr.StatusCode == http.StatusNotFound {
+			return types.AppConfig{}, fmt.Errorf("get app %s: %w", id, store.ErrNotFound)
+		}
 		return types.AppConfig{}, fmt.Errorf("get app %s: %s", id, herr.Error())
 	}
 	if app == nil {

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -487,6 +487,12 @@ func TestInProcProjectService_GetAppConfig_RoundTrips(t *testing.T) {
 	require.Equal(t, want.Helix.Name, got.Helix.Name)
 }
 
+func TestInProcProjectService_GetAppConfig_PreservesNotFound(t *testing.T) {
+	_, _, client, _, ctx := newInProcTestSetup(t)
+	_, err := client.GetAppConfig(ctx, "app-missing")
+	require.ErrorIs(t, err, helixstore.ErrNotFound)
+}
+
 // TestInProcSpawnerClient_StopExternalAgent_NoSession_ReturnsError
 // confirms a missing session ID surfaces as an error (the underlying
 // handler returns 404; the adapter wraps it as a generic error — no

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -53,7 +53,7 @@ type helixOrgScope struct {
 	// hooks — see org_graph_seed.go). nil when helix-org / the seeder isn't
 	// wired.
 	humanReconcile func(ctx context.Context, orgID string) error
-	botRepair      func(ctx context.Context, orgID string) error
+	botRepair      func(ctx context.Context, orgID, serviceKey string) error
 
 	mu           sync.Mutex
 	bootstrapped map[string]bool
@@ -108,13 +108,14 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		}
 
 		// Provision a per-org Helix service api_key for the organization owner.
-		if _, err := helixorg.NewHelixAPIKeys(s.helixStore, s.configs).Service(ctx, orgID); err != nil {
+		serviceKey, err := helixorg.NewHelixAPIKeys(s.helixStore, s.configs).Service(ctx, orgID)
+		if err != nil {
 			return nil, fmt.Errorf("provision helix-org service api key: %w", err)
 		}
 
 		if s.botRepair != nil {
-			if err := s.botRepair(ctx, orgID); err != nil {
-				return nil, fmt.Errorf("repair never-activated bots: %w", err)
+			if err := s.botRepair(ctx, orgID, serviceKey); err != nil {
+				return nil, fmt.Errorf("repair helix-org bots: %w", err)
 			}
 		}
 

--- a/api/pkg/server/helix_org_spawner_test.go
+++ b/api/pkg/server/helix_org_spawner_test.go
@@ -2,18 +2,23 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	helixorgconfig "github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/server/helixorg"
+	helixstore "github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // TestBuildHelixOrgSpawnerConfig_WiresProjectService is the regression
@@ -42,6 +47,11 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 	const orgID = "org-test"
 	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-test-key"`))
 	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+	store := helixstore.NewMockStore(gomock.NewController(t))
+	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
+		Return(&types.Organization{ID: orgID, Owner: "usr-owner"}, nil).Times(2)
+	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-test-key"}).
+		Return(&types.ApiKey{Key: "hlx-test-key", Owner: "usr-owner"}, nil)
 
 	_, _, projectSvc, _, _ := newInProcTestSetup(t)
 	hub := wakebus.New(pubsub.NewNoop())
@@ -49,6 +59,7 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 
 	cfg, err := buildHelixOrgSpawnerConfig(ctx, orgID, spawnerDeps{
 		Cfg:        reg,
+		HelixStore: store,
 		ProjectSvc: projectSvc, // the field we're pinning
 		OrgStore:   orgStore,
 		Hub:        hub,
@@ -62,6 +73,171 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 	// Same pointer round-tripped — confirms the builder copies the
 	// host-provided service, not some other one constructed inside.
 	require.Same(t, projectSvc, cfg.ProjectService.(*inProcHelixClient))
+}
+
+func TestBuildHelixOrgSpawnerConfig_ReplacesStaleServiceKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const orgID = "org-test"
+	const ownerID = "usr-owner"
+
+	orgStore := orggorm.GetOrgTestDB(t)
+	reg := helixorgconfig.New(orgStore.Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-stale"`))
+	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+
+	store := helixstore.NewMockStore(gomock.NewController(t))
+	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
+		Return(&types.Organization{ID: orgID, Owner: ownerID}, nil).Times(2)
+	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-stale"}).
+		Return(nil, helixstore.ErrNotFound)
+	store.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: ownerID}).
+		Return(&types.User{ID: ownerID}, nil)
+	store.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) { return key, nil })
+
+	_, _, projectSvc, _, _ := newInProcTestSetup(t)
+	cfg, err := buildHelixOrgSpawnerConfig(ctx, orgID, spawnerDeps{
+		Cfg:        reg,
+		HelixStore: store,
+		ProjectSvc: projectSvc,
+		OrgStore:   orgStore,
+		Hub:        wakebus.New(pubsub.NewNoop()),
+		PubSub:     pubsub.NewNoop(),
+		Logger:     slog.Default(),
+		NewID:      func() string { return "id" },
+		Now:        func() time.Time { return time.Unix(0, 0).UTC() },
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.MCPAuthBearer)
+	require.NotEqual(t, "hlx-stale", cfg.MCPAuthBearer)
+	stored, err := reg.GetString(ctx, orgID, "helix.api_key")
+	require.NoError(t, err)
+	require.Equal(t, cfg.MCPAuthBearer, stored)
+}
+
+func TestBuildHelixOrgProjectApplier_ReplacesStaleServiceKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const orgID = "org-test"
+	const ownerID = "usr-owner"
+
+	orgStore := orggorm.GetOrgTestDB(t)
+	reg := helixorgconfig.New(orgStore.Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-stale"`))
+	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+
+	store := helixstore.NewMockStore(gomock.NewController(t))
+	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
+		Return(&types.Organization{ID: orgID, Owner: ownerID}, nil)
+	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-stale"}).
+		Return(nil, helixstore.ErrNotFound)
+	store.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: ownerID}).
+		Return(&types.User{ID: ownerID}, nil)
+	store.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) { return key, nil })
+
+	_, bearer, err := buildHelixOrgProjectApplier(ctx, orgID, reg, store, nil, orgStore, slog.Default())
+	require.NoError(t, err)
+	require.NotEmpty(t, bearer)
+	require.NotEqual(t, "hlx-stale", bearer)
+}
+
+type mcpRepairProjectService struct {
+	runtimehelix.ProjectService
+	config      types.AppConfig
+	badApp      string
+	badAppError error
+	updated     types.AppConfig
+	updatedIDs  []string
+}
+
+func (s *mcpRepairProjectService) GetAppConfig(_ context.Context, appID string) (types.AppConfig, error) {
+	if appID == s.badApp {
+		return types.AppConfig{}, s.badAppError
+	}
+	return s.config, nil
+}
+
+func (s *mcpRepairProjectService) UpdateAppConfig(_ context.Context, appID string, config types.AppConfig) error {
+	s.updated = config
+	s.updatedIDs = append(s.updatedIDs, appID)
+	return nil
+}
+
+func TestRepairHelixOrgMCPServiceKeys_UpdatesLinkedApps(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const orgID = "org-test"
+
+	orgStore := orggorm.GetOrgTestDB(t)
+	worker, err := orgchart.NewNode("b-worker", "worker", nil, time.Now().UTC(), orgID)
+	require.NoError(t, err)
+	worker = worker.WithAgentID("app-worker")
+	require.NoError(t, orgStore.Nodes.Create(ctx, worker))
+
+	reg := helixorgconfig.New(orgStore.Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+	svc := &mcpRepairProjectService{config: types.AppConfig{Helix: types.AppHelixConfig{
+		Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{{
+			Name: "helix", Headers: map[string]string{"Authorization": "Bearer hlx-stale"},
+		}}}},
+	}}}
+
+	require.NoError(t, repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc))
+	require.Equal(t, "Bearer hlx-fresh", svc.updated.Helix.Assistants[0].MCPs[0].Headers["Authorization"])
+}
+
+func TestRepairHelixOrgMCPServiceKeys_ContinuesPastMissingApp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const orgID = "org-test"
+
+	orgStore := orggorm.GetOrgTestDB(t)
+	for _, worker := range []struct{ id, appID string }{{"b-bad", "app-bad"}, {"b-good", "app-good"}} {
+		node, err := orgchart.NewNode(worker.id, "worker", nil, time.Now().UTC(), orgID)
+		require.NoError(t, err)
+		require.NoError(t, orgStore.Nodes.Create(ctx, node.WithAgentID(worker.appID)))
+	}
+	reg := helixorgconfig.New(orgStore.Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+	svc := &mcpRepairProjectService{
+		badApp:      "app-bad",
+		badAppError: helixstore.ErrNotFound,
+		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{}}}},
+	}
+
+	require.NoError(t, repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc))
+	require.Equal(t, []string{"app-good"}, svc.updatedIDs)
+}
+
+func TestRepairHelixOrgMCPServiceKeys_RetriesAfterTransientAppFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const orgID = "org-test"
+
+	orgStore := orggorm.GetOrgTestDB(t)
+	for _, worker := range []struct{ id, appID string }{{"b-bad", "app-bad"}, {"b-good", "app-good"}} {
+		node, err := orgchart.NewNode(worker.id, "worker", nil, time.Now().UTC(), orgID)
+		require.NoError(t, err)
+		require.NoError(t, orgStore.Nodes.Create(ctx, node.WithAgentID(worker.appID)))
+	}
+	reg := helixorgconfig.New(orgStore.Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
+	svc := &mcpRepairProjectService{
+		badApp:      "app-bad",
+		badAppError: errors.New("database unavailable"),
+		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{}}}},
+	}
+
+	err := repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc)
+	require.ErrorContains(t, err, "database unavailable")
+	require.Equal(t, []string{"app-good"}, svc.updatedIDs)
 }
 
 // TestBuildHelixOrgSpawnerConfig_RejectsNilProjectService pins the

--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/helixml/helix/api/pkg/agent"
 	mcpclient "github.com/helixml/helix/api/pkg/agent/skill/mcp"
@@ -43,8 +45,9 @@ type ExternalMCPBackend struct {
 	clientGetter mcpclient.ClientGetter
 
 	// Cache of HTTP servers per session+mcp combination
-	servers   map[string]*externalMCPServer
-	serversMu sync.RWMutex
+	servers      map[string]*externalMCPServer
+	serversMu    sync.RWMutex
+	serverFlight singleflight.Group
 
 	// Cleanup goroutine control
 	cleanupCtx    context.Context
@@ -53,13 +56,14 @@ type ExternalMCPBackend struct {
 
 // externalMCPServer holds the MCP server for a specific external MCP
 type externalMCPServer struct {
-	httpServer *server.StreamableHTTPServer
-	mcpName    string
-	sessionID  string
-	createdAt  time.Time
-	lastUsed   time.Time          // Updated on each access to keep connection alive
-	cancelFunc context.CancelFunc // Cancel the background context when server is removed from cache
-	mu         sync.Mutex         // Protects lastUsed
+	httpServer  *server.StreamableHTTPServer
+	mcpName     string
+	sessionID   string
+	createdAt   time.Time
+	lastUsed    time.Time          // Updated on each access to keep connection alive
+	cancelFunc  context.CancelFunc // Cancel the background context when server is removed from cache
+	fingerprint [sha256.Size]byte  // Hash of the MCP config; never stores header secrets directly
+	mu          sync.Mutex         // Protects lastUsed
 }
 
 // touch updates the lastUsed timestamp
@@ -127,32 +131,25 @@ func (b *ExternalMCPBackend) cleanupLoop() {
 
 // cleanupExpiredServers removes servers that have been idle longer than the TTL
 func (b *ExternalMCPBackend) cleanupExpiredServers(ttl time.Duration) {
-	var expiredKeys []string
-	var expiredServers []*externalMCPServer
+	expired := make(map[string]*externalMCPServer)
 
 	// Find expired servers
 	b.serversMu.RLock()
 	for key, srv := range b.servers {
 		if srv.isExpired(ttl) {
-			expiredKeys = append(expiredKeys, key)
-			expiredServers = append(expiredServers, srv)
+			expired[key] = srv
 		}
 	}
 	b.serversMu.RUnlock()
 
-	if len(expiredKeys) == 0 {
+	if len(expired) == 0 {
 		return
 	}
 
-	// Remove expired servers
-	b.serversMu.Lock()
-	for _, key := range expiredKeys {
-		delete(b.servers, key)
-	}
-	b.serversMu.Unlock()
+	removed := b.deleteExpiredServers(expired)
 
 	// Cancel contexts outside the lock to avoid holding it during cleanup
-	for _, srv := range expiredServers {
+	for _, srv := range removed {
 		if srv.cancelFunc != nil {
 			srv.cancelFunc()
 		}
@@ -162,9 +159,25 @@ func (b *ExternalMCPBackend) cleanupExpiredServers(ttl time.Duration) {
 			Msg("cleaned up expired external MCP server")
 	}
 
-	log.Info().
-		Int("count", len(expiredKeys)).
-		Msg("cleaned up expired external MCP servers")
+	if len(removed) > 0 {
+		log.Info().
+			Int("count", len(removed)).
+			Msg("cleaned up expired external MCP servers")
+	}
+}
+
+func (b *ExternalMCPBackend) deleteExpiredServers(expired map[string]*externalMCPServer) []*externalMCPServer {
+	removed := make([]*externalMCPServer, 0, len(expired))
+	b.serversMu.Lock()
+	for key, snapshot := range expired {
+		if current := b.servers[key]; current != snapshot {
+			continue
+		}
+		delete(b.servers, key)
+		removed = append(removed, snapshot)
+	}
+	b.serversMu.Unlock()
+	return removed
 }
 
 // ServeHTTP implements MCPBackend
@@ -240,24 +253,18 @@ func parseMCPPath(path string) (mcpName, remaining string) {
 
 // getOrCreateServer gets or creates a Streamable HTTP server for the given session and MCP
 func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.User, sessionID, mcpName string) (*server.StreamableHTTPServer, error) {
-	// Check cache first (with TTL check)
 	cacheKey := fmt.Sprintf("%s:%s", sessionID, mcpName)
-	cacheTTL := 5 * time.Minute
-
-	b.serversMu.RLock()
-	if srv, ok := b.servers[cacheKey]; ok {
-		if !srv.isExpired(cacheTTL) {
-			// Refresh the lastUsed timestamp to keep the connection alive
-			srv.touch()
-			b.serversMu.RUnlock()
-			return srv.httpServer, nil
-		}
-		// TTL expired (idle too long), cancel old context
-		if srv.cancelFunc != nil {
-			srv.cancelFunc()
-		}
+	result, err, _ := b.serverFlight.Do(cacheKey, func() (any, error) {
+		return b.getOrCreateServerOnce(ctx, user, sessionID, mcpName, cacheKey)
+	})
+	if err != nil {
+		return nil, err
 	}
-	b.serversMu.RUnlock()
+	return result.(*server.StreamableHTTPServer), nil
+}
+
+func (b *ExternalMCPBackend) getOrCreateServerOnce(ctx context.Context, user *types.User, sessionID, mcpName, cacheKey string) (*server.StreamableHTTPServer, error) {
+	cacheTTL := 5 * time.Minute
 
 	// Get the session to find the parent app
 	session, err := b.store.GetSession(ctx, sessionID)
@@ -293,6 +300,27 @@ func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.
 	mcpConfig := b.findMCPConfig(app, projectSkills, mcpName)
 	if mcpConfig == nil {
 		return nil, fmt.Errorf("MCP server '%s' not configured for this agent", mcpName)
+	}
+	configJSON, err := json.Marshal(mcpConfig)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint MCP config: %w", err)
+	}
+	fingerprint := sha256.Sum256(configJSON)
+
+	var stale *externalMCPServer
+	b.serversMu.Lock()
+	if srv, ok := b.servers[cacheKey]; ok {
+		if srv.fingerprint == fingerprint && !srv.isExpired(cacheTTL) {
+			srv.touch()
+			b.serversMu.Unlock()
+			return srv.httpServer, nil
+		}
+		delete(b.servers, cacheKey)
+		stale = srv
+	}
+	b.serversMu.Unlock()
+	if stale != nil && stale.cancelFunc != nil {
+		stale.cancelFunc()
 	}
 
 	log.Info().
@@ -353,12 +381,13 @@ func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.
 	now := time.Now()
 	b.serversMu.Lock()
 	b.servers[cacheKey] = &externalMCPServer{
-		httpServer: httpServer,
-		mcpName:    mcpName,
-		sessionID:  sessionID,
-		createdAt:  now,
-		lastUsed:   now,
-		cancelFunc: clientCancel,
+		httpServer:  httpServer,
+		mcpName:     mcpName,
+		sessionID:   sessionID,
+		createdAt:   now,
+		lastUsed:    now,
+		cancelFunc:  clientCancel,
+		fingerprint: fingerprint,
 	}
 	b.serversMu.Unlock()
 

--- a/api/pkg/server/mcp_backend_external_test.go
+++ b/api/pkg/server/mcp_backend_external_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.uber.org/mock/gomock"
@@ -51,5 +52,117 @@ func TestExternalMCPBackendUsesProjectMCPOverride(t *testing.T) {
 
 	if _, err := backend.getOrCreateServer(context.Background(), &types.User{ID: userID}, sessionID, "helixos"); err != nil {
 		t.Fatalf("get project MCP proxy: %v", err)
+	}
+}
+
+func TestExternalMCPBackendRebuildsCachedServerWhenMCPConfigChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockGetter := mcpclient.NewMockClientGetter(ctrl)
+	oldClient := mcpclient.NewMockClient(ctrl)
+	newClient := mcpclient.NewMockClient(ctrl)
+
+	const (
+		sessionID = "ses_rotated_mcp"
+		userID    = "usr_rotated_mcp"
+		appID     = "app_rotated_mcp"
+	)
+	oldMCP := types.AssistantMCP{Name: "helix", URL: "https://org.example/mcp", Headers: map[string]string{"Authorization": "Bearer old"}}
+	newMCP := oldMCP
+	newMCP.Headers = map[string]string{"Authorization": "Bearer new"}
+	appWith := func(config types.AssistantMCP) *types.App {
+		return &types.App{ID: appID, Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{config}}}}}}
+	}
+	session := &types.Session{ID: sessionID, Owner: userID, ParentApp: appID}
+	gomock.InOrder(
+		mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil),
+		mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(appWith(oldMCP), nil),
+		mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&oldMCP)).Return(oldClient, nil),
+		oldClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil),
+		mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil),
+		mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(appWith(newMCP), nil),
+		mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&newMCP)).Return(newClient, nil),
+		newClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil),
+	)
+
+	backend := NewExternalMCPBackend(mockStore)
+	backend.clientGetter = mockGetter
+	defer backend.Stop()
+	user := &types.User{ID: userID}
+	oldServer, err := backend.getOrCreateServer(context.Background(), user, sessionID, "helix")
+	if err != nil {
+		t.Fatalf("create old MCP proxy: %v", err)
+	}
+	newServer, err := backend.getOrCreateServer(context.Background(), user, sessionID, "helix")
+	if err != nil {
+		t.Fatalf("create rotated MCP proxy: %v", err)
+	}
+	if oldServer == newServer {
+		t.Fatal("rotated MCP config reused cached proxy server")
+	}
+}
+
+func TestExternalMCPBackendCoalescesConcurrentInitialization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockGetter := mcpclient.NewMockClientGetter(ctrl)
+	mockClient := mcpclient.NewMockClient(ctrl)
+
+	const (
+		sessionID = "ses_concurrent_mcp"
+		userID    = "usr_concurrent_mcp"
+		appID     = "app_concurrent_mcp"
+	)
+	mcpConfig := types.AssistantMCP{Name: "helix", URL: "https://org.example/mcp"}
+	app := &types.App{ID: appID, Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{mcpConfig}}}}}}
+	mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(&types.Session{ID: sessionID, Owner: userID, ParentApp: appID}, nil)
+	mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(app, nil)
+	mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&mcpConfig)).Return(mockClient, nil)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	mockClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+		close(entered)
+		<-release
+		return &mcp.ListToolsResult{}, nil
+	})
+
+	backend := NewExternalMCPBackend(mockStore)
+	backend.clientGetter = mockGetter
+	defer backend.Stop()
+	user := &types.User{ID: userID}
+	results := make(chan error, 2)
+	go func() {
+		_, err := backend.getOrCreateServer(context.Background(), user, sessionID, "helix")
+		results <- err
+	}()
+	<-entered
+	go func() {
+		_, err := backend.getOrCreateServer(context.Background(), user, sessionID, "helix")
+		results <- err
+	}()
+	select {
+	case err := <-results:
+		t.Fatalf("concurrent initialization returned before the first completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("get concurrent MCP proxy: %v", err)
+		}
+	}
+}
+
+func TestExternalMCPBackendCleanupPreservesReplacement(t *testing.T) {
+	oldServer := &externalMCPServer{}
+	freshServer := &externalMCPServer{}
+	backend := &ExternalMCPBackend{servers: map[string]*externalMCPServer{"session:mcp": freshServer}}
+
+	removed := backend.deleteExpiredServers(map[string]*externalMCPServer{"session:mcp": oldServer})
+	if len(removed) != 0 {
+		t.Fatalf("removed %d servers from stale snapshot, want 0", len(removed))
+	}
+	if backend.servers["session:mcp"] != freshServer {
+		t.Fatal("cleanup deleted the fresh replacement server")
 	}
 }


### PR DESCRIPTION
## Summary

- validate the Helix Org service API key in both activation and owner-chat paths
- repair linked Bot App MCP headers during first-request bootstrap
- invalidate cached external MCP proxies when effective MCP configuration changes
- serialize proxy initialization and make TTL cleanup safe across replacements

## Recovery

After deployment, the first org-scoped request or GitHub webhook refreshes the service key and linked App MCP headers. Restart an already-failed agent session for deterministic Zed recovery.

## Tests

- CGO_ENABLED=1 go test ./pkg/server ./pkg/server/helixorg -count=1
- CGO_ENABLED=1 go test -race ./pkg/server -run TestExternalMCPBackend -count=1
- go build ./pkg/server ./pkg/store ./pkg/types
- git diff --check