### PR TITLE
fix(org): avoid bootstrap MCP validation deadlock

### DIFF
--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -724,18 +724,13 @@ func (c *inProcHelixClient) GetApp(ctx context.Context, id string) (*types.App, 
 
 // UpdateAppConfig persists a mutated app config.
 func (c *inProcHelixClient) UpdateAppConfig(ctx context.Context, id string, cfg types.AppConfig) error {
-	// updateAgent reads the existing app to preserve immutable fields, so
-	// we only need to send {id, config}.
-	body := types.App{
-		ID:     id,
-		Config: cfg,
-	}
-	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/agents/"+id, body, map[string]string{"id": id})
+	app, err := c.server.Store.GetApp(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("get app %s: %w", id, err)
 	}
-	if _, herr := c.server.updateAgent(nil, r); herr != nil {
-		return fmt.Errorf("update app %s: %s", id, herr.Error())
+	app.Config = cfg
+	if _, err := c.server.Store.UpdateApp(ctx, app); err != nil {
+		return fmt.Errorf("update app %s: %w", id, err)
 	}
 	return nil
 }

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -184,6 +185,39 @@ func TestInProcClient_MarkAgentAppAsOrgKind(t *testing.T) {
 	already := &types.App{ID: "app_bot2", AgentKind: types.AgentKindOrg}
 	st.EXPECT().GetApp(gomock.Any(), "app_bot2").Return(already, nil)
 	require.NoError(t, client.markAgentAppAsOrgKind(context.Background(), "app_bot2"))
+}
+
+func TestInProcClient_UpdateAppConfigPersistsDirectlyAndPreservesApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	created := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	existing := &types.App{
+		ID:             "app_bot",
+		Created:        created,
+		Updated:        created.Add(time.Hour),
+		OrganizationID: "org_test",
+		Owner:          "usr_owner",
+		OwnerType:      types.OwnerTypeUser,
+		Global:         true,
+		AgentKind:      types.AgentKindOrg,
+		Config:         types.AppConfig{Helix: types.AppHelixConfig{Name: "old"}},
+		User:           types.User{ID: "usr_owner", Email: "owner@helix.local"},
+	}
+	wantConfig := types.AppConfig{Helix: types.AppHelixConfig{Name: "updated"}}
+	wantApp := *existing
+	wantApp.Config = wantConfig
+
+	st.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	st.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, app *types.App) (*types.App, error) {
+			require.Same(t, existing, app)
+			require.Equal(t, &wantApp, app)
+			return app, nil
+		},
+	)
+
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
+	require.NoError(t, client.UpdateAppConfig(context.Background(), existing.ID, wantConfig))
 }
 
 func TestInProcClient_ResolvesOrganizationOwnerWithoutAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary
- persist trusted in-process MCP config repairs directly through the store
- avoid re-entering the org bootstrap middleware during MCP validation
- preserve all App metadata while replacing only the config

## Root cause
Meta showed 64 chart requests waiting on the org bootstrap singleflight. The bootstrap winner was repairing an App MCP header through `updateAgent`, whose MCP validation called back into the same org endpoint and waited on its own bootstrap. Cloudflare eventually returned 524 while the chart stayed loading.

## Tests
- `CGO_ENABLED=1 go test ./pkg/server -run "^(TestInProcClient_UpdateAppConfigPersistsDirectlyAndPreservesApp|TestRepairHelixOrgMCPServiceKeys_.*|TestEnsureBootstrap.*)$" -count=1`
- `CGO_ENABLED=1 go test ./pkg/org/infrastructure/runtime/helix -run "AttachHelixOrgMCP" -count=1`
- `go build ./pkg/server ./pkg/store ./pkg/types`
- `git diff --check`