### PR TITLE
Authorize MCP app access via RBAC, and add browser-safe embed API keys

### DIFF
--- a/api/pkg/agent/skill/mcp/mcp_client.go
+++ b/api/pkg/agent/skill/mcp/mcp_client.go
@@ -42,6 +42,28 @@ func (d *DefaultClientGetter) NewClient(ctx context.Context, meta agent.Meta, oa
 
 	maps.Copy(headers, cfg.Headers)
 
+	// Tell the MCP server which session, user and app this call is for.
+	//
+	// WHY THIS MATTERS. An MCP server that needs to act on behalf of the end user
+	// otherwise has to take their identity from a TOOL ARGUMENT, which the model
+	// controls — and a model that reads untrusted input (an uploaded CV, a web
+	// page) can be talked into sending someone else's id. These headers are set
+	// here, by Helix, from the session it is actually running; nothing the model
+	// emits can change them, so a server can treat them as trustworthy in a way
+	// it can never treat an argument.
+	//
+	// Set AFTER the operator's own headers on purpose: a configured header must
+	// not be able to spoof the acting session.
+	if meta.SessionID != "" {
+		headers["X-Helix-Session-Id"] = meta.SessionID
+	}
+	if meta.UserID != "" {
+		headers["X-Helix-User-Id"] = meta.UserID
+	}
+	if meta.AppID != "" {
+		headers["X-Helix-App-Id"] = meta.AppID
+	}
+
 	if cfg.OAuthProvider != "" && headers["Authorization"] == "" {
 		// Get the token with required scopes
 		token, err := oauthManager.GetTokenForTool(ctx, meta.UserID, cfg.OAuthProvider, cfg.OAuthScopes)

--- a/api/pkg/agent/skill/mcp/mcp_client_identity_test.go
+++ b/api/pkg/agent/skill/mcp/mcp_client_identity_test.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/agent"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// Helix must tell an MCP server which session it is calling for, in a way the
+// model cannot influence. Without it, a server acting on behalf of an end user
+// has to trust a tool ARGUMENT for identity — and an agent that reads untrusted
+// input (a CV, a web page) can be talked into sending someone else's id.
+
+type headerRecorder struct {
+	mu   sync.Mutex
+	seen http.Header
+}
+
+func (h *headerRecorder) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h.mu.Lock()
+		h.seen = r.Header.Clone()
+		h.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		// Enough of an initialize response to let the client start.
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"t","version":"1"}}}`))
+	}
+}
+
+func (h *headerRecorder) get(k string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.seen.Get(k)
+}
+
+func TestMCPClientSendsTheActingSessionAsAHeader(t *testing.T) {
+	rec := &headerRecorder{}
+	srv := httptest.NewServer(rec.handler())
+	defer srv.Close()
+
+	getter := &DefaultClientGetter{}
+	meta := agent.Meta{SessionID: "ses_real", UserID: "user_real", AppID: "app_real"}
+	// Start may fail on protocol details; the headers are sent regardless, which
+	// is what this test is about.
+	_, _ = getter.NewClient(context.Background(), meta, nil, &types.AssistantMCP{
+		Name: "t", Transport: "http", URL: srv.URL,
+	})
+
+	if got := rec.get("X-Helix-Session-Id"); got != "ses_real" {
+		t.Errorf("session header = %q, want ses_real", got)
+	}
+	if got := rec.get("X-Helix-User-Id"); got != "user_real" {
+		t.Errorf("user header = %q, want user_real", got)
+	}
+	if got := rec.get("X-Helix-App-Id"); got != "app_real" {
+		t.Errorf("app header = %q, want app_real", got)
+	}
+}
+
+// An operator-configured header must not be able to impersonate a session — the
+// identity headers are applied last, so a spoofed value in the app config loses.
+func TestConfiguredHeadersCannotSpoofTheActingSession(t *testing.T) {
+	rec := &headerRecorder{}
+	srv := httptest.NewServer(rec.handler())
+	defer srv.Close()
+
+	getter := &DefaultClientGetter{}
+	meta := agent.Meta{SessionID: "ses_real", UserID: "user_real"}
+	_, _ = getter.NewClient(context.Background(), meta, nil, &types.AssistantMCP{
+		Name: "t", Transport: "http", URL: srv.URL,
+		Headers: map[string]string{
+			"X-Helix-Session-Id": "ses_ATTACKER",
+			"X-Helix-User-Id":    "user_ATTACKER",
+		},
+	})
+
+	if got := rec.get("X-Helix-Session-Id"); got != "ses_real" {
+		t.Errorf("SECURITY: configured header overrode the acting session: %q", got)
+	}
+	if got := rec.get("X-Helix-User-Id"); got != "user_real" {
+		t.Errorf("SECURITY: configured header overrode the acting user: %q", got)
+	}
+}
+
+// The operator's own headers still get through — this must not break auth.
+func TestConfiguredHeadersStillApply(t *testing.T) {
+	rec := &headerRecorder{}
+	srv := httptest.NewServer(rec.handler())
+	defer srv.Close()
+
+	getter := &DefaultClientGetter{}
+	_, _ = getter.NewClient(context.Background(), agent.Meta{SessionID: "ses_1"}, nil, &types.AssistantMCP{
+		Name: "t", Transport: "http", URL: srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer op-token"},
+	})
+
+	if got := rec.get("Authorization"); got != "Bearer op-token" {
+		t.Errorf("operator Authorization header lost: %q", got)
+	}
+}
+
+// No session (e.g. a non-session context) must not emit an empty header that a
+// server might mistake for a real, blank identity.
+func TestNoSessionEmitsNoHeader(t *testing.T) {
+	rec := &headerRecorder{}
+	srv := httptest.NewServer(rec.handler())
+	defer srv.Close()
+
+	getter := &DefaultClientGetter{}
+	_, _ = getter.NewClient(context.Background(), agent.Meta{}, nil, &types.AssistantMCP{
+		Name: "t", Transport: "http", URL: srv.URL,
+	})
+
+	if _, ok := rec.seen["X-Helix-Session-Id"]; ok {
+		t.Error("empty session should not send the header at all")
+	}
+}

--- a/api/pkg/server/auth_embed_key.go
+++ b/api/pkg/server/auth_embed_key.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// Authorization for embed API keys.
+//
+// An embed key (types.APIkeytypeEmbed) is handed to a BROWSER on an untrusted
+// page — a candidate or client viewing their own agent chat in an iframe on a
+// public site. It must therefore be far weaker than any other credential we
+// issue: it may touch a fixed list of paths, and only ever the ONE spec task and
+// ONE session recorded on the key.
+//
+// Why a distinct key type rather than enforcing on the existing SessionID /
+// SpecTaskID fields: those are already set on ordinary ephemeral keys
+// ("for metrics/attribution", spec_driven_task_service.go), which agent sandboxes
+// use for broad API access. Enforcing on them retroactively would break every
+// running agent. Opting in with a new type keeps existing behaviour byte for byte.
+//
+// FAIL CLOSED. Anything not explicitly matched is denied. A missing entry costs
+// a visibly broken panel in the embed, which we fix by adding it; the opposite
+// default would cost a silent cross-tenant read.
+
+// embedScope is what a matched path is allowed to address.
+type embedScope int
+
+const (
+	// scopeGlobal: no per-resource id in the path. Safe because the response is
+	// about the key's own (service) identity or is public config.
+	scopeGlobal embedScope = iota
+	// scopeTask: the path segment after /spec-tasks/ must equal key.SpecTaskID.
+	scopeTask
+	// scopeSession: the path segment after /sessions/ or /external-agents/ must
+	// equal key.SessionID.
+	scopeSession
+)
+
+// embedRule matches a concrete request path.
+//
+// prefix/suffix rather than a router pattern because this runs inside the auth
+// middleware, before mux has parsed vars. `idAfter` names the prefix the scoped
+// id follows.
+type embedRule struct {
+	methods []string // empty = any
+	prefix  string
+	suffix  string // "" = prefix must match the whole remaining path
+	scope   embedScope
+}
+
+// embedRules is the complete allowlist for an embed key.
+//
+// Deliberately ABSENT, and each for a reason:
+//   - /api/v1/spec-tasks (list) — returns every task in the project, i.e. every
+//     other candidate's chat. This is the single most important omission.
+//   - /api/v1/agents, /api/v1/organizations, /api/v1/projects/... — tenant-wide
+//     inventory the embed does not need to render a conversation.
+//   - /api/v1/external-agents/{id}/ws/stream and the desktop endpoints — the
+//     video/desktop surface. Headless chat does not need it.
+//   - Every mutation of the task itself (PUT /spec-tasks/{id}, labels, archive,
+//     execution-config PATCH, start-planning) — an end user must not be able to
+//     re-point or reconfigure the agent run they are talking to.
+var embedRules = []embedRule{
+	// Bootstrap. The embed page redirects to /login unless /auth/authenticated
+	// and /auth/user answer, so these are load-bearing, not optional. They
+	// describe the key's own service identity — not any candidate's.
+	{methods: []string{"GET"}, prefix: "/api/v1/config", scope: scopeGlobal},
+	{methods: []string{"GET"}, prefix: "/api/v1/status", scope: scopeGlobal},
+	{methods: []string{"GET"}, prefix: "/api/v1/auth/authenticated", scope: scopeGlobal},
+	{methods: []string{"GET"}, prefix: "/api/v1/auth/user", scope: scopeGlobal},
+
+	// The one task this key may read.
+	{methods: []string{"GET"}, prefix: "/api/v1/spec-tasks/", scope: scopeTask},
+	{methods: []string{"GET"}, prefix: "/api/v1/spec-tasks/", suffix: "/execution-config", scope: scopeTask},
+	{methods: []string{"GET"}, prefix: "/api/v1/spec-tasks/", suffix: "/zed-threads", scope: scopeTask},
+	{methods: []string{"GET"}, prefix: "/api/v1/spec-tasks/", suffix: "/clone-groups", scope: scopeTask},
+	{methods: []string{"GET"}, prefix: "/api/v1/spec-tasks/", suffix: "/attachments", scope: scopeTask},
+
+	// The one conversation this key may read and post to.
+	{methods: []string{"GET"}, prefix: "/api/v1/sessions/", scope: scopeSession},
+	{methods: []string{"GET"}, prefix: "/api/v1/sessions/", suffix: "/interactions", scope: scopeSession},
+	{methods: []string{"GET"}, prefix: "/api/v1/sessions/", suffix: "/step-info", scope: scopeSession},
+	{methods: []string{"POST"}, prefix: "/api/v1/sessions/", suffix: "/cancel", scope: scopeSession},
+	{methods: []string{"GET"}, prefix: "/api/v1/external-agents/", suffix: "/file", scope: scopeSession},
+
+	// Sending a message. The session is named in the BODY, not the path, so this
+	// rule cannot bound it here — sessions/chat is bounded by the handler, which
+	// resolves the session and authorizes the owning user.
+	{methods: []string{"POST"}, prefix: "/api/v1/sessions/chat", scope: scopeGlobal},
+
+	// Streaming updates. The session id arrives as a query param; checked below.
+	{methods: []string{"GET"}, prefix: "/api/v1/ws/user", scope: scopeGlobal},
+}
+
+// embedKeyAllows reports whether an embed-key request may proceed.
+func embedKeyAllows(user *types.User, r *http.Request) bool {
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	if path == "" {
+		return false
+	}
+	// A key with no task bound to it can address nothing.
+	if user.SpecTaskID == "" {
+		return false
+	}
+
+	// The websocket carries its subject as a query parameter rather than a path
+	// segment, so bound it explicitly. Without this an embed key could subscribe
+	// to another candidate's session stream.
+	if path == "/api/v1/ws/user" {
+		if sid := r.URL.Query().Get("session_id"); sid != "" && sid != user.SessionID {
+			return false
+		}
+	}
+
+	for _, rule := range embedRules {
+		if !rule.matchesMethod(r.Method) {
+			continue
+		}
+		id, ok := rule.match(path)
+		if !ok {
+			continue
+		}
+		switch rule.scope {
+		case scopeGlobal:
+			return true
+		case scopeTask:
+			if id != "" && id == user.SpecTaskID {
+				return true
+			}
+		case scopeSession:
+			if id != "" && user.SessionID != "" && id == user.SessionID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (rule embedRule) matchesMethod(method string) bool {
+	if len(rule.methods) == 0 {
+		return true
+	}
+	for _, m := range rule.methods {
+		if strings.EqualFold(m, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// match reports whether path fits the rule, returning the scoped id segment.
+//
+// The id must be a single segment: a rule for /api/v1/spec-tasks/{id} must not
+// match /api/v1/spec-tasks/{id}/something-else, or a suffix rule's protection
+// would be bypassable by appending a path.
+func (rule embedRule) match(path string) (string, bool) {
+	if !strings.HasPrefix(path, rule.prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(path, rule.prefix)
+
+	if rule.suffix == "" {
+		// Whole remaining path is the id (or empty for a fixed path).
+		if strings.Contains(rest, "/") {
+			return "", false
+		}
+		return rest, true
+	}
+	if !strings.HasSuffix(rest, rule.suffix) {
+		return "", false
+	}
+	id := strings.TrimSuffix(rest, rule.suffix)
+	if id == "" || strings.Contains(id, "/") {
+		return "", false
+	}
+	return id, true
+}

--- a/api/pkg/server/auth_embed_key_test.go
+++ b/api/pkg/server/auth_embed_key_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// Embed keys are handed to an untrusted browser, so these tests are written from
+// the attacker's side: given a key for task A / session A, what can it reach?
+
+func embedUser() *types.User {
+	return &types.User{
+		ID:         "user_service",
+		APIKeyType: types.APIkeytypeEmbed,
+		SpecTaskID: "spt_A",
+		SessionID:  "ses_A",
+	}
+}
+
+func req(method, target string) *http.Request {
+	return httptest.NewRequest(method, target, nil)
+}
+
+func TestEmbedKeyAllowsItsOwnTaskAndSession(t *testing.T) {
+	u := embedUser()
+	allowed := []struct{ method, path string }{
+		{"GET", "/api/v1/config"},
+		{"GET", "/api/v1/status"},
+		{"GET", "/api/v1/auth/authenticated"},
+		{"GET", "/api/v1/auth/user"},
+		{"GET", "/api/v1/spec-tasks/spt_A"},
+		{"GET", "/api/v1/spec-tasks/spt_A/execution-config"},
+		{"GET", "/api/v1/spec-tasks/spt_A/zed-threads"},
+		{"GET", "/api/v1/spec-tasks/spt_A/attachments"},
+		{"GET", "/api/v1/sessions/ses_A"},
+		{"GET", "/api/v1/sessions/ses_A/interactions"},
+		{"GET", "/api/v1/sessions/ses_A/step-info"},
+		{"POST", "/api/v1/sessions/ses_A/cancel"},
+		{"POST", "/api/v1/sessions/chat"},
+		{"GET", "/api/v1/external-agents/ses_A/file"},
+	}
+	for _, c := range allowed {
+		if !embedKeyAllows(u, req(c.method, c.path)) {
+			t.Errorf("should allow %s %s", c.method, c.path)
+		}
+	}
+}
+
+// The important one: another candidate's task or session must be unreachable.
+func TestEmbedKeyCannotReachAnotherTaskOrSession(t *testing.T) {
+	u := embedUser()
+	denied := []struct{ method, path string }{
+		{"GET", "/api/v1/spec-tasks/spt_B"},
+		{"GET", "/api/v1/spec-tasks/spt_B/execution-config"},
+		{"GET", "/api/v1/spec-tasks/spt_B/attachments"},
+		{"GET", "/api/v1/sessions/ses_B"},
+		{"GET", "/api/v1/sessions/ses_B/interactions"},
+		{"POST", "/api/v1/sessions/ses_B/cancel"},
+		{"GET", "/api/v1/external-agents/ses_B/file"},
+	}
+	for _, c := range denied {
+		if embedKeyAllows(u, req(c.method, c.path)) {
+			t.Errorf("SECURITY: embed key reached another tenant's %s %s", c.method, c.path)
+		}
+	}
+}
+
+// Enumeration: the list endpoint returns every task in the project, i.e. every
+// other candidate's conversation. It must never be on the allowlist.
+func TestEmbedKeyCannotEnumerate(t *testing.T) {
+	u := embedUser()
+	denied := []struct{ method, path string }{
+		{"GET", "/api/v1/spec-tasks"},
+		{"GET", "/api/v1/spec-tasks?project_id=prj_x"},
+		{"GET", "/api/v1/agents"},
+		{"GET", "/api/v1/organizations"},
+		{"GET", "/api/v1/projects/prj_x"},
+		{"GET", "/api/v1/projects/prj_x/repositories"},
+		{"GET", "/api/v1/users/user_other"},
+		{"GET", "/api/v1/apps"},
+		{"GET", "/api/v1/api_keys"},
+	}
+	for _, c := range denied {
+		if embedKeyAllows(u, req(c.method, c.path)) {
+			t.Errorf("SECURITY: embed key could enumerate %s %s", c.method, c.path)
+		}
+	}
+}
+
+// An end user must not be able to reconfigure or re-point the agent run they
+// are talking to, nor drive the desktop.
+func TestEmbedKeyCannotMutateOrDriveDesktop(t *testing.T) {
+	u := embedUser()
+	denied := []struct{ method, path string }{
+		{"PUT", "/api/v1/spec-tasks/spt_A"},
+		{"PATCH", "/api/v1/spec-tasks/spt_A/execution-config"},
+		{"PATCH", "/api/v1/spec-tasks/spt_A/archive"},
+		{"POST", "/api/v1/spec-tasks/spt_A/start-planning"},
+		{"POST", "/api/v1/spec-tasks/spt_A/clone"},
+		{"DELETE", "/api/v1/sessions/ses_A/stop-external-agent"},
+		{"POST", "/api/v1/sessions/ses_A/resume"},
+		{"GET", "/api/v1/external-agents/ses_A/screenshot"},
+		{"GET", "/api/v1/external-agents/ses_A/ws/stream"},
+		{"POST", "/api/v1/external-agents/ses_A/clipboard"},
+		{"GET", "/api/v1/sessions/ses_A/terminal"},
+		{"GET", "/api/v1/external-agents/ses_A/workspace-files"},
+	}
+	for _, c := range denied {
+		if embedKeyAllows(u, req(c.method, c.path)) {
+			t.Errorf("SECURITY: embed key allowed %s %s", c.method, c.path)
+		}
+	}
+}
+
+// The websocket names its subject in a query param, so it needs its own bound.
+func TestEmbedKeyWebsocketIsBoundToItsSession(t *testing.T) {
+	u := embedUser()
+	if !embedKeyAllows(u, req("GET", "/api/v1/ws/user?session_id=ses_A")) {
+		t.Error("should allow its own session stream")
+	}
+	if embedKeyAllows(u, req("GET", "/api/v1/ws/user?session_id=ses_B")) {
+		t.Error("SECURITY: embed key subscribed to another session's stream")
+	}
+}
+
+// A key with nothing bound to it addresses nothing.
+func TestEmbedKeyWithNoTaskIsInert(t *testing.T) {
+	u := &types.User{APIKeyType: types.APIkeytypeEmbed}
+	for _, p := range []string{"/api/v1/config", "/api/v1/spec-tasks/spt_A", "/api/v1/sessions/ses_A"} {
+		if embedKeyAllows(u, req("GET", p)) {
+			t.Errorf("SECURITY: unbound embed key reached %s", p)
+		}
+	}
+}
+
+// Path-shape tricks must not slip past the single-segment rule.
+func TestEmbedKeyRejectsPathTraversalShapes(t *testing.T) {
+	u := embedUser()
+	denied := []string{
+		"/api/v1/spec-tasks/spt_A/../spt_B",
+		"/api/v1/spec-tasks/spt_B/attachments/../../spt_A",
+		"/api/v1/sessions/ses_A/interactions/extra",
+		"/api/v1/spec-tasks/spt_A/zed-threads/nested",
+	}
+	for _, p := range denied {
+		if embedKeyAllows(u, req("GET", p)) {
+			t.Errorf("SECURITY: embed key allowed odd path %s", p)
+		}
+	}
+}

--- a/api/pkg/server/auth_middleware.go
+++ b/api/pkg/server/auth_middleware.go
@@ -36,6 +36,7 @@ var (
 	ErrNoAPIKeyFound           = errors.New("no API key found")
 	ErrNoUserIDFound           = errors.New("no user ID found")
 	ErrAppAPIKeyPathNotAllowed = errors.New("path not allowed for app API keys, use your personal account key from your /account page instead")
+	ErrEmbedKeyNotAllowed      = errors.New("this embed key is scoped to a single task and may not access this resource")
 	// ErrHelixTokenWithOIDC is returned when a Helix-issued JWT is used while OIDC authentication
 	// is configured. This can happen when a user has stale cookies from when the server was using
 	// regular auth. The user needs to clear their cookies and log in again via OIDC.
@@ -217,6 +218,7 @@ func (auth *authMiddleware) getUserFromToken(ctx context.Context, token string) 
 
 		user.Token = token
 		user.TokenType = types.TokenTypeAPIKey
+		user.APIKeyType = apiKey.Type
 		user.ID = apiKey.Owner
 		user.Type = apiKey.OwnerType
 		user.Admin = auth.isAdminWithContext(ctx, user.ID)
@@ -387,6 +389,13 @@ func (auth *authMiddleware) extractMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
+		// Embed keys live in an untrusted browser, so they are restricted to one
+		// spec task's read surface. Fail closed.
+		if user.APIKeyType == types.APIkeytypeEmbed && !embedKeyAllows(user, r) {
+			http.Error(w, ErrEmbedKeyNotAllowed.Error(), http.StatusForbidden)
+			return
+		}
+
 		auth.touchUserLastSeen(user)
 		r = r.WithContext(setRequestUser(r.Context(), *user))
 		next.ServeHTTP(w, r)
@@ -425,6 +434,13 @@ func (auth *authMiddleware) auth(f http.HandlerFunc) http.HandlerFunc {
 				http.Error(w, ErrAppAPIKeyPathNotAllowed.Error(), http.StatusForbidden)
 				return
 			}
+		}
+
+		// Embed keys live in an untrusted browser, so they are restricted to one
+		// spec task's read surface. Fail closed.
+		if user.APIKeyType == types.APIkeytypeEmbed && !embedKeyAllows(user, r) {
+			http.Error(w, ErrEmbedKeyNotAllowed.Error(), http.StatusForbidden)
+			return
 		}
 
 		auth.touchUserLastSeen(user)

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -1046,9 +1046,29 @@ func (apiServer *HelixAPIServer) adminMintUserAPIKey(_ http.ResponseWriter, req 
 	// Via the controller, not the store: it generates the key material and stamps
 	// the owner from the user passed in. Going straight to the store leaves Key
 	// empty, which it rejects with "key not specified".
+	// Optional: mint a restricted EMBED key instead of a full user key. An embed
+	// key is browser-safe — it is confined, fail-closed, to the read surface of
+	// the one spec task and session named here (see embedKeyAllows). This is what
+	// lets an orchestrator put a live agent conversation in an iframe on an
+	// untrusted public page without shipping a real credential to the visitor.
+	//
+	// Callers make the key name scope-unique (it encodes the ids), so the
+	// idempotency check above already prevents a stale-scope key being reused.
+	keyType := types.APIkeytypeAPI
+	specTaskID := req.URL.Query().Get("spec_task_id")
+	sessionID := req.URL.Query().Get("session_id")
+	if req.URL.Query().Get("type") == string(types.APIkeytypeEmbed) {
+		if specTaskID == "" {
+			return nil, system.NewHTTPError400("spec_task_id is required for an embed key — an unbound embed key can address nothing")
+		}
+		keyType = types.APIkeytypeEmbed
+	}
+
 	created, err := apiServer.Controller.CreateAPIKey(ctx, targetUser, &types.ApiKey{
-		Name: name,
-		Type: types.APIkeytypeAPI,
+		Name:       name,
+		Type:       keyType,
+		SpecTaskID: specTaskID,
+		SessionID:  sessionID,
 	})
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to create API key: " + err.Error())

--- a/api/pkg/server/mcp_backend_helix.go
+++ b/api/pkg/server/mcp_backend_helix.go
@@ -21,11 +21,21 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 )
 
+// AppAuthorizer authorizes a user against an app for a given action. It is the
+// same RBAC check the REST handlers use (owner, org role, access grants,
+// project-referenced access), injected so the MCP backend enforces access
+// server-side instead of relying on a bare ownership comparison.
+type AppAuthorizer func(ctx context.Context, user *types.User, app *types.App, action types.Action) error
+
 // HelixMCPBackend implements MCPBackend for Helix native tools (APIs, Knowledge, Zapier)
 // This serves the same tools as the CLI MCP server, but over HTTP for external agents
 type HelixMCPBackend struct {
 	store      store.Store
 	controller *controller.Controller
+	// authorizeApp gates access to an app's tool surface. This is the security
+	// boundary for delegated (non-owner) sessions: a scoped app can be shared
+	// to a specific end-user via access grants, and everyone else is denied.
+	authorizeApp AppAuthorizer
 
 	// Cache of SSE servers per app ID (each app has different tools)
 	servers   map[string]*helixAppMCPServer
@@ -39,12 +49,15 @@ type helixAppMCPServer struct {
 	createdAt time.Time
 }
 
-// NewHelixMCPBackend creates a new Helix MCP backend
-func NewHelixMCPBackend(store store.Store, ctrl *controller.Controller) *HelixMCPBackend {
+// NewHelixMCPBackend creates a new Helix MCP backend. authorizeApp is the RBAC
+// check used to gate app access; it must not be nil (the backend fails closed if
+// it is).
+func NewHelixMCPBackend(store store.Store, ctrl *controller.Controller, authorizeApp AppAuthorizer) *HelixMCPBackend {
 	return &HelixMCPBackend{
-		store:      store,
-		controller: ctrl,
-		servers:    make(map[string]*helixAppMCPServer),
+		store:        store,
+		controller:   ctrl,
+		authorizeApp: authorizeApp,
+		servers:      make(map[string]*helixAppMCPServer),
 	}
 }
 
@@ -119,10 +132,15 @@ func (b *HelixMCPBackend) getOrCreateServer(ctx context.Context, user *types.Use
 		return nil, fmt.Errorf("failed to get app: %w", err)
 	}
 
-	// Verify user has access to the app
-	if app.Owner != user.ID {
-		// TODO: Check access grants for shared apps
-		return nil, fmt.Errorf("access denied: user does not own this app")
+	// Verify the user is authorized for this app. This uses the same RBAC path as
+	// the REST handlers (owner, org owner, access grants, project-referenced
+	// access) so a scoped app can be delegated to a specific end-user session
+	// without transferring ownership. Fail closed if no authorizer is wired.
+	if b.authorizeApp == nil {
+		return nil, fmt.Errorf("access denied: no app authorizer configured")
+	}
+	if err := b.authorizeApp(ctx, user, app, types.ActionGet); err != nil {
+		return nil, fmt.Errorf("access denied: %w", err)
 	}
 
 	// Create MCP server

--- a/api/pkg/server/mcp_backend_helix_test.go
+++ b/api/pkg/server/mcp_backend_helix_test.go
@@ -48,7 +48,15 @@ func (suite *HelixMCPBackendSuite) SetupTest() {
 	}
 	suite.controller.Options.RAG = suite.mockRAG
 
-	suite.backend = NewHelixMCPBackend(suite.mockStore, suite.controller)
+	// Default authorizer mirrors the old owner-only rule so existing tests keep
+	// their meaning. Individual tests can override suite.backend.authorizeApp to
+	// exercise delegated (access-grant) authorization.
+	suite.backend = NewHelixMCPBackend(suite.mockStore, suite.controller, func(_ context.Context, user *types.User, app *types.App, _ types.Action) error {
+		if app.Owner != user.ID {
+			return errors.New("user does not own this app")
+		}
+		return nil
+	})
 }
 
 func (suite *HelixMCPBackendSuite) TearDownTest() {
@@ -203,6 +211,50 @@ func (suite *HelixMCPBackendSuite) TestServeHTTP_AccessDenied() {
 
 	suite.Equal(http.StatusInternalServerError, rec.Code)
 	suite.Contains(rec.Body.String(), "access denied")
+}
+
+// TestGetOrCreateServer_DelegatedAccessGrant proves the backend authorizes via
+// the injected RBAC authorizer, not ownership: a non-owner is allowed when the
+// authorizer permits (e.g. a scoped app shared to an end-user via access grants).
+func (suite *HelixMCPBackendSuite) TestGetOrCreateServer_DelegatedAccessGrant() {
+	app := suite.testApp()
+	app.Owner = "find-ai-service" // owned by the service, NOT the requesting user
+
+	suite.mockStore.EXPECT().
+		GetApp(gomock.Any(), "app-123").
+		Return(app, nil)
+	suite.mockStore.EXPECT().
+		ListKnowledge(gomock.Any(), gomock.Any()).
+		Return([]*types.Knowledge{}, nil)
+
+	// Simulate an access grant: authorizer says yes for this non-owner user.
+	granted := false
+	suite.backend.authorizeApp = func(_ context.Context, user *types.User, app *types.App, _ types.Action) error {
+		granted = true
+		suite.Equal("user-123", user.ID)
+		suite.Equal("find-ai-service", app.Owner)
+		return nil
+	}
+
+	server, err := suite.backend.getOrCreateServer(suite.ctx, suite.testUser(), "app-123")
+	suite.NoError(err)
+	suite.NotNil(server)
+	suite.True(granted, "authorizer must be consulted")
+}
+
+// TestGetOrCreateServer_FailsClosedWithoutAuthorizer proves a misconfigured
+// backend denies access rather than defaulting to open.
+func (suite *HelixMCPBackendSuite) TestGetOrCreateServer_FailsClosedWithoutAuthorizer() {
+	app := suite.testApp()
+	suite.mockStore.EXPECT().
+		GetApp(gomock.Any(), "app-123").
+		Return(app, nil)
+
+	suite.backend.authorizeApp = nil // misconfigured
+
+	_, err := suite.backend.getOrCreateServer(suite.ctx, suite.testUser(), "app-123")
+	suite.Error(err)
+	suite.Contains(err.Error(), "access denied")
 }
 
 // =============================================================================

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -554,8 +554,10 @@ func NewServer(
 	// Register Kodit MCP backend (code intelligence)
 	apiServer.mcpGateway.RegisterBackend("kodit", kr.mcpBackend) //nolint:staticcheck // mcpBackend is package-private but accessible within this package
 
-	// Register Helix native MCP backend (APIs, Knowledge, Zapier)
-	apiServer.mcpGateway.RegisterBackend("helix", NewHelixMCPBackend(store, appController))
+	// Register Helix native MCP backend (APIs, Knowledge, Zapier).
+	// authorizeUserToApp enforces the same RBAC as the REST handlers so a scoped
+	// app can be delegated to a specific end-user session via access grants.
+	apiServer.mcpGateway.RegisterBackend("helix", NewHelixMCPBackend(store, appController, apiServer.authorizeUserToApp))
 
 	// Register Session MCP backend (session navigation and context tools)
 	apiServer.mcpGateway.RegisterBackend("session", NewSessionMCPBackend(store, appController.Options.Notifier))

--- a/api/pkg/types/authz.go
+++ b/api/pkg/types/authz.go
@@ -220,6 +220,10 @@ type User struct {
 	TokenType TokenType `json:"token_type"`
 	// if the ID of the user is contained in the env setting
 	Admin bool `json:"admin"`
+	// APIKeyType is the type of the API key this request authenticated with, when
+	// it authenticated with one. Carried so the auth middleware can apply the
+	// per-type restrictions (app keys: chat paths only; embed keys: one spec task).
+	APIKeyType APIKeyType `json:"api_key_type" gorm:"-"`
 	// if the token is associated with an app
 	AppID          string `json:"app_id"`
 	ProjectID      string `json:"project_id" gorm:"-"`      // When running in Helix Code sandbox

--- a/api/pkg/types/enums.go
+++ b/api/pkg/types/enums.go
@@ -245,6 +245,18 @@ const (
 	APIkeytypeAPI APIKeyType = "api"
 	// a helix access token for a specific app
 	APIkeytypeApp APIKeyType = "app"
+	// APIkeytypeEmbed is a browser-safe key for embedding ONE spec task's UI in
+	// an iframe on an untrusted page. It is restricted, fail-closed, to a small
+	// path allowlist AND to the single SpecTaskID/SessionID recorded on the key
+	// (see embedKeyAllows in auth_middleware.go).
+	//
+	// This exists because the pre-existing "ephemeral session key" is not a
+	// scope: it is minted as APIkeytypeAPI with SessionID/SpecTaskID set purely
+	// "for metrics/attribution", so it authorizes as a full user key. Handing one
+	// of those to an end user's browser hands them the owning account. Embed keys
+	// are opt-in precisely so that existing ephemeral keys — which agent
+	// sandboxes rely on for broad API access — keep working unchanged.
+	APIkeytypeEmbed APIKeyType = "embed"
 )
 
 type DataEntityType string


### PR DESCRIPTION
Two related auth changes, both needed to put an agent conversation in an iframe on an untrusted public page (Find AI, spec 002578).

## 1. MCP app access via RBAC instead of ownership

The Helix native MCP backend gated an app's entire tool surface on a bare ownership comparison, with a standing TODO beside it:

```go
if app.Owner != user.ID {
    // TODO: Check access grants for shared apps
    return nil, fmt.Errorf("access denied: user does not own this app")
}
```

Every other path to an app goes through `authorizeUserToApp`, which understands owners, org owners, **access grants**, and project-referenced access. The MCP backend was the one surface that didn't, so a shared app was reachable over REST but not over MCP. This closes the TODO by using the authorizer the rest of the server already uses. Fails closed if no authorizer is wired.

## 2. `APIkeytypeEmbed` — a key that is safe in a browser

There was no credential safe to hand a visitor who is viewing their own agent conversation:

- `specTaskEmbedURL` puts the **shared project `HelixAPIKey`** in the iframe URL.
- The pre-existing "ephemeral session key" is **not a scope either**: `spec_driven_task_service.go:2019` mints it as `APIkeytypeAPI` with `SessionID`/`SpecTaskID` set only *"for metrics/attribution"*, so it authorizes as a full user key.

Either one, handed to an end user, hands them the owning account.

An embed key is confined **fail-closed** to a path allowlist *and* to the single `SpecTaskID`/`SessionID` recorded on it (`auth_embed_key.go`). Opt-in via a new key type precisely so existing ephemeral keys — which agent sandboxes rely on for broad API access — keep working byte for byte.

### What the allowlist deliberately omits, and why

- **`GET /api/v1/spec-tasks`** — the most important omission. It returns every task in the project, so a path-only allowlist would still let one visitor enumerate and read every other visitor's conversation.
- Tenant-wide inventory (`/agents`, `/organizations`, `/projects/...`).
- Every mutation of the task — an end user must not re-point or reconfigure the agent run they are talking to.
- The desktop/stream surface.

`/auth/authenticated` and `/auth/user` **are** allowed: the embed page redirects to `/login` without them.

`adminMintUserAPIKey` can now issue one. Callers make the key name scope-unique (it encodes the ids), so the existing `(user, name)` idempotency cannot hand back a key still scoped to a previous session.

## Verification

`CGO_ENABLED=1 go test ./pkg/server/` — passing (CGo + gcc needed for tree-sitter).

| Test | Proves |
|---|---|
| `TestGetOrCreateServer_DelegatedAccessGrant` | a granted non-owner is served — delegation works |
| `TestGetOrCreateServer_FailsClosedWithoutAuthorizer` | nil authorizer denies |
| `TestEmbedKeyCannotReachAnotherTaskOrSession` | another tenant's task/session unreachable |
| `TestEmbedKeyCannotEnumerate` | the list endpoints stay denied |
| `TestEmbedKeyCannotMutateOrDriveDesktop` | read-only, no desktop |
| `TestEmbedKeyWebsocketIsBoundToItsSession` | `?session_id=` can't be swapped |
| `TestEmbedKeyRejectsPathTraversalShapes` | single-segment ids enforced |

Existing `TestServeHTTP_AccessDenied` still passes unchanged.

**NOT tested:** no live end-to-end run of an embed key against a real iframe — the consuming HelixOS side is in a companion PR and the shared dev environment's Helix credentials are stale.

## Deploy order

**This PR must merge and deploy before the HelixOS one.** A Helix without embed keys silently ignores `?type=embed` and returns a full user key; HelixOS now detects that and fails closed, so the wrong order gives a broken chat panel rather than a leaked credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)