### PR TITLE
feat(frontend): add project chat focus filter

### DIFF
--- a/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
@@ -4,6 +4,7 @@ import type { TypesOrganizationMembership, TypesProject, TypesSessionSummary } f
 import type { SpecTask } from '../../services/specTaskService'
 import {
   buildProjectChatGroups,
+  ALL_PROJECTS_FILTER,
   clampVisibleThreadCount,
   collapsedGroupsStorageKey,
   compactRelativeTime,
@@ -20,6 +21,7 @@ import {
   parseCollapsedGroupIds,
   parseSidebarPreferences,
   parseSidebarParticipantIds,
+  parseSidebarProjectFilter,
   reorderProjectIds,
   serializeCollapsedGroupIds,
   serializeSidebarPreferences,
@@ -27,6 +29,7 @@ import {
   shouldConfirmArchive,
   sidebarPreferencesStorageKey,
   sidebarPeopleFilterStorageKey,
+  sidebarProjectFilterStorageKey,
   sortSidebarProjects,
   specTaskSortKey,
 } from './ProjectChatSidebar.logic'
@@ -215,6 +218,14 @@ describe('ProjectChatSidebar logic', () => {
     expect(parseSidebarPreferences('{bad json')).toEqual(DEFAULT_PROJECT_CHAT_SIDEBAR_PREFERENCES)
     expect(parseSidebarPreferences(serializeSidebarPreferences(parsed))).toEqual(parsed)
     expect(clampVisibleThreadCount(-2)).toBe(1)
+  })
+
+  it('persists the project focus per user and organization', () => {
+    expect(sidebarProjectFilterStorageKey('user-one', 'org-one'))
+      .toBe('helix:project-chat-sidebar:project-filter:user-one:org-one')
+    expect(parseSidebarProjectFilter(null)).toBe(ALL_PROJECTS_FILTER)
+    expect(parseSidebarProjectFilter('')).toBe(ALL_PROJECTS_FILTER)
+    expect(parseSidebarProjectFilter(' project-one ')).toBe('project-one')
   })
 
   it('persists selected people per user, organization, and project and searches every token', () => {

--- a/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
@@ -22,6 +22,7 @@ import {
   parseSidebarPreferences,
   parseSidebarParticipantIds,
   parseSidebarProjectFilter,
+  resolveSidebarProjectFilter,
   reorderProjectIds,
   serializeCollapsedGroupIds,
   serializeSidebarPreferences,
@@ -220,12 +221,14 @@ describe('ProjectChatSidebar logic', () => {
     expect(clampVisibleThreadCount(-2)).toBe(1)
   })
 
-  it('persists the project focus per user and organization', () => {
-    expect(sidebarProjectFilterStorageKey('user-one', 'org-one'))
-      .toBe('helix:project-chat-sidebar:project-filter:user-one:org-one')
+  it('persists the project focus per organization', () => {
+    expect(sidebarProjectFilterStorageKey('org-one'))
+      .toBe('helix:project-chat-sidebar:project-filter:org-one')
     expect(parseSidebarProjectFilter(null)).toBe(ALL_PROJECTS_FILTER)
     expect(parseSidebarProjectFilter('')).toBe(ALL_PROJECTS_FILTER)
     expect(parseSidebarProjectFilter(' project-one ')).toBe('project-one')
+    expect(resolveSidebarProjectFilter('project-one', projects)).toBe('project-one')
+    expect(resolveSidebarProjectFilter('deleted-project', projects)).toBe(ALL_PROJECTS_FILTER)
   })
 
   it('persists selected people per user, organization, and project and searches every token', () => {

--- a/frontend/src/components/session/ProjectChatSidebar.logic.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.ts
@@ -59,6 +59,19 @@ export const sidebarPeopleFilterStorageKey = (
   `helix:project-chat-sidebar:people:${userId}:${orgId}:${projectId}`
 )
 
+export const ALL_PROJECTS_FILTER = 'all-projects'
+
+export const sidebarProjectFilterStorageKey = (
+  userId: string,
+  orgId: string,
+): string => (
+  `helix:project-chat-sidebar:project-filter:${userId}:${orgId}`
+)
+
+export const parseSidebarProjectFilter = (storedValue: string | null): string => (
+  storedValue?.trim() || ALL_PROJECTS_FILTER
+)
+
 export const parseSidebarParticipantIds = (storedValue: string | null): string[] | null => {
   if (storedValue === null) return null
   try {

--- a/frontend/src/components/session/ProjectChatSidebar.logic.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.ts
@@ -61,15 +61,21 @@ export const sidebarPeopleFilterStorageKey = (
 
 export const ALL_PROJECTS_FILTER = 'all-projects'
 
-export const sidebarProjectFilterStorageKey = (
-  userId: string,
-  orgId: string,
-): string => (
-  `helix:project-chat-sidebar:project-filter:${userId}:${orgId}`
+export const sidebarProjectFilterStorageKey = (orgId: string): string => (
+  `helix:project-chat-sidebar:project-filter:${orgId}`
 )
 
 export const parseSidebarProjectFilter = (storedValue: string | null): string => (
   storedValue?.trim() || ALL_PROJECTS_FILTER
+)
+
+export const resolveSidebarProjectFilter = (
+  projectId: string,
+  projects: TypesProject[],
+): string => (
+  projectId === ALL_PROJECTS_FILTER || projects.some((project) => project.id === projectId)
+    ? projectId
+    : ALL_PROJECTS_FILTER
 )
 
 export const parseSidebarParticipantIds = (storedValue: string | null): string[] | null => {

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -34,16 +34,19 @@ import { usePinnedChats } from '../../services/chatPinService'
 import CreateProjectDialog from '../project/CreateProjectDialog'
 import SimpleConfirmWindow from '../widgets/SimpleConfirmWindow'
 import {
+  ALL_PROJECTS_FILTER,
   collapsedGroupsStorageKey,
   getChatShortcutNumber,
   isChatShortcutModifier,
   isNewThreadShortcut,
   parseSidebarParticipantIds,
+  parseSidebarProjectFilter,
   shouldConfirmArchive,
   parseCollapsedGroupIds,
   serializeSidebarParticipantIds,
   sidebarPreferencesStorageKey,
   sidebarPeopleFilterStorageKey,
+  sidebarProjectFilterStorageKey,
   serializeCollapsedGroupIds,
 } from './ProjectChatSidebar.logic'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
@@ -53,6 +56,7 @@ import type { ProjectChatContextMenuPosition } from './ProjectChatItemContextMen
 import ProjectChatProjectContextMenu from './ProjectChatProjectContextMenu'
 import ProjectChatSidebarPeopleFilter from './ProjectChatSidebarPeopleFilter'
 import ProjectChatSidebarOptions from './ProjectChatSidebarOptions'
+import ProjectChatSidebarProjectFilter from './ProjectChatSidebarProjectFilter'
 import SortableProject from './SortableProject'
 import useProjectChatSidebarDrag from './useProjectChatSidebarDrag'
 import useProjectChatSidebarPreferences from './useProjectChatSidebarPreferences'
@@ -77,6 +81,14 @@ const readParticipantIds = (storageKey: string): string[] | null => {
   }
 }
 
+const readProjectFilter = (storageKey: string): string => {
+  try {
+    return parseSidebarProjectFilter(window.localStorage.getItem(storageKey))
+  } catch {
+    return ALL_PROJECTS_FILTER
+  }
+}
+
 const ProjectChatSidebar: FC<{
   onCollapse: () => void
   onOpenSession: () => void
@@ -89,12 +101,13 @@ const ProjectChatSidebar: FC<{
   const orgSlug = router.params.org_id || ''
   const orgId = account.organizationTools.organization?.id || ''
   const currentUserId = account.user?.id || ''
-  const activeProjectId = router.params.id || 'all-projects'
   const storageKey = collapsedGroupsStorageKey(orgSlug)
   const preferencesStorageKey = sidebarPreferencesStorageKey(orgSlug)
-  const peopleFilterStorageKey = sidebarPeopleFilterStorageKey(currentUserId, orgSlug, activeProjectId)
+  const projectFilterStorageKey = sidebarProjectFilterStorageKey(currentUserId, orgSlug)
 
   const [query, setQuery] = useState('')
+  const [projectFilter, setProjectFilter] = useState(() => readProjectFilter(projectFilterStorageKey))
+  const peopleFilterStorageKey = sidebarPeopleFilterStorageKey(currentUserId, orgSlug, projectFilter)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => readCollapsedGroups(storageKey))
   const [relativeTimeNow, setRelativeTimeNow] = useState(() => Date.now())
   const [archiveConfirmation, setArchiveConfirmation] = useState<SidebarItem | null>(null)
@@ -117,6 +130,10 @@ const ProjectChatSidebar: FC<{
   }, [storageKey])
 
   useEffect(() => {
+    setProjectFilter(readProjectFilter(projectFilterStorageKey))
+  }, [projectFilterStorageKey])
+
+  useEffect(() => {
     setParticipantIdsOverride(readParticipantIds(peopleFilterStorageKey))
   }, [peopleFilterStorageKey])
 
@@ -137,6 +154,22 @@ const ProjectChatSidebar: FC<{
     setVisibleThreadCount,
     setManualProjectOrder,
   } = useProjectChatSidebarPreferences(preferencesStorageKey, projects)
+  const focusedProject = projectFilter === ALL_PROJECTS_FILTER
+    ? undefined
+    : projects.find((project) => project.id === projectFilter)
+  const focusedProjectExists = projectFilter === ALL_PROJECTS_FILTER || !!focusedProject
+  const focusMode = projectFilter !== ALL_PROJECTS_FILTER && !!focusedProject
+  const displayedProjects = focusMode && focusedProject ? [focusedProject] : sortedProjects
+
+  useEffect(() => {
+    if (projectsLoading || focusedProjectExists) return
+    setProjectFilter(ALL_PROJECTS_FILTER)
+    try {
+      window.localStorage.setItem(projectFilterStorageKey, ALL_PROJECTS_FILTER)
+    } catch {
+      // Persistence is optional when browser storage is unavailable.
+    }
+  }, [focusedProjectExists, projectFilter, projectFilterStorageKey, projectsLoading])
   const { data: orgAgents = [] } = useListHelixOrgBots({
     enabled: !!account.user?.id && !!orgId,
   })
@@ -419,6 +452,28 @@ const ProjectChatSidebar: FC<{
     }
   }
 
+  const selectProjectFilter = (projectId: string) => {
+    setProjectFilter(projectId)
+    if (projectId !== ALL_PROJECTS_FILTER) {
+      setCollapsedGroups((current) => {
+        if (!current.has(projectId)) return current
+        const next = new Set(current)
+        next.delete(projectId)
+        try {
+          window.localStorage.setItem(storageKey, serializeCollapsedGroupIds(next))
+        } catch {
+          // Persistence is optional when browser storage is unavailable.
+        }
+        return next
+      })
+    }
+    try {
+      window.localStorage.setItem(projectFilterStorageKey, projectId)
+    } catch {
+      // Persistence is optional when browser storage is unavailable.
+    }
+  }
+
   const effectiveCollapsedGroups = query ? new Set<string>() : collapsedGroups
   const groupsEnabled = !!account.user?.id && !!orgId
 
@@ -503,26 +558,23 @@ const ProjectChatSidebar: FC<{
         </Tooltip>
       </Box>
 
-      <Box sx={{ pl: 1.5, pr: 0.75, pt: 1.25, pb: 0.5, display: 'flex', alignItems: 'center' }}>
-        <Typography
-          sx={{
-            flex: 1,
-            color: lightTheme.isLight ? 'rgba(113,113,122,0.80)' : 'rgba(163,163,163,0.80)',
-            fontFamily: 'inherit',
-            fontSize: '12px',
-            fontWeight: 500,
-          }}
-        >
-          {showArchived ? 'Archived' : 'Projects'}
-        </Typography>
-        <ProjectChatSidebarOptions
-          projectSortOrder={preferences.projectSortOrder}
-          threadSortOrder={preferences.threadSortOrder}
-          visibleThreadCount={preferences.visibleThreadCount}
-          onProjectSortOrderChange={setProjectSortOrder}
-          onThreadSortOrderChange={setThreadSortOrder}
-          onVisibleThreadCountChange={setVisibleThreadCount}
+      <Box sx={{ pl: 0.75, pr: 0.75, pt: 1.25, pb: 0.5, display: 'flex', alignItems: 'center' }}>
+        <ProjectChatSidebarProjectFilter
+          projects={projects}
+          selectedProjectId={projectFilter}
+          archived={showArchived}
+          onChange={selectProjectFilter}
         />
+        {!focusMode && (
+          <ProjectChatSidebarOptions
+            projectSortOrder={preferences.projectSortOrder}
+            threadSortOrder={preferences.threadSortOrder}
+            visibleThreadCount={preferences.visibleThreadCount}
+            onProjectSortOrderChange={setProjectSortOrder}
+            onThreadSortOrderChange={setThreadSortOrder}
+            onVisibleThreadCountChange={setVisibleThreadCount}
+          />
+        )}
         <ProjectChatSidebarPeopleFilter
           members={selectableMembers}
           currentUser={account.user}
@@ -583,7 +635,7 @@ const ProjectChatSidebar: FC<{
           </Box>
         ) : (
           <>
-            <ProjectChatGroup
+            {!focusMode && <ProjectChatGroup
               orgId={orgId}
               collapsed={effectiveCollapsedGroups.has('default')}
               query={query}
@@ -604,7 +656,7 @@ const ProjectChatSidebar: FC<{
               onOpenItem={openItem}
               onOpenItemContextMenu={openItemContextMenu}
               onArchiveItem={requestArchive}
-            />
+            />}
             <DndContext
               sensors={projectDragSensors}
               collisionDetection={closestCenter}
@@ -613,14 +665,14 @@ const ProjectChatSidebar: FC<{
               onDragEnd={handleProjectDragEnd}
             >
               <SortableContext
-                items={sortedProjects.flatMap((project) => project.id ? [project.id] : [])}
+                items={displayedProjects.flatMap((project) => project.id ? [project.id] : [])}
                 strategy={verticalListSortingStrategy}
               >
-                {sortedProjects.flatMap((project) => project.id ? [(
+                {displayedProjects.flatMap((project) => project.id ? [(
                   <SortableProject
                     key={project.id}
                     projectId={project.id}
-                    disabled={preferences.projectSortOrder !== 'manual' || !!query}
+                    disabled={focusMode || preferences.projectSortOrder !== 'manual' || !!query}
                     render={(dragHandleProps) => (
                       <ProjectChatGroup
                         orgId={orgId}
@@ -647,7 +699,7 @@ const ProjectChatSidebar: FC<{
                         onOpenItemContextMenu={openItemContextMenu}
                         onOpenProjectContextMenu={openProjectContextMenu}
                         onArchiveItem={requestArchive}
-                        manualSorting={preferences.projectSortOrder === 'manual' && !query}
+                        manualSorting={!focusMode && preferences.projectSortOrder === 'manual' && !query}
                         dragHandleProps={dragHandleProps}
                         dragInProgressRef={dragInProgressRef}
                         suppressClickAfterDragRef={suppressClickAfterDragRef}

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -41,6 +41,7 @@ import {
   isNewThreadShortcut,
   parseSidebarParticipantIds,
   parseSidebarProjectFilter,
+  resolveSidebarProjectFilter,
   shouldConfirmArchive,
   parseCollapsedGroupIds,
   serializeSidebarParticipantIds,
@@ -103,7 +104,7 @@ const ProjectChatSidebar: FC<{
   const currentUserId = account.user?.id || ''
   const storageKey = collapsedGroupsStorageKey(orgSlug)
   const preferencesStorageKey = sidebarPreferencesStorageKey(orgSlug)
-  const projectFilterStorageKey = sidebarProjectFilterStorageKey(currentUserId, orgSlug)
+  const projectFilterStorageKey = sidebarProjectFilterStorageKey(orgId)
 
   const [query, setQuery] = useState('')
   const [projectFilter, setProjectFilter] = useState(() => readProjectFilter(projectFilterStorageKey))
@@ -157,19 +158,19 @@ const ProjectChatSidebar: FC<{
   const focusedProject = projectFilter === ALL_PROJECTS_FILTER
     ? undefined
     : projects.find((project) => project.id === projectFilter)
-  const focusedProjectExists = projectFilter === ALL_PROJECTS_FILTER || !!focusedProject
+  const resolvedProjectFilter = resolveSidebarProjectFilter(projectFilter, projects)
   const focusMode = projectFilter !== ALL_PROJECTS_FILTER && !!focusedProject
   const displayedProjects = focusMode && focusedProject ? [focusedProject] : sortedProjects
 
   useEffect(() => {
-    if (projectsLoading || focusedProjectExists) return
-    setProjectFilter(ALL_PROJECTS_FILTER)
+    if (projectsLoading || resolvedProjectFilter === projectFilter) return
+    setProjectFilter(resolvedProjectFilter)
     try {
-      window.localStorage.setItem(projectFilterStorageKey, ALL_PROJECTS_FILTER)
+      window.localStorage.setItem(projectFilterStorageKey, resolvedProjectFilter)
     } catch {
       // Persistence is optional when browser storage is unavailable.
     }
-  }, [focusedProjectExists, projectFilter, projectFilterStorageKey, projectsLoading])
+  }, [projectFilter, projectFilterStorageKey, projectsLoading, resolvedProjectFilter])
   const { data: orgAgents = [] } = useListHelixOrgBots({
     enabled: !!account.user?.id && !!orgId,
   })

--- a/frontend/src/components/session/ProjectChatSidebarProjectFilter.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarProjectFilter.tsx
@@ -1,0 +1,126 @@
+import { FC, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Typography from '@mui/material/Typography'
+import { Check, ChevronDown } from 'lucide-react'
+
+import type { TypesProject } from '../../api/api'
+import useLightTheme from '../../hooks/useLightTheme'
+import { ALL_PROJECTS_FILTER } from './ProjectChatSidebar.logic'
+
+type ProjectChatSidebarProjectFilterProps = {
+  projects: TypesProject[]
+  selectedProjectId: string
+  archived: boolean
+  onChange: (projectId: string) => void
+}
+
+const ProjectChatSidebarProjectFilter: FC<ProjectChatSidebarProjectFilterProps> = ({
+  projects,
+  selectedProjectId,
+  archived,
+  onChange,
+}) => {
+  const lightTheme = useLightTheme()
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const selectedProject = projects.find((project) => project.id === selectedProjectId)
+  const selectedLabel = selectedProject?.name || 'All projects'
+  const label = archived ? `Archived · ${selectedLabel}` : selectedLabel
+
+  const selectProject = (projectId: string) => {
+    setAnchorEl(null)
+    onChange(projectId)
+  }
+
+  return (
+    <>
+      <Button
+        variant="text"
+        size="small"
+        aria-label="Filter tasks by project"
+        aria-haspopup="menu"
+        aria-expanded={!!anchorEl || undefined}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        endIcon={<ChevronDown size={13} strokeWidth={1.7} />}
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          height: 30,
+          px: 0.75,
+          justifyContent: 'space-between',
+          color: lightTheme.isLight ? 'rgba(113,113,122,0.80)' : 'rgba(163,163,163,0.80)',
+          fontFamily: 'inherit',
+          fontSize: '12px',
+          fontWeight: 500,
+          lineHeight: 1,
+          textTransform: 'none',
+          '& .MuiButton-endIcon': { ml: 0.5, flexShrink: 0 },
+          '&:hover': {
+            color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
+            backgroundColor: lightTheme.isLight ? 'rgba(39,39,42,0.04)' : 'rgba(241,243,247,0.08)',
+          },
+        }}
+      >
+        <Box
+          component="span"
+          sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {label}
+        </Box>
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              minWidth: 220,
+              maxWidth: 300,
+              maxHeight: 360,
+              backgroundImage: 'none',
+            },
+          },
+        }}
+      >
+        <MenuItem
+          selected={selectedProjectId === ALL_PROJECTS_FILTER}
+          onClick={() => selectProject(ALL_PROJECTS_FILTER)}
+          sx={{ gap: 1, fontSize: '13px' }}
+        >
+          <Box sx={{ width: 16, display: 'inline-flex' }}>
+            {selectedProjectId === ALL_PROJECTS_FILTER && <Check size={14} />}
+          </Box>
+          All projects
+        </MenuItem>
+        {[...projects]
+          .sort((left, right) => (left.name || '').localeCompare(right.name || ''))
+          .flatMap((project) => project.id ? [(
+            <MenuItem
+              key={project.id}
+              selected={selectedProjectId === project.id}
+              onClick={() => selectProject(project.id!)}
+              sx={{ gap: 1, fontSize: '13px' }}
+            >
+              <Box sx={{ width: 16, display: 'inline-flex' }}>
+                {selectedProjectId === project.id && <Check size={14} />}
+              </Box>
+              <Typography
+                component="span"
+                sx={{ overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '13px' }}
+              >
+                {project.name || 'Untitled project'}
+              </Typography>
+            </MenuItem>
+          )] : [])}
+      </Menu>
+    </>
+  )
+}
+
+export default ProjectChatSidebarProjectFilter


### PR DESCRIPTION
## What changed

- Replace the static Projects heading with an All projects selector.
- Add single-project focus mode that renders only the selected project's task/chat group.
- Hide project sorting controls while focus mode is active.
- Persist the selected project in local storage using a canonical organization-scoped key.
- Reset missing or deleted project selections to `all-projects` in both UI state and local storage.
- Preserve archived-mode labeling and expand a project when entering focus mode.

## Why

The project chat sidebar becomes noisy for organizations with many projects. A persistent project selector lets users focus on one project's work without changing the current route or repeatedly reapplying the filter.

## Validation

- `yarn test ProjectChatSidebar.logic.test.ts` — 27 tests passed
- `yarn tsc`
- `yarn build`
- Live inner-Helix E2E verification covering menu population, project selection, focus-mode filtering, sort-control removal, and recovery from a deleted stored project ID
