### PR TITLE
fix(org): route worker MCP through embedded API

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -107,6 +107,8 @@ func GenerateZedMCPConfig(
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
 	providerSnapshot []ProviderRef,
+	organizationID string,
+	orgWorkerID string,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
 		ContextServers: make(map[string]ContextServerConfig),
@@ -350,6 +352,15 @@ func GenerateZedMCPConfig(
 		for _, mcp := range projectSkills.MCPs {
 			serverName := sanitizeName(mcp.Name)
 			config.ContextServers[serverName] = mcpToContextServerWithProxy(ctx, mcp, userID, helixAPIURL, helixToken, oauthTokenGetter)
+		}
+	}
+
+	if organizationID != "" && orgWorkerID != "" {
+		config.ContextServers["helix"] = ContextServerConfig{
+			URL: fmt.Sprintf("%s/api/v1/mcp/helix-org/%s/workers/%s/mcp", strings.TrimRight(helixAPIURL, "/"), organizationID, orgWorkerID),
+			Headers: map[string]string{
+				"Authorization": fmt.Sprintf("Bearer %s", helixToken),
+			},
 		}
 	}
 
@@ -865,7 +876,7 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 	// Runner-side path has no provider-manager handle, so we skip provider
 	// validation here. The handler-side callers (getZedConfig,
 	// getMergedZedSettings) do pass the live provider list.
-	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil)
+	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil, session.OrganizationID, session.Metadata.OrgWorkerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Zed config: %w", err)
 	}
@@ -885,12 +896,18 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 func MergeContextServers(helixServers map[string]ContextServerConfig, userOverrides map[string]interface{}) map[string]interface{} {
 	merged := make(map[string]interface{}, len(helixServers))
 	for name, server := range helixServers {
-		entry := map[string]interface{}{
-			"command": server.Command,
-			"args":    server.Args,
-		}
-		if len(server.Env) > 0 {
-			entry["env"] = server.Env
+		entry := make(map[string]interface{})
+		if server.URL != "" {
+			entry["url"] = server.URL
+			if len(server.Headers) > 0 {
+				entry["headers"] = server.Headers
+			}
+		} else {
+			entry["command"] = server.Command
+			entry["args"] = server.Args
+			if len(server.Env) > 0 {
+				entry["env"] = server.Env
+			}
 		}
 		merged[name] = entry
 	}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -107,7 +107,6 @@ func GenerateZedMCPConfig(
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
 	providerSnapshot []ProviderRef,
-	organizationID string,
 	orgWorkerID string,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
@@ -355,9 +354,9 @@ func GenerateZedMCPConfig(
 		}
 	}
 
-	if organizationID != "" && orgWorkerID != "" {
+	if orgWorkerID != "" {
 		config.ContextServers["helix"] = ContextServerConfig{
-			URL: fmt.Sprintf("%s/api/v1/mcp/helix-org/%s/workers/%s/mcp", strings.TrimRight(helixAPIURL, "/"), organizationID, orgWorkerID),
+			URL: strings.TrimRight(helixAPIURL, "/") + "/api/v1/mcp/helix-org",
 			Headers: map[string]string{
 				"Authorization": fmt.Sprintf("Bearer %s", helixToken),
 			},
@@ -876,7 +875,7 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 	// Runner-side path has no provider-manager handle, so we skip provider
 	// validation here. The handler-side callers (getZedConfig,
 	// getMergedZedSettings) do pass the live provider list.
-	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil, session.OrganizationID, session.Metadata.OrgWorkerID)
+	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil, session.Metadata.OrgWorkerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Zed config: %w", err)
 	}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -20,6 +20,8 @@ func TestGenerateZedMCPConfigAllowsUnsandboxedCommands(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		"",
+		"",
 	)
 	assert.NoError(t, err)
 	if assert.NotNil(t, config.Agent) {
@@ -220,6 +222,8 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				nil,
 				nil,
 				tc.snapshot,
+				"",
+				"",
 			)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, cfg) || !assert.NotNil(t, cfg.Agent) {
@@ -244,6 +248,33 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateZedMCPConfigAddsDirectHelixOrgMCP(t *testing.T) {
+	config, err := GenerateZedMCPConfig(
+		context.Background(),
+		&types.App{ID: "test-app", Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			AgentType: types.AgentTypeZedExternal,
+			MCPs:      []types.AssistantMCP{{Name: "helix", URL: "http://old.example/mcp"}},
+		}}}}},
+		"user-1",
+		"session-1",
+		"http://sandbox-api:8080/",
+		"session-token",
+		false,
+		nil,
+		nil,
+		nil,
+		"org_test",
+		"b-worker",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, ContextServerConfig{
+		URL: "http://sandbox-api:8080/api/v1/mcp/helix-org/org_test/workers/b-worker/mcp",
+		Headers: map[string]string{
+			"Authorization": "Bearer session-token",
+		},
+	}, config.ContextServers["helix"])
 }
 
 // TestMapHelixToZedProvider guards the model id Helix writes into
@@ -415,7 +446,9 @@ func TestMergeContextServers(t *testing.T) {
 
 	t.Run("no user overrides preserves helix servers", func(t *testing.T) {
 		got := MergeContextServers(helix, map[string]interface{}{})
-		assert.Contains(t, got, "helix-desktop")
+		assert.Equal(t, "http://api:8080/api/v1/mcp/desktop", got["helix-desktop"].(map[string]interface{})["url"])
+		assert.Equal(t, map[string]string{"Authorization": "Bearer x"}, got["helix-desktop"].(map[string]interface{})["headers"])
+		assert.NotContains(t, got["helix-desktop"].(map[string]interface{}), "command")
 		assert.Contains(t, got, "chrome")
 	})
 

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -21,7 +21,6 @@ func TestGenerateZedMCPConfigAllowsUnsandboxedCommands(t *testing.T) {
 		nil,
 		nil,
 		"",
-		"",
 	)
 	assert.NoError(t, err)
 	if assert.NotNil(t, config.Agent) {
@@ -223,7 +222,6 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				nil,
 				tc.snapshot,
 				"",
-				"",
 			)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, cfg) || !assert.NotNil(t, cfg.Agent) {
@@ -265,12 +263,11 @@ func TestGenerateZedMCPConfigAddsDirectHelixOrgMCP(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		"org_test",
 		"b-worker",
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, ContextServerConfig{
-		URL: "http://sandbox-api:8080/api/v1/mcp/helix-org/org_test/workers/b-worker/mcp",
+		URL: "http://sandbox-api:8080/api/v1/mcp/helix-org",
 		Headers: map[string]string{
 			"Authorization": "Bearer session-token",
 		},

--- a/api/pkg/org/application/assets/assets.go
+++ b/api/pkg/org/application/assets/assets.go
@@ -31,23 +31,25 @@ type KeyGenerator func() (privateKeyPEM, publicKeyOpenSSH string, err error)
 type Encrypt func(plaintext []byte) (string, error)
 
 type Service struct {
-	assets      store.Assets
-	links       store.AssetLinks
-	nodes       store.Nodes
-	generateKey KeyGenerator
-	encrypt     Encrypt
-	now         func() time.Time
-	newID       func() string
+	assets         store.Assets
+	links          store.AssetLinks
+	nodes          store.Nodes
+	generateKey    KeyGenerator
+	encrypt        Encrypt
+	now            func() time.Time
+	newID          func() string
+	onToolsChanged func(context.Context, string)
 }
 
 type Deps struct {
-	Assets      store.Assets
-	Links       store.AssetLinks
-	Nodes       store.Nodes
-	GenerateKey KeyGenerator
-	Encrypt     Encrypt
-	Now         func() time.Time
-	NewID       func() string
+	Assets         store.Assets
+	Links          store.AssetLinks
+	Nodes          store.Nodes
+	GenerateKey    KeyGenerator
+	Encrypt        Encrypt
+	Now            func() time.Time
+	NewID          func() string
+	OnToolsChanged func(context.Context, string)
 }
 
 func New(deps Deps) (*Service, error) {
@@ -68,6 +70,7 @@ func New(deps Deps) (*Service, error) {
 	return &Service{
 		assets: deps.Assets, links: deps.Links, nodes: deps.Nodes,
 		generateKey: deps.GenerateKey, encrypt: deps.Encrypt, now: now, newID: newID,
+		onToolsChanged: deps.OnToolsChanged,
 	}, nil
 }
 
@@ -308,6 +311,7 @@ func (s *Service) Link(ctx context.Context, orgID string, assetID asset.ID, agen
 		_ = s.links.Delete(ctx, orgID, assetID, agentID)
 		return asset.Link{}, fmt.Errorf("attach asset tools to agent: %w", err)
 	}
+	s.notifyToolsChanged(ctx, agent.AgentID)
 	return link, nil
 }
 
@@ -345,7 +349,14 @@ func (s *Service) Unlink(ctx context.Context, orgID string, assetID asset.ID, ag
 		_ = s.links.Create(ctx, link)
 		return fmt.Errorf("detach asset tools from agent: %w", err)
 	}
+	s.notifyToolsChanged(ctx, agent.AgentID)
 	return nil
+}
+
+func (s *Service) notifyToolsChanged(ctx context.Context, appID string) {
+	if s.onToolsChanged != nil && appID != "" {
+		s.onToolsChanged(ctx, appID)
+	}
 }
 
 func (s *Service) Delete(ctx context.Context, orgID string, id asset.ID) error {

--- a/api/pkg/org/application/assets/assets_test.go
+++ b/api/pkg/org/application/assets/assets_test.go
@@ -27,7 +27,7 @@ func newTestService(t *testing.T) (*Service, *time.Time, string) {
 	require.NoError(t, err)
 	bot, err := orgchart.NewNode("b-agent", "agent", nil, now, "org-test")
 	require.NoError(t, err)
-	require.NoError(t, st.Nodes.Create(context.Background(), bot))
+	require.NoError(t, st.Nodes.Create(context.Background(), bot.WithAgentID("app-agent")))
 	return svc, &now, "org-test"
 }
 
@@ -46,6 +46,8 @@ func TestCreateServerEncryptsPrivateKey(t *testing.T) {
 
 func TestLinkDerivesAndRevokesServerTools(t *testing.T) {
 	svc, _, orgID := newTestService(t)
+	var notified []string
+	svc.onToolsChanged = func(_ context.Context, appID string) { notified = append(notified, appID) }
 	a, err := svc.CreateServer(context.Background(), orgID, CreateServerParams{
 		Name: "production", Address: "10.0.0.8", User: "ubuntu",
 	})
@@ -57,6 +59,7 @@ func TestLinkDerivesAndRevokesServerTools(t *testing.T) {
 	for _, name := range ServerTools {
 		require.Contains(t, bot.Tools, name)
 	}
+	require.Equal(t, []string{"app-agent"}, notified)
 
 	require.NoError(t, svc.Unlink(context.Background(), orgID, a.ID, "b-agent"))
 	bot, err = svc.nodes.Get(context.Background(), orgID, "b-agent")
@@ -64,6 +67,7 @@ func TestLinkDerivesAndRevokesServerTools(t *testing.T) {
 	for _, name := range ServerTools {
 		require.NotContains(t, bot.Tools, name)
 	}
+	require.Equal(t, []string{"app-agent", "app-agent"}, notified)
 }
 
 func TestAuthorizeRequiresLinkAndEnabledAsset(t *testing.T) {

--- a/api/pkg/org/application/dispatch/dispatcher.go
+++ b/api/pkg/org/application/dispatch/dispatcher.go
@@ -118,12 +118,7 @@ func (d *Dispatcher) DispatchHire(_ context.Context, orgID string, workerID orgc
 
 // DispatchManual fires an operator-driven activation. Used by the
 // worker UI's "Start Desktop" button to put the per-Worker project
-// through the full activation pipeline (ensureProject → AttachHelixOrgMCP
-// → ensureSession), which re-attaches the helix-org MCP entry that
-// applyProject's wholesale Config.Helix replace wipes between
-// activations. Without this path, restarting a paused desktop via
-// /sessions/{id}/resume alone leaves the desktop without the helix-org
-// MCP until the next AI activation or owner-chat call.
+// through the full activation pipeline (ensureProject -> ensureSession).
 //
 // Returns immediately; the activation runs on the per-Worker queue
 // goroutine. activationID semantics match DispatchHire — callers that

--- a/api/pkg/org/application/nodes/nodes.go
+++ b/api/pkg/org/application/nodes/nodes.go
@@ -41,12 +41,13 @@ var ErrReportingLinesUnavailable = errors.New("reporting lines not wired")
 
 // Nodes owns the node-mutation use cases.
 type Nodes struct {
-	nodes      store.Nodes
-	lines      store.ReportingLines
-	reconciler *reconcile.Reconciler
-	now        func() time.Time
-	newID      func() string
-	baseTools  []tool.Name
+	nodes          store.Nodes
+	lines          store.ReportingLines
+	reconciler     *reconcile.Reconciler
+	now            func() time.Time
+	newID          func() string
+	baseTools      []tool.Name
+	onToolsChanged func(context.Context, string)
 }
 
 // Deps are the constructor-injected collaborators for New.
@@ -64,7 +65,8 @@ type Deps struct {
 	// created Node so no Node can miss the read primitives every Node
 	// needs. Injected by the wiring (tools.BaseReadTools) to avoid an
 	// import cycle.
-	BaseTools []tool.Name
+	BaseTools      []tool.Name
+	OnToolsChanged func(context.Context, string)
 }
 
 // New constructs the Nodes service.
@@ -74,12 +76,13 @@ func New(deps Deps) *Nodes {
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Nodes{
-		nodes:      deps.Nodes,
-		lines:      deps.Lines,
-		reconciler: deps.Reconciler,
-		now:        now,
-		newID:      deps.NewID,
-		baseTools:  deps.BaseTools,
+		nodes:          deps.Nodes,
+		lines:          deps.Lines,
+		reconciler:     deps.Reconciler,
+		now:            now,
+		newID:          deps.NewID,
+		baseTools:      deps.BaseTools,
+		onToolsChanged: deps.OnToolsChanged,
 	}
 }
 
@@ -202,6 +205,9 @@ func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p 
 	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
+	if p.Tools != nil {
+		s.notifyToolsChanged(ctx, updated.AgentID)
+	}
 	return updated, nil
 }
 
@@ -240,6 +246,7 @@ func (s *Nodes) AttachTools(ctx context.Context, orgID string, id orgchart.NodeI
 	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
+	s.notifyToolsChanged(ctx, updated.AgentID)
 	return updated, nil
 }
 
@@ -278,7 +285,14 @@ func (s *Nodes) DetachTools(ctx context.Context, orgID string, id orgchart.NodeI
 	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
+	s.notifyToolsChanged(ctx, updated.AgentID)
 	return updated, nil
+}
+
+func (s *Nodes) notifyToolsChanged(ctx context.Context, appID string) {
+	if s.onToolsChanged != nil && appID != "" {
+		s.onToolsChanged(ctx, appID)
+	}
 }
 
 // AddParent wires a reporting line (reportID reports to managerID),
@@ -383,6 +397,7 @@ func (s *Nodes) Reconcile(ctx context.Context, orgID string) error {
 		if err := s.nodes.Update(ctx, updated); err != nil {
 			return fmt.Errorf("update node %q: %w", node.ID, err)
 		}
+		s.notifyToolsChanged(ctx, updated.AgentID)
 	}
 	return nil
 }

--- a/api/pkg/org/domain/activation/trigger.go
+++ b/api/pkg/org/domain/activation/trigger.go
@@ -35,7 +35,7 @@ const (
 	// TriggerManual fires when an operator manually wakes a Worker
 	// from the UI (the worker page's "Start Desktop" button).
 	// Functionally identical to TriggerHire in terms of the activation
-	// pipeline — ensureProject + AttachHelixOrgMCP + ensureSession —
+	// pipeline - ensureProject + ensureSession -
 	// just with a different label so the audit row + activation marker
 	// distinguish "operator clicked the button" from "Worker was just
 	// hired" or "Topic event arrived".

--- a/api/pkg/org/infrastructure/runtime/helix/mcp.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp.go
@@ -2,12 +2,7 @@ package helix
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
-
-	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
-	"github.com/helixml/helix/api/pkg/types"
 )
 
 // HelixOrgMCPName is the AssistantMCP.Name slot the helix-org MCP entry
@@ -15,77 +10,25 @@ import (
 // keep it stable across the codebase.
 const HelixOrgMCPName = "helix"
 
-// AttachHelixOrgMCP idempotently writes the helix-org MCP entry onto
-// the per-Worker agent app's first assistant.
-//
-// Why this isn't done inside the project-apply path: applyProject
-// (api/pkg/server/project_handlers.go) wholesale-replaces
-// agentApp.Config.Helix when an agent app already exists, so anything
-// attached previously is wiped on every re-apply. Re-attaching after
-// the apply lands is the invariant that keeps the helix-org MCP
-// present across activations. Both call sites — the Spawner (per AI
-// Worker activation) and dynamicProjectApplier (per owner-chat
-// ensureWorker call) — invoke this; the function is the single source
-// of truth for what the MCP entry looks like.
-//
-// Upsert is keyed on HelixOrgMCPName: an existing entry with the same
-// name is overwritten in place, otherwise appended. MCP configuration is
-// persisted on a long-lived app, so it must use the long-lived service key,
-// never the activation request's session-scoped bearer. Empty bearer means
-// no Authorization header is sent — fine for standalone deployments where
-// the MCP route is not auth-gated.
-func AttachHelixOrgMCP(
-	ctx context.Context,
-	svc ProjectService,
-	appID string,
-	helixOrgURL string,
-	workerID orgchart.NodeID,
-	fallbackBearer string,
-) error {
-	if svc == nil {
-		return errors.New("AttachHelixOrgMCP: ProjectService is nil")
-	}
-	if appID == "" {
-		return errors.New("AttachHelixOrgMCP: appID is empty")
-	}
-	if helixOrgURL == "" {
-		return errors.New("AttachHelixOrgMCP: helixOrgURL is empty")
-	}
-	if workerID == "" {
-		return errors.New("AttachHelixOrgMCP: workerID is empty")
-	}
-
+func RemoveHelixOrgMCP(ctx context.Context, svc ProjectService, appID string) error {
 	cfg, err := svc.GetAppConfig(ctx, appID)
 	if err != nil {
 		return fmt.Errorf("get app config: %w", err)
 	}
 	if len(cfg.Helix.Assistants) == 0 {
-		return errors.New("AttachHelixOrgMCP: app has no assistants")
+		return nil
 	}
-
-	var headers map[string]string
-	if fallbackBearer != "" {
-		headers = map[string]string{"Authorization": "Bearer " + fallbackBearer}
-	}
-	entry := types.AssistantMCP{
-		Name:      HelixOrgMCPName,
-		Transport: "http",
-		URL:       strings.TrimRight(helixOrgURL, "/") + "/workers/" + string(workerID) + "/mcp",
-		Headers:   headers,
-	}
-
-	asst := &cfg.Helix.Assistants[0]
-	replaced := false
-	for i := range asst.MCPs {
-		if asst.MCPs[i].Name == entry.Name {
-			asst.MCPs[i] = entry
-			replaced = true
-			break
+	assistant := &cfg.Helix.Assistants[0]
+	kept := assistant.MCPs[:0]
+	for _, mcp := range assistant.MCPs {
+		if mcp.Name != HelixOrgMCPName {
+			kept = append(kept, mcp)
 		}
 	}
-	if !replaced {
-		asst.MCPs = append(asst.MCPs, entry)
+	if len(kept) == len(assistant.MCPs) {
+		return nil
 	}
+	assistant.MCPs = kept
 	if err := svc.UpdateAppConfig(ctx, appID, cfg); err != nil {
 		return fmt.Errorf("update app config: %w", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
@@ -2,234 +2,35 @@ package helix
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"testing"
 
-	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// findMCP returns the AssistantMCP named `name` on assistants[0], or
-// nil if not present.
-func findMCP(cfg types.AppConfig, name string) *types.AssistantMCP {
-	if len(cfg.Helix.Assistants) == 0 {
-		return nil
-	}
-	for i := range cfg.Helix.Assistants[0].MCPs {
-		if cfg.Helix.Assistants[0].MCPs[i].Name == name {
-			return &cfg.Helix.Assistants[0].MCPs[i]
-		}
-	}
-	return nil
-}
-
-// TestAttachHelixOrgMCPAppends writes a fresh entry when no MCP with
-// HelixOrgMCPName exists yet.
-func TestAttachHelixOrgMCPAppends(t *testing.T) {
-	t.Parallel()
-	svc := newFakeProjectService()
-	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.NodeID("w-eng"), "k_service")
-	if err != nil {
-		t.Fatalf("AttachHelixOrgMCP: %v", err)
-	}
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	if svc.getAppCalls != 1 || svc.updateAppCalls != 1 {
-		t.Fatalf("expected one GetAppConfig + one UpdateAppConfig; got get=%d update=%d", svc.getAppCalls, svc.updateAppCalls)
-	}
-	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
-	if mcp == nil {
-		t.Fatalf("UpdateApp config missing %q MCP entry: %+v", HelixOrgMCPName, svc.updateAppLastCfg)
-	}
-	if mcp.Transport != "http" {
-		t.Errorf("Transport = %q, want http", mcp.Transport)
-	}
-	if !strings.HasSuffix(mcp.URL, "/workers/w-eng/mcp") {
-		t.Errorf("URL = %q, want suffix /workers/w-eng/mcp", mcp.URL)
-	}
-	if mcp.Headers["Authorization"] != "Bearer k_service" {
-		t.Errorf("Headers[Authorization] = %q, want %q", mcp.Headers["Authorization"], "Bearer k_service")
-	}
-}
-
-// TestAttachHelixOrgMCPUpsertReplacesExisting pins the idempotency
-// contract — re-attaching with a different bearer overwrites the
-// entry in place instead of appending a duplicate.
-func TestAttachHelixOrgMCPUpsertReplacesExisting(t *testing.T) {
-	t.Parallel()
+func TestRemoveHelixOrgMCP(t *testing.T) {
 	svc := newFakeProjectService()
 	svc.appConfig.Helix.Assistants[0].MCPs = []types.AssistantMCP{
-		{Name: HelixOrgMCPName, Transport: "http", URL: "http://old/workers/w-eng/mcp", Headers: map[string]string{"Authorization": "Bearer old"}},
-		{Name: "other", URL: "http://other/mcp"},
+		{Name: HelixOrgMCPName, URL: "http://old.example/mcp"},
+		{Name: "other", URL: "stdio://other"},
 	}
-	if err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.NodeID("w-eng"), "k_new"); err != nil {
-		t.Fatalf("AttachHelixOrgMCP: %v", err)
+
+	if err := RemoveHelixOrgMCP(context.Background(), svc, "app_test"); err != nil {
+		t.Fatalf("RemoveHelixOrgMCP: %v", err)
 	}
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	asst := svc.updateAppLastCfg.Helix.Assistants[0]
-	if got := len(asst.MCPs); got != 2 {
-		t.Fatalf("MCP entries = %d, want 2 (upsert must not append a duplicate); got %+v", got, asst.MCPs)
-	}
-	helix := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
-	if helix == nil {
-		t.Fatalf("helix MCP entry missing")
-	}
-	if helix.Headers["Authorization"] != "Bearer k_new" {
-		t.Errorf("upsert did not refresh bearer; got %q", helix.Headers["Authorization"])
-	}
-	if !strings.HasSuffix(helix.URL, "/workers/w-eng/mcp") {
-		t.Errorf("URL not rewritten; got %q", helix.URL)
+	got := svc.updateAppLastCfg.Helix.Assistants[0].MCPs
+	if len(got) != 1 || got[0].Name != "other" {
+		t.Fatalf("MCPs = %+v, want only other", got)
 	}
 }
 
-// TestAttachHelixOrgMCPIgnoresRequestBearer pins that a short-lived
-// activation/session token is never persisted on the long-lived app.
-func TestAttachHelixOrgMCPIgnoresRequestBearer(t *testing.T) {
-	t.Parallel()
+func TestRemoveHelixOrgMCPNoopWithoutLegacyEntry(t *testing.T) {
 	svc := newFakeProjectService()
-	ctx := WithBearerToken(context.Background(), "k_user")
-	if err := AttachHelixOrgMCP(ctx, svc, "app_test", "http://helix-org:8081", orgchart.NodeID("w-eng"), "k_service"); err != nil {
-		t.Fatalf("AttachHelixOrgMCP: %v", err)
-	}
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
-	if mcp == nil || mcp.Headers["Authorization"] != "Bearer k_service" {
-		t.Errorf("service bearer must be persisted; got %+v", mcp)
-	}
-}
+	svc.appConfig.Helix.Assistants[0].MCPs = []types.AssistantMCP{{Name: "other"}}
 
-// TestAttachHelixOrgMCPEmptyBearerOmitsHeader pins the standalone-
-// deployment shape: when neither ctx nor fallback carry a bearer, no
-// Authorization header is written. The standalone helix-org MCP is
-// not auth-gated so an empty header is correct.
-func TestAttachHelixOrgMCPEmptyBearerOmitsHeader(t *testing.T) {
-	t.Parallel()
-	svc := newFakeProjectService()
-	if err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.NodeID("w-eng"), ""); err != nil {
-		t.Fatalf("AttachHelixOrgMCP: %v", err)
+	if err := RemoveHelixOrgMCP(context.Background(), svc, "app_test"); err != nil {
+		t.Fatalf("RemoveHelixOrgMCP: %v", err)
 	}
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
-	if mcp == nil {
-		t.Fatalf("MCP entry missing")
-	}
-	if mcp.Headers != nil {
-		t.Errorf("Headers must be nil when no bearer is set; got %+v", mcp.Headers)
+	if svc.updateAppCalls != 0 {
+		t.Fatalf("UpdateAppConfig calls = %d, want 0", svc.updateAppCalls)
 	}
 }
-
-// TestAttachHelixOrgMCPRejectsMissingInputs pins the up-front
-// validation. Each failure mode returns a clear error rather than
-// nil-derefing or writing a malformed entry.
-func TestAttachHelixOrgMCPRejectsMissingInputs(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		svc     ProjectService
-		appID   string
-		url     string
-		worker  orgchart.NodeID
-		errFrag string
-	}{
-		{"nil service", nil, "app_test", "http://helix-org", "w-eng", "ProjectService is nil"},
-		{"empty appID", newFakeProjectService(), "", "http://helix-org", "w-eng", "appID is empty"},
-		{"empty URL", newFakeProjectService(), "app_test", "", "w-eng", "helixOrgURL is empty"},
-		{"empty workerID", newFakeProjectService(), "app_test", "http://helix-org", "", "workerID is empty"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := AttachHelixOrgMCP(context.Background(), tc.svc, tc.appID, tc.url, tc.worker, "")
-			if err == nil {
-				t.Fatalf("expected error containing %q, got nil", tc.errFrag)
-			}
-			if !strings.Contains(err.Error(), tc.errFrag) {
-				t.Errorf("err = %q, want contains %q", err.Error(), tc.errFrag)
-			}
-		})
-	}
-}
-
-// TestAttachHelixOrgMCPRequiresAssistant pins the contract on the
-// agent app shape: a project's auto-provisioned agent app always
-// has a [0]th assistant; if it doesn't, attach refuses rather than
-// silently appending into a zero-length slice.
-func TestAttachHelixOrgMCPRequiresAssistant(t *testing.T) {
-	t.Parallel()
-	svc := newFakeProjectService()
-	svc.appConfig = types.AppConfig{} // no assistants
-	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org", orgchart.NodeID("w-eng"), "")
-	if err == nil || !strings.Contains(err.Error(), "no assistants") {
-		t.Errorf("expected 'no assistants' error, got %v", err)
-	}
-}
-
-// TestAttachHelixOrgMCPPropagatesGetError pins the error path: a
-// failure from GetAppConfig surfaces (wrapped) rather than crashing
-// or writing garbage.
-func TestAttachHelixOrgMCPPropagatesGetError(t *testing.T) {
-	t.Parallel()
-	svc := &failingProjectService{getErr: errors.New("boom")}
-	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org", orgchart.NodeID("w-eng"), "")
-	if err == nil || !strings.Contains(err.Error(), "boom") {
-		t.Errorf("expected wrapped GetAppConfig error, got %v", err)
-	}
-}
-
-// failingProjectService stubs ProjectService so the GetAppConfig
-// error-path test can isolate failure-mode behaviour without
-// touching the fake's other state.
-type failingProjectService struct {
-	noopProjectService
-	getErr error
-}
-
-func (f *failingProjectService) GetAppConfig(_ context.Context, _ string) (types.AppConfig, error) {
-	return types.AppConfig{}, f.getErr
-}
-
-// noopProjectService satisfies ProjectService with no-op
-// implementations so test stand-ins can embed it and override only
-// the method under test.
-type noopProjectService struct{}
-
-func (noopProjectService) WhoAmI(_ context.Context) (string, error) { return "u-test", nil }
-func (noopProjectService) ApplyProject(_ context.Context, _ types.ProjectApplyRequest) (types.ProjectApplyResponse, error) {
-	return types.ProjectApplyResponse{}, nil
-}
-func (noopProjectService) GetProject(_ context.Context, _ string) (types.Project, error) {
-	return types.Project{}, nil
-}
-func (noopProjectService) UpdateProject(_ context.Context, _ string, _ types.ProjectUpdateRequest) (types.Project, error) {
-	return types.Project{}, nil
-}
-func (noopProjectService) PutProjectSecret(_ context.Context, _, _, _ string) error { return nil }
-func (noopProjectService) DeleteProjectSecret(_ context.Context, _, _ string) error { return nil }
-func (noopProjectService) ListProjectSecrets(_ context.Context, _ string) (map[string]string, error) {
-	return nil, nil
-}
-func (noopProjectService) CreateGitRepo(_ context.Context, _ types.GitRepositoryCreateRequest) (types.GitRepository, error) {
-	return types.GitRepository{}, nil
-}
-func (noopProjectService) GetGitRepo(_ context.Context, repoID string) (types.GitRepository, error) {
-	return types.GitRepository{ID: repoID, Name: repoID}, nil
-}
-func (noopProjectService) DeleteGitRepo(_ context.Context, _ string) error { return nil }
-func (noopProjectService) AttachRepoToProject(_ context.Context, _, _ string, _ bool) error {
-	return nil
-}
-func (noopProjectService) CreateBranch(_ context.Context, _, _, _ string) error { return nil }
-func (noopProjectService) GetAppConfig(_ context.Context, _ string) (types.AppConfig, error) {
-	return types.AppConfig{}, nil
-}
-func (noopProjectService) GetApp(_ context.Context, id string) (*types.App, error) {
-	return &types.App{ID: id}, nil
-}
-func (noopProjectService) UpdateAppConfig(_ context.Context, _ string, _ types.AppConfig) error {
-	return nil
-}
-func (noopProjectService) DeleteProject(_ context.Context, _ string) error { return nil }
-func (noopProjectService) DeleteApp(_ context.Context, _ string) error     { return nil }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -112,10 +112,6 @@ type ProjectService interface {
 	// trip the helix.assistants[0] MCP list for MCP attachment.
 	GetAppConfig(ctx context.Context, id string) (types.AppConfig, error)
 	GetApp(ctx context.Context, id string) (*types.App, error)
-
-	// UpdateAppConfig persists a mutated app config. WorkerProject
-	// uses this to attach helix-org's MCP server to the auto-provisioned
-	// Agent App.
 	UpdateAppConfig(ctx context.Context, id string, config types.AppConfig) error
 
 	// DeleteProject soft-deletes a Helix project and stops any active
@@ -149,10 +145,9 @@ type ProjectService interface {
 // api/pkg/server/helix_org.go satisfies ProjectService with the
 // in-process adapter that calls HelixAPIServer handlers directly.
 type WorkerProject struct {
-	Service     ProjectService
-	Store       *store.Store
-	HelixOrgURL string
-	OrgID       string
+	Service ProjectService
+	Store   *store.Store
+	OrgID   string
 	// OrgDisplayName is the org's human label, used to build the
 	// project's display name (`<Bot> @ <Org>`). The host resolves it
 	// from the main store and stamps it here; empty falls back to a
@@ -426,12 +421,6 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 			return "", "", "", fmt.Errorf("apply project for %s: %w", workerID, rerr)
 		}
 	}
-	// NB: helix-org MCP attachment is NOT done here. applyProject
-	// (helix project handler) wholesale-replaces agentApp.Config.Helix
-	// on update, so anything we attach now is clobbered on the next
-	// re-apply. The Spawner and dynamicProjectApplier call
-	// AttachHelixOrgMCP themselves *after* this Ensure returns — that's
-	// the single place MCP mutation lives.
 	if err := SaveProject(ctx, a.Store, orgID, workerID, resp.ProjectID, resp.AgentAppID, repoID); err != nil {
 		return "", "", "", fmt.Errorf("persist helix project IDs: %w", err)
 	}
@@ -448,12 +437,8 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 }
 
 func (a *WorkerProject) syncProjectRuntimeSecrets(ctx context.Context, projectID string, workerID orgchart.NodeID) {
-	// The org URL is project capability shared by every session in the worker's
-	// project. Worker identity is not: remove the legacy project secret so
-	// SpecTask sessions cannot inherit it. The spawner now stores identity and
-	// instructions on the org worker's session only.
-	if err := a.Service.PutProjectSecret(ctx, projectID, "HELIX_ORG_URL", a.HelixOrgURL); err != nil && a.Logger != nil {
-		a.Logger.Warn("put project secret HELIX_ORG_URL", "worker", workerID, "project", projectID, "err", err)
+	if err := a.Service.DeleteProjectSecret(ctx, projectID, "HELIX_ORG_URL"); err != nil && a.Logger != nil {
+		a.Logger.Warn("delete legacy project secret HELIX_ORG_URL", "worker", workerID, "project", projectID, "err", err)
 	}
 	if err := a.Service.DeleteProjectSecret(ctx, projectID, "HELIX_WORKER_ID"); err != nil && a.Logger != nil {
 		a.Logger.Warn("delete legacy project secret HELIX_WORKER_ID", "worker", workerID, "project", projectID, "err", err)

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -289,10 +289,9 @@ func newProjectTestStore(t *testing.T, roleContent string) (*store.Store, orgcha
 func newApplier(svc ProjectService, ws *Workspace, st *store.Store) *WorkerProject {
 	_ = ws
 	return &WorkerProject{
-		Service:     svc,
-		Store:       st,
-		HelixOrgURL: "http://helix-org:8081",
-		Logger:      discardLogger(),
+		Service: svc,
+		Store:   st,
+		Logger:  discardLogger(),
 	}
 }
 
@@ -333,14 +332,14 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	if svc.lastApplyReq.Spec.Agent == nil || svc.lastApplyReq.Spec.Agent.Runtime != Runtime {
 		t.Errorf("Agent runtime = %+v, want %q", svc.lastApplyReq.Spec.Agent, Runtime)
 	}
-	if svc.putSecretLast["HELIX_ORG_URL"] != "http://helix-org:8081" {
-		t.Errorf("HELIX_ORG_URL = %q", svc.putSecretLast["HELIX_ORG_URL"])
+	if _, ok := svc.putSecretLast["HELIX_ORG_URL"]; ok {
+		t.Errorf("HELIX_ORG_URL must not be stored as a project secret")
 	}
 	if _, ok := svc.putSecretLast["HELIX_WORKER_ID"]; ok {
 		t.Errorf("HELIX_WORKER_ID must not be stored as a project secret")
 	}
-	if len(svc.deletedSecrets) != 1 || svc.deletedSecrets[0] != "HELIX_WORKER_ID" {
-		t.Errorf("deleted secrets = %v, want [HELIX_WORKER_ID]", svc.deletedSecrets)
+	if len(svc.deletedSecrets) != 2 || svc.deletedSecrets[0] != "HELIX_ORG_URL" || svc.deletedSecrets[1] != "HELIX_WORKER_ID" {
+		t.Errorf("deleted secrets = %v, want [HELIX_ORG_URL HELIX_WORKER_ID]", svc.deletedSecrets)
 	}
 	if svc.createGitRepoCalls != 1 {
 		t.Errorf("CreateGitRepo calls = %d, want 1", svc.createGitRepoCalls)
@@ -866,18 +865,8 @@ func TestEnsureGetProjectErrorIsFatal(t *testing.T) {
 	}
 }
 
-// TestEnsureDoesNotTouchAgentAppMCPs pins the new contract: MCP
-// attachment is NOT WorkerProject.Ensure's responsibility. It moved
-// out into runtimehelix.AttachHelixOrgMCP, called explicitly by the
-// Spawner (per-activation) and dynamicProjectApplier (per owner-chat
-// ensureWorker). Ensure mutates the project + repo + helix-specs
-// files only.
-//
-// Why this matters: the helix project-apply path wholesale-replaces
-// agentApp.Config.Helix on update, so any MCP attached during Ensure
-// is clobbered on the next re-apply. Keeping MCP attachment outside
-// Ensure means there's exactly one place that writes the MCP entry,
-// and it's the last write before the desktop boots.
+// TestEnsureDoesNotTouchAgentAppMCPs pins that MCP configuration is
+// generated from session metadata instead of persisted by project setup.
 func TestEnsureDoesNotTouchAgentAppMCPs(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role")

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -42,8 +42,7 @@ type SpawnerConfig struct {
 	Snapshotter SessionPreamble
 	// Mirror is the transcript writer; the spawner Ensure()s it per
 	// activation. nil disables mirroring (tests / app-only wirings).
-	Mirror      *Mirror
-	HelixOrgURL string // forwarded to project secrets so the in-sandbox agent can reach helix-org's MCP server
+	Mirror *Mirror
 	// Runtime overrides the default `zed_agent` runtime. Empty falls
 	// back to helix.Runtime. See WorkerProject.Runtime for the
 	// embedded SaaS use case (`claude_code` + subscription credentials).
@@ -56,13 +55,6 @@ type SpawnerConfig struct {
 	Model    string
 	// Credentials forwards to WorkerProject.Credentials. See there.
 	Credentials string
-	// MCPAuthBearer is the fallback bearer the spawner passes to
-	// AttachHelixOrgMCP when no per-activation user bearer is on ctx.
-	// It ends up as the `Authorization: Bearer <value>` header on the
-	// helix-org MCP entry attached to each Worker's agent app. Used
-	// when HelixOrgURL routes through an auth-gated proxy (embedded
-	// SaaS alpha). Empty in standalone mode.
-	MCPAuthBearer string
 	// SpecsMandate is an optional full activation mandate override.
 	// Empty uses the Bot's current Content.
 	SpecsMandate string
@@ -110,7 +102,7 @@ type SpawnerConfig struct {
 	// Sem, when non-nil, is the inflight semaphore the Spawner acquires
 	// a slot from instead of minting its own from MaxInflight. The host
 	// builds one fresh SpawnerConfig per activation (so OrgID /
-	// HelixOrgURL stay scoped to the activating org — never frozen to
+	// OrgID stays scoped to the activating org — never frozen to
 	// whichever org activated first), and shares a single Sem across all
 	// of them to keep one process-wide inflight cap. Nil falls back to a
 	// per-config semaphore of size MaxInflight.
@@ -270,13 +262,6 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			return err
 		}
 
-		// Re-attach the helix-org MCP entry. ensureProject (and the
-		// dynamic applier that may have run before us) calls helix
-		// project-apply, which wholesale-replaces Config.Helix on
-		// update and wipes the MCP list. This is the last write to the
-		// agent app's MCPs before the desktop boots its Zed runtime.
-		cfg.ensureHelixOrgMCP(startupCtx, orgID, workerID)
-
 		// Register the worker with the transcript mirror (idempotent;
 		// the tracker persists across activations and follows the
 		// session as it churns). The spawner no longer owns a bridge.
@@ -390,7 +375,6 @@ func (c SpawnerConfig) ensureProject(ctx context.Context, orgID string, workerID
 	a := &WorkerProject{
 		Service:        c.ProjectService,
 		Store:          c.Store,
-		HelixOrgURL:    c.HelixOrgURL,
 		OrgID:          c.OrgID,
 		OrgDisplayName: c.OrgDisplayName,
 		Runtime:        c.Runtime,
@@ -401,37 +385,6 @@ func (c SpawnerConfig) ensureProject(ctx context.Context, orgID string, workerID
 	}
 	_, _, _, err := a.Ensure(ctx, orgID, workerID)
 	return err
-}
-
-// ensureHelixOrgMCP re-attaches the helix-org MCP entry to the
-// Worker's agent app on every activation. Best-effort: a failure here
-// surfaces in the desktop as "no helix-org tools", which is a
-// degraded but bootable state — failing the activation would be
-// worse. The attach is idempotent (upsert by name), so re-running on
-// every activation is safe.
-//
-// Why it runs here and not inside WorkerProject.Ensure: the project-
-// apply path on the helix side wholesale-replaces Config.Helix when
-// the agent app already exists, blowing away whatever MCPs were
-// attached on the previous activation. Re-attaching after Ensure
-// returns keeps the MCP present.
-func (c SpawnerConfig) ensureHelixOrgMCP(ctx context.Context, orgID string, workerID orgchart.NodeID) {
-	if c.ProjectService == nil || c.HelixOrgURL == "" {
-		return
-	}
-	state, err := LoadState(ctx, c.Store, orgID, workerID)
-	if err != nil {
-		if c.Logger != nil {
-			c.Logger.Warn("helix spawner: load state for MCP attach", "worker", workerID, "err", err)
-		}
-		return
-	}
-	if state.AgentID == "" {
-		return
-	}
-	if err := AttachHelixOrgMCP(ctx, c.ProjectService, state.AgentID, c.HelixOrgURL, workerID, c.MCPAuthBearer); err != nil && c.Logger != nil {
-		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "agent", state.AgentID, "err", sanitizeLogValue(err.Error()))
-	}
 }
 
 func sanitizeLogValue(value string) string {

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -181,7 +181,6 @@ func newHelixCfg(t *testing.T, fc SpawnerClient, s *store.Store) SpawnerConfig {
 		ProjectService:         newFakeProjectService(),
 		PubSub:                 newFakePubSub(),
 		Snapshotter:            NoopSessionPreamble{},
-		HelixOrgURL:            "http://helix-org:8081",
 		Provider:               "openai",
 		Model:                  "gpt-4o-mini",
 		SessionStartupTimeout:  2 * time.Second,
@@ -391,51 +390,6 @@ func TestSpawnerReadsBotAfterProjectEnsure(t *testing.T) {
 	instructions := fc.lastStartParams.Instructions
 	if !strings.Contains(instructions, "# Role: Updated During Ensure") {
 		t.Fatalf("runtime instructions used role read before project ensure: %q", instructions)
-	}
-}
-
-// TestSpawnerAttachesHelixOrgMCPEveryActivation pins the bug-fix
-// invariant: the helix-org MCP is re-attached to the Worker's agent
-// app on every activation, after ensureProject runs. helix's project-
-// apply path wholesale-replaces Config.Helix on update, so without
-// this re-attach the MCP is gone from the second activation onward
-// and the desktop runtime boots without the helix-org tools — the
-// regression behind /workers/<id>/mcp not appearing in Zed.
-func TestSpawnerAttachesHelixOrgMCPEveryActivation(t *testing.T) {
-	t.Parallel()
-	s, wid := newHelixTestStore(t)
-	fc := &fakeHelixClient{
-		startSessionID: "ses_new",
-		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
-	}
-	cfg := newHelixCfg(t, fc, s)
-	cfg.MCPAuthBearer = "k_service"
-	sp := Spawner(cfg)
-	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
-		t.Fatalf("spawn 1: %v", err)
-	}
-	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent}}); err != nil {
-		t.Fatalf("spawn 2: %v", err)
-	}
-	svc := cfg.ProjectService.(*fakeProjectService)
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	// Two activations should mean two UpdateAppConfig calls for the
-	// MCP attach (one per activation, after ensureProject). The
-	// helix-side apply path clobbers the MCP list each time so this
-	// must NOT be debounced.
-	if svc.updateAppCalls != 2 {
-		t.Errorf("UpdateAppConfig calls = %d, want 2 (one MCP re-attach per activation)", svc.updateAppCalls)
-	}
-	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
-	if mcp == nil {
-		t.Fatalf("last UpdateApp missing helix MCP entry: %+v", svc.updateAppLastCfg)
-	}
-	if !strings.HasSuffix(mcp.URL, "/workers/w-eng/mcp") {
-		t.Errorf("MCP URL = %q, want /workers/w-eng/mcp suffix", mcp.URL)
-	}
-	if mcp.Headers["Authorization"] != "Bearer k_service" {
-		t.Errorf("MCP fallback bearer not applied; Authorization = %q", mcp.Headers["Authorization"])
 	}
 }
 
@@ -1096,7 +1050,7 @@ func TestSpawnerRecordsActivationRowOnError(t *testing.T) {
 // (design/2026-06-09-org-multitenancy-spawner-leak.md).
 //
 // The old host wrapper cached ONE inner Spawner (and so one org's
-// frozen OrgID/HelixOrgURL) to share a single inflight cap. The fix
+// frozen OrgID) to share a single inflight cap. The fix
 // rebuilds a per-org SpawnerConfig every activation and instead shares
 // the cap via SpawnerConfig.Sem. If Spawner ignores cfg.Sem and mints
 // its own semaphore from MaxInflight, the global cap is silently lost.

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -152,6 +152,7 @@ type Config struct {
 	Dispatcher          EventDispatcher
 	AgentContentUpdater AgentContentUpdater
 	AgentProfileReader  AgentProfileReader
+	ToolChangeNotifier  func(context.Context, string)
 	HireHook            runtime.HireHook
 	ProjectConfig       runtime.ProjectConfig
 	// SpecTasks is the runtime port the spec-task tools dispatch on. nil
@@ -344,12 +345,13 @@ func (c Config) lifecycleService() *lifecycle.Service {
 // the REST bot handlers union the same set.
 func (c Config) botsService() *nodes.Nodes {
 	return nodes.New(nodes.Deps{
-		Nodes:      c.Store.Nodes,
-		Lines:      c.Store.ReportingLines,
-		Reconciler: c.Reconciler,
-		Now:        c.Now,
-		NewID:      c.NewID,
-		BaseTools:  BaseReadTools,
+		Nodes:          c.Store.Nodes,
+		Lines:          c.Store.ReportingLines,
+		Reconciler:     c.Reconciler,
+		Now:            c.Now,
+		NewID:          c.NewID,
+		BaseTools:      BaseReadTools,
+		OnToolsChanged: c.ToolChangeNotifier,
 	})
 }
 

--- a/api/pkg/org/interfaces/mcptools/bulk_tools_test.go
+++ b/api/pkg/org/interfaces/mcptools/bulk_tools_test.go
@@ -136,6 +136,29 @@ func TestAttachDetachTools(t *testing.T) {
 	}
 }
 
+func TestToolChangeNotifiesLinkedAgentOnce(t *testing.T) {
+	st := orggorm.GetOrgTestDB(t)
+	deps := DefaultDeps(st)
+	var notified []string
+	deps.ToolChangeNotifier = func(_ context.Context, appID string) {
+		notified = append(notified, appID)
+	}
+	bot, err := orgchart.NewNode("b-eng", "# Engineer", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Nodes.Create(context.Background(), bot.WithAgentID("app-eng")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := deps.Build().Nodes.AttachTools(context.Background(), "org-test", "b-eng", []tool.Name{PublishName}); err != nil {
+		t.Fatal(err)
+	}
+	if len(notified) != 1 || notified[0] != "app-eng" {
+		t.Fatalf("notifications = %v, want [app-eng]", notified)
+	}
+}
+
 // TestCreateBotSubscribesToTopics pins the "fewest steps" behavior: topics
 // listed at creation become real subscription rows, and an unknown topic
 // fails the whole create with no partial bot.

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -537,7 +537,7 @@ func (a *apiHandler) ensureBotChat(w http.ResponseWriter, r *http.Request) {
 
 // activateBot manually triggers an activation for a Bot. The bot
 // page's "Start Desktop" button hits this so the full activation
-// pipeline runs: ensureProject → AttachHelixOrgMCP → ensureSession →
+// pipeline runs: ensureProject → ensureSession →
 // Helix spins up the desktop container as part of session start.
 //
 // Synchronous up to ensureProject so the response carries the project +

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -278,7 +278,7 @@ type orgServices struct {
 // constructors. deps carries the clock / id-gen / topology / hire-hook
 // seams (a mcptools.Deps is already assembled by the caller).
 func buildOrgServices(st *helixorgstore.Store, deps *mcptools.Config, bc *wakebus.Bus, dispatcher *dispatch.Dispatcher, provisioners map[transport.Kind]streaming.Inbound) orgServices {
-	botsSvc := nodes.New(nodes.Deps{Nodes: st.Nodes, Lines: st.ReportingLines, Reconciler: deps.Reconciler, Now: deps.Now, NewID: deps.NewID, BaseTools: mcptools.BaseReadTools})
+	botsSvc := nodes.New(nodes.Deps{Nodes: st.Nodes, Lines: st.ReportingLines, Reconciler: deps.Reconciler, Now: deps.Now, NewID: deps.NewID, BaseTools: mcptools.BaseReadTools, OnToolsChanged: deps.ToolChangeNotifier})
 	topicsSvc := topics.New(topics.Deps{Topics: st.Topics, Now: deps.Now, NewID: deps.NewID, Provisioners: provisioners})
 	svc := orgServices{
 		Nodes:    botsSvc,
@@ -483,7 +483,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// survive restarts. Surfaced via Organization Settings at
 	// /orgs/:org_id/general (backed by
 	// /api/v1/orgs/{org}/settings). Constructed before the spawner
-	// so the spawner can read chat.app_id / helix.url at activation
+	// so the spawner can read chat.app_id at activation
 	// time.
 	configReg := configregistry.New(st.Configs)
 	helixorg.RegisterConfigSpecs(configReg)
@@ -504,6 +504,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	inProcClient := NewInProcHelixClient(cfg.APIServer, configReg)
 	deps.AgentContentUpdater = inProcClient
 	deps.AgentProfileReader = inProcClient
+	deps.ToolChangeNotifier = cfg.APIServer.publishAgentToolChange
 
 	// Wire the helix-runtime HireHook so hire_worker persists the
 	// hiring user's identifier onto the new Worker's runtime state.
@@ -922,8 +923,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Encrypt: func(plaintext []byte) (string, error) {
 			return crypto.EncryptAES256GCM(plaintext, encryptionKey)
 		},
-		Now:   deps.Now,
-		NewID: deps.NewID,
+		Now:            deps.Now,
+		NewID:          deps.NewID,
+		OnToolsChanged: deps.ToolChangeNotifier,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init assets service: %w", err)
@@ -1079,8 +1081,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Int("json_api_routes", len(extras)).
 		Msg("helix-org mounted at /api/v1/orgs/{org}/helix-org/")
 	scope := newHelixOrgScope(configReg, st, helixStore, mirror, slackRouteReconciler, helixEventsReconciler)
-	scope.botRepair = func(ctx context.Context, orgID, serviceKey string) error {
-		if err := repairHelixOrgMCPServiceKeys(ctx, orgID, serviceKey, configReg, st, inProcClient); err != nil {
+	scope.botTools = svc.Nodes
+	scope.botRepair = func(ctx context.Context, orgID, _ string) error {
+		if err := removeLegacyHelixOrgMCPs(ctx, orgID, st, inProcClient); err != nil {
 			return err
 		}
 		return repairNeverActivatedBots(ctx, orgID, st, dispatcher, configReg, inProcClient)
@@ -1259,11 +1262,8 @@ type dynamicProjectApplier struct {
 // After Ensure succeeds, re-attaches the helix-org MCP entry on the
 // per-Worker agent app. ApplyProject (called inside WorkerProject.Ensure)
 // wholesale-replaces Config.Helix on update, so any MCPs we attached
-// previously are wiped — we re-attach here to keep the MCP present.
-// The Spawner does the same on its own activations; owner-chat goes
-// through this path only.
 func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, workerID orgchart.NodeID) (projectID, agentAppID, repoID string, err error) {
-	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.helixStore, d.projectSvc, d.Store, d.logger)
+	applier, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.logger)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -1272,11 +1272,6 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 	if err != nil {
 		return "", "", "", err
 	}
-	if agentAppID != "" && applier.HelixOrgURL != "" {
-		if attachErr := runtimehelix.AttachHelixOrgMCP(ctx, d.projectSvc, agentAppID, applier.HelixOrgURL, workerID, mcpBearer); attachErr != nil && d.logger != nil {
-			d.logger.Warn("dynamic project applier: attach helix-org MCP", "worker", workerID, "app", agentAppID, "err", attachErr)
-		}
-	}
 	return projectID, agentAppID, repoID, nil
 }
 
@@ -1284,21 +1279,13 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 // both the chat bridge (owner-chat) and the spawner (AI Worker
 // activations) drive. Single source of truth for the embedded
 // SaaS's default agent configuration from the config registry,
-// subscription credentials, and
-// our MCP-gateway URL so each Worker's agent app phones home for
-// helix-org tools via Helix's auth-gated proxy rather than a
-// separate tunnel.
+// subscription credentials.
 //
 // Called per Ensure by dynamicProjectApplier so registry edits
-// (agent.default and legacy worker.* keys, helix.url/api_key)
+// (agent.default and legacy worker.* keys)
 // take effect immediately. The struct it returns is cheap to build
 // and short-lived — one apply call, then discarded.
 //
-// Also returns the service api_key as a separate value (mcpBearer)
-// for the caller to feed into runtimehelix.AttachHelixOrgMCP as the
-// fallback bearer when no per-request bearer is on ctx. The bearer
-// is no longer carried on WorkerProject because Ensure doesn't touch
-// MCPs — MCP attachment is a separate, explicit step.
 // orgDisplayName resolves an org's human label for the `<Bot> @ <Org>`
 // project name. Prefers DisplayName, falls back to the slug Name, then
 // to "" (which makes WorkerProject use a bare bot label). Best-effort:
@@ -1321,38 +1308,21 @@ func buildHelixOrgProjectApplier(
 	ctx context.Context,
 	orgID string,
 	cfg *configregistry.Registry,
-	helixStore helixstore.Store,
 	projectSvc runtimehelix.ProjectService,
 	orgStore *helixorgstore.Store,
 	logger *slog.Logger,
-) (*runtimehelix.WorkerProject, string, error) {
-	apiKey, err := helixorg.NewHelixAPIKeys(helixStore, cfg).Service(ctx, orgID)
-	if err != nil {
-		return nil, "", fmt.Errorf("provision helix-org service api key: %w", err)
-	}
-	baseURL, err := cfg.GetString(ctx, orgID, "helix.url")
-	if err != nil {
-		return nil, "", fmt.Errorf("read helix.url: %w", err)
-	}
+) (*runtimehelix.WorkerProject, error) {
 	runtime, credentials, provider, model := resolveWorkerAgentConfig(ctx, orgID, cfg)
-	// HelixOrgMCPBackend.ServeHTTP parses `<org>/workers/<id>/mcp`
-	// from the suffix path, so the org segment is required in the
-	// URL Zed will dial. The previous form
-	// `/api/v1/mcp/helix-org/workers/<id>/mcp` made the backend read
-	// "workers" as the org slug and 404 every request — the helix-org
-	// MCP was effectively unreachable from inside the sandbox.
-	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
 	return &runtimehelix.WorkerProject{
 		Service:     projectSvc,
 		Store:       orgStore,
-		HelixOrgURL: helixOrgURL,
 		OrgID:       orgID,
 		Runtime:     runtime,
 		Credentials: credentials,
 		Provider:    provider,
 		Model:       model,
 		Logger:      logger,
-	}, apiKey, nil
+	}, nil
 }
 
 // resolveWorkerAgentConfig reads the atomic default agent config (or legacy
@@ -1393,31 +1363,24 @@ func workerRuntimeSupportsSubscription(runtime string) bool {
 	return runtime == "claude_code" || runtime == "codex_cli"
 }
 
-func repairHelixOrgMCPServiceKeys(ctx context.Context, orgID, serviceKey string, cfg *configregistry.Registry, st *helixorgstore.Store, projectSvc runtimehelix.ProjectService) error {
-	baseURL, err := cfg.GetString(ctx, orgID, "helix.url")
-	if err != nil {
-		return fmt.Errorf("read helix.url: %w", err)
-	}
+func removeLegacyHelixOrgMCPs(ctx context.Context, orgID string, st *helixorgstore.Store, projectSvc runtimehelix.ProjectService) error {
 	workers, err := st.Nodes.List(ctx, orgID)
 	if err != nil {
-		return fmt.Errorf("list bots for MCP service-key repair: %w", err)
+		return fmt.Errorf("list bots for legacy MCP cleanup: %w", err)
 	}
-	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
-	var repairErrors []error
+	var cleanupErrors []error
 	for _, worker := range workers {
 		if worker.AgentID == "" {
 			continue
 		}
-		if err := runtimehelix.AttachHelixOrgMCP(ctx, projectSvc, worker.AgentID, helixOrgURL, worker.ID, serviceKey); err != nil {
+		if err := runtimehelix.RemoveHelixOrgMCP(ctx, projectSvc, worker.AgentID); err != nil {
 			if errors.Is(err, helixstore.ErrNotFound) {
-				log.Warn().Str("org_id", orgID).Str("bot_id", worker.ID).Str("app_id", worker.AgentID).Msg("repair helix-org MCP service key skipped missing app")
 				continue
 			}
-			log.Warn().Err(err).Str("org_id", orgID).Str("bot_id", worker.ID).Str("app_id", worker.AgentID).Msg("repair helix-org MCP service key failed")
-			repairErrors = append(repairErrors, fmt.Errorf("repair helix-org MCP for bot %s: %w", worker.ID, err))
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove legacy helix-org MCP from bot %s: %w", worker.ID, err))
 		}
 	}
-	return errors.Join(repairErrors...)
+	return errors.Join(cleanupErrors...)
 }
 
 // buildHelixOrgSpawnerConfig assembles the SpawnerConfig for
@@ -1426,11 +1389,6 @@ func repairHelixOrgMCPServiceKeys(ctx context.Context, orgID, serviceKey string,
 // credentials — the in-sandbox Claude Code CLI authenticates
 // Anthropic via the operator's own OAuth, so we don't pass
 // Provider/Model and the Helix-side anthropic proxy doesn't need an
-// API key configured. HelixOrgURL points at our embedded MCP gateway
-// so the Zed sandbox can reach helix-org without external tunneling;
-// the service api_key is forwarded as the MCP Authorization header
-// so the gateway can authenticate the request.
-//
 // BearerForUser resolves the hiring user's id (persisted on the
 // Worker's runtime state by hire_worker) to a current api_key at
 // activation time. This is how every per-Worker Helix project +
@@ -1472,32 +1430,17 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 	if d.ProjectSvc == nil {
 		return runtimehelix.SpawnerConfig{}, fmt.Errorf("helix-org spawner: ProjectService is required")
 	}
-	apiKey, err := helixorg.NewHelixAPIKeys(d.HelixStore, d.Cfg).Service(ctx, orgID)
-	if err != nil {
-		return runtimehelix.SpawnerConfig{}, fmt.Errorf("provision helix-org service api key: %w", err)
-	}
-	baseURL, err := d.Cfg.GetString(ctx, orgID, "helix.url")
-	if err != nil {
-		return runtimehelix.SpawnerConfig{}, fmt.Errorf("read helix.url: %w", err)
-	}
-
 	runtime, credentials, provider, model := resolveWorkerAgentConfig(ctx, orgID, d.Cfg)
-	// HelixOrgMCPBackend.ServeHTTP parses `<org>/workers/<id>/mcp`
-	// from the suffix path, so the org segment is required in the
-	// URL Zed will dial.
-	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
 	specsMandate, _ := d.Cfg.GetString(ctx, orgID, "worker.specs_mandate")
 	return runtimehelix.SpawnerConfig{
 		Client:         d.SpawnerClient,
 		ProjectService: d.ProjectSvc,
-		HelixOrgURL:    helixOrgURL,
 		OrgID:          orgID,
 		OrgDisplayName: orgDisplayName(ctx, d.HelixStore, orgID),
 		Runtime:        runtime,
 		Credentials:    credentials,
 		Provider:       provider,
 		Model:          model,
-		MCPAuthBearer:  apiKey,
 		SpecsMandate:   specsMandate,
 		Store:          d.OrgStore,
 		Hub:            d.Hub,
@@ -1516,16 +1459,8 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 // SpawnerConfig, scoped to the activating org, on every activation.
 //
 // It MUST NOT cache a single inner Spawner across orgs. SpawnerConfig
-// carries tenant-specific identity — OrgID and HelixOrgURL
-// (`/api/v1/mcp/helix-org/<orgID>`) — which the inner spawner stamps
-// onto every Worker's project (applyReq.OrganizationID, the
-// HELIX_ORG_URL project secret) and, critically, onto the helix-org
-// MCP entry it re-attaches to the Worker's agent app on every
-// activation. A cached spawner freezes the *first* activating org's
-// identity and replays it for every other org, so org B's owner ends
-// up with an MCP pointing at org A's gateway — and create_role /
-// hire_worker land in org A. (Root cause of the cross-tenant leak; see
-// design/2026-06-09-org-multitenancy-spawner-leak.md.)
+// carries tenant-specific identity in OrgID. A cached spawner freezes the
+// first activating org's identity and replays it for every other org.
 //
 // Building per activation is cheap (a handful of config-registry
 // reads) and ensures newly provisioned apps use current org defaults.
@@ -1534,11 +1469,8 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 // preserved by minting one shared semaphore here and injecting it into
 // each per-activation config via SpawnerConfig.Sem.
 //
-// The dynamic applier still runs first: it provisions (or fast-paths)
-// the per-Worker project and attaches the MCP for owner-chat's benefit.
-// The inner spawner re-attaches the MCP after its own ensureProject
-// (ApplyProject wipes Config.Helix), so both must use the correct
-// per-org URL — which they now do.
+// The dynamic applier still runs first to provision or fast-path the
+// per-Worker project.
 func lazyHelixOrgSpawner(d spawnerDeps) runtime.Spawner {
 	// One inflight cap shared across every per-org spawner config.
 	sem := make(chan struct{}, runtimehelix.DefaultMaxInflight)
@@ -1563,7 +1495,6 @@ func lazyHelixOrgSpawner(d spawnerDeps) runtime.Spawner {
 		log.Trace().
 			Str("org_id", orgID).
 			Str("worker_id", string(workerID)).
-			Str("helix_org_url", cfgVal.HelixOrgURL).
 			Str("runtime", cfgVal.Runtime).
 			Str("credentials", cfgVal.Credentials).
 			Msg("helix-org spawner: per-org activation")

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -698,8 +698,7 @@ func (c *inProcHelixClient) CreateBranch(ctx context.Context, repoID, branch, ba
 	return nil
 }
 
-// GetAppConfig returns the typed config for an App. Used by
-// runtimehelix.AttachHelixOrgMCP to round-trip MCP entries.
+// GetAppConfig returns the typed config for an App.
 func (c *inProcHelixClient) GetAppConfig(ctx context.Context, id string) (types.AppConfig, error) {
 	r, err := c.newRequest(ctx, http.MethodGet, "/api/v1/agents/"+id, nil, map[string]string{"id": id})
 	if err != nil {
@@ -733,6 +732,28 @@ func (c *inProcHelixClient) UpdateAppConfig(ctx context.Context, id string, cfg 
 		return fmt.Errorf("update app %s: %w", id, err)
 	}
 	return nil
+}
+
+func (s *HelixAPIServer) publishAgentToolChange(ctx context.Context, appID string) {
+	app, err := s.Store.GetApp(ctx, appID)
+	if err != nil {
+		log.Warn().Err(err).Str("app_id", appID).Msg("tool change: failed to get linked agent")
+		return
+	}
+	sessions, _, err := s.Store.ListSessions(ctx, store.ListSessionsQuery{
+		Owner:                 app.Owner,
+		OwnerType:             app.OwnerType,
+		OrganizationID:        app.OrganizationID,
+		AppID:                 appID,
+		IncludeExternalAgents: true,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("app_id", appID).Msg("tool change: failed to list linked sessions")
+		return
+	}
+	for _, session := range sessions {
+		s.publishAgentConfigChange(ctx, session, "tools")
+	}
 }
 
 // DeleteProject soft-deletes a Helix project and stops any sessions

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -54,6 +54,7 @@ type helixOrgScope struct {
 	// wired.
 	humanReconcile func(ctx context.Context, orgID string) error
 	botRepair      func(ctx context.Context, orgID, serviceKey string) error
+	botTools       *nodes.Nodes
 
 	mu           sync.Mutex
 	bootstrapped map[string]bool
@@ -161,7 +162,10 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		// `reports` (issue #2546). Best-effort like the topology
 		// reconcile above: a failure logs and continues so a transient
 		// DB error doesn't lock users out of the org.
-		botsSvc := nodes.New(nodes.Deps{Nodes: s.orgStore.Nodes, BaseTools: mcptools.BaseReadTools})
+		botsSvc := s.botTools
+		if botsSvc == nil {
+			botsSvc = nodes.New(nodes.Deps{Nodes: s.orgStore.Nodes, BaseTools: mcptools.BaseReadTools})
+		}
 		if err := botsSvc.Reconcile(ctx, orgID); err != nil {
 			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org role reconcile failed")
 		}

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -54,6 +54,14 @@ type helixOrgRouteTestStore struct {
 	helixstore.Store
 	role          types.OrganizationRole
 	membershipErr error
+	session       *types.Session
+}
+
+func (s *helixOrgRouteTestStore) GetSession(_ context.Context, id string) (*types.Session, error) {
+	if s.session == nil || s.session.ID != id {
+		return nil, helixstore.ErrNotFound
+	}
+	return s.session, nil
 }
 
 type bootstrapActivationDispatcher struct {
@@ -202,18 +210,59 @@ func TestHelixOrgMCPBackendDoesNotRequireFeature(t *testing.T) {
 		if orgID := helixorgserver.OrgIDFromContext(r.Context()); orgID != "org_acme" {
 			t.Errorf("org ID context = %q, want org_acme", orgID)
 		}
+		if r.URL.Path != "/orgs/org_acme/workers/b-worker/mcp" {
+			t.Errorf("path = %q, want worker-bound MCP path", r.URL.Path)
+		}
 		w.WriteHeader(http.StatusNoContent)
 	})
-	server := &HelixAPIServer{Store: &helixOrgRouteTestStore{}}
+	server := &HelixAPIServer{Store: &helixOrgRouteTestStore{session: &types.Session{
+		ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme",
+		Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"},
+	}}}
 	backend := NewHelixOrgMCPBackend(server, &helixOrgHandlers{api: downstream, scope: scope})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/acme", nil)
-	req = mux.SetURLVars(req, map[string]string{"path": "acme"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/acme/workers/b-worker/mcp", nil)
+	req = mux.SetURLVars(req, map[string]string{"path": "acme/workers/b-worker/mcp"})
 	rec := httptest.NewRecorder()
 
-	backend.ServeHTTP(rec, req, &types.User{ID: "user-1"})
+	backend.ServeHTTP(rec, req, &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"})
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+}
+
+func TestHelixOrgMCPBackendRejectsSessionRouteMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		user    *types.User
+		session *types.Session
+	}{
+		{name: "requires session key", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1"}},
+		{name: "key org mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_other"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
+		{name: "session owner mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-other", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
+		{name: "session org mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_other", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
+		{name: "session worker mismatch", path: "acme/workers/b-other/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			scope := &helixOrgScope{bootstrapped: map[string]bool{"org_acme": true}}
+			server := &HelixAPIServer{Store: &helixOrgRouteTestStore{session: tt.session}}
+			backend := NewHelixOrgMCPBackend(server, &helixOrgHandlers{api: http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }), scope: scope})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/"+tt.path, nil)
+			req = mux.SetURLVars(req, map[string]string{"path": tt.path})
+			rec := httptest.NewRecorder()
+
+			backend.ServeHTTP(rec, req, tt.user)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+			}
+			if called {
+				t.Fatal("mismatched session reached helix-org handler")
+			}
+		})
 	}
 }
 

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -220,8 +220,8 @@ func TestHelixOrgMCPBackendDoesNotRequireFeature(t *testing.T) {
 		Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"},
 	}}}
 	backend := NewHelixOrgMCPBackend(server, &helixOrgHandlers{api: downstream, scope: scope})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/acme/workers/b-worker/mcp", nil)
-	req = mux.SetURLVars(req, map[string]string{"path": "acme/workers/b-worker/mcp"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org", nil)
+	req = mux.SetURLVars(req, map[string]string{"path": ""})
 	rec := httptest.NewRecorder()
 
 	backend.ServeHTTP(rec, req, &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"})
@@ -231,18 +231,20 @@ func TestHelixOrgMCPBackendDoesNotRequireFeature(t *testing.T) {
 	}
 }
 
-func TestHelixOrgMCPBackendRejectsSessionRouteMismatch(t *testing.T) {
+func TestHelixOrgMCPBackendRejectsInvalidSessionScope(t *testing.T) {
 	tests := []struct {
-		name    string
-		path    string
-		user    *types.User
-		session *types.Session
+		name       string
+		path       string
+		user       *types.User
+		session    *types.Session
+		wantStatus int
 	}{
-		{name: "requires session key", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1"}},
-		{name: "key org mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_other"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
-		{name: "session owner mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-other", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
-		{name: "session org mismatch", path: "acme/workers/b-worker/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_other", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
-		{name: "session worker mismatch", path: "acme/workers/b-other/mcp", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}},
+		{name: "rejects suffix", path: "acme/workers/b-worker/mcp", wantStatus: http.StatusBadRequest},
+		{name: "requires session key", user: &types.User{ID: "user-1"}, wantStatus: http.StatusForbidden},
+		{name: "key org mismatch", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_other"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}, wantStatus: http.StatusForbidden},
+		{name: "session owner mismatch", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-other", OrganizationID: "org_acme", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}, wantStatus: http.StatusForbidden},
+		{name: "requires session org", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", Metadata: types.SessionMetadata{OrgWorkerID: "b-worker"}}, wantStatus: http.StatusForbidden},
+		{name: "requires session worker", user: &types.User{ID: "user-1", TokenType: types.TokenTypeAPIKey, SessionID: "ses-worker", OrganizationID: "org_acme"}, session: &types.Session{ID: "ses-worker", Owner: "user-1", OrganizationID: "org_acme"}, wantStatus: http.StatusForbidden},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -250,14 +252,14 @@ func TestHelixOrgMCPBackendRejectsSessionRouteMismatch(t *testing.T) {
 			scope := &helixOrgScope{bootstrapped: map[string]bool{"org_acme": true}}
 			server := &HelixAPIServer{Store: &helixOrgRouteTestStore{session: tt.session}}
 			backend := NewHelixOrgMCPBackend(server, &helixOrgHandlers{api: http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }), scope: scope})
-			req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org/"+tt.path, nil)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/helix-org", nil)
 			req = mux.SetURLVars(req, map[string]string{"path": tt.path})
 			rec := httptest.NewRecorder()
 
 			backend.ServeHTTP(rec, req, tt.user)
 
-			if rec.Code != http.StatusForbidden {
-				t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
 			}
 			if called {
 				t.Fatal("mismatched session reached helix-org handler")

--- a/api/pkg/server/helix_org_spawner_test.go
+++ b/api/pkg/server/helix_org_spawner_test.go
@@ -45,13 +45,9 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 	helixorg.RegisterConfigSpecs(reg)
 
 	const orgID = "org-test"
-	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-test-key"`))
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 	store := helixstore.NewMockStore(gomock.NewController(t))
 	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
-		Return(&types.Organization{ID: orgID, Owner: "usr-owner"}, nil).Times(2)
-	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-test-key"}).
-		Return(&types.ApiKey{Key: "hlx-test-key", Owner: "usr-owner"}, nil)
+		Return(&types.Organization{ID: orgID, Owner: "usr-owner"}, nil)
 
 	_, _, projectSvc, _, _ := newInProcTestSetup(t)
 	hub := wakebus.New(pubsub.NewNoop())
@@ -73,76 +69,6 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 	// Same pointer round-tripped — confirms the builder copies the
 	// host-provided service, not some other one constructed inside.
 	require.Same(t, projectSvc, cfg.ProjectService.(*inProcHelixClient))
-}
-
-func TestBuildHelixOrgSpawnerConfig_ReplacesStaleServiceKey(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	const orgID = "org-test"
-	const ownerID = "usr-owner"
-
-	orgStore := orggorm.GetOrgTestDB(t)
-	reg := helixorgconfig.New(orgStore.Configs)
-	helixorg.RegisterConfigSpecs(reg)
-	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-stale"`))
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
-
-	store := helixstore.NewMockStore(gomock.NewController(t))
-	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
-		Return(&types.Organization{ID: orgID, Owner: ownerID}, nil).Times(2)
-	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-stale"}).
-		Return(nil, helixstore.ErrNotFound)
-	store.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: ownerID}).
-		Return(&types.User{ID: ownerID}, nil)
-	store.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) { return key, nil })
-
-	_, _, projectSvc, _, _ := newInProcTestSetup(t)
-	cfg, err := buildHelixOrgSpawnerConfig(ctx, orgID, spawnerDeps{
-		Cfg:        reg,
-		HelixStore: store,
-		ProjectSvc: projectSvc,
-		OrgStore:   orgStore,
-		Hub:        wakebus.New(pubsub.NewNoop()),
-		PubSub:     pubsub.NewNoop(),
-		Logger:     slog.Default(),
-		NewID:      func() string { return "id" },
-		Now:        func() time.Time { return time.Unix(0, 0).UTC() },
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, cfg.MCPAuthBearer)
-	require.NotEqual(t, "hlx-stale", cfg.MCPAuthBearer)
-	stored, err := reg.GetString(ctx, orgID, "helix.api_key")
-	require.NoError(t, err)
-	require.Equal(t, cfg.MCPAuthBearer, stored)
-}
-
-func TestBuildHelixOrgProjectApplier_ReplacesStaleServiceKey(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	const orgID = "org-test"
-	const ownerID = "usr-owner"
-
-	orgStore := orggorm.GetOrgTestDB(t)
-	reg := helixorgconfig.New(orgStore.Configs)
-	helixorg.RegisterConfigSpecs(reg)
-	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-stale"`))
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
-
-	store := helixstore.NewMockStore(gomock.NewController(t))
-	store.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: orgID}).
-		Return(&types.Organization{ID: orgID, Owner: ownerID}, nil)
-	store.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: "hlx-stale"}).
-		Return(nil, helixstore.ErrNotFound)
-	store.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: ownerID}).
-		Return(&types.User{ID: ownerID}, nil)
-	store.EXPECT().CreateAPIKey(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) { return key, nil })
-
-	_, bearer, err := buildHelixOrgProjectApplier(ctx, orgID, reg, store, nil, orgStore, slog.Default())
-	require.NoError(t, err)
-	require.NotEmpty(t, bearer)
-	require.NotEqual(t, "hlx-stale", bearer)
 }
 
 type mcpRepairProjectService struct {
@@ -167,7 +93,7 @@ func (s *mcpRepairProjectService) UpdateAppConfig(_ context.Context, appID strin
 	return nil
 }
 
-func TestRepairHelixOrgMCPServiceKeys_UpdatesLinkedApps(t *testing.T) {
+func TestRemoveLegacyHelixOrgMCPs_UpdatesLinkedApps(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	const orgID = "org-test"
@@ -178,20 +104,15 @@ func TestRepairHelixOrgMCPServiceKeys_UpdatesLinkedApps(t *testing.T) {
 	worker = worker.WithAgentID("app-worker")
 	require.NoError(t, orgStore.Nodes.Create(ctx, worker))
 
-	reg := helixorgconfig.New(orgStore.Configs)
-	helixorg.RegisterConfigSpecs(reg)
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 	svc := &mcpRepairProjectService{config: types.AppConfig{Helix: types.AppHelixConfig{
-		Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{{
-			Name: "helix", Headers: map[string]string{"Authorization": "Bearer hlx-stale"},
-		}}}},
+		Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{{Name: "helix"}, {Name: "other", URL: "stdio://other"}}}},
 	}}}
 
-	require.NoError(t, repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc))
-	require.Equal(t, "Bearer hlx-fresh", svc.updated.Helix.Assistants[0].MCPs[0].Headers["Authorization"])
+	require.NoError(t, removeLegacyHelixOrgMCPs(ctx, orgID, orgStore, svc))
+	require.Equal(t, []types.AssistantMCP{{Name: "other", URL: "stdio://other"}}, svc.updated.Helix.Assistants[0].MCPs)
 }
 
-func TestRepairHelixOrgMCPServiceKeys_ContinuesPastMissingApp(t *testing.T) {
+func TestRemoveLegacyHelixOrgMCPs_ContinuesPastMissingApp(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	const orgID = "org-test"
@@ -202,20 +123,17 @@ func TestRepairHelixOrgMCPServiceKeys_ContinuesPastMissingApp(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, orgStore.Nodes.Create(ctx, node.WithAgentID(worker.appID)))
 	}
-	reg := helixorgconfig.New(orgStore.Configs)
-	helixorg.RegisterConfigSpecs(reg)
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 	svc := &mcpRepairProjectService{
 		badApp:      "app-bad",
 		badAppError: helixstore.ErrNotFound,
-		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{}}}},
+		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{{Name: "helix"}}}}}},
 	}
 
-	require.NoError(t, repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc))
+	require.NoError(t, removeLegacyHelixOrgMCPs(ctx, orgID, orgStore, svc))
 	require.Equal(t, []string{"app-good"}, svc.updatedIDs)
 }
 
-func TestRepairHelixOrgMCPServiceKeys_RetriesAfterTransientAppFailure(t *testing.T) {
+func TestRemoveLegacyHelixOrgMCPs_ReturnsTransientAppFailure(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	const orgID = "org-test"
@@ -226,16 +144,13 @@ func TestRepairHelixOrgMCPServiceKeys_RetriesAfterTransientAppFailure(t *testing
 		require.NoError(t, err)
 		require.NoError(t, orgStore.Nodes.Create(ctx, node.WithAgentID(worker.appID)))
 	}
-	reg := helixorgconfig.New(orgStore.Configs)
-	helixorg.RegisterConfigSpecs(reg)
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 	svc := &mcpRepairProjectService{
 		badApp:      "app-bad",
 		badAppError: errors.New("database unavailable"),
-		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{}}}},
+		config:      types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{MCPs: []types.AssistantMCP{{Name: "helix"}}}}}},
 	}
 
-	err := repairHelixOrgMCPServiceKeys(ctx, orgID, "hlx-fresh", reg, orgStore, svc)
+	err := removeLegacyHelixOrgMCPs(ctx, orgID, orgStore, svc)
 	require.ErrorContains(t, err, "database unavailable")
 	require.Equal(t, []string{"app-good"}, svc.updatedIDs)
 }
@@ -254,8 +169,6 @@ func TestBuildHelixOrgSpawnerConfig_RejectsNilProjectService(t *testing.T) {
 	helixorg.RegisterConfigSpecs(reg)
 
 	const orgID = "org-test"
-	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-test-key"`))
-	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 
 	_, err := buildHelixOrgSpawnerConfig(ctx, orgID, spawnerDeps{
 		Cfg: reg,

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -42,12 +42,6 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 		Description: "Optional full activation mandate override. When empty, every activation embeds the Worker's current role content.",
 	})
 	r.Register(configregistry.Spec{
-		Key:         "helix.url",
-		Type:        configregistry.TypeString,
-		Default:     `"http://localhost:8080"`,
-		Description: "Base URL of the Helix server this org talks to. Defaults to localhost because we're embedded in the api container.",
-	})
-	r.Register(configregistry.Spec{
 		Key:         "helix.api_key",
 		Type:        configregistry.TypeString,
 		Description: "Fallback bearer token for the embedded helix-org client when no logged-in user is on the request. Auto-provisioned for the organization owner.",

--- a/api/pkg/server/helixorg/config_specs_test.go
+++ b/api/pkg/server/helixorg/config_specs_test.go
@@ -9,6 +9,14 @@ import (
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 )
 
+func TestRegisterConfigSpecsDoesNotExposeHelixURL(t *testing.T) {
+	reg := helixorgconfig.New(orggorm.GetOrgTestDB(t).Configs)
+	RegisterConfigSpecs(reg)
+	if _, ok := reg.Spec("helix.url"); ok {
+		t.Fatal("helix.url must not be registered")
+	}
+}
+
 // TestRegisterHelixOrgConfigSpecs_RedactsTransportGitHubSecrets pins
 // down the spec registration for `transport.github`: both `token` and
 // `webhook_secret` MUST be redacted on `config get`. Without this, a

--- a/api/pkg/server/mcp_backend_helix_org.go
+++ b/api/pkg/server/mcp_backend_helix_org.go
@@ -14,15 +14,9 @@ import (
 // HelixOrgMCPBackend exposes the embedded helix-org MCP server through
 // the Helix MCP gateway. The gateway sits behind Helix's standard auth
 // chain, so by the time we get a request here the user has already
-// been authenticated by api_key; we enforce org membership and forward
-// to the in-process helix-org handler.
-//
-// The backend honours a Worker ID embedded in the suffix path:
-// `/api/v1/mcp/helix-org/workers/<id>/mcp` routes to /workers/<id>/mcp
-// in helix-org. Callers that don't specify a Worker default to
-// `w-owner`. The Spawner uses this to scope
-// each Worker activation to its own MCP path so subscribe/publish
-// land on the activating Worker, not the owner.
+// been authenticated by api_key. Organization and Worker identity come only
+// from the stored session named by that key, never from caller-controlled URL
+// segments.
 type HelixOrgMCPBackend struct {
 	apiServer  *HelixAPIServer
 	orgHandler http.Handler
@@ -30,9 +24,7 @@ type HelixOrgMCPBackend struct {
 }
 
 // NewHelixOrgMCPBackend creates a backend that proxies to the in-process
-// helix-org server handler. Tenants are identified by URL prefix
-// (suffix path starts with `{org}/...`) so each per-Worker MCP call
-// scopes to the right helix-org.
+// helix-org server handler.
 func NewHelixOrgMCPBackend(apiServer *HelixAPIServer, orgHandlers *helixOrgHandlers) *HelixOrgMCPBackend {
 	return &HelixOrgMCPBackend{
 		apiServer:  apiServer,
@@ -42,49 +34,35 @@ func NewHelixOrgMCPBackend(apiServer *HelixAPIServer, orgHandlers *helixOrgHandl
 }
 
 // ServeHTTP implements MCPBackend. The MCP gateway has already
-// authenticated the request; this backend additionally binds the URL's org and
-// worker to the session-scoped key used by that worker's desktop.
+// authenticated the request; this backend resolves the org and worker from the
+// session-scoped key used by that worker's desktop.
 func (b *HelixOrgMCPBackend) ServeHTTP(w http.ResponseWriter, r *http.Request, user *types.User) {
-	// Parse the org segment + worker ID from the suffix path the gateway
-	// captured. Accept forms:
-	//   {org}/workers/<id>/mcp     (preferred — explicit)
-	//   {org}                      (defaults to w-owner inside that org)
 	suffix := strings.Trim(mux.Vars(r)["path"], "/")
-	if suffix == "" {
-		http.Error(w, "helix-org MCP: missing org in URL", http.StatusBadRequest)
-		return
-	}
-	parts := strings.Split(suffix, "/")
-	orgSlugOrID := parts[0]
-	workerID := "w-owner"
-	if len(parts) >= 4 && parts[1] == "workers" && parts[3] == "mcp" {
-		workerID = parts[2]
-	}
-	org, err := b.apiServer.lookupOrg(r.Context(), orgSlugOrID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+	if suffix != "" {
+		http.Error(w, "helix-org MCP does not accept a suffix path", http.StatusBadRequest)
 		return
 	}
 	if user == nil || user.TokenType != types.TokenTypeAPIKey || user.SessionID == "" {
 		http.Error(w, "session-scoped API key required for helix-org MCP access", http.StatusForbidden)
 		return
 	}
-	if _, err := b.apiServer.authorizeOrgMember(r.Context(), user, org.ID); err != nil {
+	session, err := b.apiServer.Store.GetSession(r.Context(), user.SessionID)
+	if err != nil || session == nil || session.Owner != user.ID || session.OrganizationID == "" || session.Metadata.OrgWorkerID == "" || user.OrganizationID != session.OrganizationID {
+		http.Error(w, "session is not authorized for helix-org MCP access", http.StatusForbidden)
+		return
+	}
+	if _, err := b.apiServer.authorizeOrgMember(r.Context(), user, session.OrganizationID); err != nil {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
-	session, err := b.apiServer.Store.GetSession(r.Context(), user.SessionID)
-	if err != nil || session == nil || user.OrganizationID != org.ID || session.Owner != user.ID || session.OrganizationID != org.ID || session.Metadata.OrgWorkerID != workerID {
-		http.Error(w, "session does not match helix-org MCP route", http.StatusForbidden)
-		return
-	}
-	if err := b.scope.ensureBootstrap(r.Context(), org.ID); err != nil {
+	if err := b.scope.ensureBootstrap(r.Context(), session.OrganizationID); err != nil {
 		http.Error(w, "bootstrap: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	rewritten := r.Clone(helixorgserver.WithOrgID(r.Context(), org.ID))
-	rewritten.URL.Path = "/orgs/" + org.ID + "/workers/" + workerID + "/mcp"
+	workerID := session.Metadata.OrgWorkerID
+	rewritten := r.Clone(helixorgserver.WithOrgID(r.Context(), session.OrganizationID))
+	rewritten.URL.Path = "/orgs/" + session.OrganizationID + "/workers/" + workerID + "/mcp"
 	rewritten.URL.RawPath = ""
 	rewritten.RequestURI = rewritten.URL.RequestURI()
 	// Forward the authenticated user's ID so helix-org tools can

--- a/api/pkg/server/mcp_backend_helix_org.go
+++ b/api/pkg/server/mcp_backend_helix_org.go
@@ -42,7 +42,8 @@ func NewHelixOrgMCPBackend(apiServer *HelixAPIServer, orgHandlers *helixOrgHandl
 }
 
 // ServeHTTP implements MCPBackend. The MCP gateway has already
-// authenticated the request; this backend additionally enforces org membership.
+// authenticated the request; this backend additionally binds the URL's org and
+// worker to the session-scoped key used by that worker's desktop.
 func (b *HelixOrgMCPBackend) ServeHTTP(w http.ResponseWriter, r *http.Request, user *types.User) {
 	// Parse the org segment + worker ID from the suffix path the gateway
 	// captured. Accept forms:
@@ -64,8 +65,17 @@ func (b *HelixOrgMCPBackend) ServeHTTP(w http.ResponseWriter, r *http.Request, u
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+	if user == nil || user.TokenType != types.TokenTypeAPIKey || user.SessionID == "" {
+		http.Error(w, "session-scoped API key required for helix-org MCP access", http.StatusForbidden)
+		return
+	}
 	if _, err := b.apiServer.authorizeOrgMember(r.Context(), user, org.ID); err != nil {
 		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	session, err := b.apiServer.Store.GetSession(r.Context(), user.SessionID)
+	if err != nil || session == nil || user.OrganizationID != org.ID || session.Owner != user.ID || session.OrganizationID != org.ID || session.Metadata.OrgWorkerID != workerID {
+		http.Error(w, "session does not match helix-org MCP route", http.StatusForbidden)
 		return
 	}
 	if err := b.scope.ensureBootstrap(r.Context(), org.ID); err != nil {

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -164,7 +164,7 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 	// pulls don't race UpdateApp and runner traffic doesn't bump
 	// app.UpdatedAt — the in-memory rewrite still feeds Generate below.
 	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot, user.TokenType != types.TokenTypeRunner)
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, session.OrganizationID, session.Metadata.OrgWorkerID)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, session.Metadata.OrgWorkerID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -504,7 +504,7 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	// providerSnapshot=nil here: this endpoint only exposes context_servers,
 	// which don't depend on provider resolution or model validation. The
 	// daemon hits /zed-config separately and handles those concerns there.
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, session.OrganizationID, session.Metadata.OrgWorkerID)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, session.Metadata.OrgWorkerID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -164,7 +164,7 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 	// pulls don't race UpdateApp and runner traffic doesn't bump
 	// app.UpdatedAt — the in-memory rewrite still feeds Generate below.
 	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot, user.TokenType != types.TokenTypeRunner)
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, session.OrganizationID, session.Metadata.OrgWorkerID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -504,7 +504,7 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	// providerSnapshot=nil here: this endpoint only exposes context_servers,
 	// which don't depend on provider resolution or model validation. The
 	// daemon hits /zed-config separately and handles those concerns there.
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, session.OrganizationID, session.Metadata.OrgWorkerID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")


### PR DESCRIPTION
## Summary
- expose the managed helix-org MCP at the fixed sandbox API endpoint `/api/v1/mcp/helix-org`
- derive organization and worker identity exclusively from the authenticated session-scoped API key
- remove legacy `helix.url`, project secret, spawner, and persisted app MCP plumbing
- refresh running agent settings when Bot tools or linked assets change

## Verification
- `go test ./pkg/external-agent ./pkg/org/application/assets ./pkg/org/interfaces/mcptools ./pkg/org/infrastructure/runtime/helix ./pkg/server/helixorg ./pkg/server -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`