### PR TITLE
fix(docker): run controlplane under tini so orphaned git processes get reaped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,9 @@ FROM api-base AS api-dev-env
 # - Air provides hot reload for Go
 RUN go install github.com/air-verse/air@v1.52.3
 # - Install curl for Wolf API debugging, bash for git operations, and git-daemon for git-http-backend
+# - tini is PID 1 so orphaned subprocesses get reaped (see production stage comment)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl bash git-daemon-sysvinit \
+    curl bash git-daemon-sysvinit tini \
     && rm -rf /var/lib/apt/lists/*
 # - Copy tokenizers library for CGo
 COPY --from=tokenizers-lib /app/lib/libtokenizers.a /usr/lib/
@@ -51,8 +52,8 @@ WORKDIR /app/api
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=1 go build -tags ORT -ldflags "-s -w" -o /helix
-# - Entrypoint is the air command
-ENTRYPOINT ["air", "--build.bin", "/helix", "--build.cmd", "CGO_ENABLED=1 go build -tags ORT -ldflags \"-s -w\" -o /helix", "--build.stop_on_error", "true", "--"]
+# - Entrypoint is the air command, under tini so orphans are reaped
+ENTRYPOINT ["/usr/bin/tini", "--", "air", "--build.bin", "/helix", "--build.cmd", "CGO_ENABLED=1 go build -tags ORT -ldflags \"-s -w\" -o /helix", "--build.stop_on_error", "true", "--"]
 CMD ["serve"]
 
 
@@ -110,7 +111,7 @@ RUN yarn build
 # Update digest when intentionally upgrading Debian version.
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates git git-daemon-sysvinit \
+    ca-certificates git git-daemon-sysvinit tini \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=api-build-env /helix /helix
@@ -128,4 +129,9 @@ ENV FRONTEND_URL=/www
 
 EXPOSE 80
 
-ENTRYPOINT ["/helix", "serve"]
+# tini runs as PID 1 and reaps orphaned processes. Helix shells out to git, and
+# git subcommands (pack-objects, index-pack, gc --auto) outlive their parent when
+# a clone/fetch is cancelled or when git detaches maintenance on purpose. Those
+# orphans reparent to PID 1; a Go binary (or air, in the dev image) never calls
+# wait() on them, so they pile up as zombies until the PID ceiling is hit.
+ENTRYPOINT ["/usr/bin/tini", "--", "/helix", "serve"]


### PR DESCRIPTION
## Problem

A production controlplane was found with **12,486 zombie `git` processes**, all parented to PID 1:

```
Tasks: 16310 total, … 12840 zombie
  12486 zombies, parent PID = PID 1
  comm: git (12466), containerd-shim (277), cloudflared (88), helix (20)
```

They burn no CPU, but each holds a PID and an exit status. The container has no `PidsLimit`, so this is an unbounded leak that makes `ps`/`top` crawl and will eventually hit the kernel PID ceiling.

## Root cause

PID 1 in the api container is `/helix serve` (production) or `air` (dev). Neither calls `wait()` on processes it didn't spawn, and in a PID namespace *all* orphans reparent to PID 1. Helix shells out to git constantly (`gitcmd`/gitea for upload-pack, receive-pack, show, ls-tree, diff…), and git subcommands routinely outlive their immediate parent:

- `exec.CommandContext` kills only the top-level pid on cancel — when a clone is aborted, `git upload-pack` dies but its `git pack-objects` child does not.
- `git gc --auto` / `git maintenance run --auto` detach *by design* and expect an init to reap them.

Both cases reparent to PID 1, which never reaps → permanent zombie.

## Fix

Make `tini` PID 1 in both the dev and production stages. Deliberately done in the image rather than via compose `init: true`, so docker compose (dev + prod) *and* the helm charts are all covered — the charts don't override `command`/`args`, so they inherit the image entrypoint.

## Testing

Rebuilt the dev image and recreated `helix-api-1` locally, which had accumulated 1,544 zombies (1,448 `git`) with `air` as PID 1:

```
$ docker exec helix-api-1 ps -eo pid,ppid,stat,comm
    PID    PPID STAT COMMAND
      1       0 Ss   tini
      7       1 Sl   air
     60       7 Ss+  sh
     61      60 Sl+  helix
     94      61 S    git
zombies: 0
```

Then explicitly orphaned a process inside the container (`sh -c "(sleep 3; true) & exit 0"`) and confirmed it was reaped rather than left as a zombie.

**NOT tested locally:** the production stage image — the prod build is what CI does on this PR. The change there is the same two lines (install `tini`, prepend `/usr/bin/tini --` to the entrypoint).

## Follow-ups (not in this PR)

- `helix-sandbox-nvidia-1` has the same class of leak (PID 1 is `tail` from `entrypoint.sh`, 18 zombie `containerd-shim` entries). Same one-line fix in `Dockerfile.sandbox`, but it needs a sandbox rebuild + test.
- Cancelling a clone still leaves `git pack-objects` *running* until it finishes, not just unreaped. tini stops the leak; killing the process group on cancel would stop the wasted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)