### PR TITLE
fix(frontend): make spec task toolbar fit narrow panels

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -32,6 +32,7 @@ import { useListOAuthProviders, useListOAuthConnections } from "../../services/o
 import { findOAuthProviderForType, findOAuthConnectionForProvider, hasRequiredScopes, vcsScopesForProvider } from "../../utils/oauthProviders";
 import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import CIStatusIcon from "./CIStatusIcon";
+import type { ToolbarDensity } from "./SpecTaskViewToolbar";
 
 export interface RepoPR {
   repository_id?: string;
@@ -148,6 +149,8 @@ interface SpecTaskActionButtonsProps {
   task: SpecTaskForActions;
   /** Whether to use compact/inline layout (for header bars) vs stacked layout (for cards) */
   variant?: "inline" | "stacked";
+  /** How much room the host toolbar has. Only applies to the inline variant. */
+  density?: ToolbarDensity;
   /** Called when Start Planning is clicked */
   onStartPlanning?: () => Promise<void>;
   /** Ref for the Start Planning button (for focus management) */
@@ -176,8 +179,18 @@ interface SpecTaskActionButtonsProps {
   blockedReason?: string;
 }
 
+const COMPACT_BUTTON_METRICS: Record<
+  ToolbarDensity,
+  { minWidth: number; height: number; icon: number; showLabel: boolean }
+> = {
+  comfortable: { minWidth: 72, height: 40, icon: 18, showLabel: true },
+  compact: { minWidth: 56, height: 36, icon: 16, showLabel: true },
+  tight: { minWidth: 34, height: 32, icon: 17, showLabel: false },
+};
+
 interface CompactActionButtonProps {
   tooltip?: string;
+  density?: ToolbarDensity;
   color?:
     | "inherit"
     | "primary"
@@ -203,6 +216,7 @@ interface CompactActionButtonProps {
 
 function CompactActionButton({
   tooltip = "",
+  density = "comfortable",
   color = "primary",
   variant = "contained",
   disabled = false,
@@ -218,8 +232,9 @@ function CompactActionButton({
   const anchorProps = href
     ? { component: "a" as const, href, target, rel }
     : {};
+  const metrics = COMPACT_BUTTON_METRICS[density];
   return (
-    <Tooltip title={tooltip} placement="top">
+    <Tooltip title={metrics.showLabel ? tooltip : tooltip || label} placement="top">
       <span style={{ width: fullWidth ? "100%" : "auto", display: "inline-flex" }}>
         <Button
           size="small"
@@ -228,14 +243,16 @@ function CompactActionButton({
           disabled={disabled}
           fullWidth={fullWidth}
           onClick={onClick}
+          aria-label={label}
           {...anchorProps}
           sx={{
-            minWidth: 72,
-            height: 40,
-            px: 1,
+            minWidth: metrics.minWidth,
+            height: metrics.height,
+            px: metrics.showLabel ? 1 : 0.5,
             py: 0.4,
             lineHeight: 1,
             textTransform: "none",
+            flexShrink: 0,
             ...sx,
           }}
         >
@@ -247,22 +264,25 @@ function CompactActionButton({
               gap: 0.2,
               lineHeight: 0,
               "& > svg": {
-                width: 18,
-                height: 18,
+                width: metrics.icon,
+                height: metrics.icon,
               },
             }}
           >
             {icon}
-            <Typography
-              sx={{
-                fontSize: "0.65rem",
-                lineHeight: 1,
-                fontWeight: 400,
-                textTransform: "none",
-              }}
-            >
-              {label}
-            </Typography>
+            {metrics.showLabel && (
+              <Typography
+                sx={{
+                  fontSize: density === "comfortable" ? "0.65rem" : "0.6rem",
+                  lineHeight: 1,
+                  fontWeight: 400,
+                  textTransform: "none",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {label}
+              </Typography>
+            )}
           </Box>
         </Button>
       </span>
@@ -278,6 +298,7 @@ function CompactActionButton({
 export default function SpecTaskActionButtons({
   task,
   variant = "stacked",
+  density = "comfortable",
   onStartPlanning,
   startPlanningButtonRef,
   onReviewSpec,
@@ -346,6 +367,12 @@ export default function SpecTaskActionButtons({
 
   const isArchived = task.archived ?? false;
   const isInline = variant === "inline";
+  const inlineRowSx = {
+    display: "flex",
+    alignItems: "center",
+    gap: density === "comfortable" ? 1 : 0.5,
+    flexShrink: 0,
+  } as const;
 
   // Determine if this is a direct-push scenario (branch same as base) vs PR workflow
   const isDirectPush =
@@ -431,8 +458,9 @@ export default function SpecTaskActionButtons({
 
     if (isInline) {
       return (
-        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+        <Box sx={inlineRowSx}>
           <CompactActionButton
+            density={density}
             tooltip={startTooltip}
             color="warning"
             icon={
@@ -449,7 +477,7 @@ export default function SpecTaskActionButtons({
             }}
             disabled={isStartDisabled}
           />
-          {!task.just_do_it_mode && skipLink}
+          {!task.just_do_it_mode && density === "comfortable" && skipLink}
         </Box>
       );
     }
@@ -496,34 +524,30 @@ export default function SpecTaskActionButtons({
   if (task.status === "spec_generation" && isInline) {
     const isSkipping = skipSpecMutation.isPending;
     return (
-      <Box sx={{ display: "flex", gap: 1 }}>
-        <Tooltip
-          title={isArchived ? "Task is archived" : "Skip planning and start implementation"}
-          placement="top"
-        >
-          <span>
-            <Button
-              variant="outlined"
-              size="small"
-              color="warning"
-              startIcon={
-                isSkipping ? (
-                  <CircularProgress size={18} color="inherit" />
-                ) : (
-                  <SkipIcon size={18} />
-                )
-              }
-              onClick={(e) => {
-                e.stopPropagation();
-                skipSpecMutation.mutate();
-              }}
-              disabled={isArchived || isSkipping}
-              sx={buttonSx}
-            >
-              {isSkipping ? "Skipping..." : "Skip Planning"}
-            </Button>
-          </span>
-        </Tooltip>
+      <Box sx={inlineRowSx}>
+        <CompactActionButton
+          density={density}
+          tooltip={
+            isArchived
+              ? "Task is archived"
+              : "Skip planning and start implementation"
+          }
+          variant="outlined"
+          color="warning"
+          icon={
+            isSkipping ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <SkipIcon size={18} />
+            )
+          }
+          label={isSkipping ? "Skipping..." : "Skip Planning"}
+          onClick={(e) => {
+            e.stopPropagation();
+            skipSpecMutation.mutate();
+          }}
+          disabled={isArchived || isSkipping}
+        />
       </Box>
     );
   }
@@ -536,8 +560,9 @@ export default function SpecTaskActionButtons({
   ) {
     if (isInline) {
       return (
-        <Box sx={{ display: "flex", gap: 1 }}>
+        <Box sx={inlineRowSx}>
           <CompactActionButton
+            density={density}
             tooltip={isArchived ? "Task is archived" : ""}
             color="secondary"
             icon={
@@ -654,8 +679,9 @@ export default function SpecTaskActionButtons({
 
     if (isInline) {
       return (
-        <Box sx={{ display: "flex", gap: 1 }}>
+        <Box sx={inlineRowSx}>
           <CompactActionButton
+            density={density}
             tooltip={isArchived ? "Task is archived" : !hasPushed ? "Waiting for agent to push code..." : ""}
             variant="outlined"
             color="error"
@@ -674,6 +700,7 @@ export default function SpecTaskActionButtons({
             }}
           />
           <CompactActionButton
+            density={density}
             tooltip={
               isArchived
                 ? "Task is archived"
@@ -708,6 +735,7 @@ export default function SpecTaskActionButtons({
           />
           {hasDesignDocs && onReviewSpec && (
             <CompactActionButton
+              density={density}
               tooltip={isArchived ? "Task is archived" : ""}
               variant="outlined"
               color="primary"
@@ -856,8 +884,9 @@ export default function SpecTaskActionButtons({
 
       if (isInline) {
         return (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <Box sx={inlineRowSx}>
             <CompactActionButton
+              density={density}
               tooltip={isArchived ? "Task is archived" : ""}
               variant="contained"
               color="secondary"
@@ -905,8 +934,9 @@ export default function SpecTaskActionButtons({
     if (hasMultiplePRs) {
       if (isInline) {
         return (
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={inlineRowSx}>
             <CompactActionButton
+              density={density}
               tooltip={isArchived ? "Task is archived" : `${pullRequests.length} Pull Requests`}
               variant="contained"
               color="secondary"

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -123,27 +123,16 @@ import { useClaudeSubscriptions } from "../account/ClaudeSubscriptionConnect";
 import ClaudeSubscriptionConnect from "../account/ClaudeSubscriptionConnect";
 import { getTokenExpiryStatus } from "../account/claudeSubscriptionUtils";
 import {
-  CloudUpload as CloudUploadLucide,
   FileText,
-  Files,
-  SlidersHorizontal,
-  GitCompare,
-  Globe2,
-  Lock as LockLucide,
-  LockOpen as LockOpenLucide,
-  MonitorPlay,
-  MessageSquare,
-  PanelBottom,
   PanelLeft,
   PanelRight,
-  Play as PlayLucide,
-  RotateCw,
-  Square,
-  EllipsisVertical,
   Wand2,
   Share,
-  X,
 } from "lucide-react";
+import SpecTaskViewToolbar, {
+  TaskView,
+  ToolbarDensity,
+} from "./SpecTaskViewToolbar";
 
 import { getAutoOpenedSpecTasks, addAutoOpenedSpecTask } from "../../lib/specTaskAutoOpen";
 import { loadPanelLayout, savePanelLayout } from "../../lib/panelLayoutStorage";
@@ -202,7 +191,6 @@ const taskDetailsTextFieldSx = {
 
 type TaskTextField = "name" | "description";
 type TaskTextSaveStatus = "idle" | "saving" | "saved" | "error";
-type TaskView = "chat" | "desktop" | "browser" | "changes" | "files" | "details";
 
 interface SpecTaskDetailContentProps {
   taskId: string;
@@ -573,8 +561,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [selectedCloneGroupId, setSelectedCloneGroupId] = useState<
     string | null
   >(null);
-  const [actionMenuAnchorEl, setActionMenuAnchorEl] =
-    useState<HTMLElement | null>(null);
 
   // Archive state
   const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
@@ -1302,11 +1288,15 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     onTaskArchived,
   ]);
 
-  const renderTaskActions = (variant: "inline" | "stacked") => {
+  const renderTaskActions = (
+    variant: "inline" | "stacked",
+    density: ToolbarDensity = "comfortable",
+  ) => {
     if (!task) return null;
 
     return (
       <SpecTaskActionButtons
+        density={density}
         task={{
           id: task.id || "",
           status: task.status || "",
@@ -2209,19 +2199,56 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     />
   ) : undefined;
 
-  const terminalToggleButton = activeSessionId ? (
-    <Tooltip title="Toggle terminal drawer (Ctrl/Cmd+J)">
-      <IconButton
-        size="small"
-        onClick={toggleTerminalDrawer}
-        sx={taskToolbarIconButtonSx}
-        aria-label="Toggle terminal drawer"
-        aria-pressed={terminalDrawerState.open}
-      >
-        <PanelBottom size={18} />
-      </IconButton>
-    </Tooltip>
-  ) : null;
+  // Task-level actions that live in the toolbar's overflow menu alongside the
+  // desktop controls that fold into it on narrow layouts.
+  const renderTaskMenuItems = (closeMenu: () => void) => {
+    const items: React.ReactNode[] = [];
+    if (task?.design_docs_pushed_at) {
+      items.push(
+        <MenuItem
+          key="share-design-docs"
+          onClick={() => {
+            closeMenu();
+            setShareDialogOpen(true);
+          }}
+        >
+          <ListItemIcon>
+            <Share size={18} />
+          </ListItemIcon>
+          <ListItemText>Share Design Docs</ListItemText>
+        </MenuItem>,
+        <MenuItem
+          key="clone-task"
+          onClick={() => {
+            closeMenu();
+            setShowCloneDialog(true);
+          }}
+        >
+          <ListItemIcon>
+            <Wand2 size={18} />
+          </ListItemIcon>
+          <ListItemText>Clone Task</ListItemText>
+        </MenuItem>,
+      );
+    }
+    if (task?.clone_group_id) {
+      items.push(
+        <MenuItem
+          key="clone-group"
+          onClick={() => {
+            closeMenu();
+            setSelectedCloneGroupId(task.clone_group_id || null);
+          }}
+        >
+          <ListItemIcon>
+            <AccountTree sx={{ fontSize: 18 }} />
+          </ListItemIcon>
+          <ListItemText>View Batch Clone Progress</ListItemText>
+        </MenuItem>,
+      );
+    }
+    return items.length > 0 ? items : null;
+  };
 
   if (!task) {
     return (
@@ -2521,259 +2548,37 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 }}
               >
                 {/* View toggle header - above content area only */}
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    px: 1,
-                    pt: 1,
-                    pb: 0.5,
-                    minHeight: 53,
-                    flexShrink: 0,
-                    boxSizing: "border-box",
-                    borderBottom: "1px solid",
-                    borderColor: "divider",
-                    backgroundColor: "background.paper",
-                    gap: 1,
-                  }}
-                >
-                  {/* Left: View toggle icons */}
-                  <ToggleButtonGroup
-                    value={currentView}
-                    exclusive
-                    onChange={(_, newView) => handleViewChange(newView)}
-                    size="small"
-                    sx={{
-                      "& .MuiToggleButton-root": {
-                        width: 56,
-                        height: 40,
-                        minWidth: 56,
-                        p: 0,
-                        border: "none",
-                        borderRadius: "4px !important",
-                        textTransform: "none",
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "center",
-                        gap: 0.2,
-                        "&.Mui-selected": {
-                          backgroundColor: "action.selected",
-                        },
-                      },
-                    }}
-                  >
-                    <ToggleButton value="desktop" aria-label="Desktop view">
-                      <MonitorPlay size={18} />
-                      <Typography
-                        sx={{
-                          fontSize: "0.65rem",
-                          lineHeight: 1,
-                          fontWeight: 400,
-                          textTransform: "none",
-                        }}
-                      >
-                        Desktop
-                      </Typography>
-                    </ToggleButton>
-                    <ToggleButton value="browser" aria-label="Browser view">
-                      <Globe2 size={18} />
-                      <Typography
-                        sx={{
-                          fontSize: "0.65rem",
-                          lineHeight: 1,
-                          fontWeight: 400,
-                          textTransform: "none",
-                        }}
-                      >
-                        Browser
-                      </Typography>
-                    </ToggleButton>
-                    <ToggleButton value="changes" aria-label="Diff view">
-                      <GitCompare size={18} />
-                      <Typography
-                        sx={{
-                          fontSize: "0.65rem",
-                          lineHeight: 1,
-                          fontWeight: 400,
-                          textTransform: "none",
-                        }}
-                      >
-                        Diff
-                      </Typography>
-                    </ToggleButton>
-                    <ToggleButton value="files" aria-label="Files view">
-                      <Files size={18} />
-                      <Typography
-                        sx={{
-                          fontSize: "0.65rem",
-                          lineHeight: 1,
-                          fontWeight: 400,
-                          textTransform: "none",
-                        }}
-                      >
-                        Files
-                      </Typography>
-                    </ToggleButton>
-                    <ToggleButton value="details" aria-label="Details view">
-                      <SlidersHorizontal size={18} />
-                      <Typography
-                        sx={{
-                          fontSize: "0.65rem",
-                          lineHeight: 1,
-                          fontWeight: 400,
-                          textTransform: "none",
-                        }}
-                      >
-                        Details
-                      </Typography>
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-
-                  {/* Status-specific action buttons */}
-                  {renderTaskActions("inline")}
-
-                  {/* Spacer */}
-                  <Box sx={{ flex: 1 }} />
-
-                  {/* Right: Action buttons */}
-                  <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
-                    <>
-                        {terminalToggleButton}
-                        {/* Show Start button when desktop is paused */}
-                        {effectiveIsDesktopPaused && (
-                          <Tooltip title="Start desktop">
-                            <IconButton
-                              size="small"
-                              aria-label="Start desktop"
-                              onClick={handleStartSession}
-                              disabled={isStarting || isDesktopStarting}
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              {isStarting || isDesktopStarting ? (
-                                <CircularProgress size={16} />
-                              ) : (
-                                <PlayLucide size={18} />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {/* Show Stop button when desktop is running */}
-                        {isDesktopRunning && (
-                          <Tooltip title="Stop desktop">
-                            <IconButton
-                              size="small"
-                              aria-label="Stop desktop"
-                              onClick={() => setStopConfirmOpen(true)}
-                              disabled={isStopping}
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              {isStopping ? (
-                                <CircularProgress size={16} />
-                              ) : (
-                                <Square size={18} fill="currentColor" />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {/* Show Restart button only when desktop is running */}
-                        {isDesktopRunning && (
-                          <Tooltip title="Restart agent session">
-                            <IconButton
-                              size="small"
-                              aria-label="Restart agent session"
-                              onClick={() => setRestartConfirmOpen(true)}
-                              disabled={isRestarting}
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              {isRestarting ? (
-                                <CircularProgress size={16} />
-                              ) : (
-                                <RotateCw size={18} />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {/* Show Keep Alive toggle when desktop is running */}
-                        {isDesktopRunning && (
-                          <Tooltip
-                            title={
-                              task.keep_alive
-                                ? "Keep Alive ON — won't auto-sleep"
-                                : "Keep Alive OFF — will auto-sleep when idle"
-                            }
-                          >
-                            <IconButton
-                              size="small"
-                              aria-label={task.keep_alive ? "Disable keep alive" : "Enable keep alive"}
-                              onClick={handleToggleKeepAlive}
-                              disabled={updateSpecTask.isPending}
-                              sx={taskToolbarIconButtonSx}
-                              aria-pressed={task.keep_alive}
-                            >
-                              {task.keep_alive ? (
-                                <LockLucide size={18} />
-                              ) : (
-                                <LockOpenLucide size={18} />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {/* Show Upload button only when desktop is running */}
-                        {isDesktopRunning && (
-                          <Tooltip title="Upload files to sandbox">
-                            <IconButton
-                              size="small"
-                              aria-label="Upload files to sandbox"
-                              onClick={handleUploadClick}
-                              disabled={isUploading}
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              {isUploading ? (
-                                <CircularProgress size={16} />
-                              ) : (
-                                <CloudUploadLucide size={18} />
-                              )}
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                        {(task.design_docs_pushed_at || task.clone_group_id) && (
-                          <Tooltip title="More actions">
-                            <IconButton
-                              size="small"
-                              aria-label="More actions"
-                              onClick={(event) =>
-                                setActionMenuAnchorEl(event.currentTarget)
-                              }
-                              sx={taskToolbarIconButtonSx}
-                            >
-                              <EllipsisVertical size={18} />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                    </>
-                    {allowContentCollapse ? (
-                      <Tooltip title="Collapse task panel">
-                        <IconButton
-                          size="small"
-                          aria-label="Collapse task panel"
-                          onClick={collapseContentPanel}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          <PanelRight size={18} />
-                        </IconButton>
-                      </Tooltip>
-                    ) : onClose ? (
-                      <IconButton
-                        size="small"
-                        onClick={onClose}
-                        sx={taskToolbarIconButtonSx}
-                      >
-                        <X size={18} />
-                      </IconButton>
-                    ) : null}
-                  </Box>
-                </Box>
+                <SpecTaskViewToolbar
+                  currentView={currentView}
+                  onViewChange={handleViewChange}
+                  hasSession
+                  renderActions={(density) =>
+                    renderTaskActions("inline", density)
+                  }
+                  onToggleTerminal={toggleTerminalDrawer}
+                  terminalOpen={terminalDrawerState.open}
+                  showStart={effectiveIsDesktopPaused}
+                  onStart={handleStartSession}
+                  startBusy={isStarting || isDesktopStarting}
+                  showStop={isDesktopRunning}
+                  onStop={() => setStopConfirmOpen(true)}
+                  stopBusy={isStopping}
+                  showRestart={isDesktopRunning}
+                  onRestart={() => setRestartConfirmOpen(true)}
+                  restartBusy={isRestarting}
+                  showKeepAlive={isDesktopRunning}
+                  keepAlive={task.keep_alive}
+                  onToggleKeepAlive={handleToggleKeepAlive}
+                  keepAliveBusy={updateSpecTask.isPending}
+                  showUpload={isDesktopRunning}
+                  onUpload={handleUploadClick}
+                  uploadBusy={isUploading}
+                  renderMenuItems={renderTaskMenuItems}
+                  onCollapsePanel={
+                    allowContentCollapse ? collapseContentPanel : undefined
+                  }
+                  onClosePanel={allowContentCollapse ? undefined : onClose}
+                />
 
                 {/* In split-view layout, "chat" falls through to desktop since chat
                     is already visible in the left panel */}
@@ -2870,278 +2675,47 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             {/* Mobile layout OR no active session: single view at a time */}
             {/* A toolbar is useful only when there are multiple session views. */}
             {activeSessionId && (
-              <Box
-                sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                flexWrap: "wrap",
-                px: 1,
-                pt: 1,
-                pb: 0.5,
-                minHeight: 53,
-                flexShrink: 0,
-                boxSizing: "border-box",
-                borderBottom: "1px solid",
-                borderColor: "divider",
-                backgroundColor: "background.paper",
-                gap: 0.5,
-                }}
-              >
-              {/* Left: View toggle icons */}
-              <ToggleButtonGroup
-                value={currentView}
-                exclusive
-                onChange={(_, newView) => handleViewChange(newView)}
-                size="small"
-                sx={{
-                  flexShrink: 0,
-                  "& .MuiToggleButton-root": {
-                    py: 0.35,
-                    px: 0.7,
-                    minWidth: 56,
-                    border: "none",
-                    borderRadius: "4px !important",
-                    textTransform: "none",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: 0.15,
-                    "&.Mui-selected": {
-                      backgroundColor: "action.selected",
-                    },
-                  },
-                }}
-              >
-                {/* Chat tab - only on mobile when there's an active session */}
-                {activeSessionId && (
-                  <ToggleButton value="chat" aria-label="Chat view">
-                    <MessageSquare size={18} />
-                    <Typography
-                      sx={{
-                        fontSize: "0.65rem",
-                        lineHeight: 1,
-                        fontWeight: 400,
-                        textTransform: "none",
-                      }}
-                    >
-                      Chat
-                    </Typography>
-                  </ToggleButton>
-                )}
-                {activeSessionId && (
-                  <ToggleButton value="desktop" aria-label="Desktop view">
-                    <MonitorPlay size={18} />
-                    <Typography
-                      sx={{
-                        fontSize: "0.65rem",
-                        lineHeight: 1,
-                        fontWeight: 400,
-                        textTransform: "none",
-                      }}
-                    >
-                      Desktop
-                    </Typography>
-                  </ToggleButton>
-                )}
-                {activeSessionId && (
-                  <ToggleButton value="browser" aria-label="Browser view">
-                    <Globe2 size={18} />
-                    <Typography
-                      sx={{
-                        fontSize: "0.65rem",
-                        lineHeight: 1,
-                        fontWeight: 400,
-                        textTransform: "none",
-                      }}
-                    >
-                      Browser
-                    </Typography>
-                  </ToggleButton>
-                )}
-                {activeSessionId && (
-                  <ToggleButton value="changes" aria-label="Diff view">
-                    <GitCompare size={18} />
-                    <Typography
-                      sx={{
-                        fontSize: "0.65rem",
-                        lineHeight: 1,
-                        fontWeight: 400,
-                        textTransform: "none",
-                      }}
-                    >
-                      Diff
-                    </Typography>
-                  </ToggleButton>
-                )}
-                {activeSessionId && (
-                  <ToggleButton value="files" aria-label="Files view">
-                    <Files size={18} />
-                    <Typography
-                      sx={{
-                        fontSize: "0.65rem",
-                        lineHeight: 1,
-                        fontWeight: 400,
-                        textTransform: "none",
-                      }}
-                    >
-                      Files
-                    </Typography>
-                  </ToggleButton>
-                )}
-                <ToggleButton value="details" aria-label="Details view">
-                  <SlidersHorizontal size={18} />
-                  <Typography
-                    sx={{
-                      fontSize: "0.65rem",
-                      lineHeight: 1,
-                      fontWeight: 400,
-                      textTransform: "none",
-                    }}
-                  >
-                    Details
-                  </Typography>
-                </ToggleButton>
-              </ToggleButtonGroup>
-
-              {/* Status-specific action buttons */}
-              {renderTaskActions("inline")}
-
-              {/* Spacer - hidden on very small screens to allow wrapping */}
-              <Box sx={{ flex: 1, minWidth: { xs: 0, sm: 8 } }} />
-
-              {/* Right: Action buttons */}
-              <Box
-                sx={{
-                  display: "flex",
-                  gap: 0.25,
-                  alignItems: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <>
-                    {isBigScreen && chatCollapsed && (
-                      <Tooltip title="Restore split view">
-                        <IconButton
-                          size="small"
-                          aria-label="Restore split view"
-                          onClick={() => setChatCollapsed(false)}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          <PanelLeft size={18} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {terminalToggleButton}
-                    {/* Show Start button when desktop is paused */}
-                    {activeSessionId && effectiveIsDesktopPaused && (
-                      <Tooltip title="Start desktop">
-                        <IconButton
-                          size="small"
-                          aria-label="Start desktop"
-                          onClick={handleStartSession}
-                          disabled={isStarting || isDesktopStarting}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          {isStarting || isDesktopStarting ? (
-                            <CircularProgress size={16} />
-                          ) : (
-                            <PlayLucide size={18} />
-                          )}
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {/* Show Stop button when desktop is running */}
-                    {activeSessionId && isDesktopRunning && (
-                      <Tooltip title="Stop desktop">
-                        <IconButton
-                          size="small"
-                          aria-label="Stop desktop"
-                          onClick={() => setStopConfirmOpen(true)}
-                          disabled={isStopping}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          {isStopping ? (
-                            <CircularProgress size={16} />
-                          ) : (
-                            <Square size={18} fill="currentColor" />
-                          )}
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {/* Show Restart button only when desktop is running */}
-                    {activeSessionId && isDesktopRunning && (
-                      <Tooltip title="Restart agent session">
-                        <IconButton
-                          size="small"
-                          aria-label="Restart agent session"
-                          onClick={() => setRestartConfirmOpen(true)}
-                          disabled={isRestarting}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          {isRestarting ? (
-                            <CircularProgress size={16} />
-                          ) : (
-                            <RotateCw size={18} />
-                          )}
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {/* Show Upload button only when desktop is running */}
-                    {activeSessionId && isDesktopRunning && (
-                      <Tooltip title="Upload files to sandbox">
-                        <IconButton
-                          size="small"
-                          aria-label="Upload files to sandbox"
-                          onClick={handleUploadClick}
-                          disabled={isUploading}
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          {isUploading ? (
-                            <CircularProgress size={16} />
-                          ) : (
-                            <CloudUploadLucide size={18} />
-                          )}
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                    {(task.design_docs_pushed_at || task.clone_group_id) && (
-                      <Tooltip title="More actions">
-                        <IconButton
-                          size="small"
-                          aria-label="More actions"
-                          onClick={(event) =>
-                            setActionMenuAnchorEl(event.currentTarget)
-                          }
-                          sx={taskToolbarIconButtonSx}
-                        >
-                          <EllipsisVertical size={18} />
-                        </IconButton>
-                      </Tooltip>
-                    )}
-                </>
-                {allowContentCollapse && isBigScreen && activeSessionId ? (
-                  <Tooltip title="Collapse task panel">
-                    <IconButton
-                      size="small"
-                      aria-label="Collapse task panel"
-                      onClick={collapseContentPanel}
-                      sx={taskToolbarIconButtonSx}
-                    >
-                      <PanelRight size={18} />
-                    </IconButton>
-                  </Tooltip>
-                ) : onClose ? (
-                  <IconButton
-                    size="small"
-                    onClick={onClose}
-                    sx={taskToolbarIconButtonSx}
-                  >
-                    <X size={18} />
-                  </IconButton>
-                ) : null}
-              </Box>
-              </Box>
+              <SpecTaskViewToolbar
+                currentView={currentView}
+                onViewChange={handleViewChange}
+                hasSession
+                showChatTab
+                renderActions={(density) =>
+                  renderTaskActions("inline", density)
+                }
+                onToggleTerminal={toggleTerminalDrawer}
+                terminalOpen={terminalDrawerState.open}
+                showStart={effectiveIsDesktopPaused}
+                onStart={handleStartSession}
+                startBusy={isStarting || isDesktopStarting}
+                showStop={isDesktopRunning}
+                onStop={() => setStopConfirmOpen(true)}
+                stopBusy={isStopping}
+                showRestart={isDesktopRunning}
+                onRestart={() => setRestartConfirmOpen(true)}
+                restartBusy={isRestarting}
+                showKeepAlive={isDesktopRunning}
+                keepAlive={task.keep_alive}
+                onToggleKeepAlive={handleToggleKeepAlive}
+                keepAliveBusy={updateSpecTask.isPending}
+                showUpload={isDesktopRunning}
+                onUpload={handleUploadClick}
+                uploadBusy={isUploading}
+                renderMenuItems={renderTaskMenuItems}
+                onRestoreSplit={
+                  isBigScreen && chatCollapsed
+                    ? () => setChatCollapsed(false)
+                    : undefined
+                }
+                onCollapsePanel={
+                  allowContentCollapse && isBigScreen
+                    ? collapseContentPanel
+                    : undefined
+                }
+                onClosePanel={
+                  allowContentCollapse && isBigScreen ? undefined : onClose
+                }
+              />
             )}
 
             {/* Chat View - mobile only */}
@@ -3420,52 +2994,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           </Button>
         </DialogActions>
       </Dialog>
-
-      <Menu
-        anchorEl={actionMenuAnchorEl}
-        open={Boolean(actionMenuAnchorEl)}
-        onClose={() => setActionMenuAnchorEl(null)}
-      >
-        {task?.design_docs_pushed_at && (
-          <MenuItem
-            onClick={() => {
-              setActionMenuAnchorEl(null);
-              setShareDialogOpen(true);
-            }}
-          >
-            <ListItemIcon>
-              <Share size={18} />
-            </ListItemIcon>
-            <ListItemText>Share Design Docs</ListItemText>
-          </MenuItem>
-        )}
-        {task?.design_docs_pushed_at && (
-          <MenuItem
-            onClick={() => {
-              setActionMenuAnchorEl(null);
-              setShowCloneDialog(true);
-            }}
-          >
-            <ListItemIcon>
-              <Wand2 size={18} />
-            </ListItemIcon>
-            <ListItemText>Clone Task</ListItemText>
-          </MenuItem>
-        )}
-        {task?.clone_group_id && (
-          <MenuItem
-            onClick={() => {
-              setActionMenuAnchorEl(null);
-              setSelectedCloneGroupId(task.clone_group_id || null);
-            }}
-          >
-            <ListItemIcon>
-              <AccountTree sx={{ fontSize: 18 }} />
-            </ListItemIcon>
-            <ListItemText>View Batch Clone Progress</ListItemText>
-          </MenuItem>
-        )}
-      </Menu>
 
       {/* Clone Task Dialog */}
       <CloneTaskDialog

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
@@ -1,0 +1,500 @@
+import React, { ReactNode, useState } from "react";
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  CloudUpload,
+  EllipsisVertical,
+  Files,
+  Globe2,
+  Lock,
+  LockOpen,
+  LucideIcon,
+  MessageSquare,
+  MonitorPlay,
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  GitCompare,
+  Play,
+  RotateCw,
+  SlidersHorizontal,
+  Square,
+  X,
+} from "lucide-react";
+import { useElementWidth } from "../../hooks/useElementWidth";
+
+export type TaskView =
+  | "chat"
+  | "desktop"
+  | "browser"
+  | "changes"
+  | "files"
+  | "details";
+
+/**
+ * How much room the toolbar has. Derived from the toolbar's own measured width
+ * (not the viewport) because in split view the toolbar only occupies the right
+ * panel — a wide window can still leave it very narrow.
+ */
+export type ToolbarDensity = "comfortable" | "compact" | "tight";
+
+const COMPACT_BELOW = 660;
+const TIGHT_BELOW = 460;
+
+export function toolbarDensityForWidth(width: number): ToolbarDensity {
+  // Before the first measurement assume the roomiest layout; wrapping covers
+  // the single frame before the ResizeObserver reports.
+  if (width === 0) return "comfortable";
+  if (width < TIGHT_BELOW) return "tight";
+  if (width < COMPACT_BELOW) return "compact";
+  return "comfortable";
+}
+
+const TAB_METRICS: Record<
+  ToolbarDensity,
+  { width: number; height: number; icon: number; showLabel: boolean }
+> = {
+  comfortable: { width: 56, height: 40, icon: 18, showLabel: true },
+  compact: { width: 46, height: 36, icon: 16, showLabel: true },
+  tight: { width: 32, height: 32, icon: 16, showLabel: false },
+};
+
+const ICON_BUTTON_METRICS: Record<
+  ToolbarDensity,
+  { size: number; icon: number }
+> = {
+  comfortable: { size: 30, icon: 18 },
+  compact: { size: 28, icon: 16 },
+  tight: { size: 28, icon: 16 },
+};
+
+export function toolbarIconButtonSx(density: ToolbarDensity) {
+  const { size, icon } = ICON_BUTTON_METRICS[density];
+  return {
+    width: size,
+    height: size,
+    minWidth: size,
+    minHeight: size,
+    p: 0.5,
+    flexShrink: 0,
+    color: "text.secondary",
+    "& svg": { width: icon, height: icon },
+    "&:hover": {
+      color: "text.primary",
+      backgroundColor: "action.hover",
+    },
+    '&[aria-pressed="true"]': {
+      backgroundColor: "action.selected",
+    },
+  } as const;
+}
+
+interface ViewTab {
+  value: TaskView;
+  label: string;
+  icon: LucideIcon;
+  /** Only meaningful while the task has a session (desktop, diff, files, …). */
+  sessionOnly: boolean;
+  /** Chat is a tab only when chat has no panel of its own. */
+  chatOnly?: boolean;
+}
+
+const VIEW_TABS: ViewTab[] = [
+  {
+    value: "chat",
+    label: "Chat",
+    icon: MessageSquare,
+    sessionOnly: true,
+    chatOnly: true,
+  },
+  { value: "desktop", label: "Desktop", icon: MonitorPlay, sessionOnly: true },
+  { value: "browser", label: "Browser", icon: Globe2, sessionOnly: true },
+  { value: "changes", label: "Diff", icon: GitCompare, sessionOnly: true },
+  { value: "files", label: "Files", icon: Files, sessionOnly: true },
+  {
+    value: "details",
+    label: "Details",
+    icon: SlidersHorizontal,
+    sessionOnly: false,
+  },
+];
+
+/** A secondary control: an icon button while there is room, a menu item otherwise. */
+interface SecondaryControl {
+  key: string;
+  label: string;
+  tooltip?: string;
+  icon: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  busy?: boolean;
+  pressed?: boolean;
+  /** Kept inline at every density — the primary desktop lifecycle action. */
+  primary?: boolean;
+}
+
+export interface SpecTaskViewToolbarProps {
+  currentView: TaskView;
+  onViewChange: (view: TaskView | null) => void;
+  /** Whether the task has a live session (gates the session-only tabs). */
+  hasSession: boolean;
+  /** Show the Chat tab (single-column layouts where chat has no panel). */
+  showChatTab?: boolean;
+  /** Status-specific action buttons (Reject / Open PR / …). */
+  renderActions?: (density: ToolbarDensity) => ReactNode;
+
+  onToggleTerminal?: () => void;
+  terminalOpen?: boolean;
+
+  showStart?: boolean;
+  onStart?: () => void;
+  startBusy?: boolean;
+
+  showStop?: boolean;
+  onStop?: () => void;
+  stopBusy?: boolean;
+
+  showRestart?: boolean;
+  onRestart?: () => void;
+  restartBusy?: boolean;
+
+  showKeepAlive?: boolean;
+  keepAlive?: boolean;
+  onToggleKeepAlive?: () => void;
+  keepAliveBusy?: boolean;
+
+  showUpload?: boolean;
+  onUpload?: () => void;
+  uploadBusy?: boolean;
+
+  /** Restore a collapsed chat panel (split-view layouts only). */
+  onRestoreSplit?: () => void;
+
+  /** Extra items appended to the overflow menu (Share, Clone, …). */
+  renderMenuItems?: (closeMenu: () => void) => ReactNode;
+
+  /** Trailing control: collapse the content panel. Takes precedence over close. */
+  onCollapsePanel?: () => void;
+  /** Trailing control: close the task view. */
+  onClosePanel?: () => void;
+}
+
+/**
+ * The view-switcher toolbar shown above the task content, in both the split
+ * view (right panel) and the single-column layout. Everything shrinks as the
+ * toolbar narrows, and secondary controls fold into the overflow menu so the
+ * row never wraps on tablet-width panels.
+ */
+const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
+  currentView,
+  onViewChange,
+  hasSession,
+  showChatTab = false,
+  renderActions,
+  onToggleTerminal,
+  terminalOpen,
+  showStart,
+  onStart,
+  startBusy,
+  showStop,
+  onStop,
+  stopBusy,
+  showRestart,
+  onRestart,
+  restartBusy,
+  showKeepAlive,
+  keepAlive,
+  onToggleKeepAlive,
+  keepAliveBusy,
+  showUpload,
+  onUpload,
+  uploadBusy,
+  onRestoreSplit,
+  renderMenuItems,
+  onCollapsePanel,
+  onClosePanel,
+}) => {
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+  const closeMenu = () => setMenuAnchorEl(null);
+
+  // Density comes from the toolbar's own width, not the viewport: in split view
+  // the toolbar lives in the right panel, which is far narrower than the window.
+  const [toolbarRef, toolbarWidth] = useElementWidth<HTMLDivElement>();
+  const density = toolbarDensityForWidth(toolbarWidth);
+
+  const tab = TAB_METRICS[density];
+  const iconButtonSx = toolbarIconButtonSx(density);
+  const controlIconSize = ICON_BUTTON_METRICS[density].icon;
+
+  const tabs = VIEW_TABS.filter(
+    (t) => (!t.sessionOnly || hasSession) && (!t.chatOnly || showChatTab),
+  );
+
+  const controls: SecondaryControl[] = [];
+  if (onRestoreSplit) {
+    controls.push({
+      key: "restore-split",
+      label: "Restore split view",
+      icon: <PanelLeft size={controlIconSize} />,
+      onClick: onRestoreSplit,
+    });
+  }
+  if (onToggleTerminal) {
+    controls.push({
+      key: "terminal",
+      label: "Terminal",
+      tooltip: "Toggle terminal drawer (Ctrl/Cmd+J)",
+      icon: <PanelBottom size={controlIconSize} />,
+      onClick: onToggleTerminal,
+      pressed: terminalOpen,
+    });
+  }
+  if (showStart && onStart) {
+    controls.push({
+      key: "start",
+      label: "Start desktop",
+      icon: <Play size={controlIconSize} />,
+      onClick: onStart,
+      disabled: startBusy,
+      busy: startBusy,
+      primary: true,
+    });
+  }
+  if (showStop && onStop) {
+    controls.push({
+      key: "stop",
+      label: "Stop desktop",
+      icon: <Square size={controlIconSize} fill="currentColor" />,
+      onClick: onStop,
+      disabled: stopBusy,
+      busy: stopBusy,
+      primary: true,
+    });
+  }
+  if (showRestart && onRestart) {
+    controls.push({
+      key: "restart",
+      label: "Restart agent session",
+      icon: <RotateCw size={controlIconSize} />,
+      onClick: onRestart,
+      disabled: restartBusy,
+      busy: restartBusy,
+    });
+  }
+  if (showKeepAlive && onToggleKeepAlive) {
+    controls.push({
+      key: "keep-alive",
+      label: keepAlive ? "Keep Alive ON" : "Keep Alive OFF",
+      tooltip: keepAlive
+        ? "Keep Alive ON — won't auto-sleep"
+        : "Keep Alive OFF — will auto-sleep when idle",
+      icon: keepAlive ? (
+        <Lock size={controlIconSize} />
+      ) : (
+        <LockOpen size={controlIconSize} />
+      ),
+      onClick: onToggleKeepAlive,
+      disabled: keepAliveBusy,
+      pressed: keepAlive,
+    });
+  }
+  if (showUpload && onUpload) {
+    controls.push({
+      key: "upload",
+      label: "Upload files to sandbox",
+      icon: <CloudUpload size={controlIconSize} />,
+      onClick: onUpload,
+      disabled: uploadBusy,
+      busy: uploadBusy,
+    });
+  }
+
+  // Below the roomiest density only the primary lifecycle control stays inline;
+  // everything else moves into the vertical-dot menu.
+  const keepInline =
+    density === "comfortable" ? controls : controls.filter((c) => c.primary);
+  const overflow = controls.filter((c) => !keepInline.includes(c));
+
+  const extraMenuItems = renderMenuItems?.(closeMenu);
+  const hasMenu = overflow.length > 0 || !!extraMenuItems;
+
+  return (
+    <Box
+      ref={toolbarRef}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        flexWrap: "wrap",
+        minWidth: 0,
+        px: 1,
+        pt: 1,
+        pb: 0.5,
+        minHeight: density === "comfortable" ? 53 : 45,
+        flexShrink: 0,
+        boxSizing: "border-box",
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        backgroundColor: "background.paper",
+        gap: 0.5,
+      }}
+    >
+      <ToggleButtonGroup
+        value={currentView}
+        exclusive
+        onChange={(_, newView) => onViewChange(newView as TaskView | null)}
+        size="small"
+        sx={{
+          flexShrink: 0,
+          "& .MuiToggleButton-root": {
+            width: tab.width,
+            height: tab.height,
+            minWidth: tab.width,
+            p: 0,
+            border: "none",
+            borderRadius: "4px !important",
+            textTransform: "none",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 0.2,
+            "&.Mui-selected": {
+              backgroundColor: "action.selected",
+            },
+          },
+        }}
+      >
+        {tabs.map(({ value, label, icon: Icon }) => (
+          <ToggleButton
+            key={value}
+            value={value}
+            aria-label={`${label} view`}
+            // Tooltips only earn their keep once the label is gone.
+            title={tab.showLabel ? undefined : label}
+          >
+            <Icon size={tab.icon} />
+            {tab.showLabel && (
+              <Typography
+                sx={{
+                  fontSize: density === "comfortable" ? "0.65rem" : "0.6rem",
+                  lineHeight: 1,
+                  fontWeight: 400,
+                  textTransform: "none",
+                }}
+              >
+                {label}
+              </Typography>
+            )}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+
+      {renderActions?.(density)}
+
+      <Box sx={{ flex: 1, minWidth: 0 }} />
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 0.25,
+          alignItems: "center",
+          flexShrink: 0,
+        }}
+      >
+        {keepInline.map((control) => (
+          <Tooltip key={control.key} title={control.tooltip ?? control.label}>
+            <span style={{ display: "inline-flex" }}>
+              <IconButton
+                size="small"
+                aria-label={control.label}
+                aria-pressed={control.pressed}
+                onClick={control.onClick}
+                disabled={control.disabled}
+                sx={iconButtonSx}
+              >
+                {control.busy ? (
+                  <CircularProgress size={controlIconSize} />
+                ) : (
+                  control.icon
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
+        ))}
+
+        {hasMenu && (
+          <Tooltip title="More actions">
+            <IconButton
+              size="small"
+              aria-label="More actions"
+              onClick={(event) => setMenuAnchorEl(event.currentTarget)}
+              sx={iconButtonSx}
+            >
+              <EllipsisVertical size={controlIconSize} />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {onCollapsePanel ? (
+          <Tooltip title="Collapse task panel">
+            <IconButton
+              size="small"
+              aria-label="Collapse task panel"
+              onClick={onCollapsePanel}
+              sx={iconButtonSx}
+            >
+              <PanelRight size={controlIconSize} />
+            </IconButton>
+          </Tooltip>
+        ) : onClosePanel ? (
+          <Tooltip title="Close">
+            <IconButton
+              size="small"
+              aria-label="Close"
+              onClick={onClosePanel}
+              sx={iconButtonSx}
+            >
+              <X size={controlIconSize} />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Box>
+
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={Boolean(menuAnchorEl)}
+        onClose={closeMenu}
+      >
+        {overflow.map((control) => (
+          <MenuItem
+            key={control.key}
+            disabled={control.disabled}
+            onClick={() => {
+              closeMenu();
+              control.onClick();
+            }}
+          >
+            <ListItemIcon>
+              {control.busy ? <CircularProgress size={18} /> : control.icon}
+            </ListItemIcon>
+            <ListItemText>{control.label}</ListItemText>
+          </MenuItem>
+        ))}
+        {extraMenuItems}
+      </Menu>
+    </Box>
+  );
+};
+
+export default SpecTaskViewToolbar;

--- a/frontend/src/hooks/useElementWidth.ts
+++ b/frontend/src/hooks/useElementWidth.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Observe an element's rendered width. Returns a callback ref to attach to the
+ * element and its last measured width in px (0 before the first measurement).
+ *
+ * Uses a state-mirrored callback ref rather than a plain useRef so the observer
+ * effect re-runs once the node actually mounts.
+ */
+export function useElementWidth<T extends HTMLElement>(): [
+  (node: T | null) => void,
+  number,
+] {
+  const [node, setNode] = useState<T | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    if (!node) return;
+
+    const measure = (next: number) => {
+      setWidth((prev) => (Math.abs(prev - next) < 1 ? prev : next));
+    };
+
+    measure(node.getBoundingClientRect().width);
+
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      measure(
+        entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width,
+      );
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+
+  return [setNode, width];
+}
+
+export default useElementWidth;


### PR DESCRIPTION
## Problem

The `SpecTaskDetailContent` view toolbar was sized for a full-width window. On iPad-width screens — and in split view, where the toolbar only occupies the right panel — the tabs, `Reject` / `Open PR` buttons and desktop control icons overflowed off the edge. They only wrapped to a second row at phone widths.

The root cause is that the layout keyed off the *viewport* (`isBigScreen`), not the space the toolbar actually has.

## Change

Extract the two near-duplicate toolbars (split view + single column) into `SpecTaskViewToolbar`, which measures its own width with a `ResizeObserver` (`useElementWidth`) and picks a density:

| density | width | layout |
|---|---|---|
| `comfortable` | ≥ 660px | unchanged from today |
| `compact` | 460–660px | 46px tabs, 16px icons, 0.6rem labels; every secondary desktop control (terminal, restart, keep-alive, upload, restore-split) folds into the vertical-dot menu, leaving only start/stop inline |
| `tight` | < 460px | icon-only tabs and icon-only action buttons |

`SpecTaskActionButtons` gained a matching `density` prop so `Reject` / `Open PR` / `Review Spec` / `Skip Planning` shrink and, at `tight`, drop to icon-only with the label as tooltip. The inline `Skip Planning` button was converted to the same `CompactActionButton` the other inline actions already use.

Deduplicating the toolbars also fixes a drift bug: the single-column layout was missing the Keep Alive toggle the split view had.

## Testing

- `yarn build` and `tsc --noEmit` pass.
- **NOT visually verified in a browser** — the local stack's UI needs a login I don't have here. Worth an eyeball at iPad width and in split view before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)