### PR TITLE
fix(store): return org-scoped provider endpoints in ListProviderEndpoints

### DIFF
--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -339,7 +339,10 @@ func (s *HelixAPIServer) resolveModelProviderLive(ctx context.Context, modelName
 	}
 
 	if orgID != "" && orgID != ownerID {
-		if orgProviders, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{Owner: orgID}); err == nil {
+		if orgProviders, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
+			Owner:     orgID,
+			OwnerType: types.OwnerTypeOrg,
+		}); err == nil {
 			endpoints = append(endpoints, orgProviders...)
 		}
 	}

--- a/api/pkg/store/store_provider_endpoints.go
+++ b/api/pkg/store/store_provider_endpoints.go
@@ -98,15 +98,21 @@ func (s *PostgresStore) ListProviderEndpoints(ctx context.Context, q *ListProvid
 		return providerEndpoints, nil
 	}
 
+	// Resolve which endpoint_type corresponds to the requested owner type. This
+	// must match q.OwnerType so that org-scoped (endpoint_type='org') and, in
+	// the future, team-scoped endpoints are returned rather than always
+	// filtering on user-owned ('user') rows.
+	ownershipType := ownershipEndpointType(q.OwnerType)
+
 	if q.WithGlobal {
-		// User's own endpoints OR global endpoints
+		// Owner's endpoints (of the requested ownership type) OR global endpoints
 		query = query.Where(
 			"(owner = ? AND endpoint_type = ?) OR endpoint_type = ?",
-			q.Owner, types.ProviderEndpointTypeUser, types.ProviderEndpointTypeGlobal,
+			q.Owner, ownershipType, types.ProviderEndpointTypeGlobal,
 		)
 	} else {
-		// User's own endpoints only
-		query = query.Where("owner = ? AND endpoint_type = ?", q.Owner, types.ProviderEndpointTypeUser)
+		// Owner's endpoints only (of the requested ownership type)
+		query = query.Where("owner = ? AND endpoint_type = ?", q.Owner, ownershipType)
 	}
 
 	err := query.Find(&providerEndpoints).Error
@@ -114,6 +120,18 @@ func (s *PostgresStore) ListProviderEndpoints(ctx context.Context, q *ListProvid
 		return nil, err
 	}
 	return providerEndpoints, nil
+}
+
+// ownershipEndpointType maps an owner type to the provider endpoint_type used
+// for endpoints it directly owns. It defaults to user endpoints so callers that
+// don't set OwnerType keep their previous behavior.
+func ownershipEndpointType(ownerType types.OwnerType) types.ProviderEndpointType {
+	switch ownerType {
+	case types.OwnerTypeOrg:
+		return types.ProviderEndpointTypeOrg
+	default:
+		return types.ProviderEndpointTypeUser
+	}
 }
 
 func (s *PostgresStore) DeleteProviderEndpoint(ctx context.Context, id string) error {

--- a/api/pkg/store/store_provider_endpoints_test.go
+++ b/api/pkg/store/store_provider_endpoints_test.go
@@ -166,6 +166,97 @@ func (suite *PostgresStoreTestSuite) TestProviderEndpointListWithGlobalFromOther
 	assert.Equal(suite.T(), "user-private", userOnly[0].Name)
 }
 
+func (suite *PostgresStoreTestSuite) TestProviderEndpointListOrgScoped() {
+	// Regression test: org-scoped endpoints (endpoint_type='org') must be
+	// returned when the query specifies OwnerType=org. Previously the store
+	// hardcoded the ownership filter to 'user' and org endpoints were invisible.
+	userOwner := "user-" + system.GenerateUUID()
+	orgOwner := "org-" + system.GenerateUUID()
+	adminOwner := "admin-" + system.GenerateUUID()
+
+	endpoints := []*types.ProviderEndpoint{
+		{
+			Name:         "user-endpoint",
+			Owner:        userOwner,
+			OwnerType:    types.OwnerTypeUser,
+			EndpointType: types.ProviderEndpointTypeUser,
+			BaseURL:      "https://user.example.com",
+			APIKey:       "user-key",
+		},
+		{
+			Name:         "org-endpoint",
+			Owner:        orgOwner,
+			OwnerType:    types.OwnerTypeOrg,
+			EndpointType: types.ProviderEndpointTypeOrg,
+			BaseURL:      "https://org.example.com",
+			APIKey:       "org-key",
+		},
+		{
+			Name:         "global-endpoint",
+			Owner:        adminOwner,
+			EndpointType: types.ProviderEndpointTypeGlobal,
+			BaseURL:      "https://global.example.com",
+			APIKey:       "global-key",
+		},
+	}
+
+	for _, e := range endpoints {
+		created, err := suite.db.CreateProviderEndpoint(suite.ctx, e)
+		require.NoError(suite.T(), err)
+		suite.T().Cleanup(func() {
+			err := suite.db.DeleteProviderEndpoint(suite.ctx, created.ID)
+			assert.NoError(suite.T(), err)
+		})
+	}
+
+	suite.T().Run("OrgQueryReturnsOrgPlusGlobal", func(t *testing.T) {
+		listed, err := suite.db.ListProviderEndpoints(suite.ctx, &ListProviderEndpointsQuery{
+			Owner:      orgOwner,
+			OwnerType:  types.OwnerTypeOrg,
+			WithGlobal: true,
+		})
+		require.NoError(t, err)
+
+		names := make(map[string]bool)
+		for _, ep := range listed {
+			names[ep.Name] = true
+		}
+		assert.True(t, names["org-endpoint"], "org query should include the org-owned endpoint")
+		assert.True(t, names["global-endpoint"], "org query should include the global endpoint")
+		assert.False(t, names["user-endpoint"], "org query must not include the user-owned endpoint")
+		assert.Len(t, listed, 2, "org query should return exactly the org + global endpoints")
+	})
+
+	suite.T().Run("UserQueryReturnsUserPlusGlobal", func(t *testing.T) {
+		listed, err := suite.db.ListProviderEndpoints(suite.ctx, &ListProviderEndpointsQuery{
+			Owner:      userOwner,
+			OwnerType:  types.OwnerTypeUser,
+			WithGlobal: true,
+		})
+		require.NoError(t, err)
+
+		names := make(map[string]bool)
+		for _, ep := range listed {
+			names[ep.Name] = true
+		}
+		assert.True(t, names["user-endpoint"], "user query should include the user-owned endpoint")
+		assert.True(t, names["global-endpoint"], "user query should include the global endpoint")
+		assert.False(t, names["org-endpoint"], "user query must not include the org-owned endpoint")
+		assert.Len(t, listed, 2, "user query should return exactly the user + global endpoints")
+	})
+
+	suite.T().Run("OrgQueryWithoutGlobalReturnsOrgOnly", func(t *testing.T) {
+		listed, err := suite.db.ListProviderEndpoints(suite.ctx, &ListProviderEndpointsQuery{
+			Owner:      orgOwner,
+			OwnerType:  types.OwnerTypeOrg,
+			WithGlobal: false,
+		})
+		require.NoError(t, err)
+		require.Len(t, listed, 1, "org query without global should return only the org-owned endpoint")
+		assert.Equal(t, "org-endpoint", listed[0].Name)
+	})
+}
+
 func (suite *PostgresStoreTestSuite) TestProviderEndpointUpdate() {
 	endpoint := &types.ProviderEndpoint{
 		Name:         "update-test-endpoint",


### PR DESCRIPTION
## Problem

Org-scoped provider endpoints were invisible. When an org registered a provider endpoint (stored with `endpoint_type='org'`), it never showed up in `GET /api/v1/provider-endpoints?org_id=…`, and it was not resolved at inference time — so models served by that provider could not be used by the org.

## Root cause

`ListProviderEndpoints` hardcoded the ownership filter to `endpoint_type='user'` in both the `WithGlobal` and non-global branches, and completely ignored `q.OwnerType`. Org-owned endpoints (`endpoint_type='org'`) were persisted correctly but could never match the query. Separately, `resolveModelProviderLive` listed org providers without setting `OwnerType`, so even at inference the org endpoints defaulted to the user filter and were dropped.

## Fix

- Add an `ownershipEndpointType(ownerType)` helper that maps `OwnerType` → `endpoint_type` (`org` → `'org'`, default → `'user'`), keeping existing user-scoped behavior for callers that don't set `OwnerType`.
- Use the helper in both branches of `ListProviderEndpoints` instead of hardcoding `'user'`.
- Pass `OwnerType: types.OwnerTypeOrg` from `resolveModelProviderLive` when listing org providers, so org providers also route at inference.

## Testing

Added a regression test `TestProviderEndpointListOrgScoped` covering user, org, and global endpoints (org query returns org + global, user query returns user + global, and org-without-global returns org only). Left to CI (Drone) — not run locally.

## Notes

Found while registering a self-hosted DeepSeek V4 Flash provider for an org on node06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)