### PR TITLE
fix(api): reject empty desktop session IDs

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -820,6 +820,10 @@ func appendProjectSecrets(env, secrets []string) []string {
 
 // StopDesktop stops a dev container using Hydra
 func (h *HydraExecutor) StopDesktop(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("session ID is required to stop desktop")
+	}
+
 	// Detach from the caller's context immediately. Stopping a container is a
 	// state-machine transition that must run to completion regardless of whether
 	// the triggering HTTP request is still alive (browser navigation, etc.).
@@ -957,6 +961,10 @@ func (h *HydraExecutor) StopDesktop(ctx context.Context, sessionID string) error
 // revokeSessionAPIKeys revokes all ephemeral API keys associated with a session.
 // This is called when a desktop shuts down to clean up session-scoped keys.
 func (h *HydraExecutor) revokeSessionAPIKeys(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("session ID is required to revoke session keys")
+	}
+
 	// List all API keys and filter by session ID
 	// Note: This could be optimized with a store method that filters directly
 	keys, err := h.store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{})

--- a/api/pkg/external-agent/hydra_executor_stop_test.go
+++ b/api/pkg/external-agent/hydra_executor_stop_test.go
@@ -1,0 +1,18 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHydraExecutorRejectsEmptySessionIDWithoutStoreAccess(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	h := &HydraExecutor{store: mockStore}
+
+	assert.EqualError(t, h.StopDesktop(context.Background(), ""), "session ID is required to stop desktop")
+	assert.EqualError(t, h.revokeSessionAPIKeys(context.Background(), ""), "session ID is required to revoke session keys")
+}

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -1579,6 +1579,9 @@ func (o *SpecTaskOrchestrator) handleDone(ctx context.Context, task *types.SpecT
 			Msg("Task in done status but keep_alive is set - leaving desktop running")
 		return nil
 	}
+	if task.PlanningSessionID == "" {
+		return nil
+	}
 
 	err := o.containerExecutor.StopDesktop(ctx, task.PlanningSessionID)
 	if err != nil {

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -71,6 +71,14 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_KeepAliveSkipsStop() {
 	s.Require().NoError(err)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_EmptyPlanningSessionSkipsStop() {
+	err := s.orchestrator.handleDone(context.Background(), &types.SpecTask{
+		ID:     "task-without-session",
+		Status: types.TaskStatusDone,
+	})
+	s.Require().NoError(err)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_SkipsWhenStaleEvent() {
 	ctx := context.Background()
 	eventTask := &types.SpecTask{


### PR DESCRIPTION
## Summary

- skip desktop teardown when a completed spec task has no planning session
- reject empty session IDs before any Hydra desktop-stop work
- reject empty session IDs before session-scoped API-key revocation
- add regression tests proving empty IDs do not reach the executor or store

## Root cause

`SpecTaskOrchestrator.handleDone` called `StopDesktop` for a completed task whose `PlanningSessionID` was empty. The Hydra key cleanup listed all API keys and compared each key's `SessionID` with the supplied empty value. Durable API keys also have an empty `SessionID`, so they were incorrectly revoked.

The caller guard preserves valid completion of never-started tasks. The shared executor and revoker guards prevent any caller from repeating the destructive empty-ID cleanup.

## Tests

- `go test ./pkg/services -count=1`
- `go test ./pkg/external-agent -count=1`
- `git diff --check`
