### PR TITLE
fix(cli): honour spectask --name and show real agent names

### DIFF
--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -731,6 +731,9 @@ type AgentConfig struct {
 }
 
 type HelixConfig struct {
+	// Name is where an agent's display name actually lives — the top-level
+	// `name` field on the API response is always empty.
+	Name       string      `json:"name"`
 	Assistants []Assistant `json:"assistants"`
 }
 
@@ -837,7 +840,11 @@ agents.`,
 					marker = ""
 				}
 
-				fmt.Printf("Agent: %s%s\n", agent.Name, marker)
+				name := agent.Config.Helix.Name
+				if name == "" {
+					name = agent.Name
+				}
+				fmt.Printf("Agent: %s%s\n", name, marker)
 				fmt.Printf("  ID: %s\n", agent.ID)
 				fmt.Printf("  Assistant: %s\n", primary.Name)
 				if primary.AgentType != "" {

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -176,6 +176,12 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		return nil, fmt.Errorf("working branch is required for existing branch mode")
 	}
 
+	// An explicit name wins; otherwise derive one from the prompt.
+	taskName := strings.TrimSpace(req.Name)
+	if taskName == "" {
+		taskName = GenerateTaskNameFromPrompt(req.Prompt)
+	}
+
 	// Determine organization ID from project if it belongs to an org
 	organizationID := ""
 	if project != nil {
@@ -204,7 +210,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		UserID:                   req.UserID,
 		OrganizationID:           organizationID,
 		AssigneeID:               assigneeID, // Auto-started work is always assigned to the user who started it
-		Name:                     GenerateTaskNameFromPrompt(req.Prompt),
+		Name:                     taskName,
 		Description:              req.Prompt,
 		Type:                     req.Type,
 		Priority:                 req.Priority,

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -133,8 +133,10 @@ func (r SandboxResourceOverrides) ValidPreset() bool {
 
 // Request types
 type CreateTaskRequest struct {
-	ProjectID    string           `json:"project_id"`
-	Prompt       string           `json:"prompt"`
+	ProjectID string `json:"project_id"`
+	Prompt    string `json:"prompt"`
+	// Name is the task title. Empty means derive it from the prompt.
+	Name         string           `json:"name,omitempty"`
 	Type         string           `json:"type"`
 	Priority     SpecTaskPriority `json:"priority"`
 	UserID       string           `json:"user_id"`


### PR DESCRIPTION
Two small `helix spectask` CLI bugs hit while dispatching work today.

- `spectask start -n "..."` was silently dropped: `types.CreateTaskRequest` has no `Name` field, so `CreateTaskFromPrompt` always called `GenerateTaskNameFromPrompt(req.Prompt)`. Every CLI-created task ended up titled with the first 60 characters of its brief. Added `Name` to the request and used it when non-empty.
- `spectask list-agents` printed `Agent: ` for every row — an app's display name lives at `config.helix.name`; the top-level `name` is always empty.

Verified against the local stack: `list-agents` now prints "Claude Code Opus 4.8" etc., and two spec tasks created with `-n` came out with the titles I passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)