### PR TITLE
Don't redirect out of an embed to onboarding or /orgs

### DIFF
--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -16,6 +16,12 @@ import {
 } from '../types'
 import { TypesFrontendLicenseInfo, TypesServerConfigForFrontend } from '../api/api'
 
+// Embed routes are fullscreen, single-purpose views of one task or session,
+// designed to be iframed on another site. Account-level redirects (onboarding,
+// "you have no organizations") must never fire there: the visitor is not
+// onboarding, and a scoped embed key sees an empty org list by design.
+const isEmbedRoute = (routeName: string) => routeName?.startsWith('embed_')
+
 export interface IAccountContext {
   initialized: boolean,
   credits: number,
@@ -447,6 +453,11 @@ export const useAccountContext = (): IAccountContext => {
     if (user.waitlisted) return
     // Don't redirect if already on onboarding page
     if (router.name === 'onboarding') return
+    // Never redirect out of an embed. It is a fullscreen, single-purpose view of
+    // one task or session, often iframed on someone else's page — onboarding a
+    // visitor there is nonsense, and with a scoped embed key the org list is
+    // deliberately empty, which would otherwise trigger this every time.
+    if (isEmbedRoute(router.name)) return
     // Don't redirect if onboarding is already completed
     if (user.onboarding_completed) return
     // Don't redirect if user dismissed onboarding this session
@@ -466,6 +477,8 @@ export const useAccountContext = (): IAccountContext => {
     if (user.waitlisted) return
     if (!organizationTools.initialized) return
     if (router.name === 'orgs') return
+    // Same reason as the onboarding redirect above.
+    if (isEmbedRoute(router.name)) return
     // Don't redirect to /orgs if onboarding hasn't been completed yet — let the
     // onboarding redirect above handle the flow instead
     if (!user.onboarding_completed && !onboardingDismissedRef.current) return


### PR DESCRIPTION
Third and final piece of the embeddable-agent-chat work, after #2983 and #2996. Found by loading the embed in a browser against meta with both of those deployed.

## Symptom

**Every API call returned 200** — the neutering from #2996 worked exactly as intended:

```
GET /api/v1/spec-tasks/spt_01kzreqq…            200
GET /api/v1/sessions/ses_01kzreqr…              200
GET /api/v1/sessions/ses_01kzreqr…/interactions 200
GET /api/v1/organizations                       200  []
GET /api/v1/agents                              200  []
```

…and the page *still* rendered Helix's Organizations screen instead of the conversation.

## Cause

`AccountContextProvider` has two account-level redirects:

- *"Redirect to onboarding if user hasn't completed it and has no orgs"*
- *"Redirect to orgs page if user has no org memberships"*

With a scoped embed key the organization list is **empty by design** — #2996 returns `[]` rather than exposing the tenant's inventory to a visitor — so the second one fired on every load and navigated away from the embed.

## Fix

Skip both redirects on any `embed_*` route.

Deliberately keyed on the **route**, not the key type. An embed is a fullscreen, single-purpose view of one task or session, built to be iframed on someone else's site. Onboarding a visitor who is reading an agent conversation is nonsense whoever they are — a staff user opening `/embed/task/…` shouldn't be bounced to `/orgs` either. So this fixes the general case rather than special-casing embed keys.

```ts
const isEmbedRoute = (routeName: string) => routeName?.startsWith('embed_')
```

## Verification

`tsc --noEmit`: **zero errors in `account.tsx`**. Note the repo has a pre-existing baseline of 10 unrelated MUI `SxProps` errors elsewhere; this change adds none.

Browser verification of the rendered result is pending this being deployed to meta — that is the only thing left between here and a working embedded chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)