### PR TITLE
feat(projects): add repositories settings tab

### DIFF
--- a/frontend/src/components/project/ProjectSettingsSidebar.tsx
+++ b/frontend/src/components/project/ProjectSettingsSidebar.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 
 import SettingsIcon from '@mui/icons-material/Settings'
 import CodeIcon from '@mui/icons-material/Code'
-import { Bot } from 'lucide-react'
+import { Bot, GitBranch } from 'lucide-react'
 import ViewKanbanIcon from '@mui/icons-material/ViewKanban'
 import VpnKeyIcon from '@mui/icons-material/VpnKey'
 import HubIcon from '@mui/icons-material/Hub'
@@ -12,7 +12,7 @@ import PeopleIcon from '@mui/icons-material/People'
 
 import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 
-export type ProjectSettingsTab = 'general' | 'sandbox' | 'web-service' | 'agents' | 'board' | 'secrets' | 'skills' | 'access' | 'danger'
+export type ProjectSettingsTab = 'general' | 'repositories' | 'sandbox' | 'web-service' | 'agents' | 'board' | 'secrets' | 'skills' | 'access' | 'danger'
 
 interface ProjectSettingsSidebarProps {
   activeTab?: ProjectSettingsTab
@@ -35,6 +35,13 @@ const ProjectSettingsSidebar: FC<ProjectSettingsSidebarProps> = ({ activeTab = '
           icon: <SettingsIcon />,
           isActive: activeTab === 'general',
           onClick: () => handleClick('general'),
+        },
+        {
+          id: 'repositories',
+          label: 'Repositories',
+          icon: <GitBranch size={22} />,
+          isActive: activeTab === 'repositories',
+          onClick: () => handleClick('repositories'),
         },
         {
           id: 'sandbox',

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -939,8 +939,11 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
           </Typography>
         )}
       </Box>
+    </Box>
+  );
 
-      {/* Repositories */}
+  const renderRepositoriesTab = () => (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <Box>
         <Box
           sx={{
@@ -988,7 +991,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
             sx={{ textAlign: "center", py: 4 }}
           >
             No code repositories attached to this project yet. Click
-            "Attach Repository" to add one.
+            "Attach" to add one.
           </Typography>
         ) : (
           <ProjectRepositoriesList
@@ -2062,6 +2065,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
     <>
       <Container maxWidth="lg" sx={{ px: 2 }}>
         {tab ==="general" && renderGeneralTab()}
+        {tab ==="repositories" && renderRepositoriesTab()}
         {tab ==="sandbox" && renderSandboxTab()}
         {tab ==="web-service" && <WebServiceTab projectId={projectId} />}
         {tab ==="agents" && renderAgentsTab()}


### PR DESCRIPTION
## Summary

- Add a Repositories tab to project settings.
- Simplify project settings navigation and account context handling.
- Remove obsolete embed-key authentication and MCP identity plumbing.
- Update API and CLI behavior to match the revised authentication model.

## Testing

- Not run.