### PR TITLE
fix(billing): avoid summing streaming usage snapshots

### DIFF
--- a/api/pkg/anthropic/anthropic_proxy_test.go
+++ b/api/pkg/anthropic/anthropic_proxy_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 
@@ -18,9 +20,19 @@ import (
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
+
+type captureAnthropicLogStore struct {
+	calls chan *types.LLMCall
+}
+
+func (s *captureAnthropicLogStore) CreateLLMCall(_ context.Context, call *types.LLMCall) (*types.LLMCall, error) {
+	s.calls <- call
+	return call, nil
+}
 
 func TestProxySuite(t *testing.T) {
 	suite.Run(t, new(ProxySuite))
@@ -139,6 +151,74 @@ func (suite *ProxySuite) TestProxyBilling_OK() {
 	suite.Contains(string(respBody), "hello to you too")
 
 	suite.proxy.wg.Wait()
+}
+
+func TestStreamingProxyLogsCumulativeUsageSnapshot(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	modelInfoProvider, err := model.NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	logStore := &captureAnthropicLogStore{calls: make(chan *types.LLMCall, 1)}
+	proxy := New(cfg, nil, modelInfoProvider, logStore)
+
+	ctx := oai.SetContextValues(context.Background(), &oai.ContextValues{
+		InteractionID:   "interaction_123",
+		OriginalRequest: []byte(`{"model":"claude-sonnet-4-20250514","stream":true}`),
+		OwnerID:         "user-123",
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://localhost/v1/messages", nil)
+	require.NoError(t, err)
+	req = SetRequestProviderEndpoint(req, &types.ProviderEndpoint{
+		ID:      "anthropic-endpoint",
+		Name:    "anthropic",
+		BaseURL: "https://api.anthropic.com",
+	})
+	req = setStartTime(req, time.Now())
+
+	stream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":100,"cache_creation_input_tokens":20,"cache_read_input_tokens":80,"output_tokens":1}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":20}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(stream)),
+		Request:    req,
+	}
+
+	require.NoError(t, proxy.anthropicAPIProxyModifyResponse(resp))
+	forwarded, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, stream, string(forwarded))
+
+	var call *types.LLMCall
+	select {
+	case call = <-logStore.calls:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Anthropic usage log")
+	}
+	assert.EqualValues(t, 200, call.PromptTokens)
+	assert.EqualValues(t, 20, call.CompletionTokens)
+	assert.EqualValues(t, 220, call.TotalTokens)
+	assert.EqualValues(t, 80, call.CacheReadTokens)
+	assert.EqualValues(t, 20, call.CacheWriteTokens)
 }
 
 func Test_stripDateFromModelName(t *testing.T) {

--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -230,19 +230,9 @@ func appendChunk(resp *openai.ChatCompletionResponse, chunk *openai.ChatCompleti
 		}
 	}
 
-	// Append the usage
+	// Streaming usage is a cumulative snapshot for the request, not a per-chunk delta.
 	if chunk.Usage != nil {
-		resp.Usage.PromptTokens += chunk.Usage.PromptTokens
-		resp.Usage.CompletionTokens += chunk.Usage.CompletionTokens
-		resp.Usage.TotalTokens += chunk.Usage.TotalTokens
-
-		if chunk.Usage.PromptTokensDetails != nil {
-			if resp.Usage.PromptTokensDetails == nil {
-				resp.Usage.PromptTokensDetails = &openai.PromptTokensDetails{}
-			}
-			resp.Usage.PromptTokensDetails.CachedTokens += chunk.Usage.PromptTokensDetails.CachedTokens
-			resp.Usage.PromptTokensDetails.AudioTokens += chunk.Usage.PromptTokensDetails.AudioTokens
-		}
+		resp.Usage = *chunk.Usage
 	}
 }
 

--- a/api/pkg/openai/logger/openai_logger_test.go
+++ b/api/pkg/openai/logger/openai_logger_test.go
@@ -2,6 +2,11 @@ package logger
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	openai "github.com/sashabaranov/go-openai"
@@ -15,6 +20,148 @@ import (
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
+
+type captureLogStore struct {
+	calls chan *types.LLMCall
+}
+
+func (s *captureLogStore) CreateLLMCall(_ context.Context, call *types.LLMCall) (*types.LLMCall, error) {
+	s.calls <- call
+	return call, nil
+}
+
+func TestAppendChunkUsesLatestUsageSnapshot(t *testing.T) {
+	resp := &openai.ChatCompletionResponse{}
+
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Usage: &openai.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 10,
+			TotalTokens:      110,
+			PromptTokensDetails: &openai.PromptTokensDetails{
+				CachedTokens: 80,
+			},
+		},
+	})
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Usage: &openai.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			PromptTokensDetails: &openai.PromptTokensDetails{
+				CachedTokens: 80,
+			},
+		},
+	})
+
+	require.NotNil(t, resp.Usage.PromptTokensDetails)
+	assert.Equal(t, 100, resp.Usage.PromptTokens)
+	assert.Equal(t, 20, resp.Usage.CompletionTokens)
+	assert.Equal(t, 120, resp.Usage.TotalTokens)
+	assert.Equal(t, 80, resp.Usage.PromptTokensDetails.CachedTokens)
+}
+
+func TestAppendChunkAcceptsFinalOnlyUsage(t *testing.T) {
+	resp := &openai.ChatCompletionResponse{}
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{Content: "hello"},
+		}},
+	})
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Usage: &openai.Usage{
+			PromptTokens:     40,
+			CompletionTokens: 2,
+			TotalTokens:      42,
+		},
+	})
+
+	assert.Equal(t, "hello", resp.Choices[0].Message.Content)
+	assert.Equal(t, 40, resp.Usage.PromptTokens)
+	assert.Equal(t, 2, resp.Usage.CompletionTokens)
+	assert.Equal(t, 42, resp.Usage.TotalTokens)
+}
+
+func TestCreateChatCompletionStreamLogsLatestUsageSnapshot(t *testing.T) {
+	chunks := []openai.ChatCompletionStreamResponse{
+		{
+			ID: "chatcmpl_test",
+			Choices: []openai.ChatCompletionStreamChoice{{
+				Delta: openai.ChatCompletionStreamChoiceDelta{Content: "hello "},
+			}},
+			Usage: &openai.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 1,
+				TotalTokens:      101,
+				PromptTokensDetails: &openai.PromptTokensDetails{
+					CachedTokens: 80,
+				},
+			},
+		},
+		{
+			ID: "chatcmpl_test",
+			Choices: []openai.ChatCompletionStreamChoice{{
+				Delta: openai.ChatCompletionStreamChoiceDelta{Content: "world"},
+			}},
+			Usage: &openai.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 2,
+				TotalTokens:      102,
+				PromptTokensDetails: &openai.PromptTokensDetails{
+					CachedTokens: 80,
+				},
+			},
+		},
+	}
+
+	var streamBody strings.Builder
+	for _, chunk := range chunks {
+		payload, err := json.Marshal(chunk)
+		require.NoError(t, err)
+		streamBody.WriteString("data: ")
+		streamBody.Write(payload)
+		streamBody.WriteString("\n\n")
+	}
+	streamBody.WriteString("data: [DONE]\n\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamBody.String()))
+	}))
+	defer server.Close()
+
+	modelInfoProvider, err := model.NewBaseModelInfoProvider()
+	require.NoError(t, err)
+	captured := &captureLogStore{calls: make(chan *types.LLMCall, 2)}
+	middleware := Wrap(
+		nil,
+		types.ProviderOpenAI,
+		oai.New("test", server.URL, true),
+		modelInfoProvider,
+		nil,
+		captured,
+	)
+
+	stream, err := middleware.CreateChatCompletionStream(context.Background(), openai.ChatCompletionRequest{
+		Model: "gpt-3.5-turbo",
+	})
+	require.NoError(t, err)
+	for {
+		_, err = stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+	middleware.wg.Wait()
+
+	require.Equal(t, 1, len(captured.calls))
+	call := <-captured.calls
+	assert.Equal(t, int64(100), call.PromptTokens)
+	assert.Equal(t, int64(2), call.CompletionTokens)
+	assert.Equal(t, int64(102), call.TotalTokens)
+	assert.Equal(t, int64(80), call.CacheReadTokens)
+}
 
 func Test_computeTokenUsage_SingleMessage(t *testing.T) {
 	enc, err := tokenizer.Get(tokenizer.Cl100kBase)


### PR DESCRIPTION
## Root cause

The OpenAI-compatible streaming logger treated each chunk usage object as an incremental delta. Providers such as DeepSeek return cumulative request-level snapshots, so prompt, completion, total, and cached token counts were added repeatedly and massively inflated billing.

## Change

- Replace accumulated usage with the latest non-nil streaming snapshot.
- Cover cumulative multi-chunk usage and final-only usage at the aggregation layer.
- Cover the full streaming middleware-to-LLM-log path.
- Audit the Anthropic proxy and add a regression test proving its SDK accumulator already replaces message_start output usage with the final message_delta snapshot while preserving cache usage.

## Impact

New OpenAI-compatible streaming calls are logged and billed from the provider final cumulative usage rather than the sum of every snapshot. This does not reconcile historical LLM-call or wallet rows.

## Checks

- go test ./pkg/anthropic ./pkg/openai/logger ./pkg/openai -count=1
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- git diff --check