### PR TITLE
fix(usage): preserve managed provider attribution

### DIFF
--- a/api/pkg/server/usage_handlers.go
+++ b/api/pkg/server/usage_handlers.go
@@ -301,6 +301,8 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 	modelProviders := make(map[string]string)
 	modelInfo := make(map[string]*types.ModelInfo)
 	missingModelInfo := make(map[string]bool)
+	endpointProviders := make(map[string]string)
+	checkedEndpoints := make(map[string]bool)
 
 	for _, row := range summary.CostBreakdown {
 		key := row.Provider + ":" + row.Model
@@ -352,9 +354,27 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 			summary.SubscriptionSavings += estimatedCost
 		}
 		modelCosts[key] += estimatedCost
-		displayProvider := row.Provider
-		if info != nil && info.ProviderSlug != "" {
+		displayProvider := ""
+		if strings.HasPrefix(row.Provider, system.ProviderEndpointPrefix) && s.Store != nil {
+			if !checkedEndpoints[row.Provider] {
+				checkedEndpoints[row.Provider] = true
+				endpoint, endpointErr := s.Store.GetProviderEndpoint(ctx, &store.GetProviderEndpointsQuery{ID: row.Provider})
+				if endpointErr != nil {
+					log.Debug().Err(endpointErr).Str("provider", row.Provider).
+						Msg("failed to resolve provider endpoint for organization usage")
+				} else if endpoint != nil && endpoint.EndpointType == types.ProviderEndpointTypeGlobal && endpoint.OwnerType == types.OwnerTypeSystem {
+					// Database-backed system globals are Helix-managed inference routes
+					// (for example vLLM or SGLang), not the catalog provider for the model ID.
+					endpointProviders[row.Provider] = "helix/" + endpoint.Name
+				}
+			}
+			displayProvider = endpointProviders[row.Provider]
+		}
+		if displayProvider == "" && info != nil && info.ProviderSlug != "" {
 			displayProvider = info.ProviderSlug
+		}
+		if displayProvider == "" {
+			displayProvider = row.Provider
 		}
 		modelProviders[key] = displayProvider
 

--- a/api/pkg/server/usage_handlers_test.go
+++ b/api/pkg/server/usage_handlers_test.go
@@ -60,6 +60,60 @@ func TestEnrichOrgUsageCostsSeparatesSavingsAndHelixCredits(t *testing.T) {
 	require.Equal(t, "openai", summary.Models[0].Provider)
 }
 
+func TestEnrichOrgUsageCostsUsesGlobalEndpointAttribution(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	modelInfo := model.NewMockModelInfoProvider(ctrl)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore, modelInfoProvider: modelInfo}
+	date := time.Date(2026, 8, 11, 0, 0, 0, 0, time.UTC)
+	summary := &types.OrgUsageSummaryResponse{
+		Metrics: []*types.AggregatedUsageMetric{{Date: date}},
+		Models: []types.UsageBreakdownRow{{
+			ID: "pe_node06:deepseek-v4-flash", Provider: "pe_node06", Model: "deepseek-v4-flash",
+		}},
+		CostBreakdown: []types.UsageCostBreakdownRow{{
+			Date:             date,
+			Source:           types.UsageMetricSourceHelixProxy,
+			Provider:         "pe_node06",
+			Model:            "deepseek-v4-flash",
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			TotalCost:        42,
+		}},
+	}
+	modelInfo.EXPECT().GetModelInfo(gomock.Any(), &model.ModelInfoRequest{
+		Provider: "pe_node06",
+		Model:    "deepseek-v4-flash",
+	}).Return(&types.ModelInfo{
+		ProviderSlug: "baidu/fp8",
+		Pricing: types.Pricing{
+			Prompt:     "1",
+			Completion: "1",
+		},
+	}, nil)
+	mockStore.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: "pe_node06"}).
+		Return(&types.ProviderEndpoint{
+			ID:           "pe_node06",
+			Name:         "ds4-flash-node06",
+			EndpointType: types.ProviderEndpointTypeGlobal,
+			OwnerType:    types.OwnerTypeSystem,
+		}, nil)
+
+	server.enrichOrgUsageCosts(context.Background(), summary)
+
+	require.Equal(t, 42.0, summary.RawTokenCost)
+	require.Len(t, summary.Providers, 1)
+	require.Equal(t, "helix/ds4-flash-node06", summary.Providers[0].Provider)
+	require.Equal(t, "helix/ds4-flash-node06", summary.Providers[0].Name)
+	require.Equal(t, 42.0, summary.Providers[0].TotalCost)
+	require.Len(t, summary.ProviderTimeSeries, 1)
+	require.Equal(t, "helix/ds4-flash-node06", summary.ProviderTimeSeries[0].Provider)
+	require.Len(t, summary.Models, 1)
+	require.Equal(t, "helix/ds4-flash-node06", summary.Models[0].Provider)
+	require.Equal(t, 42.0, summary.Models[0].TotalCost)
+}
+
 func TestMergeSandboxUsageCostsAddsSandboxSpend(t *testing.T) {
 	date := time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC)
 	metrics := []*types.AggregatedUsageMetric{

--- a/frontend/src/components/orgs/OrgUsage.test.tsx
+++ b/frontend/src/components/orgs/OrgUsage.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { UsageProviderIcon } from './OrgUsage'
+
+describe('UsageProviderIcon', () => {
+  it('uses the Helix logo for globally managed inference providers', () => {
+    const { container } = render(<UsageProviderIcon provider="helix/ds4-flash-node06" size={18} />)
+
+    const image = container.querySelector('img')
+    expect(image).not.toBeNull()
+    expect(image?.getAttribute('src')).toContain('logo.png')
+    expect(image).toHaveStyle({ width: '18px', height: '18px' })
+  })
+})

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -28,6 +28,7 @@ import SimpleTable, { ITableField } from '../widgets/SimpleTable'
 import ShadcnAreaChart, { ShadcnSeries } from '../usage/ShadcnAreaChart'
 import { PROVIDERS } from '../providers/types'
 import { useGetOrgUsage } from '../../services/orgService'
+import helixLogo from '../../../assets/img/logo.png'
 import {
   buildCacheHitRatioChartData,
   getAggregateCacheHitRatio,
@@ -73,6 +74,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   azure: '#0078d4',
   'amazon-bedrock': '#ff9900',
   deepseek: '#4d6bfe',
+  helix: '#2563eb',
 }
 
 const toDateInput = (date: Date) => date.toISOString().slice(0, 10)
@@ -133,6 +135,7 @@ const providerKey = (provider?: string) => (provider || 'unknown').toLowerCase()
 const providerColor = (provider: string, index: number, isLight: boolean) => {
   const key = providerKey(provider)
   if (key === 'openai' || key === 'xai') return isLight ? '#111827' : PROVIDER_COLORS[key]
+  if (key === 'helix' || key.startsWith('helix/')) return PROVIDER_COLORS.helix
   return PROVIDER_COLORS[key] || CHART_COLORS[index % CHART_COLORS.length]
 }
 
@@ -142,7 +145,11 @@ const providerDefinition = (provider?: string) => {
   return PROVIDERS.find(item => item.id === `user/${key}` || item.alias.includes(key))
 }
 
-const UsageProviderIcon: FC<{ provider?: string; size?: number }> = ({ provider, size = 16 }) => {
+export const UsageProviderIcon: FC<{ provider?: string; size?: number }> = ({ provider, size = 16 }) => {
+  const key = providerKey(provider)
+  if (key === 'helix' || key.startsWith('helix/')) {
+    return <Box component="img" src={helixLogo} alt="" sx={{ width: size, height: size, objectFit: 'contain' }} />
+  }
   const definition = providerDefinition(provider)
   if (!definition) return <Cloud size={size} aria-hidden="true" />
   if (typeof definition.logo === 'string') {


### PR DESCRIPTION
## Root cause

Organization usage replaced the recorded provider-endpoint identity with the provider slug from the model pricing catalog. A globally managed vLLM/SGLang endpoint serving `deepseek-v4-flash` therefore appeared as `baidu/fp8`, because that is the catalog entry for the same bare model ID.

## Change

- Resolve database-backed, system-owned global endpoint IDs as `helix/<endpoint name>` before applying catalog display attribution.
- Keep the already recorded `total_cost` authoritative.
- Use the Helix logo and color for `helix/*` usage providers.
- Add backend coverage for attribution and cost preservation plus frontend coverage for the Helix icon.

## Impact

Usage routed through endpoints such as `ds4-flash-node06` is displayed as `helix/ds4-flash-node06` without changing its configured price or historical token totals.

## Checks

- `go test ./pkg/server -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `yarn test OrgUsage.test.tsx --run`
- `yarn build`
- `git diff --check`
