### PR TITLE
fix(zed): use provider-advertised context limits

### DIFF
--- a/api/pkg/openai/openai_client_test.go
+++ b/api/pkg/openai/openai_client_test.go
@@ -241,6 +241,37 @@ func TestTLSSkipVerify_SelfSignedCert(t *testing.T) {
 	})
 }
 
+func TestListModelsNormalizesCompatibleContextLengthFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/models", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{
+			"data": [
+				{"id":"vllm-model","max_model_len":262144},
+				{"id":"compatible-model","max_context_length":131072},
+				{"id":"canonical-wins","context_length":65536,"max_model_len":393216},
+				{"id":"nested-model","model_info":{"context_length":32768}}
+			]
+		}`)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	client := New("test-api-key", ts.URL, false)
+	models, err := client.ListModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, models, 4)
+
+	modelsByID := make(map[string]types.OpenAIModel, len(models))
+	for _, listedModel := range models {
+		modelsByID[listedModel.ID] = listedModel
+	}
+	assert.Equal(t, 262144, modelsByID["vllm-model"].ContextLength, "vLLM max_model_len should be normalized")
+	assert.Equal(t, 131072, modelsByID["compatible-model"].ContextLength, "max_context_length should be normalized")
+	assert.Equal(t, 65536, modelsByID["canonical-wins"].ContextLength, "canonical context_length should take precedence")
+	assert.Equal(t, 32768, modelsByID["nested-model"].ContextLength, "nested model_info context should be used as a final fallback")
+}
+
 // TestOld2525Behavior_WithActualOpenAIClient tests the ACTUAL OpenAI client
 // code path to see if there's a bug in how TLSSkipVerify is applied.
 // This simulates the exact 2.5.25 code to find the real issue.

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -613,11 +613,14 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 			// app.Owner drives the actor identity here — buildCodeAgentConfig
 			// has no session/request context. Org providers are still
 			// resolved via the org bucket inside getProviderSnapshot.
-			snapshot, err := apiServer.getProviderSnapshot(ctx, app.Owner, app)
+			endpoints, err := apiServer.listEndpointsForApp(ctx, app.Owner, app)
 			if err != nil {
 				log.Warn().Err(err).Str("app_id", app.ID).Msg("buildCodeAgentConfig: provider snapshot unavailable; model prefix may not match agent.default_model")
 			}
+			snapshot := providerSnapshotFromEndpoints(endpoints)
 			cfg := apiServer.buildCodeAgentConfigFromAssistant(ctx, &assistant, helixURL, snapshot)
+			_, modelName := external_agent.AssistantModelSelection(&assistant)
+			apiServer.applyAdvertisedModelLimits(ctx, cfg, modelName, endpoints)
 			if cfg != nil && cfg.Runtime == types.CodeAgentRuntimeGooseCode && projectID != "" && len(assistant.GooseRecipes) > 0 {
 				if err := apiServer.resolveGooseRecipesIntoConfig(ctx, app, &assistant, projectID, cfg); err != nil {
 					log.Warn().Err(err).Str("app_id", app.ID).Str("project_id", projectID).Msg("buildCodeAgentConfig: failed to resolve goose recipes; slash commands will be unavailable in this session")
@@ -762,6 +765,52 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 		ReasoningEffort:  normalizeCodeAgentReasoningEffort(runtime, assistant.ReasoningEffort),
 		MaxTokens:        maxTokens,
 		MaxOutputTokens:  maxOutputTokens,
+	}
+}
+
+// applyAdvertisedModelLimits makes the selected provider's /v1/models response
+// authoritative for its context window. The bundled model catalogue is still
+// used by buildCodeAgentConfigFromAssistant as a fallback for providers that do
+// not advertise a context length or are temporarily unavailable.
+func (apiServer *HelixAPIServer) applyAdvertisedModelLimits(ctx context.Context, cfg *types.CodeAgentConfig, modelName string, endpoints []*types.ProviderEndpoint) {
+	if cfg == nil || cfg.Provider == "" || modelName == "" {
+		return
+	}
+
+	bareModelName := strings.TrimPrefix(modelName, cfg.Provider+"/")
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.Name != cfg.Provider {
+			continue
+		}
+
+		providerModels, err := apiServer.getProviderModels(ctx, endpoint)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("provider", cfg.Provider).
+				Str("model", modelName).
+				Msg("buildCodeAgentConfig: provider model metadata unavailable; using catalogue token limits")
+			return
+		}
+
+		for _, advertisedModel := range providerModels.Models {
+			advertisedBareName := strings.TrimPrefix(advertisedModel.ID, cfg.Provider+"/")
+			if advertisedModel.ID != modelName && advertisedBareName != bareModelName {
+				continue
+			}
+			if advertisedModel.ContextLength <= 0 {
+				continue
+			}
+
+			catalogueContextLength := cfg.MaxTokens
+			cfg.MaxTokens = advertisedModel.ContextLength
+			log.Debug().
+				Str("provider", cfg.Provider).
+				Str("model", modelName).
+				Int("advertised_context_length", advertisedModel.ContextLength).
+				Int("catalogue_context_length", catalogueContextLength).
+				Msg("buildCodeAgentConfig: using provider-advertised context length")
+			return
+		}
 	}
 }
 
@@ -977,11 +1026,18 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorI
 	if err != nil {
 		return nil, err
 	}
+	return providerSnapshotFromEndpoints(endpoints), nil
+}
+
+func providerSnapshotFromEndpoints(endpoints []*types.ProviderEndpoint) []external_agent.ProviderRef {
 	refs := make([]external_agent.ProviderRef, 0, len(endpoints))
 	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
 		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name})
 	}
-	return refs, nil
+	return refs
 }
 
 // listEndpointsForApp returns ProviderEndpoint records available to the app.

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -2,10 +2,19 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/dgraph-io/ristretto/v2"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/openai"
+	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
@@ -388,6 +397,141 @@ func TestBuildCodeAgentConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := apiServer.buildCodeAgentConfig(ctx, tt.app, helixURL, "")
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildCodeAgentConfigProviderAdvertisedContextLength(t *testing.T) {
+	const (
+		providerName          = "ds4-flash-node06"
+		modelName             = "deepseek-v4-flash"
+		providerBaseURL       = "http://ds4-loadbalancer/v1"
+		catalogueContext      = 1048576
+		catalogueOutputTokens = 131072
+	)
+
+	tests := []struct {
+		name                 string
+		advertisedContext    int
+		catalogueUnavailable bool
+		providerListErr      error
+		providerModelsErr    error
+		wantContext          int
+		wantOutputTokens     int
+	}{
+		{
+			name:              "advertised context overrides larger catalogue value",
+			advertisedContext: 262144,
+			wantContext:       262144,
+			wantOutputTokens:  catalogueOutputTokens,
+		},
+		{
+			name:                 "advertised context works without catalogue metadata",
+			advertisedContext:    262144,
+			catalogueUnavailable: true,
+			wantContext:          262144,
+		},
+		{
+			name:              "zero advertised context falls back to catalogue",
+			advertisedContext: 0,
+			wantContext:       catalogueContext,
+			wantOutputTokens:  catalogueOutputTokens,
+		},
+		{
+			name:             "provider endpoint lookup failure falls back to catalogue",
+			providerListErr:  errors.New("provider registry unavailable"),
+			wantContext:      catalogueContext,
+			wantOutputTokens: catalogueOutputTokens,
+		},
+		{
+			name:              "provider models failure falls back to catalogue",
+			providerModelsErr: errors.New("models endpoint unavailable"),
+			wantContext:       catalogueContext,
+			wantOutputTokens:  catalogueOutputTokens,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			providerManager := manager.NewMockProviderManager(ctrl)
+			providerClient := openai.NewMockClient(ctrl)
+			modelInfoProvider := model.NewMockModelInfoProvider(ctrl)
+
+			cache, err := ristretto.NewCache(&ristretto.Config[string, string]{
+				NumCounters: 1e3,
+				MaxCost:     1 << 20,
+				BufferItems: 64,
+			})
+			require.NoError(t, err)
+			defer cache.Close()
+
+			cfg := &config.ServerConfig{}
+			cfg.WebServer.ModelsCacheTTL = time.Minute
+			apiServer := &HelixAPIServer{
+				Cfg:               cfg,
+				providerManager:   providerManager,
+				modelInfoProvider: modelInfoProvider,
+				cache:             cache,
+			}
+
+			endpoint := &types.ProviderEndpoint{
+				ID:      "pe_ds4",
+				Name:    providerName,
+				Owner:   "user-1",
+				BaseURL: providerBaseURL,
+			}
+
+			providerManager.EXPECT().
+				ListProviderEndpoints(gomock.Any(), "user-1").
+				Return(func() []*types.ProviderEndpoint {
+					if tt.providerListErr != nil {
+						return nil
+					}
+					return []*types.ProviderEndpoint{endpoint}
+				}(), tt.providerListErr)
+
+			if tt.providerListErr == nil {
+				providerManager.EXPECT().
+					GetClient(gomock.Any(), &manager.GetClientRequest{Provider: providerName, Owner: "user-1"}).
+					Return(providerClient, nil)
+				providerClient.EXPECT().
+					ListModels(gomock.Any()).
+					Return(func() []types.OpenAIModel {
+						if tt.providerModelsErr != nil {
+							return nil
+						}
+						return []types.OpenAIModel{{ID: modelName, ContextLength: tt.advertisedContext}}
+					}(), tt.providerModelsErr)
+			}
+
+			modelInfoProvider.EXPECT().
+				GetModelInfo(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *model.ModelInfoRequest) (*types.ModelInfo, error) {
+					if tt.catalogueUnavailable {
+						return nil, errors.New("model not in catalogue")
+					}
+					return &types.ModelInfo{
+						ContextLength:       catalogueContext,
+						MaxCompletionTokens: catalogueOutputTokens,
+					}, nil
+				}).AnyTimes()
+
+			app := &types.App{
+				Owner: "user-1",
+				Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+					AgentType:               types.AgentTypeZedExternal,
+					GenerationModelProvider: providerName,
+					GenerationModel:         modelName,
+					CodeAgentRuntime:        types.CodeAgentRuntimeZedAgent,
+				}}}},
+			}
+
+			got := apiServer.buildCodeAgentConfig(context.Background(), app, "http://helix-api:8080", "")
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantContext, got.MaxTokens)
+			assert.Equal(t, tt.wantOutputTokens, got.MaxOutputTokens)
+			assert.Equal(t, providerName+"/"+modelName, got.Model)
 		})
 	}
 }

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/lib/pq"
@@ -119,6 +120,46 @@ type OpenAIModel struct {
 	ContextLength int                `json:"context_length,omitempty"`
 	Enabled       bool               `json:"enabled,omitempty"`
 	ModelInfo     *ModelInfo         `json:"model_info,omitempty"`
+}
+
+// UnmarshalJSON accepts the context-window fields commonly returned by
+// OpenAI-compatible servers. OpenAI itself does not define a standard context
+// field on /v1/models, while vLLM uses max_model_len and some compatible
+// servers use max_context_length. Normalize all of them into ContextLength so
+// downstream code has one authoritative field to consume.
+func (m *OpenAIModel) UnmarshalJSON(data []byte) error {
+	type openAIModelAlias OpenAIModel
+
+	var decoded openAIModelAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var compatibleFields struct {
+		MaxModelLen      int `json:"max_model_len"`
+		MaxContextLength int `json:"max_context_length"`
+	}
+	if err := json.Unmarshal(data, &compatibleFields); err != nil {
+		return err
+	}
+
+	*m = OpenAIModel(decoded)
+	if m.ContextLength > 0 {
+		return nil
+	}
+	if compatibleFields.MaxModelLen > 0 {
+		m.ContextLength = compatibleFields.MaxModelLen
+		return nil
+	}
+	if compatibleFields.MaxContextLength > 0 {
+		m.ContextLength = compatibleFields.MaxContextLength
+		return nil
+	}
+	if m.ModelInfo != nil && m.ModelInfo.ContextLength > 0 {
+		m.ContextLength = m.ModelInfo.ContextLength
+	}
+
+	return nil
 }
 
 // UpdateProviderEndpoint used for updating a provider endpoint through the API


### PR DESCRIPTION
## Root cause

Zed configuration used the bundled model catalog context window even when a globally configured OpenAI-compatible provider advertised a different limit. That can make Zed send requests beyond the actual vLLM/SGLang endpoint capacity.

## Change

- normalize compatible `/v1/models` context-length fields
- load the selected provider's advertised model metadata while building Zed configuration
- override `max_tokens` with the provider-advertised context limit while retaining the catalog fallback and output-token limit
- add regression coverage for response normalization and Zed configuration

## Impact

Globally configured compatible endpoints such as `ds4-flash-node06` now drive Zed's context window from their own advertised limits instead of an unrelated public model variant.

## Checks

- `go test ./pkg/openai -run TestListModelsNormalizesCompatibleContextLengthFields -count=1`
- `go test ./pkg/server -run TestBuildCodeAgentConfigProviderAdvertisedContextLength -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
