### PR TITLE
Pass the acting session through the external MCP proxy

### DIFF
--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -337,8 +337,15 @@ func (b *ExternalMCPBackend) getOrCreateServerOnce(ctx context.Context, user *ty
 	// The TTL is based on lastUsed timestamp, not creation time.
 	clientCtx, clientCancel := context.WithCancel(context.Background())
 
-	// Create MCP client to the external server
-	externalClient, err := b.clientGetter.NewClient(clientCtx, agent.Meta{UserID: user.ID}, nil, mcpConfig)
+	// Create MCP client to the external server.
+	//
+	// SessionID is load-bearing, not decoration. NewClient turns Meta into the
+	// X-Helix-Session-Id header, which is how an external MCP server learns which
+	// session a call is for without trusting a model-supplied tool argument. This
+	// is the only path Zed's tool calls take, so omitting it left every such
+	// server unable to identify the caller — Find AI's tools failed with "this
+	// tool requires a signed-in session" for exactly this reason.
+	externalClient, err := b.clientGetter.NewClient(clientCtx, proxyMeta(user, sessionID), nil, mcpConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to external MCP server: %w", err)
 	}
@@ -472,5 +479,18 @@ func (b *ExternalMCPBackend) createToolHandler(client mcpclient.Client, toolName
 			Msg("external MCP tool call succeeded")
 
 		return result, nil
+	}
+}
+
+// proxyMeta is the identity travelling with a proxied tool call.
+//
+// Extracted so it can be tested: the SessionID here becomes the
+// X-Helix-Session-Id header, and dropping it silently breaks every external MCP
+// server that authorizes per user rather than per org.
+func proxyMeta(user *types.User, sessionID string) agent.Meta {
+	return agent.Meta{
+		UserID:    user.ID,
+		SessionID: sessionID,
+		AppID:     user.AppID,
 	}
 }

--- a/api/pkg/server/mcp_backend_external_test.go
+++ b/api/pkg/server/mcp_backend_external_test.go
@@ -166,3 +166,22 @@ func TestExternalMCPBackendCleanupPreservesReplacement(t *testing.T) {
 		t.Fatal("cleanup deleted the fresh replacement server")
 	}
 }
+
+
+// The external proxy is the only path Zed's tool calls take, so the acting
+// session must travel with them. Without it an external MCP server cannot tell
+// which user a call is for except by trusting a model-supplied argument — Find
+// AI's tools failed closed with "requires a signed-in session" for exactly this
+// reason, on production.
+func TestProxyMetaCarriesTheActingSession(t *testing.T) {
+	m := proxyMeta(&types.User{ID: "user_1", AppID: "app_1"}, "ses_real")
+	if m.SessionID != "ses_real" {
+		t.Errorf("SessionID = %q, want ses_real — the X-Helix-Session-Id header depends on it", m.SessionID)
+	}
+	if m.UserID != "user_1" {
+		t.Errorf("UserID = %q, want user_1", m.UserID)
+	}
+	if m.AppID != "app_1" {
+		t.Errorf("AppID = %q, want app_1", m.AppID)
+	}
+}


### PR DESCRIPTION
Found by watching a live agent fail on production.

## Symptom

Every Find AI tool call from a real agent session came back:

```
Tool Call: mcp__helixos__findai_me          Status: Failed
  Error: this tool requires a signed-in Find AI session
Tool Call: mcp__helixos__findai_my_profile  Status: Failed
  Error: this tool requires a signed-in Find AI session
Tool Call: mcp__helixos__findai_search_open_roles  Status: Failed
  Error: this tool requires a signed-in Find AI session
```

The agent then told the user it had "an auth hiccup" and couldn't load their profile.

## Cause

#2983 added `X-Helix-Session-Id`, set by `DefaultClientGetter.NewClient` from `agent.Meta`, so an external MCP server can identify the caller without trusting a model-supplied tool argument.

`ExternalMCPBackend` calls that same `NewClient` — but built its Meta with only the user:

```go
b.clientGetter.NewClient(clientCtx, agent.Meta{UserID: user.ID}, nil, mcpConfig)
```

No `SessionID`, so `NewClient` skipped the session header, so the server had nothing to resolve the caller from. The backend already has the session in hand (`sessionID := user.SessionID`, taken from the session-scoped key) — it just wasn't passed on.

## Why it matters beyond Find AI

This proxy is the **only** path Zed's tool calls take. Any external MCP server that wants to authorize per *user* rather than per *org* was silently unable to, and would have had to fall back to trusting an argument the model controls — exactly what the header exists to avoid.

## Change

Pass `SessionID` (and `AppID`) through. Meta construction is extracted as `proxyMeta` so it's testable rather than buried inline in a 200-line function.

## Tests

- `TestProxyMetaCarriesTheActingSession` — the proxy's Meta carries session, user and app
- `TestMCPClientSendsTheActingSessionAsAHeader` (#2983) — Meta becomes the header
- `TestConfiguredHeadersCannotSpoofTheActingSession` (#2983) — app config can't override it

Together those cover the whole chain. Verified against a live session on meta; will confirm the tools succeed once this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)