### PR TITLE
Let an embedder pin the theme with ?theme=

### DIFF
--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -5,7 +5,29 @@ import useApi from '../hooks/useApi'
 import { PaletteMode } from '@mui/material'
 import { APP_FONT_FAMILY, APP_MONO_FONT_FAMILY } from '../styles/typography'
 
+// themePinnedByQuery reports whether the embedder stated the mode explicitly.
+function themePinnedByQuery(): boolean {
+  try {
+    const q = new URLSearchParams(window.location.search).get('theme')
+    return q === 'dark' || q === 'light'
+  } catch {
+    return false
+  }
+}
+
 function getInitialMode(): PaletteMode {
+  // An explicit ?theme= wins over the OS preference.
+  //
+  // This exists for embedding. An iframe inherits the VIEWER's OS setting, not
+  // the host page's, so a dark site embedding Helix gets a white panel dropped
+  // into it and cannot do anything about it from the parent — the frame is
+  // cross-origin. Letting the embedder state the mode is the only fix available
+  // to them.
+  try {
+    const q = new URLSearchParams(window.location.search).get('theme')
+    if (q === 'dark' || q === 'light') return q
+  } catch { /* malformed query string — fall through to the OS preference */ }
+
   if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
   return 'dark'
 }
@@ -93,6 +115,11 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   // local state and push to the API so the user's spec-task GNOME desktops and
   // Zed editors flip too via the settings-sync-daemon's WS subscription.
   useEffect(() => {
+    // A pinned ?theme= must stay pinned. Otherwise an embedder's dark panel
+    // would flip to light the moment the VIEWER's OS changed — a setting the
+    // embedding site has no control over and no way to observe.
+    if (themePinnedByQuery()) return
+
     const mql = window.matchMedia('(prefers-color-scheme: light)')
     const handler = (e: MediaQueryListEvent) => {
       const next: PaletteMode = e.matches ? 'light' : 'dark'


### PR DESCRIPTION
One commit. Found while embedding the spec-task chat in a dark third-party site (Find AI).

## Problem

An iframe resolves `prefers-color-scheme` from the **viewer's operating system**, not from the host page — and the frame is cross-origin, so the embedding site cannot restyle it.

The result: a dark site embeds Helix, and any visitor on a light-mode machine gets a white panel dropped into the middle of it. The embedder has no way to detect this and no way to fix it.

## Change

Honour an explicit `?theme=dark|light` in `getInitialMode`, ahead of the OS preference.

Also keep it pinned: the live OS-preference watcher is skipped when the mode came from the query. Without that guard, a viewer changing their OS appearance mid-session would flip an embedded panel out from under the site hosting it — a setting that site can neither see nor control.

Falls through to the existing OS-preference behaviour when the parameter is absent or malformed, so nothing changes for normal use.

## Verification

`tsc --noEmit` — zero errors in `contexts/theme.tsx` (the repo has a pre-existing baseline of unrelated MUI `SxProps` errors elsewhere).

**Not visually verified yet** — that needs this and the companion find-ai change both deployed. I'll confirm the embedded panel renders dark once it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)