### PR TITLE
fix(preview): preserve sandbox browser paths

### DIFF
--- a/api/pkg/server/vhost_middleware.go
+++ b/api/pkg/server/vhost_middleware.go
@@ -178,7 +178,7 @@ func (m *VHostMiddleware) dispatchSandboxPreview(w http.ResponseWriter, r *http.
 			http.Error(w, "preview target session has no sandbox", http.StatusServiceUnavailable)
 			return
 		}
-		m.apiServer.proxyToContainer(w, r, sess.SandboxID, targetID, route.Port, r.URL.Path, "")
+		m.apiServer.proxyToContainer(w, r, sess.SandboxID, targetID, route.Port, r.URL.Path, "", true)
 		return
 	}
 	if strings.HasPrefix(targetID, "sbx_") {
@@ -189,7 +189,7 @@ func (m *VHostMiddleware) dispatchSandboxPreview(w http.ResponseWriter, r *http.
 		}
 		// Sandbox-API containers are registered in hydra under
 		// req.SessionID = sandbox.ID (see sandbox/controller_provision.go).
-		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, "")
+		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, "", true)
 		return
 	}
 	http.Error(w, "unrecognised preview target id format", http.StatusBadRequest)
@@ -229,7 +229,7 @@ func (m *VHostMiddleware) dispatchProjectWebService(w http.ResponseWriter, r *ht
 	// route.TargetID is the projectID for a web-service route → lets the holding
 	// page distinguish "starting up" (deploy in flight) from "temporarily
 	// unavailable" (down / crashed).
-	m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, route.TargetID)
+	m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, route.TargetID, false)
 }
 
 // stripPort removes a trailing :port from a Host header value, taking

--- a/api/pkg/server/vhost_proxy.go
+++ b/api/pkg/server/vhost_proxy.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +13,9 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/hydra"
@@ -23,6 +29,17 @@ import (
 // ErrorHandler serves the branded holding page instead of leaking hydra's 502
 // body (which carries the internal container IP) to the public.
 var errUpstreamUnavailable = errors.New("web service upstream unavailable")
+
+const sandboxBrowserBridgeJavaScript = `(()=>{const send=(navigationType)=>window.parent.postMessage({type:'helix:sandbox-browser:navigate',href:window.location.href,navigationType},'*');const pushState=history.pushState;history.pushState=function(...args){const result=pushState.apply(this,args);send('push');return result};const replaceState=history.replaceState;history.replaceState=function(...args){const result=replaceState.apply(this,args);send('replace');return result};addEventListener('popstate',()=>send('pop'));addEventListener('hashchange',()=>send('push'));addEventListener('pageshow',()=>send('load'));send('load')})()`
+
+const sandboxBrowserBridgeScript = "<script>" + sandboxBrowserBridgeJavaScript + "</script>"
+
+const maxSandboxBrowserHTMLSize = 8 << 20
+
+var (
+	htmlHeadPattern = regexp.MustCompile(`(?i)<head(?:\s[^>]*)?>`)
+	htmlOpenPattern = regexp.MustCompile(`(?i)<html(?:\s[^>]*)?>`)
+)
 
 // proxyToContainer forwards an HTTP request to a port inside a sandbox
 // container via the hydra dev-container proxy, reached over RevDial.
@@ -48,6 +65,9 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 	// state-aware ("starting up" vs "temporarily unavailable"). Empty for
 	// sandbox previews, which always get the optimistic starting-up page.
 	projectID string,
+	// browserBridge injects navigation reporting into sandbox-preview HTML so
+	// the cross-origin SandboxBrowser iframe can keep its address bar in sync.
+	browserBridge bool,
 ) {
 	if sandboxID == "" {
 		http.Error(w, "no sandbox associated with route", http.StatusServiceUnavailable)
@@ -75,6 +95,12 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 		req.URL.Path = hydraPath
 		req.URL.RawPath = ""
 		req.URL.RawQuery = r.URL.RawQuery
+		if browserBridge {
+			// The response bridge rewrites HTML, so ask the upstream for an
+			// identity body. If it still compresses the response, the modifier
+			// safely leaves that response untouched.
+			req.Header.Del("Accept-Encoding")
+		}
 	}
 
 	proxy.Transport = &revdialTransport{
@@ -90,6 +116,9 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 		if resp.Header.Get("X-Helix-Upstream-Unavailable") != "" {
 			_ = resp.Body.Close()
 			return errUpstreamUnavailable
+		}
+		if browserBridge {
+			return injectSandboxBrowserBridge(resp)
 		}
 		return nil
 	}
@@ -109,6 +138,83 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 	}
 
 	proxy.ServeHTTP(w, r)
+}
+
+func injectSandboxBrowserBridge(resp *http.Response) error {
+	contentEncoding := strings.TrimSpace(resp.Header.Get("Content-Encoding"))
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotModified ||
+		!strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") ||
+		(contentEncoding != "" && !strings.EqualFold(contentEncoding, "identity")) ||
+		(resp.Request != nil && resp.Request.Method == http.MethodHead) {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSandboxBrowserHTMLSize+1))
+	if err != nil {
+		return fmt.Errorf("read sandbox preview HTML: %w", err)
+	}
+	if len(body) > maxSandboxBrowserHTMLSize {
+		resp.Body = &readerWithCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), resp.Body),
+			Closer: resp.Body,
+		}
+		return nil
+	}
+	if err := resp.Body.Close(); err != nil {
+		return fmt.Errorf("close sandbox preview HTML: %w", err)
+	}
+
+	match := htmlHeadPattern.FindIndex(body)
+	insertAt := 0
+	if match != nil {
+		insertAt = match[1]
+	} else if match = htmlOpenPattern.FindIndex(body); match != nil {
+		insertAt = match[1]
+	}
+	rewritten := make([]byte, 0, len(body)+len(sandboxBrowserBridgeScript))
+	rewritten = append(rewritten, body[:insertAt]...)
+	rewritten = append(rewritten, sandboxBrowserBridgeScript...)
+	rewritten = append(rewritten, body[insertAt:]...)
+
+	resp.Body = io.NopCloser(bytes.NewReader(rewritten))
+	resp.ContentLength = int64(len(rewritten))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
+	resp.Header.Del("Content-MD5")
+	resp.Header.Del("ETag")
+	allowSandboxBrowserBridgeInCSP(resp.Header)
+	return nil
+}
+
+func allowSandboxBrowserBridgeInCSP(header http.Header) {
+	policies := header.Values("Content-Security-Policy")
+	if len(policies) == 0 {
+		return
+	}
+	bridgeHash := sha256.Sum256([]byte(sandboxBrowserBridgeJavaScript))
+	hashSource := "'sha256-" + base64.StdEncoding.EncodeToString(bridgeHash[:]) + "'"
+	header.Del("Content-Security-Policy")
+	for _, policy := range policies {
+		header.Add("Content-Security-Policy", appendCSPSource(policy, hashSource))
+	}
+}
+
+func appendCSPSource(policy, source string) string {
+	directives := strings.Split(policy, ";")
+	for _, directiveName := range []string{"script-src-elem", "script-src", "default-src"} {
+		for index, directive := range directives {
+			fields := strings.Fields(directive)
+			if len(fields) > 0 && strings.EqualFold(fields[0], directiveName) {
+				directives[index] = strings.TrimSpace(directive) + " " + source
+				return strings.Join(directives, ";")
+			}
+		}
+	}
+	return strings.TrimSuffix(policy, ";") + "; script-src " + source
+}
+
+type readerWithCloser struct {
+	io.Reader
+	io.Closer
 }
 
 // writeStartingUpPage serves a branded, auto-refreshing holding page when the

--- a/api/pkg/server/vhost_proxy_test.go
+++ b/api/pkg/server/vhost_proxy_test.go
@@ -2,14 +2,91 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestInjectSandboxBrowserBridge(t *testing.T) {
+	original := "<!doctype html><html><head><title>App</title></head><body>hello</body></html>"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":            []string{"text/html; charset=utf-8"},
+			"Content-Length":          []string{strconv.Itoa(len(original))},
+			"Content-Security-Policy": []string{"default-src 'self'; script-src 'self'"},
+			"ETag":                    []string{`"old"`},
+		},
+		Body:          io.NopCloser(strings.NewReader(original)),
+		ContentLength: int64(len(original)),
+	}
+
+	require.NoError(t, injectSandboxBrowserBridge(response))
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "<head>"+sandboxBrowserBridgeScript+"<title>")
+	require.Equal(t, int64(len(body)), response.ContentLength)
+	require.Equal(t, strconv.Itoa(len(body)), response.Header.Get("Content-Length"))
+	require.Empty(t, response.Header.Get("ETag"))
+	require.Contains(t, response.Header.Get("Content-Security-Policy"), "script-src 'self' 'sha256-")
+}
+
+func TestInjectSandboxBrowserBridgeSkipsCompressedHTML(t *testing.T) {
+	original := "<html><head></head><body>compressed</body></html>"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":     []string{"text/html"},
+			"Content-Encoding": []string{"gzip"},
+		},
+		Body: io.NopCloser(strings.NewReader(original)),
+	}
+
+	require.NoError(t, injectSandboxBrowserBridge(response))
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, original, string(body))
+}
+
+func TestInjectSandboxBrowserBridgePreservesDoctypeWithoutHead(t *testing.T) {
+	original := "<!doctype html><html><body>hello</body></html>"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":     []string{"text/html"},
+			"Content-Encoding": []string{"identity"},
+		},
+		Body: io.NopCloser(strings.NewReader(original)),
+	}
+
+	require.NoError(t, injectSandboxBrowserBridge(response))
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(body), "<!doctype html><html>"+sandboxBrowserBridgeScript))
+}
+
+func TestInjectSandboxBrowserBridgeLeavesOversizedHTMLIntact(t *testing.T) {
+	original := bytes.Repeat([]byte("a"), maxSandboxBrowserHTMLSize+1)
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+		Body: io.NopCloser(bytes.NewReader(original)),
+	}
+
+	require.NoError(t, injectSandboxBrowserBridge(response))
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, original, body)
+}
 
 func TestReadRevdialResponsePreservesUpgradeConnection(t *testing.T) {
 	client, upstream := net.Pipe()

--- a/frontend/src/components/tasks/SandboxBrowser.test.tsx
+++ b/frontend/src/components/tasks/SandboxBrowser.test.tsx
@@ -43,6 +43,47 @@ describe('SandboxBrowser', () => {
     })
   })
 
+  it('automatically opens the saved address on mount', async () => {
+    window.localStorage.setItem(
+      'helix.sandboxBrowser.url.ses_test',
+      'http://localhost:8080/docs/deploy-sovereign-server',
+    )
+
+    render(<SandboxBrowser sessionId="ses_test" />)
+
+    const frame = await screen.findByTitle(
+      'Sandbox browser: http://localhost:8080/docs/deploy-sovereign-server',
+    )
+    expect(frame).toHaveAttribute(
+      'src',
+      'http://share-blue-fox.dev.localhost:8080/docs/deploy-sovereign-server',
+    )
+    expect(screen.getByRole('textbox', { name: 'Sandbox browser address' }))
+      .toHaveValue('http://localhost:8080/docs/deploy-sovereign-server')
+    expect(previewMocks.refetch).not.toHaveBeenCalled()
+    expect(previewMocks.create).not.toHaveBeenCalled()
+  })
+
+  it('automatically opens the saved address after switching sessions', async () => {
+    window.localStorage.setItem(
+      'helix.sandboxBrowser.url.ses_first',
+      'http://localhost:8080/first',
+    )
+    window.localStorage.setItem(
+      'helix.sandboxBrowser.url.ses_second',
+      'http://localhost:8080/second',
+    )
+
+    const { rerender } = render(<SandboxBrowser sessionId="ses_first" />)
+    await screen.findByTitle('Sandbox browser: http://localhost:8080/first')
+
+    rerender(<SandboxBrowser sessionId="ses_second" />)
+
+    await screen.findByTitle('Sandbox browser: http://localhost:8080/second')
+    expect(screen.getByRole('textbox', { name: 'Sandbox browser address' }))
+      .toHaveValue('http://localhost:8080/second')
+  })
+
   it('opens a localhost path through the existing preview hostname', async () => {
     render(<SandboxBrowser sessionId="ses_test" />)
 
@@ -88,6 +129,7 @@ describe('SandboxBrowser', () => {
   it('opens multiple tabs and supports the file-tab close actions', async () => {
     render(<SandboxBrowser sessionId="ses_test" />)
 
+    await screen.findByTitle('Sandbox browser: http://localhost:8080/')
     expect(screen.getAllByRole('tab')).toHaveLength(1)
     fireEvent.click(screen.getByRole('button', { name: 'New browser tab' }))
     fireEvent.click(screen.getByRole('button', { name: 'New browser tab' }))

--- a/frontend/src/components/tasks/SandboxBrowser.test.tsx
+++ b/frontend/src/components/tasks/SandboxBrowser.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const previewMocks = vi.hoisted(() => ({
@@ -128,5 +128,72 @@ describe('SandboxBrowser', () => {
     fireEvent.click(screen.getAllByRole('tab')[0])
     expect(firstFrame).toBeVisible()
     expect(secondFrame).not.toBeVisible()
+  })
+
+  it('tracks iframe navigation and reloads the current path', async () => {
+    render(<SandboxBrowser sessionId="ses_test" />)
+
+    const address = screen.getByRole('textbox', { name: 'Sandbox browser address' })
+    fireEvent.change(address, { target: { value: 'http://localhost:8080/' } })
+    fireEvent.submit(address.closest('form')!)
+    const firstFrame = await screen.findByTitle('Sandbox browser: http://localhost:8080/')
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'helix:sandbox-browser:navigate',
+          href: 'http://share-blue-fox.dev.localhost:8080/dashboard?q=one#status',
+          navigationType: 'push',
+        },
+        origin: 'http://share-blue-fox.dev.localhost:8080',
+        source: (firstFrame as HTMLIFrameElement).contentWindow,
+      }))
+    })
+
+    await waitFor(() => expect(address).toHaveValue(
+      'http://localhost:8080/dashboard?q=one#status',
+    ))
+    const navigatedFrame = screen.getByTitle(
+      'Sandbox browser: http://localhost:8080/dashboard?q=one#status',
+    )
+    expect(navigatedFrame).toBe(firstFrame)
+    expect(navigatedFrame).toHaveAttribute(
+      'src',
+      'http://share-blue-fox.dev.localhost:8080/',
+    )
+    expect(window.localStorage.getItem('helix.sandboxBrowser.url.ses_test'))
+      .toBe('http://localhost:8080/dashboard?q=one#status')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload browser preview' }))
+    const reloadedFrame = await screen.findByTitle(
+      'Sandbox browser: http://localhost:8080/dashboard?q=one#status',
+    )
+    expect(reloadedFrame).toHaveAttribute(
+      'src',
+      'http://share-blue-fox.dev.localhost:8080/dashboard?q=one#status',
+    )
+  })
+
+  it('ignores navigation messages that do not match the preview origin', async () => {
+    render(<SandboxBrowser sessionId="ses_test" />)
+
+    const address = screen.getByRole('textbox', { name: 'Sandbox browser address' })
+    fireEvent.change(address, { target: { value: 'http://localhost:8080/' } })
+    fireEvent.submit(address.closest('form')!)
+    const frame = await screen.findByTitle('Sandbox browser: http://localhost:8080/')
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'helix:sandbox-browser:navigate',
+          href: 'https://example.com/phishing',
+          navigationType: 'push',
+        },
+        origin: 'https://example.com',
+        source: (frame as HTMLIFrameElement).contentWindow,
+      }))
+    })
+
+    expect(address).toHaveValue('http://localhost:8080/')
   })
 })

--- a/frontend/src/components/tasks/SandboxBrowser.tsx
+++ b/frontend/src/components/tasks/SandboxBrowser.tsx
@@ -117,8 +117,13 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
   const nextTabId = useRef(1)
   const iframeRefs = useRef(new Map<string, HTMLIFrameElement>())
   const activeTabIdRef = useRef<string | null>('browser-0')
+  const loadedSessionIdRef = useRef(sessionId)
+  const autoNavigateAddressRef = useRef<string | null>(
+    window.localStorage.getItem(storageKey) ?? defaultAddress,
+  )
+  const navigationRequestsRef = useRef(new Map<string, number>())
   const [tabs, setTabs] = useState<BrowserTab[]>(() => [
-    createBrowserTab('browser-0', window.localStorage.getItem(storageKey) ?? defaultAddress),
+    createBrowserTab('browser-0', autoNavigateAddressRef.current ?? defaultAddress),
   ])
   const [activeTabId, setActiveTabId] = useState<string | null>('browser-0')
   const [tabContextMenu, setTabContextMenu] = useState<TabContextMenu | null>(null)
@@ -131,12 +136,15 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
   activeTabIdRef.current = activeTabId
 
   useEffect(() => {
+    if (loadedSessionIdRef.current === sessionId) return
+    loadedSessionIdRef.current = sessionId
     const nextStorageKey = `helix.sandboxBrowser.url.${sessionId}`
+    const address = window.localStorage.getItem(nextStorageKey) ?? defaultAddress
     nextTabId.current = 1
     iframeRefs.current.clear()
-    setTabs([
-      createBrowserTab('browser-0', window.localStorage.getItem(nextStorageKey) ?? defaultAddress),
-    ])
+    navigationRequestsRef.current.clear()
+    autoNavigateAddressRef.current = address
+    setTabs([createBrowserTab('browser-0', address)])
     setActiveTabId('browser-0')
     setTabContextMenu(null)
   }, [sessionId])
@@ -207,6 +215,103 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
     : undefined
   const isLoading = createToken.isPending
 
+  const findOrCreateRoute = async (port: number): Promise<TypesVHostRoute> => {
+    const cached = tokensQuery.data?.find((route) => route.port === port)
+    if (cached) return cached
+
+    const refreshed = await tokensQuery.refetch()
+    const existing = refreshed.data?.find((route) => route.port === port)
+    if (existing) return existing
+
+    const created = await createToken.mutateAsync(port)
+    if (!created?.hostname) throw new Error('Preview route was created without a hostname')
+    return created
+  }
+
+  const updateTab = (tabId: string, update: (tab: BrowserTab) => BrowserTab) => {
+    setTabs((currentTabs) => currentTabs.map((tab) => tab.id === tabId ? update(tab) : tab))
+  }
+
+  const navigate = async (tabId: string, input: string) => {
+    const requestId = (navigationRequestsRef.current.get(tabId) ?? 0) + 1
+    navigationRequestsRef.current.set(tabId, requestId)
+    updateTab(tabId, (tab) => ({ ...tab, error: '' }))
+    try {
+      const target = parseSandboxBrowserTarget(input)
+      const route = await findOrCreateRoute(target.port)
+      if (navigationRequestsRef.current.get(tabId) !== requestId) return
+      if (!route.url) throw new Error('Preview route has no public URL')
+
+      const entry = {
+        displayUrl: target.displayUrl,
+        previewUrl: sandboxPreviewUrl(route.url, target.path, previewURLHTTPS),
+      }
+      updateTab(tabId, (tab) => {
+        const nextHistory = [...tab.history.slice(0, tab.historyIndex + 1), entry]
+        return {
+          ...tab,
+          address: target.displayUrl,
+          error: '',
+          frameUrl: entry.previewUrl,
+          history: nextHistory,
+          historyIndex: nextHistory.length - 1,
+        }
+      })
+      window.localStorage.setItem(storageKey, target.displayUrl)
+    } catch (navigateError) {
+      if (navigationRequestsRef.current.get(tabId) !== requestId) return
+      updateTab(tabId, (tab) => ({ ...tab, error: errorMessage(navigateError) }))
+    }
+  }
+
+  useEffect(() => {
+    if (configQuery.isLoading || !previewConfigured) return
+    const address = autoNavigateAddressRef.current
+    if (!address) return
+    autoNavigateAddressRef.current = null
+    void navigate('browser-0', address)
+  }, [configQuery.isLoading, previewConfigured, sessionId])
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    if (activeTab) void navigate(activeTab.id, activeTab.address)
+  }
+
+  const moveHistory = (tabId: string, nextIndex: number) => {
+    const tab = tabs.find((candidate) => candidate.id === tabId)
+    const next = tab?.history[nextIndex]
+    if (!next) return
+    updateTab(tabId, (currentTab) => ({
+      ...currentTab,
+      address: next.displayUrl,
+      error: '',
+      frameUrl: next.previewUrl,
+      historyIndex: nextIndex,
+      reloadNonce: currentTab.reloadNonce + 1,
+    }))
+  }
+
+  const addTab = () => {
+    const tabId = `browser-${nextTabId.current}`
+    nextTabId.current += 1
+    setTabs((currentTabs) => [...currentTabs, createBrowserTab(tabId)])
+    setActiveTabId(tabId)
+    setTabContextMenu(null)
+  }
+
+  const closeTabs = (targetTabId: string, action: SandboxBrowserTabCloseAction) => {
+    const result = closeSandboxBrowserTabs(
+      tabs.map((tab) => tab.id),
+      activeTabId,
+      targetTabId,
+      action,
+    )
+    const remainingTabIds = new Set(result.openTabIds)
+    setTabs((currentTabs) => currentTabs.filter((tab) => remainingTabIds.has(tab.id)))
+    setActiveTabId(result.activeTabId)
+    setTabContextMenu(null)
+  }
+
   if (configQuery.isLoading) {
     return (
       <Box sx={{ flex: 1, minHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -257,91 +362,6 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
         </Box>
       </Box>
     )
-  }
-
-  const findOrCreateRoute = async (port: number): Promise<TypesVHostRoute> => {
-    const cached = tokensQuery.data?.find((route) => route.port === port)
-    if (cached) return cached
-
-    const refreshed = await tokensQuery.refetch()
-    const existing = refreshed.data?.find((route) => route.port === port)
-    if (existing) return existing
-
-    const created = await createToken.mutateAsync(port)
-    if (!created?.hostname) throw new Error('Preview route was created without a hostname')
-    return created
-  }
-
-  const updateTab = (tabId: string, update: (tab: BrowserTab) => BrowserTab) => {
-    setTabs((currentTabs) => currentTabs.map((tab) => tab.id === tabId ? update(tab) : tab))
-  }
-
-  const navigate = async (tabId: string, input: string) => {
-    updateTab(tabId, (tab) => ({ ...tab, error: '' }))
-    try {
-      const target = parseSandboxBrowserTarget(input)
-      const route = await findOrCreateRoute(target.port)
-      if (!route.url) throw new Error('Preview route has no public URL')
-
-      const entry = {
-        displayUrl: target.displayUrl,
-        previewUrl: sandboxPreviewUrl(route.url, target.path, previewURLHTTPS),
-      }
-      updateTab(tabId, (tab) => {
-        const nextHistory = [...tab.history.slice(0, tab.historyIndex + 1), entry]
-        return {
-          ...tab,
-          address: target.displayUrl,
-          error: '',
-          frameUrl: entry.previewUrl,
-          history: nextHistory,
-          historyIndex: nextHistory.length - 1,
-        }
-      })
-      window.localStorage.setItem(storageKey, target.displayUrl)
-    } catch (navigateError) {
-      updateTab(tabId, (tab) => ({ ...tab, error: errorMessage(navigateError) }))
-    }
-  }
-
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault()
-    if (activeTab) void navigate(activeTab.id, activeTab.address)
-  }
-
-  const moveHistory = (tabId: string, nextIndex: number) => {
-    const tab = tabs.find((candidate) => candidate.id === tabId)
-    const next = tab?.history[nextIndex]
-    if (!next) return
-    updateTab(tabId, (currentTab) => ({
-      ...currentTab,
-      address: next.displayUrl,
-      error: '',
-      frameUrl: next.previewUrl,
-      historyIndex: nextIndex,
-      reloadNonce: currentTab.reloadNonce + 1,
-    }))
-  }
-
-  const addTab = () => {
-    const tabId = `browser-${nextTabId.current}`
-    nextTabId.current += 1
-    setTabs((currentTabs) => [...currentTabs, createBrowserTab(tabId)])
-    setActiveTabId(tabId)
-    setTabContextMenu(null)
-  }
-
-  const closeTabs = (targetTabId: string, action: SandboxBrowserTabCloseAction) => {
-    const result = closeSandboxBrowserTabs(
-      tabs.map((tab) => tab.id),
-      activeTabId,
-      targetTabId,
-      action,
-    )
-    const remainingTabIds = new Set(result.openTabIds)
-    setTabs((currentTabs) => currentTabs.filter((tab) => remainingTabIds.has(tab.id)))
-    setActiveTabId(result.activeTabId)
-    setTabContextMenu(null)
   }
 
   return (
@@ -579,8 +599,8 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
               <Globe2 size={38} strokeWidth={1.4} />
               <Typography variant="h6" sx={{ mt: 1.5 }}>Open a sandbox web app</Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
-                Enter a localhost URL above, such as http://localhost:8080, then press Enter.
-                Traffic goes through Helix to this task&apos;s sandbox.
+                The saved localhost URL opens automatically. Enter a different URL above to
+                navigate within this task&apos;s sandbox.
               </Typography>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1.5 }}>
                 Opening a port creates a shareable preview URL. Anyone with that unguessable URL can

--- a/frontend/src/components/tasks/SandboxBrowser.tsx
+++ b/frontend/src/components/tasks/SandboxBrowser.tsx
@@ -29,7 +29,9 @@ import {
   useSessionPreviewTokens,
 } from '../../services/sessionPreviewService'
 import {
+  isSandboxBrowserNavigationMessage,
   parseSandboxBrowserTarget,
+  sandboxDisplayUrlFromPreview,
   sandboxPreviewUrl,
   sandboxPreviewURLWithScheme,
 } from './sandboxBrowserUrl'
@@ -50,6 +52,7 @@ interface BrowserHistoryEntry {
 interface BrowserTab {
   address: string
   error: string
+  frameUrl: string
   history: BrowserHistoryEntry[]
   historyIndex: number
   id: string
@@ -68,6 +71,7 @@ function createBrowserTab(id: string, address = defaultAddress): BrowserTab {
   return {
     address,
     error: '',
+    frameUrl: '',
     history: [],
     historyIndex: -1,
     id,
@@ -111,6 +115,8 @@ function errorMessage(error: unknown): string {
 const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
   const storageKey = `helix.sandboxBrowser.url.${sessionId}`
   const nextTabId = useRef(1)
+  const iframeRefs = useRef(new Map<string, HTMLIFrameElement>())
+  const activeTabIdRef = useRef<string | null>('browser-0')
   const [tabs, setTabs] = useState<BrowserTab[]>(() => [
     createBrowserTab('browser-0', window.localStorage.getItem(storageKey) ?? defaultAddress),
   ])
@@ -122,15 +128,75 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
   const tokensQuery = useSessionPreviewTokens(sessionId, previewConfigured)
   const createToken = useCreateSessionPreviewToken(sessionId)
 
+  activeTabIdRef.current = activeTabId
+
   useEffect(() => {
     const nextStorageKey = `helix.sandboxBrowser.url.${sessionId}`
     nextTabId.current = 1
+    iframeRefs.current.clear()
     setTabs([
       createBrowserTab('browser-0', window.localStorage.getItem(nextStorageKey) ?? defaultAddress),
     ])
     setActiveTabId('browser-0')
     setTabContextMenu(null)
   }, [sessionId])
+
+  useEffect(() => {
+    const handlePreviewNavigation = (event: MessageEvent) => {
+      if (!isSandboxBrowserNavigationMessage(event.data)) return
+      const frameEntry = [...iframeRefs.current.entries()].find(([, frame]) => (
+        frame.contentWindow === event.source
+      ))
+      if (!frameEntry) return
+      const [tabId] = frameEntry
+
+      setTabs((currentTabs) => currentTabs.map((tab) => {
+        if (tab.id !== tabId || tab.historyIndex < 0) return tab
+        const currentEntry = tab.history[tab.historyIndex]
+        const resolvedPreviewUrl = sandboxPreviewURLWithScheme(
+          currentEntry.previewUrl,
+          previewURLHTTPS,
+        )
+        if (event.origin !== new URL(resolvedPreviewUrl).origin) return tab
+        const displayUrl = sandboxDisplayUrlFromPreview(
+          currentEntry.displayUrl,
+          resolvedPreviewUrl,
+          event.data.href,
+        )
+        if (!displayUrl) return tab
+        if (activeTabIdRef.current === tabId) {
+          window.localStorage.setItem(`helix.sandboxBrowser.url.${sessionId}`, displayUrl)
+        }
+        if (displayUrl === currentEntry.displayUrl) {
+          return { ...tab, address: displayUrl }
+        }
+
+        const nextEntry = { displayUrl, previewUrl: event.data.href }
+        if (event.data.navigationType === 'replace') {
+          const history = [...tab.history]
+          history[tab.historyIndex] = nextEntry
+          return { ...tab, address: displayUrl, history }
+        }
+        if (event.data.navigationType === 'pop') {
+          const historyIndex = tab.history.findIndex((entry) => entry.displayUrl === displayUrl)
+          if (historyIndex >= 0) {
+            return { ...tab, address: displayUrl, historyIndex }
+          }
+        }
+
+        const history = [...tab.history.slice(0, tab.historyIndex + 1), nextEntry]
+        return {
+          ...tab,
+          address: displayUrl,
+          history,
+          historyIndex: history.length - 1,
+        }
+      }))
+    }
+
+    window.addEventListener('message', handlePreviewNavigation)
+    return () => window.removeEventListener('message', handlePreviewNavigation)
+  }, [previewURLHTTPS, sessionId])
 
   const activeTab = tabs.find((tab) => tab.id === activeTabId)
   const current = activeTab && activeTab.historyIndex >= 0
@@ -227,6 +293,7 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
           ...tab,
           address: target.displayUrl,
           error: '',
+          frameUrl: entry.previewUrl,
           history: nextHistory,
           historyIndex: nextHistory.length - 1,
         }
@@ -250,7 +317,9 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
       ...currentTab,
       address: next.displayUrl,
       error: '',
+      frameUrl: next.previewUrl,
       historyIndex: nextIndex,
+      reloadNonce: currentTab.reloadNonce + 1,
     }))
   }
 
@@ -425,7 +494,11 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
             <IconButton
               aria-label="Reload browser preview"
               disabled={!current || isLoading}
-              onClick={() => updateTab(activeTab.id, (tab) => ({ ...tab, reloadNonce: tab.reloadNonce + 1 }))}
+              onClick={() => updateTab(activeTab.id, (tab) => ({
+                ...tab,
+                frameUrl: current?.previewUrl || tab.frameUrl,
+                reloadNonce: tab.reloadNonce + 1,
+              }))}
               sx={browserButtonSx}
             >
               {isLoading ? <CircularProgress size={16} /> : <RotateCw />}
@@ -472,9 +545,9 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden', backgroundColor: '#000' }}>
         {tabs.map((tab) => {
           const tabCurrent = tab.historyIndex >= 0 ? tab.history[tab.historyIndex] : undefined
-          if (!tabCurrent) return null
+          if (!tabCurrent || !tab.frameUrl) return null
           const resolvedPreviewUrl = sandboxPreviewURLWithScheme(
-            tabCurrent.previewUrl,
+            tab.frameUrl,
             previewURLHTTPS,
           )
           return (
@@ -487,7 +560,11 @@ const SandboxBrowser: FC<SandboxBrowserProps> = ({ sessionId }) => {
               }}
             >
               <iframe
-                key={`${resolvedPreviewUrl}:${tab.reloadNonce}`}
+                key={`${tab.id}:${tab.reloadNonce}`}
+                ref={(frame) => {
+                  if (frame) iframeRefs.current.set(tab.id, frame)
+                  else iframeRefs.current.delete(tab.id)
+                }}
                 src={resolvedPreviewUrl}
                 title={`Sandbox browser: ${tabCurrent.displayUrl}`}
                 allow="clipboard-read; clipboard-write; fullscreen"

--- a/frontend/src/components/tasks/sandboxBrowserUrl.test.ts
+++ b/frontend/src/components/tasks/sandboxBrowserUrl.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  isSandboxBrowserNavigationMessage,
   parseSandboxBrowserTarget,
+  sandboxDisplayUrlFromPreview,
   sandboxPreviewUrl,
   sandboxPreviewURLWithScheme,
 } from './sandboxBrowserUrl'
@@ -59,5 +61,41 @@ describe('sandboxPreviewUrl', () => {
       'https://share-blue-fox.dev.localhost:8080/dashboard?q=one#status',
       false,
     )).toBe('http://share-blue-fox.dev.localhost:8080/dashboard?q=one#status')
+  })
+})
+
+describe('sandboxDisplayUrlFromPreview', () => {
+  it('maps a navigated preview path back to its localhost address', () => {
+    expect(sandboxDisplayUrlFromPreview(
+      'http://localhost:8080/',
+      'http://share-blue-fox.dev.localhost:8080/',
+      'http://share-blue-fox.dev.localhost:8080/dashboard?q=one#status',
+    )).toBe('http://localhost:8080/dashboard?q=one#status')
+  })
+
+  it('rejects navigation reports from another origin', () => {
+    expect(sandboxDisplayUrlFromPreview(
+      'http://localhost:8080/',
+      'http://share-blue-fox.dev.localhost:8080/',
+      'https://example.com/dashboard',
+    )).toBeUndefined()
+  })
+})
+
+describe('isSandboxBrowserNavigationMessage', () => {
+  it('accepts complete bridge messages', () => {
+    expect(isSandboxBrowserNavigationMessage({
+      type: 'helix:sandbox-browser:navigate',
+      href: 'http://share-blue-fox.dev.localhost:8080/dashboard',
+      navigationType: 'push',
+    })).toBe(true)
+  })
+
+  it('rejects malformed bridge messages', () => {
+    expect(isSandboxBrowserNavigationMessage({
+      type: 'helix:sandbox-browser:navigate',
+      href: 42,
+      navigationType: 'push',
+    })).toBe(false)
   })
 })

--- a/frontend/src/components/tasks/sandboxBrowserUrl.ts
+++ b/frontend/src/components/tasks/sandboxBrowserUrl.ts
@@ -4,6 +4,14 @@ export interface SandboxBrowserTarget {
   path: string
 }
 
+export type SandboxBrowserNavigationType = 'load' | 'pop' | 'push' | 'replace'
+
+export interface SandboxBrowserNavigationMessage {
+  type: 'helix:sandbox-browser:navigate'
+  href: string
+  navigationType: SandboxBrowserNavigationType
+}
+
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'])
 
 export function parseSandboxBrowserTarget(input: string): SandboxBrowserTarget {
@@ -58,4 +66,40 @@ export function sandboxPreviewURLWithScheme(url: string, https: boolean): string
   }
   base.protocol = https ? 'https:' : 'http:'
   return base.toString()
+}
+
+export function sandboxDisplayUrlFromPreview(
+  displayUrl: string,
+  previewUrl: string,
+  href: string,
+): string | undefined {
+  let display: URL
+  let preview: URL
+  let navigated: URL
+  try {
+    display = new URL(displayUrl)
+    preview = new URL(previewUrl)
+    navigated = new URL(href)
+  } catch {
+    return undefined
+  }
+  if (navigated.origin !== preview.origin) return undefined
+
+  display.pathname = navigated.pathname
+  display.search = navigated.search
+  display.hash = navigated.hash
+  return display.toString()
+}
+
+export function isSandboxBrowserNavigationMessage(
+  data: unknown,
+): data is SandboxBrowserNavigationMessage {
+  if (typeof data !== 'object' || data === null) return false
+  const message = data as Partial<SandboxBrowserNavigationMessage>
+  return message.type === 'helix:sandbox-browser:navigate' &&
+    typeof message.href === 'string' &&
+    (message.navigationType === 'load' ||
+      message.navigationType === 'pop' ||
+      message.navigationType === 'push' ||
+      message.navigationType === 'replace')
 }


### PR DESCRIPTION
## Summary

- automatically open the saved/default sandbox browser URL when the Browser view mounts or changes sessions
- inject a preview-only navigation bridge into sandbox HTML responses
- synchronize the SandboxBrowser address, history, and persisted URL with iframe navigation
- reload the tracked path without remounting SPAs during normal navigation
- validate navigation messages against the exact iframe window and preview origin

## Verification

- go test ./pkg/server -run TestInjectSandboxBrowserBridge\|TestReadRevdialResponsePreservesUpgradeConnection\|TestDispatchSandboxPreviewUsesSessionSandboxIDAsRevDialHost -count=1
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- yarn test SandboxBrowser.test.tsx sandboxBrowserUrl.test.ts
- yarn build
- live Chromium: clicked /docs/macos in a running sandbox preview, observed redirect tracking to /docs/install-mac, then reloaded and remained on /docs/install-mac