### PR TITLE
fix(frontend): show only agents in fresh org charts

### DIFF
--- a/frontend/src/components/helix-org/chartEntityVisibility.test.ts
+++ b/frontend/src/components/helix-org/chartEntityVisibility.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   loadHiddenChartEntityIDs,
   saveHiddenChartEntityIDs,
+  selectedChartEntityIDs,
 } from './chartEntityVisibility'
 
 describe('chartEntityVisibility', () => {
@@ -35,5 +36,16 @@ describe('chartEntityVisibility', () => {
     expect(loadHiddenChartEntityIDs(userID, orgID)).toBeNull()
     window.localStorage.setItem(key, 'not-json')
     expect(loadHiddenChartEntityIDs(userID, orgID)).toBeNull()
+  })
+
+  it('defaults fresh charts to agents only and applies saved settings exactly', () => {
+    expect(selectedChartEntityIDs('agents', ['bot_one'], null)).toEqual(['bot_one'])
+    expect(selectedChartEntityIDs('processors', ['processor_one'], null)).toEqual([])
+    expect(selectedChartEntityIDs('assets', ['asset_one'], null)).toEqual([])
+
+    const saved = { agents: ['bot_one'], processors: [], assets: ['asset_one'] }
+    expect(selectedChartEntityIDs('agents', ['bot_one', 'bot_two'], saved)).toEqual(['bot_two'])
+    expect(selectedChartEntityIDs('processors', ['processor_one'], saved)).toEqual(['processor_one'])
+    expect(selectedChartEntityIDs('assets', ['asset_one'], saved)).toEqual([])
   })
 })

--- a/frontend/src/components/helix-org/chartEntityVisibility.ts
+++ b/frontend/src/components/helix-org/chartEntityVisibility.ts
@@ -2,10 +2,14 @@ export type ChartEntityKind = 'agents' | 'processors' | 'assets'
 
 export type HiddenChartEntityIDs = Record<ChartEntityKind, string[]>
 
-export const EMPTY_HIDDEN_CHART_ENTITY_IDS: HiddenChartEntityIDs = {
-  agents: [],
-  processors: [],
-  assets: [],
+export const selectedChartEntityIDs = (
+  kind: ChartEntityKind,
+  optionIDs: string[],
+  hiddenIDs: HiddenChartEntityIDs | null,
+): string[] => {
+  if (hiddenIDs === null) return kind === 'agents' ? optionIDs : []
+  const hidden = new Set(hiddenIDs[kind])
+  return optionIDs.filter((id) => !hidden.has(id))
 }
 
 const storageKey = (userID: string, orgID: string): string =>

--- a/frontend/src/components/helix-org/chartTopicVisibility.test.ts
+++ b/frontend/src/components/helix-org/chartTopicVisibility.test.ts
@@ -15,14 +15,8 @@ describe('chartTopicVisibility', () => {
     window.localStorage.clear()
   })
 
-  it('hides direct messages, local topics, and other topics by default', () => {
-    expect(DEFAULT_CHART_TOPIC_FILTERS).toEqual([
-      'webhook',
-      'github',
-      'gitlab',
-      'postmark',
-      'cron',
-    ])
+  it('hides all topics by default', () => {
+    expect(DEFAULT_CHART_TOPIC_FILTERS).toEqual([])
   })
 
   it('separates direct messages from other local topics', () => {

--- a/frontend/src/components/helix-org/chartTopicVisibility.ts
+++ b/frontend/src/components/helix-org/chartTopicVisibility.ts
@@ -11,9 +11,7 @@ export const CHART_TOPIC_FILTERS = [
 
 export type ChartTopicFilter = (typeof CHART_TOPIC_FILTERS)[number]['id']
 
-export const DEFAULT_CHART_TOPIC_FILTERS: ChartTopicFilter[] = CHART_TOPIC_FILTERS
-  .map((filter) => filter.id)
-  .filter((filter) => filter !== 'direct_messages' && filter !== 'local' && filter !== 'other')
+export const DEFAULT_CHART_TOPIC_FILTERS: ChartTopicFilter[] = []
 
 type TopicIdentity = {
   name: string

--- a/frontend/src/pages/HelixOrgChart.assets.test.tsx
+++ b/frontend/src/pages/HelixOrgChart.assets.test.tsx
@@ -191,7 +191,7 @@ describe('HelixOrgChart processors and people panel', () => {
     ]))
   })
 
-  it('collapses and expands the people panel', () => {
+  it('starts collapsed and expands the people panel', () => {
     render(
       <ThemeProvider theme={createTheme()}>
         <PeoplePanel
@@ -201,8 +201,6 @@ describe('HelixOrgChart processors and people panel', () => {
       </ThemeProvider>,
     )
 
-    expect(screen.getByText('Alice')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('People'))
     expect(screen.queryByText('Alice')).not.toBeInTheDocument()
     fireEvent.click(screen.getByText('People'))
     expect(screen.getByText('Alice')).toBeInTheDocument()

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -80,10 +80,10 @@ import ChartTopicVisibilityMenu from '../components/helix-org/ChartTopicVisibili
 import ChartVisibilityMenu, { chartToolbarButtonSizeSx } from '../components/helix-org/ChartVisibilityMenu'
 import {
   ChartEntityKind,
-  EMPTY_HIDDEN_CHART_ENTITY_IDS,
   HiddenChartEntityIDs,
   loadHiddenChartEntityIDs,
   saveHiddenChartEntityIDs,
+  selectedChartEntityIDs,
 } from '../components/helix-org/chartEntityVisibility'
 import {
   CHAT_BOT_FOCUS_EVENT,
@@ -2248,7 +2248,7 @@ type Selection =
 // a person to open their profile.
 export const PeoplePanel: FC<{ people: BotDTO[]; onSelect: (botId: string) => void }> = ({ people, onSelect }) => {
   const lightTheme = useLightTheme()
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(false)
   const toggleExpanded = () => setExpanded((current) => !current)
   if (people.length === 0) return null
   const bg = lightTheme.isLight ? 'rgba(255,255,255,0.96)' : 'rgba(28,28,32,0.96)'
@@ -2337,7 +2337,7 @@ const HelixOrgChart: FC = () => {
   const assetIDs = useMemo(() => assetsData.map((asset) => asset.id ?? '').filter(Boolean), [assetsData])
   const assetHealth = useAssetHealth(assetIDs, { refetchInterval: 15000 })
   const { data: streamsData } = useListHelixOrgTopics()
-  const { data: processorsData } = useListHelixOrgProcessors()
+  const { data: processorsData, isLoading: processorsLoading } = useListHelixOrgProcessors()
   const { data: savedPositions = {} } = useListChartPositions()
   const { data: projects = [] } = useListProjects(orgID, { enabled: !!orgID })
   const upsertPositions = useUpsertChartPositions()
@@ -2512,34 +2512,34 @@ const HelixOrgChart: FC = () => {
 
   const visibilityScope = userID && orgID ? `${userID}:${orgID}` : ''
   const entityVisibilityScopeRef = useRef(visibilityScope)
-  const [hiddenEntityIDs, setHiddenEntityIDs] = useState<HiddenChartEntityIDs>(() => (
+  const [hiddenEntityIDs, setHiddenEntityIDs] = useState<HiddenChartEntityIDs | null>(() => (
     visibilityScope
-      ? loadHiddenChartEntityIDs(userID, orgID) ?? { ...EMPTY_HIDDEN_CHART_ENTITY_IDS }
-      : { ...EMPTY_HIDDEN_CHART_ENTITY_IDS }
+      ? loadHiddenChartEntityIDs(userID, orgID)
+      : null
   ))
   useEffect(() => {
     if (!visibilityScope) {
       entityVisibilityScopeRef.current = ''
-      setHiddenEntityIDs({ ...EMPTY_HIDDEN_CHART_ENTITY_IDS })
+      setHiddenEntityIDs(null)
       return
     }
     if (visibilityScope === entityVisibilityScopeRef.current) return
     entityVisibilityScopeRef.current = visibilityScope
-    setHiddenEntityIDs(loadHiddenChartEntityIDs(userID, orgID) ?? { ...EMPTY_HIDDEN_CHART_ENTITY_IDS })
+    setHiddenEntityIDs(loadHiddenChartEntityIDs(userID, orgID))
   }, [userID, orgID, visibilityScope])
 
-  const selectedAgentIDs = useMemo(() => {
-    const hidden = new Set(hiddenEntityIDs.agents)
-    return agentOptions.map((option) => option.id).filter((id) => !hidden.has(id))
-  }, [agentOptions, hiddenEntityIDs.agents])
-  const selectedProcessorIDs = useMemo(() => {
-    const hidden = new Set(hiddenEntityIDs.processors)
-    return processorOptions.map((option) => option.id).filter((id) => !hidden.has(id))
-  }, [processorOptions, hiddenEntityIDs.processors])
-  const selectedAssetIDs = useMemo(() => {
-    const hidden = new Set(hiddenEntityIDs.assets)
-    return assetOptions.map((option) => option.id).filter((id) => !hidden.has(id))
-  }, [assetOptions, hiddenEntityIDs.assets])
+  const selectedAgentIDs = useMemo(
+    () => selectedChartEntityIDs('agents', agentOptions.map((option) => option.id), hiddenEntityIDs),
+    [agentOptions, hiddenEntityIDs],
+  )
+  const selectedProcessorIDs = useMemo(
+    () => selectedChartEntityIDs('processors', processorOptions.map((option) => option.id), hiddenEntityIDs),
+    [processorOptions, hiddenEntityIDs],
+  )
+  const selectedAssetIDs = useMemo(
+    () => selectedChartEntityIDs('assets', assetOptions.map((option) => option.id), hiddenEntityIDs),
+    [assetOptions, hiddenEntityIDs],
+  )
 
   const updateEntityVisibility = (
     kind: ChartEntityKind,
@@ -2547,8 +2547,13 @@ const HelixOrgChart: FC = () => {
     selectedIDs: string[],
   ) => {
     const selected = new Set(selectedIDs)
+    const current = hiddenEntityIDs ?? {
+      agents: [],
+      processors: processorOptions.map((option) => option.id),
+      assets: assetOptions.map((option) => option.id),
+    }
     const next = {
-      ...hiddenEntityIDs,
+      ...current,
       [kind]: options.map((option) => option.id).filter((id) => !selected.has(id)),
     }
     setHiddenEntityIDs(next)
@@ -2996,7 +3001,7 @@ const HelixOrgChart: FC = () => {
             overflow: 'hidden',
           }}
         >
-          {visibilityReady && <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
+          {visibilityReady && !isLoading && !assetsLoading && !processorsLoading && <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
             <ChartTopicVisibilityMenu selected={visibleTopicFilters} onChange={onTopicFiltersChange} />
             <ChartVisibilityMenu
               label="Agents"


### PR DESCRIPTION
## Summary
- show agents as the only expanded org chart entity type by default
- hide topics, processors, and assets until explicitly selected
- collapse the people panel by default while preserving all existing visibility controls and saved preferences

## Verification
- focused Vitest: 16 passed
- `yarn build`
- live Playwright: fresh chart showed Agents 1/1 and Topics 0/8 with people collapsed
- live Playwright: enabled Cron and confirmed Topics 1/8 persisted after reload