### PR TITLE
fix(frontend): persist manual color scheme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,8 +52,16 @@
             // dark mode for users who prefer light. Mirrors the logic in
             // contexts/theme.tsx getInitialMode().
             (function () {
-                var mode = (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches)
-                    ? 'light' : 'dark';
+                var query = null;
+                var stored = null;
+                try { query = new URLSearchParams(window.location.search).get('theme'); } catch (e) {}
+                try { stored = localStorage.getItem('themeMode'); } catch (e) {}
+                var mode = query === 'light' || query === 'dark'
+                    ? query
+                    : stored === 'light' || stored === 'dark'
+                        ? stored
+                        : (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches)
+                            ? 'light' : 'dark';
                 var bg = mode === 'light' ? '#ffffff' : '#121214';
                 var fg = mode === 'light' ? '#333' : '#e0e0e0';
                 document.documentElement.style.backgroundColor = bg;

--- a/frontend/src/contexts/theme.test.ts
+++ b/frontend/src/contexts/theme.test.ts
@@ -1,6 +1,91 @@
-import { describe, expect, it } from 'vitest'
+import React, { useContext } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getDialogStyleTokens, getFlatSelectOverrides, getTooltipStyleOverrides } from './theme'
+import {
+  getDialogStyleTokens,
+  getFlatSelectOverrides,
+  getTooltipStyleOverrides,
+  ThemeContext,
+  ThemeProviderWrapper,
+} from './theme'
+
+const { updateColorScheme, api } = vi.hoisted(() => {
+  const updateColorScheme = vi.fn(() => Promise.resolve())
+  return {
+    updateColorScheme,
+    api: {
+      getApiClient: () => ({ v1UsersMeColorSchemeUpdate: updateColorScheme }),
+    },
+  }
+})
+
+vi.mock('../hooks/useApi', () => ({ default: () => api }))
+
+let systemThemeHandler: ((event: MediaQueryListEvent) => void) | undefined
+
+function setSystemLightMode(matches: boolean) {
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches,
+    addEventListener: (_event: string, handler: (event: MediaQueryListEvent) => void) => {
+      systemThemeHandler = handler
+    },
+    removeEventListener: vi.fn(),
+  })))
+}
+
+function ThemeToggle() {
+  const { mode, toggleMode } = useContext(ThemeContext)
+  return React.createElement('button', { onClick: toggleMode }, mode)
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  window.history.replaceState({}, '', '/')
+  systemThemeHandler = undefined
+  updateColorScheme.mockClear()
+  setSystemLightMode(true)
+})
+
+describe('theme mode preference', () => {
+  it('persists a manual toggle and ignores later OS changes', () => {
+    const { unmount } = render(React.createElement(
+      ThemeProviderWrapper,
+      null,
+      React.createElement(ThemeToggle),
+    ))
+
+    fireEvent.click(screen.getByRole('button', { name: 'light' }))
+    expect(screen.getByRole('button', { name: 'dark' })).toBeInTheDocument()
+    expect(localStorage.getItem('themeMode')).toBe('dark')
+
+    act(() => systemThemeHandler?.({ matches: true } as MediaQueryListEvent))
+    expect(screen.getByRole('button', { name: 'dark' })).toBeInTheDocument()
+    expect(updateColorScheme).toHaveBeenCalledTimes(1)
+    expect(updateColorScheme).toHaveBeenCalledWith({ color_scheme: 'dark' })
+
+    unmount()
+    render(React.createElement(
+      ThemeProviderWrapper,
+      null,
+      React.createElement(ThemeToggle),
+    ))
+    expect(screen.getByRole('button', { name: 'dark' })).toBeInTheDocument()
+  })
+
+  it('gives an explicit query mode precedence over the stored mode', () => {
+    localStorage.setItem('themeMode', 'dark')
+    window.history.replaceState({}, '', '/?theme=light')
+
+    render(React.createElement(
+      ThemeProviderWrapper,
+      null,
+      React.createElement(ThemeToggle),
+    ))
+
+    expect(screen.getByRole('button', { name: 'light' })).toBeInTheDocument()
+  })
+})
 
 describe('tooltip theme', () => {
   it('uses the compact bordered surface in dark mode', () => {

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -5,6 +5,8 @@ import useApi from '../hooks/useApi'
 import { PaletteMode } from '@mui/material'
 import { APP_FONT_FAMILY, APP_MONO_FONT_FAMILY } from '../styles/typography'
 
+const THEME_MODE_KEY = 'themeMode'
+
 // themePinnedByQuery reports whether the embedder stated the mode explicitly.
 function themePinnedByQuery(): boolean {
   try {
@@ -15,8 +17,17 @@ function themePinnedByQuery(): boolean {
   }
 }
 
+function storedThemeMode(): PaletteMode | null {
+  try {
+    const stored = localStorage.getItem(THEME_MODE_KEY)
+    return stored === 'dark' || stored === 'light' ? stored : null
+  } catch {
+    return null
+  }
+}
+
 function getInitialMode(): PaletteMode {
-  // An explicit ?theme= wins over the OS preference.
+  // An explicit ?theme= wins over the browser override and OS preference.
   //
   // This exists for embedding. An iframe inherits the VIEWER's OS setting, not
   // the host page's, so a dark site embedding Helix gets a white panel dropped
@@ -26,16 +37,14 @@ function getInitialMode(): PaletteMode {
   try {
     const q = new URLSearchParams(window.location.search).get('theme')
     if (q === 'dark' || q === 'light') return q
-  } catch { /* malformed query string — fall through to the OS preference */ }
+  } catch { /* malformed query string — fall through to the browser override */ }
+
+  const stored = storedThemeMode()
+  if (stored) return stored
 
   if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
   return 'dark'
 }
-
-// Drop a stale preference from earlier versions that pinned the mode in
-// localStorage. We now keep the mode in memory only — every reload re-resolves
-// from the OS, and OS transitions or manual toggles set the current mode.
-try { localStorage.removeItem('themeMode') } catch { /* ignore */ }
 
 export const ThemeContext = React.createContext({
   mode: 'dark' as PaletteMode,
@@ -110,10 +119,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const api = useApi()
   const [mode, setMode] = useState<PaletteMode>(getInitialMode)
 
-  // Live OS preference sync. The most recent change wins, regardless of source —
-  // an OS transition here, a manual toggle in toggleMode below. We always update
-  // local state and push to the API so the user's spec-task GNOME desktops and
-  // Zed editors flip too via the settings-sync-daemon's WS subscription.
+  // Live OS preference sync while the browser has no explicit override.
   useEffect(() => {
     // A pinned ?theme= must stay pinned. Otherwise an embedder's dark panel
     // would flip to light the moment the VIEWER's OS changed — a setting the
@@ -122,6 +128,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
 
     const mql = window.matchMedia('(prefers-color-scheme: light)')
     const handler = (e: MediaQueryListEvent) => {
+      if (storedThemeMode()) return
       const next: PaletteMode = e.matches ? 'light' : 'dark'
       setMode(next)
       api.getApiClient().v1UsersMeColorSchemeUpdate({ color_scheme: next })
@@ -406,6 +413,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const toggleMode = () => {
     setMode((prevMode) => {
       const next = prevMode === 'dark' ? 'light' : 'dark'
+      try { localStorage.setItem(THEME_MODE_KEY, next) } catch { /* ignore */ }
       // Fire-and-forget: persist to the user's account so any spec-task
       // sessions they own can mirror the theme into GNOME and Zed within
       // ~100ms via the settings-sync-daemon's WS subscription.


### PR DESCRIPTION
## Summary

- persist a manually selected light or dark mode in the browser
- keep explicit `?theme=` overrides ahead of stored and macOS preferences
- prevent macOS appearance changes from replacing a manual selection

## Root cause

The theme toggle only updated React state. Reloads and macOS automatic appearance events resolved the theme from `prefers-color-scheme` again, so a manual dark selection returned to light.

## Verification

- `yarn test src/contexts/theme.test.ts` (7 tests passed)
- `yarn tsc`
- `yarn build`
- standalone Playwright: emulated light macOS preference retained dark mode across two reloads