### PR TITLE
Propagate inference session header

### DIFF
--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -298,6 +298,9 @@ func (c *InternalHelixServer) dispatchAndPublish(req *types.RunnerLLMInferenceRe
 		return
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if req.SessionID != "" {
+		httpReq.Header.Set(types.SessionIDHeader, req.SessionID)
+	}
 
 	if err := httpReq.Write(conn); err != nil {
 		publishErr("write request to tunnel: " + err.Error())

--- a/api/pkg/openai/helix_openai_server_dispatch_test.go
+++ b/api/pkg/openai/helix_openai_server_dispatch_test.go
@@ -1,0 +1,79 @@
+package openai
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+type staticRevDialer struct {
+	conn net.Conn
+}
+
+func (d *staticRevDialer) Dial(_ context.Context, _ string) (net.Conn, error) {
+	return d.conn, nil
+}
+
+func TestDispatchAndPublishSessionIDHeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		sessionID     string
+		wantHeader    string
+		wantHeaderSet bool
+	}{
+		{name: "propagates stable session ID", sessionID: "ses-stable", wantHeader: "ses-stable", wantHeaderSet: true},
+		{name: "omits header without session ID"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientConn, upstreamConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = upstreamConn.Close()
+			})
+
+			type upstreamResult struct {
+				request *http.Request
+				err     error
+			}
+			result := make(chan upstreamResult, 1)
+			go func() {
+				defer upstreamConn.Close()
+				request, err := http.ReadRequest(bufio.NewReader(upstreamConn))
+				if err == nil {
+					_, err = io.Copy(io.Discard, request.Body)
+				}
+				if err == nil {
+					_, err = fmt.Fprint(upstreamConn, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}")
+				}
+				result <- upstreamResult{request: request, err: err}
+			}()
+
+			server := &InternalHelixServer{
+				pubsub: pubsub.NewNoop(),
+				dialer: &staticRevDialer{conn: clientConn},
+			}
+			server.dispatchAndPublish(&types.RunnerLLMInferenceRequest{
+				RequestID: "req-test",
+				OwnerID:   "user-test",
+				SessionID: test.sessionID,
+			}, "sandbox-test", "/v1/chat/completions", []byte(`{"model":"test"}`))
+
+			upstream := <-result
+			require.NoError(t, upstream.err)
+			header, headerSet := upstream.request.Header[http.CanonicalHeaderKey(types.SessionIDHeader)]
+			require.Equal(t, test.wantHeaderSet, headerSet)
+			if test.wantHeaderSet {
+				require.Equal(t, []string{test.wantHeader}, header)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Forward the existing internal runner session ID as `X-Session-ID` on API-to-Hydra inference requests. Omit the header when no session ID exists.

## Why

mini-dynamo's exact-placement canary needs a stable session cohort. Request-token hashing is unsuitable because the cohort would change as a conversation grows. Helix already has the stable session ID, and the downstream reverse proxies preserve custom headers.

## Validation

- focused propagation/omission test
- race-enabled focused test
- `go vet ./pkg/openai`
- `go test ./pkg/openai -count=1`
- `git diff --check`

No session IDs or credentials are added to logs.
