### PR TITLE
feat(git): show repository entry timestamps

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -39075,6 +39075,9 @@ const docTemplate = `{
                 "is_dir": {
                     "type": "boolean"
                 },
+                "last_commit_at": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -39071,6 +39071,9 @@
                 "is_dir": {
                     "type": "boolean"
                 },
+                "last_commit_at": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -11929,6 +11929,8 @@ definitions:
     properties:
       is_dir:
         type: boolean
+      last_commit_at:
+        type: string
       name:
         type: string
       path:

--- a/api/pkg/services/git_repository_service_contents.go
+++ b/api/pkg/services/git_repository_service_contents.go
@@ -245,9 +245,18 @@ func (s *GitRepositoryService) BrowseTree(ctx context.Context, repoID string, pa
 		return nil, fmt.Errorf("failed to list tree entries: %w", err)
 	}
 
+	treePath := path
+	if treePath == "." {
+		treePath = ""
+	}
+	commitsInfo, _, err := entries.GetCommitsInfo(ctx, "", commit, treePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tree entry commits: %w", err)
+	}
+
 	// Build tree entries
 	result := make([]types.TreeEntry, 0, len(entries))
-	for _, entry := range entries {
+	for i, entry := range entries {
 		entryPath := path
 		if entryPath == "." || entryPath == "" {
 			entryPath = entry.Name()
@@ -264,11 +273,17 @@ func (s *GitRepositoryService) BrowseTree(ctx context.Context, repoID string, pa
 			size = entry.Size()
 		}
 
+		var lastCommitAt *time.Time
+		if commitsInfo[i].Commit != nil {
+			lastCommitAt = &commitsInfo[i].Commit.Author.When
+		}
+
 		result = append(result, types.TreeEntry{
-			Name:  entry.Name(),
-			Path:  entryPath,
-			IsDir: isDir,
-			Size:  size,
+			Name:         entry.Name(),
+			Path:         entryPath,
+			IsDir:        isDir,
+			Size:         size,
+			LastCommitAt: lastCommitAt,
 		})
 	}
 

--- a/api/pkg/services/git_repository_service_contents_test.go
+++ b/api/pkg/services/git_repository_service_contents_test.go
@@ -142,26 +142,24 @@ func TestBranchIsolation(t *testing.T) {
 	err = giteagit.InitRepository(ctx, tempWorkPath, false, "sha1")
 	require.NoError(t, err)
 
-	// Create initial file
+	initialCommitTime := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	// Create initial files
 	require.NoError(t, os.WriteFile(filepath.Join(tempWorkPath, "README.md"), []byte("# Test Repo"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tempWorkPath, "docs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempWorkPath, "docs", "guide.md"), []byte("main"), 0644))
 
 	// Add and commit
 	err = giteagit.AddChanges(ctx, tempWorkPath, true)
 	require.NoError(t, err)
 
-	err = giteagit.CommitChanges(ctx, tempWorkPath, giteagit.CommitChangesOptions{
-		Message: "Initial commit",
-		Author: &giteagit.Signature{
-			Name:  "Test Author",
-			Email: "test@example.com",
-			When:  time.Now(),
-		},
-		Committer: &giteagit.Signature{
-			Name:  "Test Author",
-			Email: "test@example.com",
-			When:  time.Now(),
-		},
-	})
+	_, _, err = gitcmd.NewCommand().
+		AddOptionValues("-c", "user.name=Test Author").
+		AddOptionValues("-c", "user.email=test@example.com").
+		AddArguments("commit").
+		AddOptionFormat("--date=%s", initialCommitTime.Format(time.RFC3339)).
+		AddOptionFormat("--message=%s", "Initial commit").
+		RunStdString(ctx, &gitcmd.RunOpts{Dir: tempWorkPath})
 	require.NoError(t, err)
 
 	// Add bare repo as remote and push
@@ -196,7 +194,7 @@ func TestBranchIsolation(t *testing.T) {
 	err = service.CreateBranch(context.Background(), repoID, "feature-branch", "master")
 	require.NoError(t, err)
 
-	filePath := "branch-specific-file.txt"
+	filePath := "docs/guide.md"
 	fileContent := "This file is only on feature-branch"
 
 	_, err = service.CreateOrUpdateFileContents(
@@ -214,25 +212,40 @@ func TestBranchIsolation(t *testing.T) {
 	featureBranchEntries, err := service.BrowseTree(context.Background(), repoID, ".", "feature-branch")
 	require.NoError(t, err)
 
-	foundInFeatureBranch := false
+	var featureDirectoryCommit time.Time
 	for _, entry := range featureBranchEntries {
-		if entry.Name == filePath {
-			foundInFeatureBranch = true
-			assert.False(t, entry.IsDir)
+		if entry.Name == "docs" {
+			require.NotNil(t, entry.LastCommitAt)
+			featureDirectoryCommit = *entry.LastCommitAt
+			assert.True(t, entry.IsDir)
 			break
 		}
 	}
-	assert.True(t, foundInFeatureBranch, "File should be visible on feature-branch")
+	require.False(t, featureDirectoryCommit.IsZero())
+	assert.True(t, featureDirectoryCommit.After(initialCommitTime))
+
+	featureDirectoryEntries, err := service.BrowseTree(context.Background(), repoID, "docs", "feature-branch")
+	require.NoError(t, err)
+	require.Len(t, featureDirectoryEntries, 1)
+	require.NotNil(t, featureDirectoryEntries[0].LastCommitAt)
+	assert.Equal(t, featureDirectoryCommit, *featureDirectoryEntries[0].LastCommitAt)
 
 	masterEntries, err := service.BrowseTree(context.Background(), repoID, ".", "master")
 	require.NoError(t, err)
 
-	foundInMaster := false
+	var masterDirectoryCommit time.Time
 	for _, entry := range masterEntries {
-		if entry.Name == filePath {
-			foundInMaster = true
+		if entry.Name == "docs" {
+			require.NotNil(t, entry.LastCommitAt)
+			masterDirectoryCommit = *entry.LastCommitAt
 			break
 		}
 	}
-	assert.False(t, foundInMaster, "File should NOT be visible on master branch")
+	assert.True(t, initialCommitTime.Equal(masterDirectoryCommit))
+
+	masterDirectoryEntries, err := service.BrowseTree(context.Background(), repoID, "docs", "master")
+	require.NoError(t, err)
+	require.Len(t, masterDirectoryEntries, 1)
+	require.NotNil(t, masterDirectoryEntries[0].LastCommitAt)
+	assert.True(t, initialCommitTime.Equal(*masterDirectoryEntries[0].LastCommitAt))
 }

--- a/api/pkg/types/git_repositories.go
+++ b/api/pkg/types/git_repositories.go
@@ -218,10 +218,11 @@ type CreateSampleRepositoryRequest struct {
 
 // TreeEntry represents a file or directory in a repository
 type TreeEntry struct {
-	Name  string `json:"name"`
-	Path  string `json:"path"`
-	IsDir bool   `json:"is_dir"`
-	Size  int64  `json:"size"`
+	Name         string     `json:"name"`
+	Path         string     `json:"path"`
+	IsDir        bool       `json:"is_dir"`
+	Size         int64      `json:"size"`
+	LastCommitAt *time.Time `json:"last_commit_at,omitempty"`
 }
 
 // GitRepositoryTreeResponse represents the response for browsing repository tree

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7491,6 +7491,7 @@ export interface TypesToolZapierConfig {
 
 export interface TypesTreeEntry {
   is_dir?: boolean;
+  last_commit_at?: string;
   name?: string;
   path?: string;
   size?: number;

--- a/frontend/src/components/git/CodeTab.tsx
+++ b/frontend/src/components/git/CodeTab.tsx
@@ -61,6 +61,7 @@ import {
 import useSnackbar from '../../hooks/useSnackbar'
 import BranchSelect from './BranchSelect'
 import ExternalStatus from './ExternalStatus'
+import { formatDate, formatRelativeTime } from '../../utils/format'
 
 const getFallbackBranch = (defaultBranch: string | undefined, branches: string[] | null | undefined): string => {
   if (!branches || branches.length === 0) {
@@ -587,6 +588,13 @@ const CodeTab: FC<CodeTabProps> = ({
                           <Typography variant="body2" sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: 500 }}>
                             {entry?.name}
                           </Typography>
+                          {entry?.last_commit_at && (
+                            <Tooltip title={formatDate(entry.last_commit_at)}>
+                              <Typography variant="caption" color="text.secondary">
+                                {formatRelativeTime(entry.last_commit_at)}
+                              </Typography>
+                            </Tooltip>
+                          )}
                           {!entry?.is_dir && entry?.size !== undefined && (
                             <Typography variant="caption" color="text.secondary">
                               {entry.size > 1024

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -11929,6 +11929,8 @@ definitions:
     properties:
       is_dir:
         type: boolean
+      last_commit_at:
+        type: string
       name:
         type: string
       path:

--- a/openapi.json
+++ b/openapi.json
@@ -43614,6 +43614,9 @@
                     "is_dir": {
                         "type": "boolean"
                     },
+                    "last_commit_at": {
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -39071,6 +39071,9 @@
                 "is_dir": {
                     "type": "boolean"
                 },
+                "last_commit_at": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },


### PR DESCRIPTION
## Summary

- add each file and directory latest commit timestamp to repository tree responses
- show relative timestamps with full dates on hover in the git browser
- resolve timestamps with one batched Git history traversal per directory listing

## Verification

- `go test ./pkg/services -run "^(TestCreateFileAndBrowseTree|TestBranchIsolation)$" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`

## Known verification gap

- Full frontend build reaches 22,262 transformed modules, then fails on the pre-existing `WorkspaceReviewMessage.tsx` / `workspaceReviewMessage.ts` filename case collision outside this diff.
- Browser E2E is pending deployment on Prime.