### PR TITLE
feat(session): add execution controls and interrupt to chat composer

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -17586,6 +17586,120 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sessions/{id}/execution-config": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Update session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/foreground-thread": {
             "post": {
                 "security": [
@@ -20373,7 +20487,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.SpecTaskExecutionConfig"
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
                         }
                     },
                     "404": {
@@ -27920,6 +28034,46 @@ const docTemplate = `{
                 }
             }
         },
+        "types.AgentExecutionConfig": {
+            "type": "object",
+            "properties": {
+                "agent_available": {
+                    "type": "boolean"
+                },
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_name": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides is the override set the fields above were resolved\nwith, so a caller can round-trip an edit without having to know which\nrecord (task or session) stores it.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
+                },
+                "credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider_ref": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "service_tier": {
+                    "type": "string"
+                }
+            }
+        },
         "types.AgentHelixConfig": {
             "type": "object",
             "properties": {
@@ -33110,7 +33264,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "compute": {
-                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "description": "Compute is sandbox runtime spend. It answers the date range, project, and\ntask filters; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.OrgComputeUsage"
@@ -36298,6 +36452,37 @@ const docTemplate = `{
                 }
             }
         },
+        "types.SessionExecutionConfigUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                }
+            }
+        },
+        "types.SessionExecutionConfigUpdateResponse": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_thread_restarted": {
+                    "type": "boolean"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                }
+            }
+        },
         "types.SessionInfo": {
             "type": "object",
             "properties": {
@@ -36371,6 +36556,14 @@ const docTemplate = `{
                 "callback_url": {
                     "description": "Webhook URL to POST on session completion",
                     "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides customizes the coding model for THIS session without\nmutating its Agent. Set from the chat composer's execution controls on\nsessions that own their configuration (org bot chat, project chat).\nSpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is\nauthoritative there, so there is exactly one source of truth per session.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
                 },
                 "code_agent_runtime": {
                     "description": "Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.)",
@@ -37622,38 +37815,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "review_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.SpecTaskExecutionConfig": {
-            "type": "object",
-            "properties": {
-                "agent_available": {
-                    "type": "boolean"
-                },
-                "agent_id": {
-                    "type": "string"
-                },
-                "agent_name": {
-                    "type": "string"
-                },
-                "credential_type": {
-                    "$ref": "#/definitions/types.CodeAgentCredentialType"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "provider_ref": {
-                    "type": "string"
-                },
-                "reasoning_effort": {
-                    "type": "string"
-                },
-                "runtime": {
-                    "$ref": "#/definitions/types.CodeAgentRuntime"
-                },
-                "service_tier": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/execution_config.go
+++ b/api/pkg/server/execution_config.go
@@ -240,6 +240,32 @@ type codeAgentConfigTarget struct {
 	handoffReason string
 }
 
+// persistSpecTaskCodeAgentConfig writes a coding identity onto a SpecTask row.
+// Both endpoints use it: the task's own, and the session's when that session is
+// driven by a task and so writes through to it.
+func (s *HelixAPIServer) persistSpecTaskCodeAgentConfig(
+	task *types.SpecTask,
+) func(context.Context, string, *types.CodeAgentOverrides) error {
+	return func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error {
+		task.HelixAppID = agentID
+		task.CodeAgentOverrides = overrides
+		return s.Store.UpdateSpecTask(ctx, task)
+	}
+}
+
+// persistSessionCodeAgentConfig writes a coding identity onto a session row.
+// The agent id is ignored on purpose: switchAgentInPlaceForNextTurn repoints
+// ParentApp itself, and it owns that binding.
+func (s *HelixAPIServer) persistSessionCodeAgentConfig(
+	session *types.Session,
+) func(context.Context, string, *types.CodeAgentOverrides) error {
+	return func(ctx context.Context, _ string, overrides *types.CodeAgentOverrides) error {
+		session.Metadata.CodeAgentOverrides = overrides
+		_, err := s.Store.UpdateSession(ctx, *session)
+		return err
+	}
+}
+
 // applyCodeAgentExecutionConfig validates the requested identity, persists it,
 // and — when a session is live — cancels the in-flight turn and starts a fresh
 // ACP thread seeded with the prior transcript. Returns whether anything changed

--- a/api/pkg/server/execution_config.go
+++ b/api/pkg/server/execution_config.go
@@ -1,0 +1,315 @@
+package server
+
+// Shared code-agent execution configuration. A SpecTask and a plain chat
+// session (org bot chat, project chat) both run the same Zed/ACP machinery, so
+// both resolve their coding identity and apply model/reasoning changes through
+// the helpers here. The only difference between the two surfaces is WHERE the
+// overrides are persisted, which each caller supplies as codeAgentConfigTarget.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// effectiveCodeAgentOverrides picks the overrides that apply to a session's
+// next turn. A SpecTask owns the configuration of the sessions it drives, so
+// its overrides win; every other session carries its own.
+func effectiveCodeAgentOverrides(session *types.Session, task *types.SpecTask) *types.CodeAgentOverrides {
+	if task != nil {
+		return task.CodeAgentOverrides
+	}
+	if session == nil {
+		return nil
+	}
+	return session.Metadata.CodeAgentOverrides
+}
+
+// resolveExecutionConfig describes the coding identity produced by an Agent
+// plus a set of overrides. snapshotSessionID, when set, is used to reconstruct
+// the identity of surfaces whose Agent has since been deleted, from the
+// session's interaction snapshots.
+func (s *HelixAPIServer) resolveExecutionConfig(
+	ctx context.Context,
+	appID string,
+	overrides *types.CodeAgentOverrides,
+	snapshotSessionID string,
+) (*types.AgentExecutionConfig, error) {
+	config := &types.AgentExecutionConfig{AgentID: appID, CodeAgentOverrides: overrides}
+
+	if appID != "" {
+		app, err := s.Store.GetApp(ctx, appID)
+		switch {
+		case err == nil:
+			config.AgentAvailable = true
+			config.AgentName = app.Config.Helix.Name
+			effectiveApp := external_agent.ApplyCodeAgentOverrides(app, overrides)
+			if assistant := external_agent.FindZedExternalAssistant(effectiveApp); assistant != nil {
+				config.Runtime = assistant.CodeAgentRuntime
+				if config.Runtime == "" {
+					config.Runtime = types.CodeAgentRuntimeZedAgent
+				}
+				config.CredentialType = assistant.CodeAgentCredentialType
+				config.ProviderRef, config.Model = acpUsageProviderAndModel(assistant)
+				if assistant.CodeAgentRuntime != types.CodeAgentRuntimeClaudeCode &&
+					assistant.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI {
+					if assistant.GenerationModelProvider != "" {
+						config.ProviderRef = assistant.GenerationModelProvider
+					}
+					if assistant.GenerationModel != "" {
+						config.Model = assistant.GenerationModel
+					}
+				}
+				config.ReasoningEffort = assistant.ReasoningEffort
+			}
+		case errors.Is(err, store.ErrNotFound):
+			// Continue with interaction/session snapshots below.
+		default:
+			return nil, fmt.Errorf("failed to load agent: %w", err)
+		}
+	}
+
+	if !config.AgentAvailable && snapshotSessionID != "" {
+		interactions, _, err := s.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
+			SessionID: snapshotSessionID,
+			Page:      0,
+			PerPage:   20,
+			Order:     "created DESC",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load interactions: %w", err)
+		}
+		for _, interaction := range interactions {
+			if interaction.CodeAgentConfigSnapshot == nil {
+				continue
+			}
+			snapshot := interaction.CodeAgentConfigSnapshot
+			config.Runtime = snapshot.Runtime
+			config.CredentialType = snapshot.CredentialType
+			config.ProviderRef = snapshot.Provider
+			config.Model = snapshot.Model
+			break
+		}
+
+		session, err := s.Store.GetSession(ctx, snapshotSessionID)
+		switch {
+		case err == nil:
+			if config.Runtime == "" {
+				config.Runtime = session.Metadata.CodeAgentRuntime
+			}
+			if config.AgentName == "" {
+				config.AgentName = session.Metadata.ZedAgentName
+			}
+		case errors.Is(err, store.ErrNotFound):
+		default:
+			return nil, fmt.Errorf("failed to load session: %w", err)
+		}
+	}
+
+	if config.Runtime == "" {
+		config.Runtime = types.CodeAgentRuntimeZedAgent
+	}
+	if config.AgentName == "" {
+		config.AgentName = string(config.Runtime)
+	}
+	if overrides != nil {
+		if overrides.ProviderRef != "" {
+			config.ProviderRef = overrides.ProviderRef
+		}
+		if overrides.Model != "" {
+			config.Model = overrides.Model
+		}
+		if overrides.ReasoningEffort != "" {
+			config.ReasoningEffort = overrides.ReasoningEffort
+		}
+		config.ServiceTier = overrides.ServiceTier
+	}
+
+	return config, nil
+}
+
+// validateCodeAgentOverrides rejects overrides that the Agent cannot honour —
+// unsupported reasoning efforts, a service tier on a non-Codex runtime, a
+// provider on a subscription agent, or a model the actor has no provider for.
+func (s *HelixAPIServer) validateCodeAgentOverrides(
+	ctx context.Context,
+	appID string,
+	overrides *types.CodeAgentOverrides,
+	actorID string,
+) error {
+	if overrides == nil {
+		return fmt.Errorf("code-agent overrides are required")
+	}
+	if overrides.ProviderRef != "" && overrides.Model == "" {
+		return fmt.Errorf("model is required when provider_ref is set")
+	}
+	effort := strings.ToLower(strings.TrimSpace(overrides.ReasoningEffort))
+	switch effort {
+	case "", "none", "low", "medium", "high", "xhigh", "max", "ultra":
+	default:
+		return fmt.Errorf("unsupported reasoning effort %q", overrides.ReasoningEffort)
+	}
+	if overrides.ServiceTier != "" && overrides.ServiceTier != "fast" {
+		return fmt.Errorf("unsupported service tier %q", overrides.ServiceTier)
+	}
+	app, err := s.Store.GetApp(ctx, appID)
+	if err != nil {
+		return fmt.Errorf("failed to load agent: %w", err)
+	}
+	effectiveApp := external_agent.ApplyCodeAgentOverrides(app, overrides)
+	assistant := external_agent.FindZedExternalAssistant(effectiveApp)
+	if assistant == nil {
+		return fmt.Errorf("agent has no coding assistant")
+	}
+	if overrides.ServiceTier != "" && assistant.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI {
+		return fmt.Errorf("service tier is only supported by Codex")
+	}
+	if assistant.CodeAgentCredentialType.IsSubscription() && overrides.ProviderRef != "" {
+		return fmt.Errorf("subscription agents cannot override provider_ref")
+	}
+	snapshot, err := s.getProviderSnapshot(ctx, actorID, app)
+	if err != nil {
+		return fmt.Errorf("failed to load providers: %w", err)
+	}
+	if reason := external_agent.ValidateAssistantModelConfig(effectiveApp, snapshot); reason != "" {
+		return fmt.Errorf("%s", reason)
+	}
+	return nil
+}
+
+// cancelTurnsForSwitch drains every in-flight turn so the agent is idle before
+// its configuration is swapped underneath it.
+func (s *HelixAPIServer) cancelTurnsForSwitch(ctx context.Context, sessionID string) error {
+	const maxTurns = 100
+	for i := 0; i < maxTurns; i++ {
+		status, err := s.cancelActiveTurn(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+		if status == "noop" {
+			return nil
+		}
+	}
+	return fmt.Errorf("more than %d active turns remain", maxTurns)
+}
+
+func (s *HelixAPIServer) codeAgentRuntimeForApp(ctx context.Context, appID string) (types.CodeAgentRuntime, error) {
+	app, err := s.Store.GetApp(ctx, appID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load agent: %w", err)
+	}
+	assistant := external_agent.FindZedExternalAssistant(app)
+	if assistant == nil {
+		return "", fmt.Errorf("agent has no coding assistant")
+	}
+	if assistant.CodeAgentRuntime == "" {
+		return types.CodeAgentRuntimeZedAgent, nil
+	}
+	return assistant.CodeAgentRuntime, nil
+}
+
+// codeAgentConfigTarget is the surface whose coding identity is being changed:
+// its current identity, where to persist a new one, and the live session (if
+// any) that has to be restarted onto it.
+type codeAgentConfigTarget struct {
+	// surface names the caller in user-facing errors ("spec tasks", "sessions").
+	surface string
+	// requiredAgentKind, when set, restricts which Agents this surface may
+	// switch TO. Spec tasks take coding agents only; a chat session takes any
+	// Agent with a coding assistant, which includes an org chart's bots.
+	requiredAgentKind string
+	// session runs the agent. Nil when the surface has not started one yet, in
+	// which case the new configuration simply applies on first start.
+	session *types.Session
+	// agentID and overrides are the currently persisted identity, used for the
+	// no-op check and for rolling back a failed switch.
+	agentID   string
+	overrides *types.CodeAgentOverrides
+	// persist writes a new identity to whichever record owns it (a SpecTask row
+	// for task surfaces, the session row otherwise).
+	persist func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error
+	// handoffReason is shown to the freshly started agent thread.
+	handoffReason string
+}
+
+// applyCodeAgentExecutionConfig validates the requested identity, persists it,
+// and — when a session is live — cancels the in-flight turn and starts a fresh
+// ACP thread seeded with the prior transcript. Returns whether anything changed
+// and whether a new agent thread was started. Persistence is rolled back if the
+// switch fails, so the stored identity always matches the running agent.
+func (s *HelixAPIServer) applyCodeAgentExecutionConfig(
+	ctx context.Context,
+	user *types.User,
+	target codeAgentConfigTarget,
+	req types.SessionExecutionConfigUpdateRequest,
+) (changed bool, restarted bool, httpErr *system.HTTPError) {
+	targetAgentID := target.agentID
+	// Only a genuine change of Agent is re-checked: re-sending the surface's
+	// current agent id alongside a model edit is not an agent switch, and must
+	// not be held to the switch-target rules.
+	if req.AgentID != "" && req.AgentID != target.agentID {
+		targetAgentID = req.AgentID
+		targetApp, appErr := s.Store.GetApp(ctx, targetAgentID)
+		if appErr != nil {
+			return false, false, system.NewHTTPError400("selected agent not found")
+		}
+		if authErr := s.authorizeUserToApp(ctx, user, targetApp, types.ActionGet); authErr != nil {
+			return false, false, system.NewHTTPError403(authErr.Error())
+		}
+		if target.requiredAgentKind != "" {
+			if kindErr := requireAgentKind(targetApp, target.requiredAgentKind, target.surface); kindErr != nil {
+				return false, false, system.NewHTTPError400(kindErr.Error())
+			}
+		}
+	}
+	if err := s.validateCodeAgentOverrides(ctx, targetAgentID, req.CodeAgentOverrides, user.ID); err != nil {
+		return false, false, system.NewHTTPError400(err.Error())
+	}
+	if targetAgentID == target.agentID && reflect.DeepEqual(target.overrides, req.CodeAgentOverrides) {
+		return false, false, nil
+	}
+
+	if target.session != nil {
+		if cancelErr := s.cancelTurnsForSwitch(ctx, target.session.ID); cancelErr != nil {
+			return false, false, system.NewHTTPError409(
+				fmt.Sprintf("failed to stop the current agent turn before switching: %v", cancelErr))
+		}
+	}
+
+	if err := target.persist(ctx, targetAgentID, req.CodeAgentOverrides); err != nil {
+		return false, false, system.NewHTTPError500(fmt.Sprintf("failed to save code-agent overrides: %v", err))
+	}
+	rollback := func() {
+		if err := target.persist(ctx, target.agentID, target.overrides); err != nil {
+			log.Error().Err(err).
+				Str("surface", target.surface).
+				Str("agent_id", target.agentID).
+				Msg("Failed to roll back code-agent overrides after a failed switch")
+		}
+	}
+
+	if target.session == nil {
+		return true, false, nil
+	}
+
+	runtime, err := s.codeAgentRuntimeForApp(ctx, targetAgentID)
+	if err != nil {
+		rollback()
+		return false, false, system.NewHTTPError400(err.Error())
+	}
+	if switchErr := s.switchAgentInPlaceForNextTurn(
+		ctx, target.session, runtime, targetAgentID, true, target.handoffReason,
+	); switchErr != nil {
+		rollback()
+		return false, false, switchErr
+	}
+	return true, true, nil
+}

--- a/api/pkg/server/external_agent_usage.go
+++ b/api/pkg/server/external_agent_usage.go
@@ -105,17 +105,18 @@ func (s *HelixAPIServer) codeAgentConfigSnapshot(ctx context.Context, session *t
 	}
 
 	appID := session.ParentApp
-	var overrides *types.CodeAgentOverrides
+	var task *types.SpecTask
 	if session.Metadata.SpecTaskID != "" {
-		task, err := s.Controller.Options.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+		loaded, err := s.Controller.Options.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get spec task %s for ACP usage: %w", session.Metadata.SpecTaskID, err)
 		}
+		task = loaded
 		if task.HelixAppID != "" {
 			appID = task.HelixAppID
 		}
-		overrides = task.CodeAgentOverrides
 	}
+	overrides := effectiveCodeAgentOverrides(session, task)
 	if appID == "" {
 		return nil, nil
 	}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1057,6 +1057,8 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/sessions/{id}/messages", system.Wrapper(apiServer.sendSessionMessage)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/sessions/{id}/fork", system.Wrapper(apiServer.forkSession)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/sessions/{id}/switch-agent", system.Wrapper(apiServer.switchAgent)).Methods(http.MethodPost)
+	authRouter.HandleFunc("/sessions/{id}/execution-config", apiServer.getSessionExecutionConfig).Methods(http.MethodGet)
+	authRouter.HandleFunc("/sessions/{id}/execution-config", apiServer.updateSessionExecutionConfig).Methods(http.MethodPatch)
 	authRouter.HandleFunc("/sessions/{id}/agent-config-applied", system.Wrapper(apiServer.agentConfigApplied)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/sessions/{id}/workspace-status", system.Wrapper(apiServer.workspaceStatus)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/sessions/{id}/stop-external-agent", system.Wrapper(apiServer.stopExternalAgentSession)).Methods(http.MethodDelete)

--- a/api/pkg/server/session_execution_config_handlers.go
+++ b/api/pkg/server/session_execution_config_handlers.go
@@ -1,0 +1,198 @@
+package server
+
+// Session-scoped code-agent configuration. Chat surfaces that run an external
+// coding agent without a SpecTask — org bot chat, project chat — own their
+// model/reasoning choice on the session row itself. SpecTask sessions delegate
+// to their task, which stays the single source of truth for those.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// sessionExecutionConfigSurface resolves who owns a session's coding identity.
+// A SpecTask session's task is authoritative — getZedConfig reads the task
+// first — so the session row never carries competing overrides.
+type sessionExecutionConfigSurface struct {
+	session   *types.Session
+	task      *types.SpecTask
+	agentID   string
+	overrides *types.CodeAgentOverrides
+}
+
+func (s *HelixAPIServer) sessionExecutionConfigSurface(ctx context.Context, session *types.Session) (*sessionExecutionConfigSurface, error) {
+	surface := &sessionExecutionConfigSurface{
+		session:   session,
+		agentID:   session.ParentApp,
+		overrides: session.Metadata.CodeAgentOverrides,
+	}
+	if session.Metadata.SpecTaskID == "" {
+		return surface, nil
+	}
+	task, err := s.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load session's spec task: %w", err)
+	}
+	surface.task = task
+	surface.overrides = task.CodeAgentOverrides
+	if task.HelixAppID != "" {
+		surface.agentID = task.HelixAppID
+	}
+	return surface, nil
+}
+
+// getSessionExecutionConfig godoc
+// @Summary Get session execution configuration
+// @Description Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.
+// @Tags Sessions
+// @Produce json
+// @Param id path string true "Session ID"
+// @Success 200 {object} types.AgentExecutionConfig
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Router /api/v1/sessions/{id}/execution-config [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) getSessionExecutionConfig(w http.ResponseWriter, r *http.Request) {
+	user := getRequestUser(r)
+	if user == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	ctx := r.Context()
+	session, err := s.Store.GetSession(ctx, mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if err := s.authorizeUserToSession(ctx, user, session, types.ActionGet); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	surface, err := s.sessionExecutionConfigSurface(ctx, session)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	config, err := s.resolveExecutionConfig(ctx, surface.agentID, surface.overrides, session.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeResponse(w, config, http.StatusOK)
+}
+
+// updateSessionExecutionConfig godoc
+// @Summary Update session execution configuration
+// @Description Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.
+// @Tags Sessions
+// @Accept json
+// @Produce json
+// @Param id path string true "Session ID"
+// @Param request body types.SessionExecutionConfigUpdateRequest true "Execution configuration"
+// @Success 200 {object} types.SessionExecutionConfigUpdateResponse
+// @Failure 400 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 409 {object} types.APIError
+// @Router /api/v1/sessions/{id}/execution-config [patch]
+// @Security BearerAuth
+func (s *HelixAPIServer) updateSessionExecutionConfig(w http.ResponseWriter, r *http.Request) {
+	user := getRequestUser(r)
+	if user == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	var req types.SessionExecutionConfigUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.CodeAgentOverrides == nil {
+		http.Error(w, "code_agent_overrides is required", http.StatusBadRequest)
+		return
+	}
+
+	// Switching an agent outlives the browser request: it cancels the turn,
+	// rewrites config, and seeds a new thread.
+	ctx, cancel := detachContext(r.Context(), 30*time.Second)
+	defer cancel()
+
+	session, err := s.Store.GetSession(ctx, mux.Vars(r)["id"])
+	if err != nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if err := s.authorizeUserToSession(ctx, user, session, types.ActionUpdate); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if session.Metadata.AgentType != string(types.AgentTypeZedExternal) {
+		http.Error(w, "session does not run an external coding agent", http.StatusBadRequest)
+		return
+	}
+	// A paused session is a frozen checkpoint — reconfigure its active
+	// descendant instead, exactly as switch-agent requires.
+	if session.Metadata.Paused {
+		http.Error(w, fmt.Sprintf("session is paused (reason: %s); reconfigure its active descendant instead",
+			session.Metadata.PausedReason), http.StatusConflict)
+		return
+	}
+
+	surface, err := s.sessionExecutionConfigSurface(ctx, session)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if surface.agentID == "" {
+		http.Error(w, "session has no agent to configure", http.StatusBadRequest)
+		return
+	}
+
+	response := &types.SessionExecutionConfigUpdateResponse{
+		SessionID:          session.ID,
+		AgentID:            surface.agentID,
+		CodeAgentOverrides: surface.overrides,
+	}
+	if surface.task != nil {
+		response.SpecTaskID = surface.task.ID
+	}
+
+	_, restarted, httpErr := s.applyCodeAgentExecutionConfig(ctx, user, codeAgentConfigTarget{
+		surface:       "coding sessions",
+		session:       session,
+		agentID:       surface.agentID,
+		overrides:     surface.overrides,
+		handoffReason: "The coding agent or model configuration changed for this session.",
+		persist: func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error {
+			if surface.task != nil {
+				surface.task.HelixAppID = agentID
+				surface.task.CodeAgentOverrides = overrides
+				return s.Store.UpdateSpecTask(ctx, surface.task)
+			}
+			// switchAgentInPlaceForNextTurn repoints ParentApp itself; persist
+			// the overrides and let it own the agent binding.
+			session.Metadata.CodeAgentOverrides = overrides
+			_, err := s.Store.UpdateSession(ctx, *session)
+			return err
+		},
+	}, req)
+	if httpErr != nil {
+		http.Error(w, httpErr.Message, httpErr.StatusCode)
+		return
+	}
+
+	response.AgentThreadRestarted = restarted
+	response.CodeAgentOverrides = req.CodeAgentOverrides
+	if req.AgentID != "" {
+		response.AgentID = req.AgentID
+	}
+	writeResponse(w, response, http.StatusOK)
+}

--- a/api/pkg/server/session_execution_config_handlers.go
+++ b/api/pkg/server/session_execution_config_handlers.go
@@ -165,24 +165,18 @@ func (s *HelixAPIServer) updateSessionExecutionConfig(w http.ResponseWriter, r *
 		response.SpecTaskID = surface.task.ID
 	}
 
+	persist := s.persistSessionCodeAgentConfig(session)
+	if surface.task != nil {
+		persist = s.persistSpecTaskCodeAgentConfig(surface.task)
+	}
+
 	_, restarted, httpErr := s.applyCodeAgentExecutionConfig(ctx, user, codeAgentConfigTarget{
 		surface:       "coding sessions",
 		session:       session,
 		agentID:       surface.agentID,
 		overrides:     surface.overrides,
 		handoffReason: "The coding agent or model configuration changed for this session.",
-		persist: func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error {
-			if surface.task != nil {
-				surface.task.HelixAppID = agentID
-				surface.task.CodeAgentOverrides = overrides
-				return s.Store.UpdateSpecTask(ctx, surface.task)
-			}
-			// switchAgentInPlaceForNextTurn repoints ParentApp itself; persist
-			// the overrides and let it own the agent binding.
-			session.Metadata.CodeAgentOverrides = overrides
-			_, err := s.Store.UpdateSession(ctx, *session)
-			return err
-		},
+		persist:       persist,
 	}, req)
 	if httpErr != nil {
 		http.Error(w, httpErr.Message, httpErr.StatusCode)

--- a/api/pkg/server/session_execution_config_handlers_test.go
+++ b/api/pkg/server/session_execution_config_handlers_test.go
@@ -1,0 +1,257 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/store/memorystore"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedCodingAgent(mem *memorystore.MemoryStore, id, provider, model string) {
+	mem.SeedApp(&types.App{
+		ID:        id,
+		Owner:     "user_a",
+		AgentKind: types.AgentKindCoding,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Name: id,
+			Assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				CodeAgentRuntime:        types.CodeAgentRuntimeZedAgent,
+				GenerationModelProvider: provider,
+				GenerationModel:         model,
+			}},
+		}},
+	})
+}
+
+// newOrgChatSession is an org bot / project chat session: an external coding
+// agent with no SpecTask behind it, so it owns its own configuration.
+func newOrgChatSession(owner string) *types.Session {
+	session := newTestParentSession(owner)
+	session.Metadata.SpecTaskID = ""
+	session.Metadata.SessionRole = "exploratory"
+	session.Metadata.CodeAgentRuntime = types.CodeAgentRuntimeZedAgent
+	session.Metadata.ZedAgentName = types.CodeAgentRuntimeZedAgent.ZedAgentName()
+	return session
+}
+
+func callGetSessionExecutionConfig(t *testing.T, srv *HelixAPIServer, user types.User, sessionID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+sessionID+"/execution-config", http.NoBody)
+	req = mux.SetURLVars(req, map[string]string{"id": sessionID})
+	req = req.WithContext(setRequestUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+	srv.getSessionExecutionConfig(rr, req)
+	return rr
+}
+
+func callUpdateSessionExecutionConfig(
+	t *testing.T,
+	srv *HelixAPIServer,
+	user types.User,
+	sessionID string,
+	body types.SessionExecutionConfigUpdateRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+sessionID+"/execution-config", bytes.NewReader(raw))
+	req = mux.SetURLVars(req, map[string]string{"id": sessionID})
+	req = req.WithContext(setRequestUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+	srv.updateSessionExecutionConfig(rr, req)
+	return rr
+}
+
+func TestGetSessionExecutionConfigReportsSessionOverrides(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	session := newOrgChatSession("user_a")
+	session.Metadata.CodeAgentOverrides = &types.CodeAgentOverrides{
+		ProviderRef:     "openai",
+		Model:           "gpt-5",
+		ReasoningEffort: "high",
+	}
+	seedParentWithInteractions(t, mem, session, 1)
+
+	rr := callGetSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var config types.AgentExecutionConfig
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &config))
+	assert.True(t, config.AgentAvailable)
+	assert.Equal(t, "app_parent", config.AgentID)
+	// The session's overrides win over the agent's own model selection.
+	assert.Equal(t, "openai", config.ProviderRef)
+	assert.Equal(t, "gpt-5", config.Model)
+	assert.Equal(t, "high", config.ReasoningEffort)
+	// ...and are echoed so the composer can round-trip an edit.
+	require.NotNil(t, config.CodeAgentOverrides)
+	assert.Equal(t, "gpt-5", config.CodeAgentOverrides.Model)
+}
+
+// A SpecTask session reports its TASK's configuration, not the session row's:
+// the task is the single source of truth for the sessions it drives.
+func TestGetSessionExecutionConfigPrefersSpecTask(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	seedCodingAgent(mem, "app_task", "anthropic", "claude-sonnet-4-7")
+	session := newTestParentSession("user_a")
+	seedParentWithInteractions(t, mem, session, 1)
+	mem.SeedSpecTask(&types.SpecTask{
+		ID:                session.Metadata.SpecTaskID,
+		HelixAppID:        "app_task",
+		PlanningSessionID: session.ID,
+		CodeAgentOverrides: &types.CodeAgentOverrides{
+			Model: "claude-haiku-4-5",
+		},
+	})
+
+	rr := callGetSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var config types.AgentExecutionConfig
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &config))
+	assert.Equal(t, "app_task", config.AgentID)
+	assert.Equal(t, "claude-haiku-4-5", config.Model)
+}
+
+func TestUpdateSessionExecutionConfigPersistsOverridesAndRestartsThread(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	ctx := context.Background()
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	session := newOrgChatSession("user_a")
+	session.Metadata.ZedThreadID = "ctx_old_thread"
+	seedParentWithInteractions(t, mem, session, 2)
+
+	rr := callUpdateSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID,
+		types.SessionExecutionConfigUpdateRequest{
+			CodeAgentOverrides: &types.CodeAgentOverrides{
+				ProviderRef:     "anthropic",
+				Model:           "claude-sonnet-4-7",
+				ReasoningEffort: "low",
+			},
+		})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var response types.SessionExecutionConfigUpdateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.True(t, response.AgentThreadRestarted)
+	assert.Empty(t, response.SpecTaskID)
+
+	updated, err := mem.GetSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.Metadata.CodeAgentOverrides)
+	assert.Equal(t, "claude-sonnet-4-7", updated.Metadata.CodeAgentOverrides.Model)
+	assert.Equal(t, "low", updated.Metadata.CodeAgentOverrides.ReasoningEffort)
+	// The next turn must open a NEW Zed thread on the new configuration.
+	assert.Empty(t, updated.Metadata.ZedThreadID)
+	assert.False(t, updated.Metadata.AgentSwitchedAt.IsZero())
+}
+
+// The session endpoint is the generic one: a SpecTask session writes through to
+// its task so the two surfaces cannot drift apart.
+func TestUpdateSessionExecutionConfigWritesThroughToSpecTask(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	ctx := context.Background()
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	session := newTestParentSession("user_a")
+	session.Metadata.CodeAgentRuntime = types.CodeAgentRuntimeZedAgent
+	session.Metadata.ZedAgentName = types.CodeAgentRuntimeZedAgent.ZedAgentName()
+	seedParentWithInteractions(t, mem, session, 1)
+	mem.SeedSpecTask(&types.SpecTask{
+		ID:                session.Metadata.SpecTaskID,
+		HelixAppID:        "app_parent",
+		PlanningSessionID: session.ID,
+	})
+
+	rr := callUpdateSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID,
+		types.SessionExecutionConfigUpdateRequest{
+			CodeAgentOverrides: &types.CodeAgentOverrides{
+				ProviderRef: "anthropic",
+				Model:       "claude-sonnet-4-7",
+			},
+		})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var response types.SessionExecutionConfigUpdateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, session.Metadata.SpecTaskID, response.SpecTaskID)
+
+	task, err := mem.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+	require.NoError(t, err)
+	require.NotNil(t, task.CodeAgentOverrides)
+	assert.Equal(t, "claude-sonnet-4-7", task.CodeAgentOverrides.Model)
+
+	updated, err := mem.GetSession(ctx, session.ID)
+	require.NoError(t, err)
+	assert.Nil(t, updated.Metadata.CodeAgentOverrides, "task-driven sessions must not carry competing overrides")
+}
+
+func TestUpdateSessionExecutionConfigRejectsNonCodingSession(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	session := newOrgChatSession("user_a")
+	session.Metadata.AgentType = "helix"
+	seedParentWithInteractions(t, mem, session, 1)
+
+	rr := callUpdateSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID,
+		types.SessionExecutionConfigUpdateRequest{
+			CodeAgentOverrides: &types.CodeAgentOverrides{Model: "gpt-5"},
+		})
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "external coding agent")
+}
+
+func TestUpdateSessionExecutionConfigRejectsUnsupportedReasoningEffort(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	session := newOrgChatSession("user_a")
+	seedParentWithInteractions(t, mem, session, 1)
+
+	rr := callUpdateSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID,
+		types.SessionExecutionConfigUpdateRequest{
+			CodeAgentOverrides: &types.CodeAgentOverrides{ReasoningEffort: "turbo"},
+		})
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unsupported reasoning effort")
+}
+
+// A no-op PATCH must not restart the agent thread — re-opening the picker and
+// re-selecting the current model should cost nothing.
+func TestUpdateSessionExecutionConfigNoOpDoesNotRestartThread(t *testing.T) {
+	srv, mem := newForkTestServer(t)
+	ctx := context.Background()
+	seedCodingAgent(mem, "app_parent", "anthropic", "claude-opus-4-7")
+	session := newOrgChatSession("user_a")
+	session.Metadata.ZedThreadID = "ctx_old_thread"
+	session.Metadata.CodeAgentOverrides = &types.CodeAgentOverrides{
+		ProviderRef: "anthropic",
+		Model:       "claude-sonnet-4-7",
+	}
+	seedParentWithInteractions(t, mem, session, 1)
+
+	rr := callUpdateSessionExecutionConfig(t, srv, types.User{ID: "user_a"}, session.ID,
+		types.SessionExecutionConfigUpdateRequest{
+			CodeAgentOverrides: &types.CodeAgentOverrides{
+				ProviderRef: "anthropic",
+				Model:       "claude-sonnet-4-7",
+			},
+		})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var response types.SessionExecutionConfigUpdateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.False(t, response.AgentThreadRestarted)
+
+	updated, err := mem.GetSession(ctx, session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ctx_old_thread", updated.Metadata.ZedThreadID, "a no-op must leave the live thread alone")
+}

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -191,8 +191,7 @@ func (s *HelixAPIServer) createTaskFromPrompt(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if req.CodeAgentOverrides != nil {
-		candidate := &types.SpecTask{HelixAppID: req.AppID}
-		if err := s.validateTaskCodeAgentOverrides(ctx, candidate, req.CodeAgentOverrides, user.ID); err != nil {
+		if err := s.validateCodeAgentOverrides(ctx, req.AppID, req.CodeAgentOverrides, user.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/api/pkg/server/spec_task_execution_config_handlers.go
+++ b/api/pkg/server/spec_task_execution_config_handlers.go
@@ -3,16 +3,12 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
-	external_agent "github.com/helixml/helix/api/pkg/external-agent"
-	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -23,7 +19,7 @@ import (
 // @Tags spec-driven-tasks
 // @Produce json
 // @Param taskId path string true "SpecTask ID"
-// @Success 200 {object} types.SpecTaskExecutionConfig
+// @Success 200 {object} types.AgentExecutionConfig
 // @Failure 404 {object} types.APIError
 // @Router /api/v1/spec-tasks/{taskId}/execution-config [get]
 // @Security BearerAuth
@@ -54,98 +50,8 @@ func (s *HelixAPIServer) getSpecTaskExecutionConfig(w http.ResponseWriter, r *ht
 	writeResponse(w, config, http.StatusOK)
 }
 
-func (s *HelixAPIServer) resolveSpecTaskExecutionConfig(ctx context.Context, task *types.SpecTask) (*types.SpecTaskExecutionConfig, error) {
-	config := &types.SpecTaskExecutionConfig{AgentID: task.HelixAppID}
-
-	if task.HelixAppID != "" {
-		app, err := s.Store.GetApp(ctx, task.HelixAppID)
-		switch {
-		case err == nil:
-			config.AgentAvailable = true
-			config.AgentName = app.Config.Helix.Name
-			effectiveApp := external_agent.ApplyCodeAgentOverrides(app, task.CodeAgentOverrides)
-			if assistant := external_agent.FindZedExternalAssistant(effectiveApp); assistant != nil {
-				config.Runtime = assistant.CodeAgentRuntime
-				if config.Runtime == "" {
-					config.Runtime = types.CodeAgentRuntimeZedAgent
-				}
-				config.CredentialType = assistant.CodeAgentCredentialType
-				config.ProviderRef, config.Model = acpUsageProviderAndModel(assistant)
-				if assistant.CodeAgentRuntime != types.CodeAgentRuntimeClaudeCode &&
-					assistant.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI {
-					if assistant.GenerationModelProvider != "" {
-						config.ProviderRef = assistant.GenerationModelProvider
-					}
-					if assistant.GenerationModel != "" {
-						config.Model = assistant.GenerationModel
-					}
-				}
-				config.ReasoningEffort = assistant.ReasoningEffort
-			}
-		case errors.Is(err, store.ErrNotFound):
-			// Continue with interaction/session snapshots below.
-		default:
-			return nil, fmt.Errorf("failed to load task agent: %w", err)
-		}
-	}
-
-	if !config.AgentAvailable && task.PlanningSessionID != "" {
-		interactions, _, err := s.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
-			SessionID: task.PlanningSessionID,
-			Page:      0,
-			PerPage:   20,
-			Order:     "created DESC",
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to load task interactions: %w", err)
-		}
-		for _, interaction := range interactions {
-			if interaction.CodeAgentConfigSnapshot == nil {
-				continue
-			}
-			snapshot := interaction.CodeAgentConfigSnapshot
-			config.Runtime = snapshot.Runtime
-			config.CredentialType = snapshot.CredentialType
-			config.ProviderRef = snapshot.Provider
-			config.Model = snapshot.Model
-			break
-		}
-
-		session, err := s.Store.GetSession(ctx, task.PlanningSessionID)
-		switch {
-		case err == nil:
-			if config.Runtime == "" {
-				config.Runtime = session.Metadata.CodeAgentRuntime
-			}
-			if config.AgentName == "" {
-				config.AgentName = session.Metadata.ZedAgentName
-			}
-		case errors.Is(err, store.ErrNotFound):
-		default:
-			return nil, fmt.Errorf("failed to load task session: %w", err)
-		}
-	}
-
-	if config.Runtime == "" {
-		config.Runtime = types.CodeAgentRuntimeZedAgent
-	}
-	if config.AgentName == "" {
-		config.AgentName = string(config.Runtime)
-	}
-	if task.CodeAgentOverrides != nil {
-		if task.CodeAgentOverrides.ProviderRef != "" {
-			config.ProviderRef = task.CodeAgentOverrides.ProviderRef
-		}
-		if task.CodeAgentOverrides.Model != "" {
-			config.Model = task.CodeAgentOverrides.Model
-		}
-		if task.CodeAgentOverrides.ReasoningEffort != "" {
-			config.ReasoningEffort = task.CodeAgentOverrides.ReasoningEffort
-		}
-		config.ServiceTier = task.CodeAgentOverrides.ServiceTier
-	}
-
-	return config, nil
+func (s *HelixAPIServer) resolveSpecTaskExecutionConfig(ctx context.Context, task *types.SpecTask) (*types.AgentExecutionConfig, error) {
+	return s.resolveExecutionConfig(ctx, task.HelixAppID, task.CodeAgentOverrides, task.PlanningSessionID)
 }
 
 // updateSpecTaskExecutionConfig godoc
@@ -228,33 +134,8 @@ func (s *HelixAPIServer) updateSpecTaskExecutionConfig(w http.ResponseWriter, r 
 		return
 	}
 
-	targetAgentID := task.HelixAppID
-	if req.AgentID != "" {
-		targetAgentID = req.AgentID
-		targetApp, appErr := s.Store.GetApp(ctx, targetAgentID)
-		if appErr != nil {
-			http.Error(w, "selected agent not found", http.StatusBadRequest)
-			return
-		}
-		if authErr := s.authorizeUserToApp(ctx, user, targetApp, types.ActionGet); authErr != nil {
-			http.Error(w, authErr.Error(), http.StatusForbidden)
-			return
-		}
-		if kindErr := requireAgentKind(targetApp, types.AgentKindCoding, "spec tasks"); kindErr != nil {
-			http.Error(w, kindErr.Error(), http.StatusBadRequest)
-			return
-		}
-	}
-	candidate := *task
-	candidate.HelixAppID = targetAgentID
-	if err := s.validateTaskCodeAgentOverrides(ctx, &candidate, req.CodeAgentOverrides, user.ID); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if task.HelixAppID == targetAgentID && reflect.DeepEqual(task.CodeAgentOverrides, req.CodeAgentOverrides) {
-		writeResponse(w, response, http.StatusOK)
-		return
-	}
+	// A task that has already started owns a live session; the switch has to
+	// land on it as well as on the task row.
 	var session *types.Session
 	if task.PlanningSessionID != "" {
 		session, err = s.Store.GetSession(ctx, task.PlanningSessionID)
@@ -262,108 +143,33 @@ func (s *HelixAPIServer) updateSpecTaskExecutionConfig(w http.ResponseWriter, r 
 			http.Error(w, "task session not found", http.StatusConflict)
 			return
 		}
-		if cancelErr := s.cancelSpecTaskTurnsForSwitch(ctx, session.ID); cancelErr != nil {
-			http.Error(w, fmt.Sprintf("failed to stop the current agent turn before switching: %v", cancelErr), http.StatusConflict)
-			return
-		}
 	}
 
-	oldOverrides := task.CodeAgentOverrides
-	oldAgentID := task.HelixAppID
-	task.HelixAppID = targetAgentID
-	task.CodeAgentOverrides = req.CodeAgentOverrides
-	if err := s.Store.UpdateSpecTask(ctx, task); err != nil {
-		http.Error(w, fmt.Sprintf("failed to save code-agent overrides: %v", err), http.StatusInternalServerError)
+	changed, restarted, httpErr := s.applyCodeAgentExecutionConfig(ctx, user, codeAgentConfigTarget{
+		surface:           "spec tasks",
+		requiredAgentKind: types.AgentKindCoding,
+		session:           session,
+		agentID:           task.HelixAppID,
+		overrides:         task.CodeAgentOverrides,
+		handoffReason:     "The coding agent or model configuration changed for this task.",
+		persist: func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error {
+			task.HelixAppID = agentID
+			task.CodeAgentOverrides = overrides
+			return s.Store.UpdateSpecTask(ctx, task)
+		},
+	}, types.SessionExecutionConfigUpdateRequest{
+		AgentID:            req.AgentID,
+		CodeAgentOverrides: req.CodeAgentOverrides,
+	})
+	if httpErr != nil {
+		http.Error(w, httpErr.Message, httpErr.StatusCode)
 		return
 	}
-	if task.PlanningSessionID != "" {
-		runtime, err := s.codeAgentRuntimeForTask(ctx, task)
-		if err != nil {
-			task.HelixAppID = oldAgentID
-			task.CodeAgentOverrides = oldOverrides
-			_ = s.Store.UpdateSpecTask(ctx, task)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if switchErr := s.switchAgentInPlaceForNextTurn(ctx, session, runtime, targetAgentID, true, "The coding agent or model configuration changed for this task."); switchErr != nil {
-			task.HelixAppID = oldAgentID
-			task.CodeAgentOverrides = oldOverrides
-			_ = s.Store.UpdateSpecTask(ctx, task)
-			http.Error(w, switchErr.Error(), switchErr.StatusCode)
-			return
-		}
-		response.AgentThreadRestarted = true
+	if !changed {
+		writeResponse(w, response, http.StatusOK)
+		return
 	}
+	response.AgentThreadRestarted = restarted
 	response.Task = task
 	writeResponse(w, response, http.StatusOK)
-}
-
-func (s *HelixAPIServer) cancelSpecTaskTurnsForSwitch(ctx context.Context, sessionID string) error {
-	const maxTurns = 100
-	for i := 0; i < maxTurns; i++ {
-		status, err := s.cancelActiveTurn(ctx, sessionID)
-		if err != nil {
-			return err
-		}
-		if status == "noop" {
-			return nil
-		}
-	}
-	return fmt.Errorf("more than %d active turns remain", maxTurns)
-}
-
-func (s *HelixAPIServer) validateTaskCodeAgentOverrides(ctx context.Context, task *types.SpecTask, overrides *types.CodeAgentOverrides, actorID string) error {
-	if overrides == nil {
-		return fmt.Errorf("code-agent overrides are required")
-	}
-	if overrides.ProviderRef != "" && overrides.Model == "" {
-		return fmt.Errorf("model is required when provider_ref is set")
-	}
-	effort := strings.ToLower(strings.TrimSpace(overrides.ReasoningEffort))
-	switch effort {
-	case "", "none", "low", "medium", "high", "xhigh", "max", "ultra":
-	default:
-		return fmt.Errorf("unsupported reasoning effort %q", overrides.ReasoningEffort)
-	}
-	if overrides.ServiceTier != "" && overrides.ServiceTier != "fast" {
-		return fmt.Errorf("unsupported service tier %q", overrides.ServiceTier)
-	}
-	app, err := s.Store.GetApp(ctx, task.HelixAppID)
-	if err != nil {
-		return fmt.Errorf("failed to load task agent: %w", err)
-	}
-	effectiveApp := external_agent.ApplyCodeAgentOverrides(app, overrides)
-	assistant := external_agent.FindZedExternalAssistant(effectiveApp)
-	if assistant == nil {
-		return fmt.Errorf("task agent has no coding assistant")
-	}
-	if overrides.ServiceTier != "" && assistant.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI {
-		return fmt.Errorf("service tier is only supported by Codex")
-	}
-	if assistant.CodeAgentCredentialType.IsSubscription() && overrides.ProviderRef != "" {
-		return fmt.Errorf("subscription agents cannot override provider_ref")
-	}
-	snapshot, err := s.getProviderSnapshot(ctx, actorID, app)
-	if err != nil {
-		return fmt.Errorf("failed to load providers: %w", err)
-	}
-	if reason := external_agent.ValidateAssistantModelConfig(effectiveApp, snapshot); reason != "" {
-		return fmt.Errorf("%s", reason)
-	}
-	return nil
-}
-
-func (s *HelixAPIServer) codeAgentRuntimeForTask(ctx context.Context, task *types.SpecTask) (types.CodeAgentRuntime, error) {
-	app, err := s.Store.GetApp(ctx, task.HelixAppID)
-	if err != nil {
-		return "", fmt.Errorf("failed to load task agent: %w", err)
-	}
-	assistant := external_agent.FindZedExternalAssistant(app)
-	if assistant == nil {
-		return "", fmt.Errorf("task agent has no coding assistant")
-	}
-	if assistant.CodeAgentRuntime == "" {
-		return types.CodeAgentRuntimeZedAgent, nil
-	}
-	return assistant.CodeAgentRuntime, nil
 }

--- a/api/pkg/server/spec_task_execution_config_handlers.go
+++ b/api/pkg/server/spec_task_execution_config_handlers.go
@@ -152,11 +152,7 @@ func (s *HelixAPIServer) updateSpecTaskExecutionConfig(w http.ResponseWriter, r 
 		agentID:           task.HelixAppID,
 		overrides:         task.CodeAgentOverrides,
 		handoffReason:     "The coding agent or model configuration changed for this task.",
-		persist: func(ctx context.Context, agentID string, overrides *types.CodeAgentOverrides) error {
-			task.HelixAppID = agentID
-			task.CodeAgentOverrides = overrides
-			return s.Store.UpdateSpecTask(ctx, task)
-		},
+		persist:           s.persistSpecTaskCodeAgentConfig(task),
 	}, types.SessionExecutionConfigUpdateRequest{
 		AgentID:            req.AgentID,
 		CodeAgentOverrides: req.CodeAgentOverrides,

--- a/api/pkg/server/spec_task_execution_config_handlers_test.go
+++ b/api/pkg/server/spec_task_execution_config_handlers_test.go
@@ -121,7 +121,7 @@ func TestGetSpecTaskExecutionConfigReturnsLegacyPersonalAgentSnapshot(t *testing
 	server.getSpecTaskExecutionConfig(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	var response types.SpecTaskExecutionConfig
+	var response types.AgentExecutionConfig
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 	require.True(t, response.AgentAvailable)
 	require.Equal(t, "Opus 4.5 in Zed Agent (1)", response.AgentName)
@@ -163,7 +163,7 @@ func TestGetSpecTaskExecutionConfigFallsBackToSessionForDeletedAgent(t *testing.
 	server.getSpecTaskExecutionConfig(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	var response types.SpecTaskExecutionConfig
+	var response types.AgentExecutionConfig
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 	require.False(t, response.AgentAvailable)
 	require.Equal(t, "deleted-app", response.AgentID)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -17582,6 +17582,120 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/execution-config": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Update session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/foreground-thread": {
             "post": {
                 "security": [
@@ -20369,7 +20483,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.SpecTaskExecutionConfig"
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
                         }
                     },
                     "404": {
@@ -27916,6 +28030,46 @@
                 }
             }
         },
+        "types.AgentExecutionConfig": {
+            "type": "object",
+            "properties": {
+                "agent_available": {
+                    "type": "boolean"
+                },
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_name": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides is the override set the fields above were resolved\nwith, so a caller can round-trip an edit without having to know which\nrecord (task or session) stores it.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
+                },
+                "credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider_ref": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "service_tier": {
+                    "type": "string"
+                }
+            }
+        },
         "types.AgentHelixConfig": {
             "type": "object",
             "properties": {
@@ -33106,7 +33260,7 @@
                     "type": "number"
                 },
                 "compute": {
-                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "description": "Compute is sandbox runtime spend. It answers the date range, project, and\ntask filters; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.OrgComputeUsage"
@@ -36294,6 +36448,37 @@
                 }
             }
         },
+        "types.SessionExecutionConfigUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                }
+            }
+        },
+        "types.SessionExecutionConfigUpdateResponse": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_thread_restarted": {
+                    "type": "boolean"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                }
+            }
+        },
         "types.SessionInfo": {
             "type": "object",
             "properties": {
@@ -36367,6 +36552,14 @@
                 "callback_url": {
                     "description": "Webhook URL to POST on session completion",
                     "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides customizes the coding model for THIS session without\nmutating its Agent. Set from the chat composer's execution controls on\nsessions that own their configuration (org bot chat, project chat).\nSpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is\nauthoritative there, so there is exactly one source of truth per session.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
                 },
                 "code_agent_runtime": {
                     "description": "Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.)",
@@ -37618,38 +37811,6 @@
                     "type": "string"
                 },
                 "review_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.SpecTaskExecutionConfig": {
-            "type": "object",
-            "properties": {
-                "agent_available": {
-                    "type": "boolean"
-                },
-                "agent_id": {
-                    "type": "string"
-                },
-                "agent_name": {
-                    "type": "string"
-                },
-                "credential_type": {
-                    "$ref": "#/definitions/types.CodeAgentCredentialType"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "provider_ref": {
-                    "type": "string"
-                },
-                "reasoning_effort": {
-                    "type": "string"
-                },
-                "runtime": {
-                    "$ref": "#/definitions/types.CodeAgentRuntime"
-                },
-                "service_tier": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3636,6 +3636,34 @@ definitions:
           type: string
         type: object
     type: object
+  types.AgentExecutionConfig:
+    properties:
+      agent_available:
+        type: boolean
+      agent_id:
+        type: string
+      agent_name:
+        type: string
+      code_agent_overrides:
+        allOf:
+        - $ref: '#/definitions/types.CodeAgentOverrides'
+        description: |-
+          CodeAgentOverrides is the override set the fields above were resolved
+          with, so a caller can round-trip an edit without having to know which
+          record (task or session) stores it.
+      credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      model:
+        type: string
+      provider_ref:
+        type: string
+      reasoning_effort:
+        type: string
+      runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
+      service_tier:
+        type: string
+    type: object
   types.AgentHelixConfig:
     properties:
       assistants:
@@ -7442,8 +7470,8 @@ definitions:
         allOf:
         - $ref: '#/definitions/types.OrgComputeUsage'
         description: |-
-          Compute is sandbox runtime spend. It answers the date range and the
-          project filter; the token-shaped filters (model, provider, session)
+          Compute is sandbox runtime spend. It answers the date range, project, and
+          task filters; the token-shaped filters (model, provider, session)
           don't apply to a container and leave it untouched.
       export_apps:
         items:
@@ -9840,6 +9868,26 @@ definitions:
         - $ref: '#/definitions/types.SessionType'
         description: e.g. text, image
     type: object
+  types.SessionExecutionConfigUpdateRequest:
+    properties:
+      agent_id:
+        type: string
+      code_agent_overrides:
+        $ref: '#/definitions/types.CodeAgentOverrides'
+    type: object
+  types.SessionExecutionConfigUpdateResponse:
+    properties:
+      agent_id:
+        type: string
+      agent_thread_restarted:
+        type: boolean
+      code_agent_overrides:
+        $ref: '#/definitions/types.CodeAgentOverrides'
+      session_id:
+        type: string
+      spec_task_id:
+        type: string
+    type: object
   types.SessionInfo:
     properties:
       auth_provider:
@@ -9907,6 +9955,15 @@ definitions:
       callback_url:
         description: Webhook URL to POST on session completion
         type: string
+      code_agent_overrides:
+        allOf:
+        - $ref: '#/definitions/types.CodeAgentOverrides'
+        description: |-
+          CodeAgentOverrides customizes the coding model for THIS session without
+          mutating its Agent. Set from the chat composer's execution controls on
+          sessions that own their configuration (org bot chat, project chat).
+          SpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is
+          authoritative there, so there is exactly one source of truth per session.
       code_agent_runtime:
         allOf:
         - $ref: '#/definitions/types.CodeAgentRuntime'
@@ -10853,27 +10910,6 @@ definitions:
     required:
     - decision
     - review_id
-    type: object
-  types.SpecTaskExecutionConfig:
-    properties:
-      agent_available:
-        type: boolean
-      agent_id:
-        type: string
-      agent_name:
-        type: string
-      credential_type:
-        $ref: '#/definitions/types.CodeAgentCredentialType'
-      model:
-        type: string
-      provider_ref:
-        type: string
-      reasoning_effort:
-        type: string
-      runtime:
-        $ref: '#/definitions/types.CodeAgentRuntime'
-      service_tier:
-        type: string
     type: object
   types.SpecTaskExecutionConfigUpdateRequest:
     properties:
@@ -24375,6 +24411,83 @@ paths:
       summary: Update Codex credentials for a session
       tags:
       - Codex
+  /api/v1/sessions/{id}/execution-config:
+    get:
+      description: Returns the session's current coding identity without exposing
+        Agent secrets. Sessions belonging to a SpecTask report the task's configuration.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.AgentExecutionConfig'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Get session execution configuration
+      tags:
+      - Sessions
+    patch:
+      consumes:
+      - application/json
+      description: Replaces the session's code-agent overrides, and optionally switches
+        it to a different Agent. The in-flight turn is cancelled and a new ACP thread
+        starts with the prior transcript. Sessions belonging to a SpecTask write through
+        to the task.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Execution configuration
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.SessionExecutionConfigUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.SessionExecutionConfigUpdateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Update session execution configuration
+      tags:
+      - Sessions
   /api/v1/sessions/{id}/foreground-thread:
     post:
       description: |-
@@ -26136,7 +26249,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.SpecTaskExecutionConfig'
+            $ref: '#/definitions/types.AgentExecutionConfig'
         "404":
           description: Not Found
           schema:

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -85,12 +85,7 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 			Config: types.AppConfig{},
 		}
 	}
-	app = external_agent.ApplyCodeAgentOverrides(app, func() *types.CodeAgentOverrides {
-		if specTask == nil {
-			return nil
-		}
-		return specTask.CodeAgentOverrides
-	}())
+	app = external_agent.ApplyCodeAgentOverrides(app, effectiveCodeAgentOverrides(session, specTask))
 
 	// Generate Zed MCP config
 	// Use SERVER_URL for external-facing URLs (browser access)

--- a/api/pkg/types/agent_execution.go
+++ b/api/pkg/types/agent_execution.go
@@ -1,0 +1,54 @@
+package types
+
+// Execution configuration shared by every surface that runs an external coding
+// agent. A SpecTask and a plain chat session (org bot chat, project chat) both
+// run the same Zed/ACP machinery, so both describe their coding identity with
+// AgentExecutionConfig and both customize it with CodeAgentOverrides.
+
+// CodeAgentOverrides customizes the coding model for a single execution surface
+// — one SpecTask or one session — without mutating the reusable Agent
+// configuration it was created from.
+type CodeAgentOverrides struct {
+	ProviderRef     string `json:"provider_ref,omitempty"`
+	Model           string `json:"model,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	ServiceTier     string `json:"service_tier,omitempty"`
+}
+
+// AgentExecutionConfig describes a surface's current coding identity without
+// exposing the reusable Agent or its secrets. AgentAvailable is false when the
+// surface points at an Agent that has since been deleted.
+type AgentExecutionConfig struct {
+	AgentID         string                  `json:"agent_id,omitempty"`
+	AgentName       string                  `json:"agent_name,omitempty"`
+	AgentAvailable  bool                    `json:"agent_available"`
+	Runtime         CodeAgentRuntime        `json:"runtime,omitempty"`
+	CredentialType  CodeAgentCredentialType `json:"credential_type,omitempty"`
+	ProviderRef     string                  `json:"provider_ref,omitempty"`
+	Model           string                  `json:"model,omitempty"`
+	ReasoningEffort string                  `json:"reasoning_effort,omitempty"`
+	ServiceTier     string                  `json:"service_tier,omitempty"`
+	// CodeAgentOverrides is the override set the fields above were resolved
+	// with, so a caller can round-trip an edit without having to know which
+	// record (task or session) stores it.
+	CodeAgentOverrides *CodeAgentOverrides `json:"code_agent_overrides,omitempty"`
+}
+
+// SessionExecutionConfigUpdateRequest replaces a session's coding identity.
+// CodeAgentOverrides is always the full replacement set; AgentID switches the
+// session to a different Agent (and therefore possibly a different runtime).
+type SessionExecutionConfigUpdateRequest struct {
+	AgentID            string              `json:"agent_id,omitempty"`
+	CodeAgentOverrides *CodeAgentOverrides `json:"code_agent_overrides,omitempty"`
+}
+
+// SessionExecutionConfigUpdateResponse reports where the change landed.
+// SpecTaskID is set when the session belongs to a SpecTask, because the task —
+// not the session — owns the overrides in that case.
+type SessionExecutionConfigUpdateResponse struct {
+	SessionID            string              `json:"session_id"`
+	SpecTaskID           string              `json:"spec_task_id,omitempty"`
+	AgentID              string              `json:"agent_id,omitempty"`
+	CodeAgentOverrides   *CodeAgentOverrides `json:"code_agent_overrides,omitempty"`
+	AgentThreadRestarted bool                `json:"agent_thread_restarted"`
+}

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -82,15 +82,6 @@ type StartPlanningOptions struct {
 	Timezone string `json:"timezone,omitempty"`
 }
 
-// CodeAgentOverrides customizes the coding model for one SpecTask without
-// mutating the reusable Agent configuration it was created from.
-type CodeAgentOverrides struct {
-	ProviderRef     string `json:"provider_ref,omitempty"`
-	Model           string `json:"model,omitempty"`
-	ReasoningEffort string `json:"reasoning_effort,omitempty"`
-	ServiceTier     string `json:"service_tier,omitempty"`
-}
-
 const (
 	DefaultSpecTaskSandboxVCPUs    = 4
 	DefaultSpecTaskSandboxMemoryMB = 8192
@@ -467,20 +458,6 @@ type SpecTaskExecutionConfigUpdateRequest struct {
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
 }
 
-// SpecTaskExecutionConfig describes the task's current coding identity without
-// exposing the reusable Agent or its secrets. AgentAvailable is false when a
-// legacy task points at an Agent that has since been deleted.
-type SpecTaskExecutionConfig struct {
-	AgentID         string                  `json:"agent_id,omitempty"`
-	AgentName       string                  `json:"agent_name,omitempty"`
-	AgentAvailable  bool                    `json:"agent_available"`
-	Runtime         CodeAgentRuntime        `json:"runtime,omitempty"`
-	CredentialType  CodeAgentCredentialType `json:"credential_type,omitempty"`
-	ProviderRef     string                  `json:"provider_ref,omitempty"`
-	Model           string                  `json:"model,omitempty"`
-	ReasoningEffort string                  `json:"reasoning_effort,omitempty"`
-	ServiceTier     string                  `json:"service_tier,omitempty"`
-}
 
 type SpecTaskExecutionConfigUpdateResponse struct {
 	Task                    *SpecTask `json:"task"`

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -490,6 +490,14 @@ type SessionMetadata struct {
 	PausedScreenshotPath    string               `json:"paused_screenshot_path,omitempty"`    // Path to saved screenshot when agent is paused
 	CodeAgentRuntime        CodeAgentRuntime     `json:"code_agent_runtime,omitempty"`        // Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.)
 	StatusMessage           string               `json:"status_message,omitempty"`            // Transient status message shown during startup (e.g., "Unpacking build cache (2.1/7.0 GB)")
+
+	// CodeAgentOverrides customizes the coding model for THIS session without
+	// mutating its Agent. Set from the chat composer's execution controls on
+	// sessions that own their configuration (org bot chat, project chat).
+	// SpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is
+	// authoritative there, so there is exactly one source of truth per session.
+	CodeAgentOverrides *CodeAgentOverrides `json:"code_agent_overrides,omitempty"`
+
 	// Container fields (Hydra executor)
 	ContainerName string `json:"container_name,omitempty"` // Docker container name
 	ContainerID   string `json:"container_id,omitempty"`   // Docker container ID

--- a/design/2026-08-13-session-execution-controls.md
+++ b/design/2026-08-13-session-execution-controls.md
@@ -1,0 +1,115 @@
+# Execution controls + interrupt for org-chart chat sessions
+
+Date: 2026-08-13
+
+## Problem
+
+`/orgs/{org}/chat/session/{id}` (the org-chart bot chat, `pages/Session.tsx`
+with `orgChatView`) runs the same external coding agent as a spec task, but its
+composer had neither an interrupt button nor any way to change the model,
+provider, or reasoning effort. The only escape was the agent's settings page,
+which does not restart the running ACP thread — so a model change silently did
+nothing until the next thread.
+
+Spec tasks already have all of this in `SpecTaskExecutionControls`, mounted as
+the composer's `leadingActions`. The requirement was parity, reusing the same
+composer rather than building a second one.
+
+## Why the spec-task endpoint could not just be reused
+
+`PATCH /spec-tasks/{id}/execution-config` stores the overrides on the SpecTask
+row. An org bot session has no SpecTask, so there was nowhere to put them.
+
+Everything *downstream* of storage was already session-scoped:
+`cancelActiveTurn`, `switchAgentInPlaceForNextTurn`, and the `getZedConfig` read
+that materialises the model into the sandbox all key on a session. Only the
+storage location differed between the two surfaces.
+
+## Design
+
+**One mechanism, two storage locations.** `api/pkg/server/execution_config.go`
+holds the shared logic; each surface supplies a `codeAgentConfigTarget`
+describing its current identity and how to persist a new one:
+
+- SpecTask surface → writes `SpecTask.CodeAgentOverrides` (unchanged behaviour).
+- Session surface → writes `Session.Metadata.CodeAgentOverrides` (new).
+
+`applyCodeAgentExecutionConfig` then does the same thing for both: validate,
+no-op check, drain in-flight turns, persist, resolve the runtime, switch the
+agent in place, and roll the persist back if the switch fails.
+
+**One source of truth per session.** A session that belongs to a SpecTask
+delegates to the task — `sessionExecutionConfigSurface` resolves the owner, and
+the session endpoint writes through to the task row. This matters because
+`getZedConfig` reads the task first; a session-level override on a task session
+would be silently ignored. Task-driven sessions therefore never carry their own
+overrides, and the session endpoint is safe to call from any chat surface
+(spec-task execution sessions are reachable from this same org-chat URL via the
+executions history).
+
+**Kind restriction moved to the caller.** Spec tasks may only run
+`coding_agent` apps. An org chart's bots run on `org_agent` apps, which have a
+`zed_external` assistant but would fail that check. `requiredAgentKind` is now
+per-surface, and it is only enforced when the Agent actually changes — resending
+the current agent id alongside a model edit is not an agent switch.
+
+**`SpecTaskExecutionConfig` → `AgentExecutionConfig`.** The DTO describes a
+coding identity, not a task; both surfaces return it. It also now echoes the
+override set it was resolved from, so a composer can round-trip an edit without
+knowing which record stores it.
+
+## API
+
+| | |
+|---|---|
+| `GET /api/v1/sessions/{id}/execution-config` | → `types.AgentExecutionConfig` |
+| `PATCH /api/v1/sessions/{id}/execution-config` | `{agent_id?, code_agent_overrides}` → `types.SessionExecutionConfigUpdateResponse` |
+
+Rejected: non-`zed_external` sessions (400), paused sessions (409 — reconfigure
+the active descendant, same rule as switch-agent). Embed keys cannot reach
+either route: the allowlist's `/api/v1/sessions/` rule matches a single trailing
+segment only, which is the documented intent (an embed user must not reconfigure
+the agent they are talking to).
+
+## Frontend
+
+`Session.tsx` mounts the existing `SpecTaskExecutionControls` as the composer's
+`leadingActions` for external-agent sessions, and wires `onCancel` to
+`v1SessionsCancelCreate` — the same props `AgentChat` passes on the spec-task
+page. No new composer.
+
+Two adjustments to the shared control:
+
+- `onSandboxResourceOverridesChange` is now optional; the compute control is
+  hidden when a surface has no resizable sandbox of its own. Session-level
+  sandbox sizing is **not** part of this change.
+- The picker's agent list must include the session's own Agent even when it is
+  not a coding agent, otherwise an org bot's own model and reasoning are not
+  editable (`selectCodingAgents` deliberately excludes `org_agent`).
+
+## Verification
+
+Backend: 7 new tests in `session_execution_config_handlers_test.go` (in-process
+`NewTestServer` + memorystore), plus the existing spec-task and switch-agent
+suites, which cover the refactor.
+
+Live, against the running dev stack on the org bot session in the bug report
+(`ses_01kzgrzwybcw3qcg8bj9jqbsyv`, "Software Engineer" @ unmanned-org):
+
+- `GET` returned the bot's identity (zed_agent / ds4-flash-node06 /
+  deepseek-v4-flash / medium).
+- Changing reasoning Medium → High **from the composer control**: persisted
+  `{"reasoning_effort":"high"}` on the session row, cleared the Zed thread and
+  opened a new one, seeded `fork_seed` + `fork_handoff`, and the live agent
+  completed the handoff turn. `GET /zed-config` then reported
+  `reasoning_effort: high`.
+- Resetting to Default cleared the override and `/zed-config` returned to
+  `medium`. Both switches produced a fresh thread.
+- The model picker lists the bot's agent with its full provider/model set.
+
+Not observed live: the Stop button rendered mid-turn on this page. The browser
+session was signed in as an admin who is not the session owner, so
+`checkOwnership` blocks sending from it. The composer's props were verified on
+the live page instead (`onCancel` present, `isCancelling`, `sendMode: direct`),
+and the render-and-click contract is covered by the existing
+`RobustPromptInput` tests.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2332,6 +2332,24 @@ export interface TypesAgentConfig {
   secrets?: Record<string, string>;
 }
 
+export interface TypesAgentExecutionConfig {
+  agent_available?: boolean;
+  agent_id?: string;
+  agent_name?: string;
+  /**
+   * CodeAgentOverrides is the override set the fields above were resolved
+   * with, so a caller can round-trip an edit without having to know which
+   * record (task or session) stores it.
+   */
+  code_agent_overrides?: TypesCodeAgentOverrides;
+  credential_type?: TypesCodeAgentCredentialType;
+  model?: string;
+  provider_ref?: string;
+  reasoning_effort?: string;
+  runtime?: TypesCodeAgentRuntime;
+  service_tier?: string;
+}
+
 export interface TypesAgentHelixConfig {
   assistants?: TypesAssistantConfig[];
   avatar?: string;
@@ -4689,8 +4707,8 @@ export interface TypesOrgUsageSummaryResponse {
   apps?: TypesUsageBreakdownRow[];
   cache_savings?: number;
   /**
-   * Compute is sandbox runtime spend. It answers the date range and the
-   * project filter; the token-shaped filters (model, provider, session)
+   * Compute is sandbox runtime spend. It answers the date range, project, and
+   * task filters; the token-shaped filters (model, provider, session)
    * don't apply to a container and leave it untouched.
    */
   compute?: TypesOrgComputeUsage;
@@ -6222,6 +6240,19 @@ export interface TypesSessionChatRequest {
   type?: TypesSessionType;
 }
 
+export interface TypesSessionExecutionConfigUpdateRequest {
+  agent_id?: string;
+  code_agent_overrides?: TypesCodeAgentOverrides;
+}
+
+export interface TypesSessionExecutionConfigUpdateResponse {
+  agent_id?: string;
+  agent_thread_restarted?: boolean;
+  code_agent_overrides?: TypesCodeAgentOverrides;
+  session_id?: string;
+  spec_task_id?: string;
+}
+
 export interface TypesSessionInfo {
   auth_provider?: TypesAuthProvider;
   created_at?: string;
@@ -6269,6 +6300,14 @@ export interface TypesSessionMetadata {
   avatar?: string;
   /** Webhook URL to POST on session completion */
   callback_url?: string;
+  /**
+   * CodeAgentOverrides customizes the coding model for THIS session without
+   * mutating its Agent. Set from the chat composer's execution controls on
+   * sessions that own their configuration (org bot chat, project chat).
+   * SpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is
+   * authoritative there, so there is exactly one source of truth per session.
+   */
+  code_agent_overrides?: TypesCodeAgentOverrides;
   /** Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.) */
   code_agent_runtime?: TypesCodeAgentRuntime;
   /** Docker container ID */
@@ -6845,18 +6884,6 @@ export interface TypesSpecTaskDesignReviewSubmitRequest {
   decision: "approve" | "request_changes";
   overall_comment?: string;
   review_id: string;
-}
-
-export interface TypesSpecTaskExecutionConfig {
-  agent_available?: boolean;
-  agent_id?: string;
-  agent_name?: string;
-  credential_type?: TypesCodeAgentCredentialType;
-  model?: string;
-  provider_ref?: string;
-  reasoning_effort?: string;
-  runtime?: TypesCodeAgentRuntime;
-  service_tier?: string;
 }
 
 export interface TypesSpecTaskExecutionConfigUpdateRequest {
@@ -16566,6 +16593,48 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.
+     *
+     * @tags Sessions
+     * @name V1SessionsExecutionConfigDetail
+     * @summary Get session execution configuration
+     * @request GET:/api/v1/sessions/{id}/execution-config
+     * @secure
+     */
+    v1SessionsExecutionConfigDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesAgentExecutionConfig, TypesAPIError>({
+        path: `/api/v1/sessions/${id}/execution-config`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.
+     *
+     * @tags Sessions
+     * @name V1SessionsExecutionConfigPartialUpdate
+     * @summary Update session execution configuration
+     * @request PATCH:/api/v1/sessions/{id}/execution-config
+     * @secure
+     */
+    v1SessionsExecutionConfigPartialUpdate: (
+      id: string,
+      request: TypesSessionExecutionConfigUpdateRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesSessionExecutionConfigUpdateResponse, TypesAPIError>({
+        path: `/api/v1/sessions/${id}/execution-config`,
+        method: "PATCH",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Tells the per-spec-task Zed desktop to open (foreground) the thread that belongs to THIS session, so the streamed desktop tracks the session the user is viewing. A spec task can have multiple sessions/threads sharing one desktop; the chat panel and message routing are already session-scoped, but nothing previously told the desktop to follow the selected session — so the foregrounded thread could differ from the one messages were sent to. This is session-scoped and never guesses a "latest" thread. It no-ops (200) when the session has no thread yet or the desktop WS is not connected, and crucially NEVER auto-starts a dev container (foregrounding must not boot a desktop).
      *
      * @tags Sessions
@@ -17676,7 +17745,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1SpecTasksExecutionConfigDetail: (taskId: string, params: RequestParams = {}) =>
-      this.request<TypesSpecTaskExecutionConfig, TypesAPIError>({
+      this.request<TypesAgentExecutionConfig, TypesAPIError>({
         path: `/api/v1/spec-tasks/${taskId}/execution-config`,
         method: "GET",
         secure: true,

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -61,6 +61,7 @@ import { getCSRFToken } from "../../utils/csrf";
 import SpecTaskActionButtons from "./SpecTaskActionButtons";
 import TaskAttachmentsPanel from "./TaskAttachmentsPanel";
 import useSnackbar from "../../hooks/useSnackbar";
+import useCodeAgentConfigChange from "../../hooks/useCodeAgentConfigChange";
 import useAccount from "../../hooks/useAccount";
 import useApi from "../../hooks/useApi";
 import useRouter from "../../hooks/useRouter";
@@ -421,20 +422,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     return selectCodingAgents(apps.apps);
   }, [apps.apps]);
 
-  const handleAgentModelChange = useCallback(async (
-    agentId: string,
-    codeAgentOverrides: TypesCodeAgentOverrides,
-  ) => {
-    const result = await updateExecutionConfig.mutateAsync({
-      agent_id: agentId,
-      code_agent_overrides: codeAgentOverrides,
-    });
-    snackbar.success(
-      result?.agent_thread_restarted
-        ? "Coding configuration updated — a new agent thread is starting"
-        : "Coding configuration updated",
-    );
-  }, [updateExecutionConfig, snackbar]);
+  const handleAgentModelChange = useCodeAgentConfigChange(updateExecutionConfig.mutateAsync);
 
   const handleSandboxResourcesChange = useCallback(async (sandboxResourceOverrides: TypesSandboxResourceOverrides) => {
     const result = await updateExecutionConfig.mutateAsync({

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -14,7 +14,7 @@ import { ChevronDown, Cpu } from "lucide-react";
 import {
   TypesCodeAgentOverrides,
   TypesSandboxResourceOverrides,
-  TypesSpecTaskExecutionConfig,
+  TypesAgentExecutionConfig,
 } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAssistantConfig } from "../../types";
 import useSnackbar from "../../hooks/useSnackbar";
@@ -32,10 +32,12 @@ interface SpecTaskExecutionControlsProps {
   agents: IApp[];
   selectedAgentId: string;
   codeAgentOverrides?: TypesCodeAgentOverrides;
-  currentExecutionConfig?: TypesSpecTaskExecutionConfig;
+  currentExecutionConfig?: TypesAgentExecutionConfig;
   sandboxResourceOverrides?: TypesSandboxResourceOverrides;
   onAgentModelChange: (agentId: string, value: TypesCodeAgentOverrides) => MaybePromise;
-  onSandboxResourceOverridesChange: (value: TypesSandboxResourceOverrides) => MaybePromise;
+  // Omitted by surfaces that don't own a resizable sandbox (plain chat
+  // sessions); the compute control is then hidden rather than inert.
+  onSandboxResourceOverridesChange?: (value: TypesSandboxResourceOverrides) => MaybePromise;
   disabled?: boolean;
   compact?: boolean;
   grouped?: boolean;
@@ -167,6 +169,7 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
 
   const selectSandbox = async (preset: typeof SANDBOX_PRESETS[number]) => {
     setCpuAnchor(null);
+    if (!onSandboxResourceOverridesChange) return;
     setIsSaving(true);
     try {
       await onSandboxResourceOverridesChange({
@@ -217,7 +220,7 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
     )
   ) : null;
 
-  const computeControl = (
+  const computeControl = !onSandboxResourceOverridesChange ? null : (
     <Tooltip title={`Change sandbox size (${sandboxLabel})`}>
       <Box component="span" sx={{ display: "inline-flex" }}>
         <Button
@@ -263,8 +266,12 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
             {reasoningControl}
           </Stack>
 
-          <Typography variant="body2" color="text.secondary">Compute:</Typography>
-          <Box sx={{ minWidth: 0 }}>{computeControl}</Box>
+          {computeControl && (
+            <>
+              <Typography variant="body2" color="text.secondary">Compute:</Typography>
+              <Box sx={{ minWidth: 0 }}>{computeControl}</Box>
+            </>
+          )}
         </Box>
       ) : (
         <Stack

--- a/frontend/src/components/tasks/SpecTaskModelPicker.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.tsx
@@ -13,7 +13,7 @@ import {
 import { ChevronDown, Search } from "lucide-react";
 import type {
   TypesProviderEndpoint,
-  TypesSpecTaskExecutionConfig,
+  TypesAgentExecutionConfig,
 } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAssistantConfig } from "../../types";
 import { useGetOrgByName } from "../../services/orgService";
@@ -38,7 +38,7 @@ interface SpecTaskModelPickerProps {
   selectedAgentId: string;
   model: string;
   providerRefValue: string;
-  currentExecutionConfig?: TypesSpecTaskExecutionConfig;
+  currentExecutionConfig?: TypesAgentExecutionConfig;
   disabled?: boolean;
   onSelectAgentModel: (agentId: string, provider: string, model: string) => void;
 }
@@ -78,7 +78,7 @@ const SpecTaskModelPickerView: FC<{
   selectedAgentId: string;
   model: string;
   providerRefValue: string;
-  currentExecutionConfig?: TypesSpecTaskExecutionConfig;
+  currentExecutionConfig?: TypesAgentExecutionConfig;
   loading?: boolean;
   disabled?: boolean;
   onSelectAgentModel: (agentId: string, provider: string, model: string) => void;

--- a/frontend/src/hooks/useCodeAgentConfigChange.ts
+++ b/frontend/src/hooks/useCodeAgentConfigChange.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react'
+import { TypesCodeAgentOverrides } from '../api/api'
+import useSnackbar from './useSnackbar'
+
+// Both execution-config endpoints take the same coding-identity change and
+// report the same way, so the surfaces that mount SpecTaskExecutionControls
+// share one handler rather than each re-deriving the request and the wording.
+interface CodeAgentConfigRequest {
+  agent_id?: string
+  code_agent_overrides?: TypesCodeAgentOverrides
+}
+
+interface CodeAgentConfigResult {
+  agent_thread_restarted?: boolean
+}
+
+/**
+ * Builds the `onAgentModelChange` handler for SpecTaskExecutionControls.
+ *
+ * Pass the `mutateAsync` of whichever execution-config mutation owns the
+ * surface — useUpdateSpecTaskExecutionConfig on the task page,
+ * useUpdateSessionExecutionConfig in a chat session.
+ */
+export default function useCodeAgentConfigChange(
+  mutateAsync: (request: CodeAgentConfigRequest) => Promise<CodeAgentConfigResult | undefined>,
+) {
+  const snackbar = useSnackbar()
+
+  return useCallback(async (agentId: string, codeAgentOverrides: TypesCodeAgentOverrides) => {
+    const result = await mutateAsync({
+      agent_id: agentId,
+      code_agent_overrides: codeAgentOverrides,
+    })
+    snackbar.success(
+      result?.agent_thread_restarted
+        ? 'Coding configuration updated — a new agent thread is starting'
+        : 'Coding configuration updated',
+    )
+  }, [mutateAsync, snackbar])
+}

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -22,7 +22,13 @@ import useRouter from '../hooks/useRouter'
 import useAccount from '../hooks/useAccount'
 import { useTheme } from '@mui/material/styles'
 import SimpleConfirmWindow from '../components/widgets/SimpleConfirmWindow'
-import { useGetSession, useUpdateSession, useGetSessionIdleStatus } from '../services/sessionService'
+import {
+  useGetSession,
+  useUpdateSession,
+  useGetSessionIdleStatus,
+  useGetSessionExecutionConfig,
+  useUpdateSessionExecutionConfig,
+} from '../services/sessionService'
 
 import {
   INTERACTION_STATE_EDITING,
@@ -33,11 +39,12 @@ import {
   IShareSessionInstructions,
 } from '../types'
 
-import { TypesAgentType, TypesMessageContentType, TypesMessage, TypesStepInfo, TypesSession, TypesInteractionState } from '../api/api'
+import { TypesAgentType, TypesCodeAgentOverrides, TypesMessageContentType, TypesMessage, TypesStepInfo, TypesSession, TypesInteractionState } from '../api/api'
 
 import { useStreaming } from '../contexts/streaming'
 
-import { getAssistant } from '../utils/apps'
+import { getAssistant, selectCodingAgents } from '../utils/apps'
+import SpecTaskExecutionControls from '../components/tasks/SpecTaskExecutionControls'
 import useApps from '../hooks/useApps'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import useLightTheme from '../hooks/useLightTheme'
@@ -271,6 +278,7 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
   const [appID, setAppID] = useState<string | null>(null)
   const [assistantID, setAssistantID] = useState<string | null>(null)
   const [filterMap, setFilterMap] = useState<Record<string, string>>({})
+  const [isCancelling, setIsCancelling] = useState(false)
 
   const isExternalAgent = session?.data?.config?.agent_type === TypesAgentType.AgentTypeZedExternal
 
@@ -290,6 +298,54 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
 
   // Add ref to store current scroll position
   const scrollPositionRef = useRef<number>(0)
+
+  // External coding-agent sessions (org bot chat, project chat) get the same
+  // composer controls as a spec task: model/provider, reasoning, harness — and
+  // a stop button, because their turns are long-running.
+  const { data: executionConfig } = useGetSessionExecutionConfig(sessionID, isExternalAgent)
+  const updateExecutionConfig = useUpdateSessionExecutionConfig(sessionID)
+  const sessionAgentID = executionConfig?.agent_id || session?.data?.parent_app || ''
+  // The session's OWN agent always belongs in the picker, even when it isn't a
+  // coding agent — an org chart's bots run on org_agent apps, and their model
+  // and reasoning are exactly what this composer edits.
+  const executionAgents = useMemo(() => {
+    const coding = selectCodingAgents(apps.apps)
+    const sessionAgent = apps.apps?.find((app) => app.id === sessionAgentID)
+    if (!sessionAgent || coding.some((app) => app.id === sessionAgent.id)) return coding
+    return [sessionAgent, ...coding]
+  }, [apps.apps, sessionAgentID])
+
+  const handleAgentModelChange = useCallback(async (
+    agentId: string,
+    codeAgentOverrides: TypesCodeAgentOverrides,
+  ) => {
+    const result = await updateExecutionConfig.mutateAsync({
+      agent_id: agentId,
+      code_agent_overrides: codeAgentOverrides,
+    })
+    snackbar.success(
+      result?.agent_thread_restarted
+        ? 'Coding configuration updated — a new agent thread is starting'
+        : 'Coding configuration updated',
+    )
+  }, [updateExecutionConfig, snackbar])
+
+  const handleCancelTurn = useCallback(async () => {
+    if (isCancelling) return
+    setIsCancelling(true)
+    try {
+      const response = await api.getApiClient().v1SessionsCancelCreate(sessionID)
+      if (response.data?.status === 'noop') {
+        snackbar.info('The agent is no longer running a turn')
+      }
+      await refetchSession()
+    } catch (error: any) {
+      snackbar.error(error?.message || 'Failed to interrupt current turn')
+    } finally {
+      setIsCancelling(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionID, isCancelling])
 
   // Callback to handle model changes from AdvancedModelPicker
   const handleModelChange = useCallback((provider: string, modelName: string) => {
@@ -1379,6 +1435,19 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
                     onHeightChange={scrollToBottom}
                     autoFocus
                     isAgentBusy={loading}
+                    onCancel={isExternalAgent ? handleCancelTurn : undefined}
+                    isCancelling={isCancelling}
+                    leadingActions={isExternalAgent ? (
+                      <SpecTaskExecutionControls
+                        agents={executionAgents}
+                        selectedAgentId={sessionAgentID}
+                        codeAgentOverrides={executionConfig?.code_agent_overrides}
+                        currentExecutionConfig={executionConfig}
+                        onAgentModelChange={handleAgentModelChange}
+                        disabled={updateExecutionConfig.isPending}
+                        compact
+                      />
+                    ) : undefined}
                     placeholder={
                       session.data.type === SESSION_TYPE_TEXT
                         ? session.data.parent_app

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -17,6 +17,7 @@ import Row from '../components/widgets/Row'
 import Cell from '../components/widgets/Cell'
 
 import useSnackbar from '../hooks/useSnackbar'
+import useCodeAgentConfigChange from '../hooks/useCodeAgentConfigChange'
 import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useAccount from '../hooks/useAccount'
@@ -315,20 +316,7 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
     return [sessionAgent, ...coding]
   }, [apps.apps, sessionAgentID])
 
-  const handleAgentModelChange = useCallback(async (
-    agentId: string,
-    codeAgentOverrides: TypesCodeAgentOverrides,
-  ) => {
-    const result = await updateExecutionConfig.mutateAsync({
-      agent_id: agentId,
-      code_agent_overrides: codeAgentOverrides,
-    })
-    snackbar.success(
-      result?.agent_thread_restarted
-        ? 'Coding configuration updated — a new agent thread is starting'
-        : 'Coding configuration updated',
-    )
-  }, [updateExecutionConfig, snackbar])
+  const handleAgentModelChange = useCodeAgentConfigChange(updateExecutionConfig.mutateAsync)
 
   const handleCancelTurn = useCallback(async () => {
     if (isCancelling) return

--- a/frontend/src/services/sessionService.ts
+++ b/frontend/src/services/sessionService.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import useApi from '../hooks/useApi';
-import { ServerForkSessionRequest, ServerSwitchAgentRequest, TypesSession } from '../api/api';
+import {
+  ServerForkSessionRequest,
+  ServerSwitchAgentRequest,
+  TypesSession,
+  TypesSessionExecutionConfigUpdateRequest,
+} from '../api/api';
 import { QueryClient } from '@tanstack/react-query';
 
 export const SESSION_STEPS_QUERY_KEY = (id: string) => [
@@ -199,6 +204,44 @@ export function useSwitchAgent(sessionId: string) {
       apiClient.v1SessionsSwitchAgentCreate(sessionId, request).then((res) => res.data),
     onSuccess: () => {
       // The session's agent changed in place; refresh its row + any lists.
+      queryClient.invalidateQueries({ queryKey: GET_SESSION_QUERY_KEY(sessionId) })
+      queryClient.invalidateQueries({ queryKey: ["sessions"] })
+    },
+  })
+}
+
+export const SESSION_EXECUTION_CONFIG_QUERY_KEY = (sessionId: string) => [
+  "session-execution-config",
+  sessionId,
+]
+
+// The session's current coding identity (agent, runtime, provider, model,
+// reasoning effort) — the same shape a spec task reports, because both run the
+// same external coding agent.
+export function useGetSessionExecutionConfig(sessionId: string, enabled = true) {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+
+  return useQuery({
+    queryKey: SESSION_EXECUTION_CONFIG_QUERY_KEY(sessionId),
+    queryFn: () => apiClient.v1SessionsExecutionConfigDetail(sessionId).then((res) => res.data),
+    enabled: enabled && !!sessionId,
+  })
+}
+
+// Changing the model/reasoning cancels the in-flight turn and starts a fresh
+// agent thread seeded with the prior transcript, so the session row itself
+// changes too.
+export function useUpdateSessionExecutionConfig(sessionId: string) {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: TypesSessionExecutionConfigUpdateRequest) =>
+      apiClient.v1SessionsExecutionConfigPartialUpdate(sessionId, request).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SESSION_EXECUTION_CONFIG_QUERY_KEY(sessionId) })
       queryClient.invalidateQueries({ queryKey: GET_SESSION_QUERY_KEY(sessionId) })
       queryClient.invalidateQueries({ queryKey: ["sessions"] })
     },

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3636,6 +3636,34 @@ definitions:
           type: string
         type: object
     type: object
+  types.AgentExecutionConfig:
+    properties:
+      agent_available:
+        type: boolean
+      agent_id:
+        type: string
+      agent_name:
+        type: string
+      code_agent_overrides:
+        allOf:
+        - $ref: '#/definitions/types.CodeAgentOverrides'
+        description: |-
+          CodeAgentOverrides is the override set the fields above were resolved
+          with, so a caller can round-trip an edit without having to know which
+          record (task or session) stores it.
+      credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      model:
+        type: string
+      provider_ref:
+        type: string
+      reasoning_effort:
+        type: string
+      runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
+      service_tier:
+        type: string
+    type: object
   types.AgentHelixConfig:
     properties:
       assistants:
@@ -7442,8 +7470,8 @@ definitions:
         allOf:
         - $ref: '#/definitions/types.OrgComputeUsage'
         description: |-
-          Compute is sandbox runtime spend. It answers the date range and the
-          project filter; the token-shaped filters (model, provider, session)
+          Compute is sandbox runtime spend. It answers the date range, project, and
+          task filters; the token-shaped filters (model, provider, session)
           don't apply to a container and leave it untouched.
       export_apps:
         items:
@@ -9840,6 +9868,26 @@ definitions:
         - $ref: '#/definitions/types.SessionType'
         description: e.g. text, image
     type: object
+  types.SessionExecutionConfigUpdateRequest:
+    properties:
+      agent_id:
+        type: string
+      code_agent_overrides:
+        $ref: '#/definitions/types.CodeAgentOverrides'
+    type: object
+  types.SessionExecutionConfigUpdateResponse:
+    properties:
+      agent_id:
+        type: string
+      agent_thread_restarted:
+        type: boolean
+      code_agent_overrides:
+        $ref: '#/definitions/types.CodeAgentOverrides'
+      session_id:
+        type: string
+      spec_task_id:
+        type: string
+    type: object
   types.SessionInfo:
     properties:
       auth_provider:
@@ -9907,6 +9955,15 @@ definitions:
       callback_url:
         description: Webhook URL to POST on session completion
         type: string
+      code_agent_overrides:
+        allOf:
+        - $ref: '#/definitions/types.CodeAgentOverrides'
+        description: |-
+          CodeAgentOverrides customizes the coding model for THIS session without
+          mutating its Agent. Set from the chat composer's execution controls on
+          sessions that own their configuration (org bot chat, project chat).
+          SpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is
+          authoritative there, so there is exactly one source of truth per session.
       code_agent_runtime:
         allOf:
         - $ref: '#/definitions/types.CodeAgentRuntime'
@@ -10853,27 +10910,6 @@ definitions:
     required:
     - decision
     - review_id
-    type: object
-  types.SpecTaskExecutionConfig:
-    properties:
-      agent_available:
-        type: boolean
-      agent_id:
-        type: string
-      agent_name:
-        type: string
-      credential_type:
-        $ref: '#/definitions/types.CodeAgentCredentialType'
-      model:
-        type: string
-      provider_ref:
-        type: string
-      reasoning_effort:
-        type: string
-      runtime:
-        $ref: '#/definitions/types.CodeAgentRuntime'
-      service_tier:
-        type: string
     type: object
   types.SpecTaskExecutionConfigUpdateRequest:
     properties:
@@ -24375,6 +24411,83 @@ paths:
       summary: Update Codex credentials for a session
       tags:
       - Codex
+  /api/v1/sessions/{id}/execution-config:
+    get:
+      description: Returns the session's current coding identity without exposing
+        Agent secrets. Sessions belonging to a SpecTask report the task's configuration.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.AgentExecutionConfig'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Get session execution configuration
+      tags:
+      - Sessions
+    patch:
+      consumes:
+      - application/json
+      description: Replaces the session's code-agent overrides, and optionally switches
+        it to a different Agent. The in-flight turn is cancelled and a new ACP thread
+        starts with the prior transcript. Sessions belonging to a SpecTask write through
+        to the task.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Execution configuration
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.SessionExecutionConfigUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.SessionExecutionConfigUpdateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Update session execution configuration
+      tags:
+      - Sessions
   /api/v1/sessions/{id}/foreground-thread:
     post:
       description: |-
@@ -26136,7 +26249,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.SpecTaskExecutionConfig'
+            $ref: '#/definitions/types.AgentExecutionConfig'
         "404":
           description: Not Found
           schema:

--- a/openapi.json
+++ b/openapi.json
@@ -21032,6 +21032,149 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/execution-config": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.",
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get session execution configuration",
+                "parameters": [
+                    {
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.AgentExecutionConfig"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.",
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Update session execution configuration",
+                "parameters": [
+                    {
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.SessionExecutionConfigUpdateRequest"
+                            }
+                        }
+                    },
+                    "description": "Execution configuration",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.SessionExecutionConfigUpdateResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/foreground-thread": {
             "post": {
                 "security": [
@@ -24374,7 +24517,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/types.SpecTaskExecutionConfig"
+                                    "$ref": "#/components/schemas/types.AgentExecutionConfig"
                                 }
                             }
                         }
@@ -32461,6 +32604,46 @@
                     }
                 }
             },
+            "types.AgentExecutionConfig": {
+                "type": "object",
+                "properties": {
+                    "agent_available": {
+                        "type": "boolean"
+                    },
+                    "agent_id": {
+                        "type": "string"
+                    },
+                    "agent_name": {
+                        "type": "string"
+                    },
+                    "code_agent_overrides": {
+                        "description": "CodeAgentOverrides is the override set the fields above were resolved\nwith, so a caller can round-trip an edit without having to know which\nrecord (task or session) stores it.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.CodeAgentOverrides"
+                            }
+                        ]
+                    },
+                    "credential_type": {
+                        "$ref": "#/components/schemas/types.CodeAgentCredentialType"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "provider_ref": {
+                        "type": "string"
+                    },
+                    "reasoning_effort": {
+                        "type": "string"
+                    },
+                    "runtime": {
+                        "$ref": "#/components/schemas/types.CodeAgentRuntime"
+                    },
+                    "service_tier": {
+                        "type": "string"
+                    }
+                }
+            },
             "types.AgentHelixConfig": {
                 "type": "object",
                 "properties": {
@@ -37651,7 +37834,7 @@
                         "type": "number"
                     },
                     "compute": {
-                        "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                        "description": "Compute is sandbox runtime spend. It answers the date range, project, and\ntask filters; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/types.OrgComputeUsage"
@@ -40839,6 +41022,37 @@
                     }
                 }
             },
+            "types.SessionExecutionConfigUpdateRequest": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string"
+                    },
+                    "code_agent_overrides": {
+                        "$ref": "#/components/schemas/types.CodeAgentOverrides"
+                    }
+                }
+            },
+            "types.SessionExecutionConfigUpdateResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string"
+                    },
+                    "agent_thread_restarted": {
+                        "type": "boolean"
+                    },
+                    "code_agent_overrides": {
+                        "$ref": "#/components/schemas/types.CodeAgentOverrides"
+                    },
+                    "session_id": {
+                        "type": "string"
+                    },
+                    "spec_task_id": {
+                        "type": "string"
+                    }
+                }
+            },
             "types.SessionInfo": {
                 "type": "object",
                 "properties": {
@@ -40912,6 +41126,14 @@
                     "callback_url": {
                         "description": "Webhook URL to POST on session completion",
                         "type": "string"
+                    },
+                    "code_agent_overrides": {
+                        "description": "CodeAgentOverrides customizes the coding model for THIS session without\nmutating its Agent. Set from the chat composer's execution controls on\nsessions that own their configuration (org bot chat, project chat).\nSpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is\nauthoritative there, so there is exactly one source of truth per session.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.CodeAgentOverrides"
+                            }
+                        ]
                     },
                     "code_agent_runtime": {
                         "description": "Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.)",
@@ -42163,38 +42385,6 @@
                         "type": "string"
                     },
                     "review_id": {
-                        "type": "string"
-                    }
-                }
-            },
-            "types.SpecTaskExecutionConfig": {
-                "type": "object",
-                "properties": {
-                    "agent_available": {
-                        "type": "boolean"
-                    },
-                    "agent_id": {
-                        "type": "string"
-                    },
-                    "agent_name": {
-                        "type": "string"
-                    },
-                    "credential_type": {
-                        "$ref": "#/components/schemas/types.CodeAgentCredentialType"
-                    },
-                    "model": {
-                        "type": "string"
-                    },
-                    "provider_ref": {
-                        "type": "string"
-                    },
-                    "reasoning_effort": {
-                        "type": "string"
-                    },
-                    "runtime": {
-                        "$ref": "#/components/schemas/types.CodeAgentRuntime"
-                    },
-                    "service_tier": {
                         "type": "string"
                     }
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -17582,6 +17582,120 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/execution-config": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the session's current coding identity without exposing Agent secrets. Sessions belonging to a SpecTask report the task's configuration.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the session's code-agent overrides, and optionally switches it to a different Agent. The in-flight turn is cancelled and a new ACP thread starts with the prior transcript. Sessions belonging to a SpecTask write through to the task.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Update session execution configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Execution configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SessionExecutionConfigUpdateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/foreground-thread": {
             "post": {
                 "security": [
@@ -20369,7 +20483,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.SpecTaskExecutionConfig"
+                            "$ref": "#/definitions/types.AgentExecutionConfig"
                         }
                     },
                     "404": {
@@ -27916,6 +28030,46 @@
                 }
             }
         },
+        "types.AgentExecutionConfig": {
+            "type": "object",
+            "properties": {
+                "agent_available": {
+                    "type": "boolean"
+                },
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_name": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides is the override set the fields above were resolved\nwith, so a caller can round-trip an edit without having to know which\nrecord (task or session) stores it.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
+                },
+                "credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider_ref": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "service_tier": {
+                    "type": "string"
+                }
+            }
+        },
         "types.AgentHelixConfig": {
             "type": "object",
             "properties": {
@@ -33106,7 +33260,7 @@
                     "type": "number"
                 },
                 "compute": {
-                    "description": "Compute is sandbox runtime spend. It answers the date range and the\nproject filter; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
+                    "description": "Compute is sandbox runtime spend. It answers the date range, project, and\ntask filters; the token-shaped filters (model, provider, session)\ndon't apply to a container and leave it untouched.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.OrgComputeUsage"
@@ -36294,6 +36448,37 @@
                 }
             }
         },
+        "types.SessionExecutionConfigUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                }
+            }
+        },
+        "types.SessionExecutionConfigUpdateResponse": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string"
+                },
+                "agent_thread_restarted": {
+                    "type": "boolean"
+                },
+                "code_agent_overrides": {
+                    "$ref": "#/definitions/types.CodeAgentOverrides"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "spec_task_id": {
+                    "type": "string"
+                }
+            }
+        },
         "types.SessionInfo": {
             "type": "object",
             "properties": {
@@ -36367,6 +36552,14 @@
                 "callback_url": {
                     "description": "Webhook URL to POST on session completion",
                     "type": "string"
+                },
+                "code_agent_overrides": {
+                    "description": "CodeAgentOverrides customizes the coding model for THIS session without\nmutating its Agent. Set from the chat composer's execution controls on\nsessions that own their configuration (org bot chat, project chat).\nSpecTask sessions leave this nil — SpecTask.CodeAgentOverrides is\nauthoritative there, so there is exactly one source of truth per session.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.CodeAgentOverrides"
+                        }
+                    ]
                 },
                 "code_agent_runtime": {
                     "description": "Which code agent runtime is used (zed_agent, qwen_code, claude_code, etc.)",
@@ -37618,38 +37811,6 @@
                     "type": "string"
                 },
                 "review_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.SpecTaskExecutionConfig": {
-            "type": "object",
-            "properties": {
-                "agent_available": {
-                    "type": "boolean"
-                },
-                "agent_id": {
-                    "type": "string"
-                },
-                "agent_name": {
-                    "type": "string"
-                },
-                "credential_type": {
-                    "$ref": "#/definitions/types.CodeAgentCredentialType"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "provider_ref": {
-                    "type": "string"
-                },
-                "reasoning_effort": {
-                    "type": "string"
-                },
-                "runtime": {
-                    "$ref": "#/definitions/types.CodeAgentRuntime"
-                },
-                "service_tier": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## What

The org-chart bot chat (`/orgs/{org}/chat/session/{id}`) runs the same external coding agent as a spec task, but its composer had no interrupt button and no way to change the model, provider, or reasoning effort. This gives it the **same** controls the spec-task chat already has — the same `SpecTaskExecutionControls` in the same `RobustPromptInput`, not a second composer.

Before: attach button only. After: model/provider picker (with harness), reasoning + service tier, and a stop button while the agent is working.

## Why it needed a backend change

`PATCH /spec-tasks/{id}/execution-config` stores overrides on the SpecTask row. An org bot session has no SpecTask, so there was nowhere to put them.

Everything downstream was already session-scoped — `cancelActiveTurn`, `switchAgentInPlaceForNextTurn`, and the `getZedConfig` read that materialises the model into the sandbox. Only the storage location differed. So `api/pkg/server/execution_config.go` now holds the shared path (validate → no-op check → drain in-flight turns → persist → switch agent in place → roll back on failure), and each surface supplies a `codeAgentConfigTarget` saying where its overrides live:

- SpecTask surface → `SpecTask.CodeAgentOverrides` (unchanged behaviour)
- Session surface → `Session.Metadata.CodeAgentOverrides` (new)

**One source of truth per session.** A session belonging to a SpecTask writes *through* to the task, because `getZedConfig` reads the task first — a session-level override there would be silently ignored. That also makes the session endpoint safe to call from any chat surface, including spec-task execution sessions, which are reachable from this same org-chat URL via the executions history.

**Kind restriction is now per-surface.** Spec tasks still take `coding_agent` apps only. An org chart's bots run on `org_agent` apps, which have a `zed_external` assistant but would fail that check. It's also only enforced on a *genuine* agent change — resending the current agent id alongside a model edit is not a switch.

`SpecTaskExecutionConfig` → `AgentExecutionConfig`: it describes a coding identity, not a task, and both surfaces return it. It now also echoes the override set it was resolved from, so a composer can round-trip an edit without knowing which record stores it.

## API

| | |
|---|---|
| `GET /api/v1/sessions/{id}/execution-config` | → `types.AgentExecutionConfig` |
| `PATCH /api/v1/sessions/{id}/execution-config` | `{agent_id?, code_agent_overrides}` → `types.SessionExecutionConfigUpdateResponse` |

Rejected: non-`zed_external` sessions (400) and paused sessions (409 — reconfigure the active descendant, same rule as switch-agent). Embed keys can't reach either route; the allowlist's `/api/v1/sessions/` rule matches a single trailing segment only, which is the documented intent.

## Not included

Session-level sandbox sizing. `onSandboxResourceOverridesChange` is now optional on the shared control and the compute button is hidden when a surface has no resizable sandbox of its own, rather than rendering an inert control. Spec tasks are unaffected.

## Testing

7 new backend tests (in-process `NewTestServer` + memorystore) cover session-owned overrides, SpecTask write-through, the no-op guard, and both rejections. Existing spec-task, switch-agent, and `RobustPromptInput` suites cover the refactor. `go test ./pkg/server/ ./pkg/types/ ./pkg/external-agent/` and `yarn build` are green.

Verified live against a real org bot session on the dev stack ("Software Engineer" @ unmanned-org), driving the composer control itself:

- Medium → High persisted `{"reasoning_effort":"high"}` on the session row, cleared the Zed thread and opened a new one, seeded `fork_seed` + `fork_handoff`, and the **live agent completed the handoff turn**. `GET /zed-config` then reported `reasoning_effort: high`.
- Resetting to Default cleared the override and `/zed-config` returned to `medium`.
- The model picker lists the bot's agent with its full provider/model set.

**Not observed live:** the Stop button rendered mid-turn on this page — the browser was signed in as an admin who isn't the session owner, and `checkOwnership` blocks sending from it. The composer's props were verified on the live page instead (`onCancel` present, `isCancelling`, `sendMode: direct`), and the render-and-click contract is covered by the existing `RobustPromptInput` tests.

Design notes: `design/2026-08-13-session-execution-controls.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
