### PR TITLE
fix(org): recover failed GitHub webhook deliveries

### DIFF
--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v61/github"
@@ -222,6 +223,49 @@ type WebhookSummary struct {
 	ID     int64
 	Events []string
 	Active bool
+}
+
+type WebhookDelivery struct {
+	ID          int64
+	GUID        string
+	DeliveredAt time.Time
+	StatusCode  int
+}
+
+func (c *Client) ListWebhookDeliveries(owner, repo string, hookID int64, cursor string) ([]WebhookDelivery, string, error) {
+	deliveries, resp, err := c.client.Repositories.ListHookDeliveries(c.ctx, owner, repo, hookID, &github.ListCursorOptions{
+		PerPage: 100,
+		Cursor:  cursor,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	out := make([]WebhookDelivery, 0, len(deliveries))
+	for _, delivery := range deliveries {
+		if delivery == nil {
+			continue
+		}
+		out = append(out, WebhookDelivery{
+			ID:          delivery.GetID(),
+			GUID:        delivery.GetGUID(),
+			DeliveredAt: delivery.GetDeliveredAt().Time,
+			StatusCode:  delivery.GetStatusCode(),
+		})
+	}
+	next := ""
+	if resp != nil {
+		next = resp.Cursor
+	}
+	return out, next, nil
+}
+
+func (c *Client) RedeliverWebhookDelivery(owner, repo string, hookID, deliveryID int64) error {
+	_, _, err := c.client.Repositories.RedeliverHookDelivery(c.ctx, owner, repo, hookID, deliveryID)
+	var accepted *github.AcceptedError
+	if errors.As(err, &accepted) {
+		return nil
+	}
+	return err
 }
 
 // FindWebhook returns the repo webhook whose payload URL matches `url`.

--- a/api/pkg/github/client_test.go
+++ b/api/pkg/github/client_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestWebhookSettingsURL(t *testing.T) {
@@ -35,6 +36,37 @@ func TestWebhookSettingsURL(t *testing.T) {
 	want := "https://github.com/helixml/helix/settings/hooks/123"
 	if got != want {
 		t.Errorf("WebhookSettingsURL = %q, want %q", got, want)
+	}
+}
+
+func TestWebhookDeliveryRecoveryClient(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.String())
+		}
+		w.Header().Set("Link", `<http://`+r.Host+r.URL.Path+`?cursor=next>; rel="next"`)
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 7, "guid": "g-1", "delivered_at": now, "status_code": 521}})
+	})
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries/7/attempts", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := newTestGitHubClient(t, srv)
+
+	deliveries, cursor, err := c.ListWebhookDeliveries("helixml", "helix", 42, "")
+	if err != nil || cursor != "next" || len(deliveries) != 1 || deliveries[0].ID != 7 || deliveries[0].StatusCode != 521 {
+		t.Fatalf("deliveries = %+v, cursor = %q, err = %v", deliveries, cursor, err)
+	}
+	if err := c.RedeliverWebhookDelivery("helixml", "helix", 42, 7); err != nil {
+		t.Fatalf("redeliver: %v", err)
 	}
 }
 

--- a/api/pkg/org/infrastructure/transports/github/delivery_reconciler.go
+++ b/api/pkg/org/infrastructure/transports/github/delivery_reconciler.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -14,9 +15,21 @@ import (
 )
 
 const (
-	deliveryPollInterval = 5 * time.Minute
-	deliveryRetention    = 72 * time.Hour
+	deliveryPollInterval    = 5 * time.Minute
+	deliveryRetention       = 72 * time.Hour
+	deliveryListPageLimit   = 10
+	deliveryRedeliveryLimit = 20
 )
+
+type deliveryScan struct {
+	cursor     string
+	deliveries []githubclient.WebhookDelivery
+	complete   bool
+}
+
+func deliveryHookKey(owner, repo string, hookID int64) string {
+	return fmt.Sprintf("%s/%s/%d", strings.ToLower(owner), strings.ToLower(repo), hookID)
+}
 
 type DeliveryReconciler struct {
 	store            *store.Store
@@ -24,10 +37,18 @@ type DeliveryReconciler struct {
 	baseURL          string
 	logger           *slog.Logger
 	checkpointByHook map[string]int64
+	scanByHook       map[string]*deliveryScan
 }
 
 func NewDeliveryReconciler(st *store.Store, token TokenResolver, baseURL string, logger *slog.Logger) *DeliveryReconciler {
-	return &DeliveryReconciler{store: st, token: token, baseURL: baseURL, logger: logger, checkpointByHook: map[string]int64{}}
+	return &DeliveryReconciler{
+		store:            st,
+		token:            token,
+		baseURL:          baseURL,
+		logger:           logger,
+		checkpointByHook: map[string]int64{},
+		scanByHook:       map[string]*deliveryScan{},
+	}
 }
 
 func (r *DeliveryReconciler) Run(ctx context.Context) {
@@ -50,6 +71,8 @@ func (r *DeliveryReconciler) reconcile(ctx context.Context) {
 		r.logger.Error("github delivery recovery: list topics", "err", err)
 		return
 	}
+	live := make(map[string]struct{})
+	seen := make(map[string]struct{})
 	for _, topic := range topics {
 		if ctx.Err() != nil {
 			return
@@ -62,6 +85,8 @@ func (r *DeliveryReconciler) reconcile(ctx context.Context) {
 		if !ok || owner == "" || repo == "" {
 			continue
 		}
+		key := deliveryHookKey(owner, repo, cfg.WebhookID)
+		live[key] = struct{}{}
 		token, err := r.token(ctx, topic.OrganizationID)
 		if err != nil || token == "" {
 			r.logger.Error("github delivery recovery: resolve credentials", "org", topic.OrganizationID, "topic", topic.ID, "err", err)
@@ -72,53 +97,140 @@ func (r *DeliveryReconciler) reconcile(ctx context.Context) {
 			r.logger.Error("github delivery recovery: create client", "org", topic.OrganizationID, "topic", topic.ID, "err", err)
 			continue
 		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
 		if err := r.reconcileHook(ctx, client, owner, repo, cfg.WebhookID); err != nil {
 			r.logger.Error("github delivery recovery: reconcile hook", "org", topic.OrganizationID, "topic", topic.ID, "repo", cfg.Repo, "hook", cfg.WebhookID, "err", err)
+		}
+	}
+	for key := range r.checkpointByHook {
+		if _, ok := live[key]; !ok {
+			delete(r.checkpointByHook, key)
+		}
+	}
+	for key := range r.scanByHook {
+		if _, ok := live[key]; !ok {
+			delete(r.scanByHook, key)
 		}
 	}
 }
 
 func (r *DeliveryReconciler) reconcileHook(ctx context.Context, client *githubclient.Client, owner, repo string, hookID int64) error {
-	key := fmt.Sprintf("%s/%s/%d", owner, repo, hookID)
+	key := deliveryHookKey(owner, repo, hookID)
 	checkpoint := r.checkpointByHook[key]
+	scan := r.scanByHook[key]
+	if scan == nil {
+		scan = &deliveryScan{}
+		r.scanByHook[key] = scan
+	}
 
 	cutoff := time.Now().Add(-deliveryRetention)
-	var deliveries []githubclient.WebhookDelivery
-	cursor := ""
-	for {
-		batch, next, err := client.ListWebhookDeliveries(owner, repo, hookID, cursor)
+	requests := 0
+	known := make(map[int64]struct{}, len(scan.deliveries))
+	for _, delivery := range scan.deliveries {
+		known[delivery.ID] = struct{}{}
+	}
+	if !scan.complete && scan.cursor != "" && len(scan.deliveries) > 0 {
+		refreshCursor := ""
+		refreshReady := false
+		var refreshed []githubclient.WebhookDelivery
+		refreshSeen := make(map[int64]struct{})
+		for requests < deliveryListPageLimit {
+			batch, next, err := client.ListWebhookDeliveries(owner, repo, hookID, refreshCursor)
+			if err != nil {
+				return err
+			}
+			requests++
+			overlapped := false
+			for _, delivery := range batch {
+				if _, ok := known[delivery.ID]; ok {
+					overlapped = true
+					continue
+				}
+				if _, ok := refreshSeen[delivery.ID]; !ok {
+					refreshed = append(refreshed, delivery)
+					refreshSeen[delivery.ID] = struct{}{}
+				}
+			}
+			if overlapped {
+				scan.deliveries = append(scan.deliveries, refreshed...)
+				for id := range refreshSeen {
+					known[id] = struct{}{}
+				}
+				refreshReady = true
+				break
+			}
+			if next == "" {
+				scan.deliveries = refreshed
+				known = refreshSeen
+				scan.cursor = ""
+				scan.complete = true
+				refreshReady = true
+				break
+			}
+			refreshCursor = next
+		}
+		if !refreshReady {
+			return ctx.Err()
+		}
+	}
+	for requests < deliveryListPageLimit {
+		if scan.complete {
+			break
+		}
+		batch, next, err := client.ListWebhookDeliveries(owner, repo, hookID, scan.cursor)
 		if err != nil {
 			return err
 		}
+		requests++
 		reached := next == ""
 		for _, delivery := range batch {
 			if delivery.ID == checkpoint || delivery.DeliveredAt.Before(cutoff) {
 				reached = true
 				break
 			}
-			deliveries = append(deliveries, delivery)
+			if _, ok := known[delivery.ID]; !ok {
+				scan.deliveries = append(scan.deliveries, delivery)
+				known[delivery.ID] = struct{}{}
+			}
 		}
 		if reached {
-			break
+			slices.SortFunc(scan.deliveries, func(a, b githubclient.WebhookDelivery) int {
+				return cmp.Compare(a.ID, b.ID)
+			})
+			scan.complete = true
+			continue
 		}
-		cursor = next
+		scan.cursor = next
+	}
+	if !scan.complete {
+		return ctx.Err()
 	}
 
-	slices.Reverse(deliveries)
 	latest := make(map[string]int64)
-	for _, delivery := range deliveries {
+	for _, delivery := range scan.deliveries {
 		if delivery.GUID != "" {
 			latest[delivery.GUID] = delivery.ID
 		}
 	}
-	for _, delivery := range deliveries {
+	redeliveries := 0
+	for len(scan.deliveries) > 0 {
+		delivery := scan.deliveries[0]
 		if latest[delivery.GUID] == delivery.ID && (delivery.StatusCode < 200 || delivery.StatusCode >= 300) {
+			if redeliveries == deliveryRedeliveryLimit {
+				return ctx.Err()
+			}
+			redeliveries++
 			if err := client.RedeliverWebhookDelivery(owner, repo, hookID, delivery.ID); err != nil {
 				return fmt.Errorf("redeliver %s delivery %d: %w", delivery.GUID, delivery.ID, err)
 			}
 			r.logger.Info("github delivery recovery: requested redelivery", "repo", owner+"/"+repo, "hook", hookID, "delivery", delivery.ID, "guid", delivery.GUID)
 		}
 		r.checkpointByHook[key] = delivery.ID
+		scan.deliveries = scan.deliveries[1:]
 	}
+	delete(r.scanByHook, key)
 	return ctx.Err()
 }

--- a/api/pkg/org/infrastructure/transports/github/delivery_reconciler.go
+++ b/api/pkg/org/infrastructure/transports/github/delivery_reconciler.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	githubclient "github.com/helixml/helix/api/pkg/github"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+)
+
+const (
+	deliveryPollInterval = 5 * time.Minute
+	deliveryRetention    = 72 * time.Hour
+)
+
+type DeliveryReconciler struct {
+	store            *store.Store
+	token            TokenResolver
+	baseURL          string
+	logger           *slog.Logger
+	checkpointByHook map[string]int64
+}
+
+func NewDeliveryReconciler(st *store.Store, token TokenResolver, baseURL string, logger *slog.Logger) *DeliveryReconciler {
+	return &DeliveryReconciler{store: st, token: token, baseURL: baseURL, logger: logger, checkpointByHook: map[string]int64{}}
+}
+
+func (r *DeliveryReconciler) Run(ctx context.Context) {
+	r.reconcile(ctx)
+	ticker := time.NewTicker(deliveryPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reconcile(ctx)
+		}
+	}
+}
+
+func (r *DeliveryReconciler) reconcile(ctx context.Context) {
+	topics, err := r.store.Topics.ListByTransportKind(ctx, transport.KindGitHub)
+	if err != nil {
+		r.logger.Error("github delivery recovery: list topics", "err", err)
+		return
+	}
+	for _, topic := range topics {
+		if ctx.Err() != nil {
+			return
+		}
+		cfg, err := topic.Transport.GitHubConfig()
+		if err != nil || cfg.WebhookID == 0 {
+			continue
+		}
+		owner, repo, ok := strings.Cut(cfg.Repo, "/")
+		if !ok || owner == "" || repo == "" {
+			continue
+		}
+		token, err := r.token(ctx, topic.OrganizationID)
+		if err != nil || token == "" {
+			r.logger.Error("github delivery recovery: resolve credentials", "org", topic.OrganizationID, "topic", topic.ID, "err", err)
+			continue
+		}
+		client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token, BaseURL: r.baseURL})
+		if err != nil {
+			r.logger.Error("github delivery recovery: create client", "org", topic.OrganizationID, "topic", topic.ID, "err", err)
+			continue
+		}
+		if err := r.reconcileHook(ctx, client, owner, repo, cfg.WebhookID); err != nil {
+			r.logger.Error("github delivery recovery: reconcile hook", "org", topic.OrganizationID, "topic", topic.ID, "repo", cfg.Repo, "hook", cfg.WebhookID, "err", err)
+		}
+	}
+}
+
+func (r *DeliveryReconciler) reconcileHook(ctx context.Context, client *githubclient.Client, owner, repo string, hookID int64) error {
+	key := fmt.Sprintf("%s/%s/%d", owner, repo, hookID)
+	checkpoint := r.checkpointByHook[key]
+
+	cutoff := time.Now().Add(-deliveryRetention)
+	var deliveries []githubclient.WebhookDelivery
+	cursor := ""
+	for {
+		batch, next, err := client.ListWebhookDeliveries(owner, repo, hookID, cursor)
+		if err != nil {
+			return err
+		}
+		reached := next == ""
+		for _, delivery := range batch {
+			if delivery.ID == checkpoint || delivery.DeliveredAt.Before(cutoff) {
+				reached = true
+				break
+			}
+			deliveries = append(deliveries, delivery)
+		}
+		if reached {
+			break
+		}
+		cursor = next
+	}
+
+	slices.Reverse(deliveries)
+	latest := make(map[string]int64)
+	for _, delivery := range deliveries {
+		if delivery.GUID != "" {
+			latest[delivery.GUID] = delivery.ID
+		}
+	}
+	for _, delivery := range deliveries {
+		if latest[delivery.GUID] == delivery.ID && (delivery.StatusCode < 200 || delivery.StatusCode >= 300) {
+			if err := client.RedeliverWebhookDelivery(owner, repo, hookID, delivery.ID); err != nil {
+				return fmt.Errorf("redeliver %s delivery %d: %w", delivery.GUID, delivery.ID, err)
+			}
+			r.logger.Info("github delivery recovery: requested redelivery", "repo", owner+"/"+repo, "hook", hookID, "delivery", delivery.ID, "guid", delivery.GUID)
+		}
+		r.checkpointByHook[key] = delivery.ID
+	}
+	return ctx.Err()
+}

--- a/api/pkg/org/infrastructure/transports/github/delivery_reconciler_test.go
+++ b/api/pkg/org/infrastructure/transports/github/delivery_reconciler_test.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	githubclient "github.com/helixml/helix/api/pkg/github"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 )
 
 func TestReconcileHookDoesNotAdvanceAfterIncompleteScan(t *testing.T) {
@@ -63,7 +66,7 @@ func TestReconcileHookDoesNotAdvanceAfterIncompleteScan(t *testing.T) {
 	defer server.Close()
 	client := newDeliveryTestClient(t, server)
 	reconciler := newDeliveryTestReconciler()
-	key := "helixml/helix/42"
+	key := deliveryHookKey("helixml", "helix", 42)
 	reconciler.checkpointByHook[key] = 10000
 
 	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err == nil {
@@ -125,7 +128,7 @@ func TestReconcileHookCheckpointsAcceptedRedeliveries(t *testing.T) {
 	defer server.Close()
 	client := newDeliveryTestClient(t, server)
 	reconciler := newDeliveryTestReconciler()
-	key := "helixml/helix/42"
+	key := deliveryHookKey("helixml", "helix", 42)
 
 	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err == nil {
 		t.Fatal("reconcileHook error = nil, want redelivery error")
@@ -147,6 +150,217 @@ func TestReconcileHookCheckpointsAcceptedRedeliveries(t *testing.T) {
 	}
 }
 
+func TestReconcileHookResumesBoundedBacklog(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	var mu sync.Mutex
+	listRequests := 0
+	attempts := map[int64]int{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries", func(w http.ResponseWriter, req *http.Request) {
+		page := 1
+		if cursor := req.URL.Query().Get("cursor"); cursor != "" {
+			var err error
+			page, err = strconv.Atoi(strings.TrimPrefix(cursor, "page-"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		mu.Lock()
+		listRequests++
+		request := listRequests
+		mu.Unlock()
+		newerID := int64(24 - page*2)
+		batch := []githubclient.WebhookDelivery{
+			{ID: newerID, GUID: "delivery-" + strconv.FormatInt(newerID, 10), DeliveredAt: now.Add(-time.Duration(page) * time.Minute), StatusCode: 500},
+			{ID: newerID - 1, GUID: "delivery-" + strconv.FormatInt(newerID-1, 10), DeliveredAt: now.Add(-time.Duration(page) * time.Minute), StatusCode: 500},
+		}
+		if page == 2 {
+			batch[0].GUID = "page-two-failure"
+		}
+		if page == 1 && request > deliveryListPageLimit {
+			batch = append([]githubclient.WebhookDelivery{{ID: 23, GUID: "page-two-failure", DeliveredAt: now, StatusCode: 204}}, batch...)
+		}
+		if page < 11 {
+			w.Header().Set("Link", `<http://`+req.Host+req.URL.Path+`?cursor=page-`+strconv.Itoa(page+1)+`>; rel="next"`)
+		}
+		writeDeliveries(t, w, batch)
+	})
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries/", func(w http.ResponseWriter, req *http.Request) {
+		id, err := strconv.ParseInt(strings.Split(req.URL.Path, "/")[9], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		attempts[id]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := newDeliveryTestClient(t, server)
+	reconciler := newDeliveryTestReconciler()
+	key := deliveryHookKey("helixml", "helix", 42)
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if listRequests != deliveryListPageLimit || len(attempts) != 0 || reconciler.checkpointByHook[key] != 0 {
+		t.Fatalf("cycle 1: list requests = %d, redeliveries = %d, checkpoint = %d", listRequests, len(attempts), reconciler.checkpointByHook[key])
+	}
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if listRequests != 12 || len(attempts) != deliveryRedeliveryLimit || attempts[20] != 0 || reconciler.checkpointByHook[key] != 21 {
+		t.Fatalf("cycle 2: list requests = %d, redeliveries = %d, stale page-2 attempts = %d, checkpoint = %d", listRequests, len(attempts), attempts[20], reconciler.checkpointByHook[key])
+	}
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if listRequests != 12 || len(attempts) != 21 || reconciler.checkpointByHook[key] != 23 {
+		t.Fatalf("cycle 3: list requests = %d, redeliveries = %d, checkpoint = %d", listRequests, len(attempts), reconciler.checkpointByHook[key])
+	}
+	for id := int64(1); id <= 22; id++ {
+		want := 1
+		if id == 20 {
+			want = 0
+		}
+		if attempts[id] != want {
+			t.Fatalf("delivery %d attempts = %d, want %d", id, attempts[id], want)
+		}
+	}
+}
+
+func TestReconcileHookProgressesAfterOverlapAtListLimit(t *testing.T) {
+	now := time.Now().UTC()
+	cycleRequests := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries", func(w http.ResponseWriter, req *http.Request) {
+		cycleRequests++
+		cursor := req.URL.Query().Get("cursor")
+		if cursor == "old-page" {
+			writeDeliveries(t, w, []githubclient.WebhookDelivery{{ID: 9, GUID: "older", DeliveredAt: now.Add(-time.Hour), StatusCode: 204}})
+			return
+		}
+		page := 1
+		if cursor != "" {
+			var err error
+			page, err = strconv.Atoi(strings.TrimPrefix(cursor, "page-"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		id := int64(20 - page)
+		w.Header().Set("Link", `<http://`+req.Host+req.URL.Path+`?cursor=page-`+strconv.Itoa(page+1)+`>; rel="next"`)
+		writeDeliveries(t, w, []githubclient.WebhookDelivery{{ID: id, GUID: "delivery-" + strconv.FormatInt(id, 10), DeliveredAt: now, StatusCode: 204}})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := newDeliveryTestClient(t, server)
+	reconciler := newDeliveryTestReconciler()
+	key := deliveryHookKey("helixml", "helix", 42)
+	reconciler.scanByHook[key] = &deliveryScan{
+		cursor:     "old-page",
+		deliveries: []githubclient.WebhookDelivery{{ID: 10, GUID: "overlap", DeliveredAt: now.Add(-time.Minute), StatusCode: 204}},
+	}
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if cycleRequests != deliveryListPageLimit || reconciler.checkpointByHook[key] != 0 {
+		t.Fatalf("cycle 1: list requests = %d, checkpoint = %d", cycleRequests, reconciler.checkpointByHook[key])
+	}
+
+	cycleRequests = 0
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if cycleRequests != 2 || reconciler.checkpointByHook[key] != 19 {
+		t.Fatalf("cycle 2: list requests = %d, checkpoint = %d", cycleRequests, reconciler.checkpointByHook[key])
+	}
+	if _, ok := reconciler.scanByHook[key]; ok {
+		t.Fatal("completed scan was not removed")
+	}
+}
+
+func TestReconcileCanonicalHookAndCleansStaleState(t *testing.T) {
+	var lists, redeliveries int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/HelixML/Helix/hooks/42/deliveries", func(w http.ResponseWriter, _ *http.Request) {
+		lists++
+		writeDeliveries(t, w, []githubclient.WebhookDelivery{{ID: 1, GUID: "failed", DeliveredAt: time.Now(), StatusCode: 500}})
+	})
+	mux.HandleFunc("/api/v3/repos/HelixML/Helix/hooks/42/deliveries/1/attempts", func(w http.ResponseWriter, _ *http.Request) {
+		redeliveries++
+		w.WriteHeader(http.StatusAccepted)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	st := memory.New()
+	for i, repo := range []string{"HelixML/Helix", "helixml/helix"} {
+		cfg, err := json.Marshal(transport.GitHubConfig{Repo: repo, Events: []string{"*"}, WebhookID: 42})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.Topics.Create(context.Background(), streaming.Topic{
+			ID:             "topic-" + strconv.Itoa(i),
+			OrganizationID: "org-test",
+			Name:           "topic-" + strconv.Itoa(i),
+			CreatedAt:      time.Now(),
+			Transport:      transport.Transport{Kind: transport.KindGitHub, Config: cfg},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tokenFails := false
+	reconciler := NewDeliveryReconciler(st, func(context.Context, string) (string, error) {
+		if tokenFails {
+			return "", io.ErrUnexpectedEOF
+		}
+		return "token", nil
+	}, server.URL+"/", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	staleKey := deliveryHookKey("old", "repo", 7)
+	reconciler.checkpointByHook[staleKey] = 9
+	reconciler.scanByHook[staleKey] = &deliveryScan{cursor: "old"}
+
+	reconciler.reconcile(context.Background())
+	if lists != 1 || redeliveries != 1 {
+		t.Fatalf("lists = %d, redeliveries = %d, want 1 each", lists, redeliveries)
+	}
+	if _, ok := reconciler.checkpointByHook[staleKey]; ok {
+		t.Fatal("stale checkpoint was not removed")
+	}
+	if _, ok := reconciler.scanByHook[staleKey]; ok {
+		t.Fatal("stale scan was not removed")
+	}
+	if len(reconciler.checkpointByHook) != 1 {
+		t.Fatalf("checkpoints = %v, want one canonical hook", reconciler.checkpointByHook)
+	}
+	liveKey := deliveryHookKey("HELIXML", "HELIX", 42)
+	reconciler.scanByHook[liveKey] = &deliveryScan{cursor: "resume"}
+	tokenFails = true
+	reconciler.reconcile(context.Background())
+	if _, ok := reconciler.scanByHook[liveKey]; !ok {
+		t.Fatal("live scan was removed after credential resolution failed")
+	}
+
+	for i := range 2 {
+		if err := st.Topics.Delete(context.Background(), "org-test", "topic-"+strconv.Itoa(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tokenFails = false
+	reconciler.reconcile(context.Background())
+	if len(reconciler.checkpointByHook) != 0 || len(reconciler.scanByHook) != 0 {
+		t.Fatalf("orphan state remains: checkpoints = %v, scans = %v", reconciler.checkpointByHook, reconciler.scanByHook)
+	}
+}
+
 func newDeliveryTestClient(t *testing.T, server *httptest.Server) *githubclient.Client {
 	t.Helper()
 	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: context.Background(), Token: "test-token", BaseURL: server.URL + "/"})
@@ -157,7 +371,11 @@ func newDeliveryTestClient(t *testing.T, server *httptest.Server) *githubclient.
 }
 
 func newDeliveryTestReconciler() *DeliveryReconciler {
-	return &DeliveryReconciler{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), checkpointByHook: map[string]int64{}}
+	return &DeliveryReconciler{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		checkpointByHook: map[string]int64{},
+		scanByHook:       map[string]*deliveryScan{},
+	}
 }
 
 func writeDeliveries(t *testing.T, w http.ResponseWriter, deliveries []githubclient.WebhookDelivery) {

--- a/api/pkg/org/infrastructure/transports/github/delivery_reconciler_test.go
+++ b/api/pkg/org/infrastructure/transports/github/delivery_reconciler_test.go
@@ -1,0 +1,179 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	githubclient "github.com/helixml/helix/api/pkg/github"
+)
+
+func TestReconcileHookDoesNotAdvanceAfterIncompleteScan(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	var mu sync.Mutex
+	pageTwoFails := true
+	var redeliveries []int64
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries", func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Query().Get("cursor") == "page-2" {
+			mu.Lock()
+			fails := pageTwoFails
+			mu.Unlock()
+			if fails {
+				http.Error(w, "temporary failure", http.StatusInternalServerError)
+				return
+			}
+			writeDeliveries(t, w, []githubclient.WebhookDelivery{
+				{ID: 50, GUID: "page-two-success", DeliveredAt: now.Add(-100 * time.Second), StatusCode: 204},
+				{ID: 49, GUID: "page-two-failure", DeliveredAt: now.Add(-101 * time.Second), StatusCode: 502},
+				{ID: 10000, GUID: "checkpoint", DeliveredAt: now.Add(-102 * time.Second), StatusCode: 204},
+			})
+			return
+		}
+
+		batch := make([]githubclient.WebhookDelivery, 0, 100)
+		for id := int64(150); id > 50; id-- {
+			status := http.StatusNoContent
+			batch = append(batch, githubclient.WebhookDelivery{ID: id, GUID: "delivery-" + strconv.FormatInt(id, 10), DeliveredAt: now.Add(-time.Duration(150-id) * time.Second), StatusCode: status})
+		}
+		w.Header().Set("Link", `<http://`+req.Host+req.URL.Path+`?cursor=page-2>; rel="next"`)
+		writeDeliveries(t, w, batch)
+	})
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries/", func(w http.ResponseWriter, req *http.Request) {
+		id, err := strconv.ParseInt(strings.Split(req.URL.Path, "/")[9], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		redeliveries = append(redeliveries, id)
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := newDeliveryTestClient(t, server)
+	reconciler := newDeliveryTestReconciler()
+	key := "helixml/helix/42"
+	reconciler.checkpointByHook[key] = 10000
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err == nil {
+		t.Fatal("reconcileHook error = nil, want page 2 error")
+	}
+	if got := reconciler.checkpointByHook[key]; got != 10000 {
+		t.Fatalf("checkpoint = %d, want 10000", got)
+	}
+	mu.Lock()
+	if len(redeliveries) != 0 {
+		t.Fatalf("redeliveries after incomplete scan = %v, want none", redeliveries)
+	}
+	pageTwoFails = false
+	mu.Unlock()
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+	if got := reconciler.checkpointByHook[key]; got != 150 {
+		t.Fatalf("checkpoint = %d, want 150", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(redeliveries) != 1 || redeliveries[0] != 49 {
+		t.Fatalf("redeliveries = %v, want [49]", redeliveries)
+	}
+}
+
+func TestReconcileHookCheckpointsAcceptedRedeliveries(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	var mu sync.Mutex
+	attempts := map[int64]int{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries", func(w http.ResponseWriter, _ *http.Request) {
+		writeDeliveries(t, w, []githubclient.WebhookDelivery{
+			{ID: 3, GUID: "third", DeliveredAt: now, StatusCode: 500},
+			{ID: 2, GUID: "second", DeliveredAt: now.Add(-time.Minute), StatusCode: 500},
+			{ID: 1, GUID: "first", DeliveredAt: now.Add(-2 * time.Minute), StatusCode: 500},
+		})
+	})
+	mux.HandleFunc("/api/v3/repos/helixml/helix/hooks/42/deliveries/", func(w http.ResponseWriter, req *http.Request) {
+		id, err := strconv.ParseInt(strings.Split(req.URL.Path, "/")[9], 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mu.Lock()
+		attempts[id]++
+		attempt := attempts[id]
+		mu.Unlock()
+		if id == 2 && attempt == 1 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := newDeliveryTestClient(t, server)
+	reconciler := newDeliveryTestReconciler()
+	key := "helixml/helix/42"
+
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err == nil {
+		t.Fatal("reconcileHook error = nil, want redelivery error")
+	}
+	if got := reconciler.checkpointByHook[key]; got != 1 {
+		t.Fatalf("checkpoint after partial failure = %d, want 1", got)
+	}
+	if err := reconciler.reconcileHook(context.Background(), client, "helixml", "helix", 42); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts[1] != 1 || attempts[2] != 2 || attempts[3] != 1 {
+		t.Fatalf("redelivery attempts = %v, want map[1:1 2:2 3:1]", attempts)
+	}
+	if got := reconciler.checkpointByHook[key]; got != 3 {
+		t.Fatalf("checkpoint = %d, want 3", got)
+	}
+}
+
+func newDeliveryTestClient(t *testing.T, server *httptest.Server) *githubclient.Client {
+	t.Helper()
+	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: context.Background(), Token: "test-token", BaseURL: server.URL + "/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func newDeliveryTestReconciler() *DeliveryReconciler {
+	return &DeliveryReconciler{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), checkpointByHook: map[string]int64{}}
+}
+
+func writeDeliveries(t *testing.T, w http.ResponseWriter, deliveries []githubclient.WebhookDelivery) {
+	t.Helper()
+	type response struct {
+		ID          int64     `json:"id"`
+		GUID        string    `json:"guid"`
+		DeliveredAt time.Time `json:"delivered_at"`
+		StatusCode  int       `json:"status_code"`
+	}
+	body := make([]response, len(deliveries))
+	for i, delivery := range deliveries {
+		body[i] = response(delivery)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/api/pkg/org/infrastructure/transports/github/github.go
+++ b/api/pkg/org/infrastructure/transports/github/github.go
@@ -325,27 +325,13 @@ func (t *Transport) HandleInbound() http.Handler {
 
 		now := nowUTC()
 		for _, s := range topics {
-			event, err := streaming.NewMessageEvent(
-				streaming.EventID("e-"+uuid.NewString()),
-				s.ID,
-				"", // system-emitted: external sender, no helix Worker source
-				msg,
-				now,
-				t.orgID,
-			)
+			appended, err := t.appendInbound(r.Context(), s.ID, deliveryID, msg, now)
 			if err != nil {
-				t.logger.Error("github.inbound: build event", "topic", s.ID, "err", err)
-				continue
-			}
-			if err := t.store.Events.Append(r.Context(), event); err != nil {
 				t.logger.Error("github.inbound: append", "topic", s.ID, "err", err)
 				continue
 			}
-			if t.broadcaster != nil {
-				t.broadcaster.Notify(t.orgID, s.ID)
-			}
-			if t.dispatcher != nil {
-				t.dispatcher.Dispatch(r.Context(), event)
+			if !appended {
+				continue
 			}
 			t.logger.Info("github.inbound",
 				"topic", s.ID, "repo", repo, "event", eventType,
@@ -462,35 +448,45 @@ func (t *Transport) HandleInboundForTopic(topicID streaming.TopicID) http.Handle
 			Extra:     extraJSON,
 		}
 		now := nowUTC()
-		event, err := streaming.NewMessageEvent(
-			streaming.EventID("e-"+uuid.NewString()),
-			topic.ID,
-			"",
-			msg,
-			now,
-			t.orgID,
-		)
+		appended, err := t.appendInbound(r.Context(), topic.ID, deliveryID, msg, now)
 		if err != nil {
-			t.logger.Error("github.inbound.topic: build event", "topic", topicID, "err", err)
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		if err := t.store.Events.Append(r.Context(), event); err != nil {
 			t.logger.Error("github.inbound.topic: append", "topic", topicID, "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
-		if t.broadcaster != nil {
-			t.broadcaster.Notify(t.orgID, topic.ID)
-		}
-		if t.dispatcher != nil {
-			t.dispatcher.Dispatch(r.Context(), event)
+		if !appended {
+			w.WriteHeader(http.StatusNoContent)
+			return
 		}
 		t.logger.Info("github.inbound.topic",
 			"topic", topic.ID, "repo", repo, "event", eventType,
 			"delivery", deliveryID, "from", msg.From)
 		w.WriteHeader(http.StatusNoContent)
 	})
+}
+
+func (t *Transport) appendInbound(ctx context.Context, topicID streaming.TopicID, deliveryID string, msg streaming.Message, now time.Time) (bool, error) {
+	eventID := streaming.EventID("e-" + uuid.NewString())
+	if deliveryID != "" {
+		eventID = streaming.EventID("e-" + uuid.NewSHA1(uuid.NameSpaceOID, []byte(string(topicID)+"\x00"+deliveryID)).String())
+	}
+	event, err := streaming.NewMessageEvent(eventID, topicID, "", msg, now, t.orgID)
+	if err != nil {
+		return false, err
+	}
+	if err := t.store.Events.Append(ctx, event); err != nil {
+		if errors.Is(err, store.ErrConflict) {
+			return false, nil
+		}
+		return false, err
+	}
+	if t.broadcaster != nil {
+		t.broadcaster.Notify(t.orgID, topicID)
+	}
+	if t.dispatcher != nil {
+		t.dispatcher.Dispatch(ctx, event)
+	}
+	return true, nil
 }
 
 // matchingTopics returns every github-transport Topic whose repo

--- a/api/pkg/org/infrastructure/transports/github/github_test.go
+++ b/api/pkg/org/infrastructure/transports/github/github_test.go
@@ -39,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
@@ -533,6 +534,32 @@ func TestInboundDeliveryIDIsMessageID(t *testing.T) {
 	msg, _ := events[0].Message()
 	if msg.MessageID != "particular-uuid-here" {
 		t.Fatalf("MessageID = %q, want particular-uuid-here", msg.MessageID)
+	}
+}
+
+func TestInboundDuplicateDeliveryDispatchesOnce(t *testing.T) {
+	t.Parallel()
+	tp, st, dispatcher, _, reg := newTestTransport(t)
+	setGitHubConfig(t, reg, "tok", testWebhookSecret)
+	seedGitHubTopic(t, st, "s-github", "helixml/helix-org", []string{"issues"})
+
+	body, _ := json.Marshal(issuesOpenedPayload("helixml/helix-org"))
+	for range 2 {
+		if got := post(t, tp.HandleInbound(), body, "issues", "same-delivery", "").StatusCode; got != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", got)
+		}
+	}
+
+	events, err := st.Events.ListForTopic(context.Background(), "org-test", "s-github", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || len(dispatcher.snapshot()) != 1 {
+		t.Fatalf("events = %d, dispatches = %d; want 1 each", len(events), len(dispatcher.snapshot()))
+	}
+	wantID := streaming.EventID("e-" + uuid.NewSHA1(uuid.NameSpaceOID, []byte("s-github\x00same-delivery")).String())
+	if events[0].ID != wantID {
+		t.Fatalf("event ID = %q, want %q", events[0].ID, wantID)
 	}
 }
 

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -82,7 +82,8 @@ type helixOrgHandlers struct {
 	// streamCron is the in-process scheduler that fires events on
 	// KindCron topics. The server's run loop calls Start on it in a
 	// goroutine so it runs for the lifetime of the API process.
-	streamCron *streamcron.Scheduler
+	streamCron        *streamcron.Scheduler
+	githubDeliveryRun func(ctx context.Context)
 	// publicGitHubWebhook is the inbound /github/webhook handler
 	// mounted on the INSECURE router. GitHub deliveries carry no
 	// helix session cookie or API key — they authenticate via the
@@ -333,6 +334,9 @@ func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRou
 				log.Error().Err(err).Msg("streamcron scheduler exited with error")
 			}
 		}()
+	}
+	if orgHandlers.githubDeliveryRun != nil {
+		go orgHandlers.githubDeliveryRun(ctx)
 	}
 	if orgHandlers.assetSSHProxyRun != nil {
 		go func() {
@@ -732,6 +736,12 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	if err != nil {
 		return nil, fmt.Errorf("init streamcron scheduler: %w", err)
 	}
+	githubDeliveryReconciler := githubtransport.NewDeliveryReconciler(
+		st,
+		githubtransport.TokenResolver(gitHubTokenResolver),
+		cfg.APIServer.Cfg.GitHub.APIBaseURL(),
+		logger,
+	)
 
 	// Prompts registry — drives slash-command typeahead in the chat
 	// composer (/help, /role, /worker, …) and surfaces the same set as
@@ -1224,6 +1234,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 		lifecycle:                    lifecycleSvc,
 		seeder:                       seeder,
 		streamCron:                   streamCronScheduler,
+		githubDeliveryRun:            githubDeliveryReconciler.Run,
 		publicGitHubWebhook:          publicGitHubWebhook,
 		publicGitHubWebhookForStream: publicGitHubWebhookForStream,
 		publicGitLabWebhookForTopic:  publicGitLabWebhookForTopic,

--- a/design/2026-08-13-github-webhook-delivery-recovery.md
+++ b/design/2026-08-13-github-webhook-delivery-recovery.md
@@ -25,8 +25,15 @@ The API starts a GitHub delivery reconciler once at startup and runs it every
 deliveries, groups attempts by GitHub delivery GUID, and requests redelivery of
 the latest failed attempt for each GUID. Each scan follows GitHub's cursors
 until it reaches the prior delivery checkpoint, the 72-hour retention boundary,
-or the end. The checkpoint advances after each successfully processed attempt,
-so a later redelivery error leaves that delivery retryable without resubmitting
+or the end. A hook lists at most 10 pages (1,000 deliveries) and requests at
+most 20 redeliveries per 5-minute cycle. Incomplete scans retain their cursor
+and collected pages in memory, and completed scans retain unprocessed
+deliveries, so the next cycle resumes rather than starting over. Before
+continuing a saved cursor, the reconciler refreshes the current head until it
+overlaps the saved scan, ensuring newer attempts supersede older failures. The
+checkpoint does not advance until all required pages have been seen, then
+advances after each successfully processed attempt. A later redelivery error or
+cycle ceiling therefore leaves that delivery retryable without resubmitting
 earlier accepted requests. Redelivery uses the existing signed webhook path.
 
 Event IDs are deterministic from `(topic ID, X-GitHub-Delivery)`. A replay
@@ -37,8 +44,10 @@ the same delivery twice.
 
 - Retain and consider deliveries for 72 hours (3 days).
 - Delivery checkpoints are in process memory and reset when the API restarts.
-- A hook with more than 72 hours of retained deliveries is bounded by the
-  retention window rather than by a fixed page count.
+- Per hook and cycle, issue at most 10 delivery-list requests and 20 redelivery
+  requests. Listing and redelivery resume from in-memory state on later cycles.
+- Repository names are case-insensitive for hook identity. Deleted,
+  reconfigured, and invalid Topic hooks have their in-memory state removed.
 
 ## Verification status
 

--- a/design/2026-08-13-github-webhook-delivery-recovery.md
+++ b/design/2026-08-13-github-webhook-delivery-recovery.md
@@ -1,0 +1,54 @@
+# GitHub webhook delivery recovery
+
+Date: 2026-08-13
+Status: implemented in an uncommitted review worktree
+
+## Incident
+
+GitHub recorded an HTTP 521 for the affected delivery while the Meta API was
+restarting. The request never reached Helix. This is the proven root cause for
+the incident affecting https://github.com/helixml/helix/pull/3020.
+
+## Evidence correction
+
+An absent row in `org_events` does not by itself prove that GitHub never
+delivered the request. The GitHub handlers intentionally return 204 without
+appending an event for valid no-op deliveries, including a repository or event
+that has no matching Topic. They also return 204 when a deterministic duplicate
+event is already present. Delivery evidence must therefore come from GitHub's
+hook-delivery history and the Helix handler logs, not from `org_events` alone.
+
+## Structural fix
+
+The API starts a GitHub delivery reconciler once at startup and runs it every
+5 minutes. For each configured GitHub Topic it polls the hook's recent
+deliveries, groups attempts by GitHub delivery GUID, and requests redelivery of
+the latest failed attempt for each GUID. Each scan follows GitHub's cursors
+until it reaches the prior delivery checkpoint, the 72-hour retention boundary,
+or the end. The checkpoint advances after each successfully processed attempt,
+so a later redelivery error leaves that delivery retryable without resubmitting
+earlier accepted requests. Redelivery uses the existing signed webhook path.
+
+Event IDs are deterministic from `(topic ID, X-GitHub-Delivery)`. A replay
+therefore conflicts with the existing event instead of appending or dispatching
+the same delivery twice.
+
+## Explicit ceilings
+
+- Retain and consider deliveries for 72 hours (3 days).
+- Delivery checkpoints are in process memory and reset when the API restarts.
+- A hook with more than 72 hours of retained deliveries is bounded by the
+  retention window rather than by a fixed page count.
+
+## Verification status
+
+Focused tests passed:
+
+    go test ./pkg/github ./pkg/org/infrastructure/transports/github
+    go test -race ./pkg/github ./pkg/org/infrastructure/transports/github
+    go build ./pkg/server/ ./pkg/store/ ./pkg/types/
+
+The tests cover GitHub delivery listing/redelivery, multi-page checkpoint
+recovery, partial-batch retry progress, and duplicate delivery idempotency. A
+live GitHub redelivery, the Meta restart, and production deployment behavior
+were not verified here.


### PR DESCRIPTION
## Summary

- reconcile failed GitHub repository webhook deliveries at startup and every 5 minutes
- make replayed ingress idempotent using deterministic topic and delivery event IDs
- preserve cursor progress across multi-page scans and partial redelivery failures

## Root cause

GitHub delivery for https://github.com/helixml/helix/pull/3020 received HTTP 521 while the Meta API was restarting. GitHub does not automatically retry failed webhook deliveries.

## Verification

- `go test ./pkg/github ./pkg/org/infrastructure/transports/github ./pkg/org/application/publishing ./pkg/org/application/processing ./pkg/org/application/dispatch ./pkg/org/infrastructure/agentdelivery -count=1`
- `go test -race ./pkg/github ./pkg/org/infrastructure/transports/github -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`

NOT tested against live GitHub or GHES redelivery.