### PR TITLE
fix(frontend): group tools across hidden reasoning

### DIFF
--- a/frontend/src/components/session/InteractionInference.timeline.test.ts
+++ b/frontend/src/components/session/InteractionInference.timeline.test.ts
@@ -79,7 +79,7 @@ describe("buildActivityTimeline", () => {
     ]);
   });
 
-  it("groups only contiguous live tool calls and hides thoughts while working", () => {
+  it("groups live tool calls across hidden thoughts while working", () => {
     const entries = [
       entry("1", "text", "Visible progress update"),
       entry("2", "tool_call", "first output", "first tool"),
@@ -99,11 +99,10 @@ describe("buildActivityTimeline", () => {
       },
       {
         type: "tools",
-        entries: [{ toolName: "first tool" }],
-      },
-      {
-        type: "tools",
-        entries: [{ toolName: "second tool" }],
+        entries: [
+          { toolName: "first tool" },
+          { toolName: "second tool" },
+        ],
       },
     ]);
   });

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -114,11 +114,8 @@ export function buildActivityTimeline(
       return;
     }
 
-    // Any text entry ends the current tool run, even when its thinking content
-    // is hidden while streaming.
-    currentToolSegment = undefined;
-
     if (index === finalTextIndex) {
+      currentToolSegment = undefined;
       if (hasThinking(entry.content)) {
         activitySegments.push({
           type: "text",
@@ -134,6 +131,7 @@ export function buildActivityTimeline(
     const renderThinking = !isStreaming && hasThinking(entry.content);
     const renderContent = hasVisibleAssistantText(entry.content);
     if (renderThinking || renderContent) {
+      currentToolSegment = undefined;
       activitySegments.push({
         type: "text",
         entry,


### PR DESCRIPTION
## Summary
- keep streaming tool calls in one work-log group when only hidden reasoning snapshots occur between them
- preserve visible assistant progress and completed reasoning as group boundaries
- update the activity timeline regression test

## Root cause
The activity timeline reset its current tool group for every text entry. Streaming reasoning entries are intentionally hidden, so alternating reasoning and tool entries rendered as many one-call work logs instead of one latest call with a previous-call disclosure.

## Testing
- yarn test src/components/session/InteractionInference.timeline.test.ts src/components/session/WorkLog.test.tsx
- yarn build
- live task UI: verified a 91-call run renders one latest call plus +90 previous tool calls; expanded and collapsed the disclosure successfully