### PR TITLE
fix(org): preserve repositories on agent deletion

### DIFF
--- a/api/pkg/controller/knowledge/crawler/default_test.go
+++ b/api/pkg/controller/knowledge/crawler/default_test.go
@@ -2,6 +2,10 @@ package crawler
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -15,16 +19,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const deterministicHTML = `<!doctype html><html><head><title>Deterministic Crawler Fixture</title><meta name="description" content="A local crawler fixture."></head><body><article><h1>Deterministic Crawler Fixture</h1><p>This deterministic page exercises the real Chrome navigation and readability extraction path without relying on public DNS.</p><p>Its <strong>browser-backed markdown</strong> output proves HTML conversion still runs.</p></article></body></html>`
+
+func startCrawlerFixture(t *testing.T, cfg *config.ServerConfig) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(deterministicHTML))
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { require.NoError(t, server.Shutdown(context.Background())) })
+
+	host := "127.0.0.1"
+	if cfg.RAG.Crawler.LauncherEnabled {
+		launcherURL, err := url.Parse(cfg.RAG.Crawler.LauncherURL)
+		require.NoError(t, err)
+		conn, err := net.Dial("udp", launcherURL.Host)
+		require.NoError(t, err)
+		host = conn.LocalAddr().(*net.UDPAddr).IP.String()
+		require.NoError(t, conn.Close())
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	return fmt.Sprintf("http://%s/", net.JoinHostPort(host, fmt.Sprint(port)))
+}
+
 func TestDefault_Crawl(t *testing.T) {
 	// Skip test if Chrome service is not available (e.g., in local development)
 	if testing.Short() {
 		t.Skip("Skipping crawler test in short mode")
 	}
 
+	cfg, err := config.LoadServerConfig()
+	require.NoError(t, err)
+	fixtureURL := startCrawlerFixture(t, &cfg)
 	k := &types.Knowledge{
 		Source: types.KnowledgeSource{
 			Web: &types.KnowledgeSourceWeb{
-				URLs: []string{"https://example.com"},
+				URLs: []string{fixtureURL},
 				Crawler: &types.WebsiteCrawler{
 					Enabled: false,
 				},
@@ -33,9 +66,6 @@ func TestDefault_Crawl(t *testing.T) {
 		},
 	}
 
-	cfg, err := config.LoadServerConfig()
-	require.NoError(t, err)
-
 	browserManager, err := browser.New(&cfg)
 	require.NoError(t, err)
 
@@ -46,65 +76,18 @@ func TestDefault_Crawl(t *testing.T) {
 	d, err := NewDefault(browserManager, k, updateProgress)
 	require.NoError(t, err)
 
+	d.disableDomainCheck = true
 	docs, err := d.Crawl(context.Background())
 	require.NoError(t, err)
-
-	// This integration smoke test verifies browser crawling against a stable
-	// public page. Crawl errors are returned as diagnostic documents.
-	var (
-		exampleDomainFound bool
-		successfulDocs     int
-	)
-	for _, doc := range docs {
-		if doc.Message != "" || doc.StatusCode < 200 || doc.StatusCode >= 300 {
-			continue
-		}
-		successfulDocs++
-
-		if strings.Contains(doc.Title, "Example Domain") {
-			exampleDomainFound = true
-		}
-	}
-
-	require.Positive(t, successfulDocs, "no successful documents crawled")
-	require.True(t, exampleDomainFound, "Example Domain token not found in any crawled doc")
-
-	t.Logf("successful docs: %d", successfulDocs)
-}
-
-func TestDefault_CrawlSingle(t *testing.T) {
-	// Skip test if Chrome service is not available (e.g., in local development)
-	if testing.Short() {
-		t.Skip("Skipping crawler test in short mode")
-	}
-	k := &types.Knowledge{
-		Source: types.KnowledgeSource{
-			Web: &types.KnowledgeSourceWeb{
-				URLs: []string{"https://www.theguardian.com/uk-news/2024/sep/13/plans-unveiled-for-cheaper-high-speed-alternative-to-scrapped-hs2-northern-leg"},
-				Crawler: &types.WebsiteCrawler{
-					Enabled: false, // Will do single URL
-				},
-			},
-		},
-	}
-
-	cfg, err := config.LoadServerConfig()
-	require.NoError(t, err)
-
-	browserManager, err := browser.New(&cfg)
-	require.NoError(t, err)
-
-	updateProgress := func(progress types.KnowledgeProgress) {
-		t.Logf("progress: %+v", progress)
-	}
-
-	d, err := NewDefault(browserManager, k, updateProgress)
-	require.NoError(t, err)
-
-	docs, err := d.Crawl(context.Background())
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, len(docs))
+	require.Len(t, docs, 1)
+	doc := docs[0]
+	require.Equal(t, 200, doc.StatusCode)
+	require.Equal(t, fixtureURL, doc.SourceURL)
+	require.Equal(t, "Deterministic Crawler Fixture", doc.Title)
+	require.Contains(t, doc.Description, "local crawler fixture")
+	require.Contains(t, doc.Content, "real Chrome navigation")
+	require.Contains(t, doc.Content, "**browser-backed markdown**")
+	require.NotContains(t, doc.Content, "<strong>")
 }
 
 func TestDefault_CrawlSingle_Slow(t *testing.T) {
@@ -238,8 +221,10 @@ func TestDefault_ConvertHTMLToMarkdown(t *testing.T) {
 	b, err := browserManager.GetBrowser()
 	require.NoError(t, err)
 
-	doc, err := d.crawlWithBrowser(ctx, b, "https://news.ycombinator.com/news")
+	fixtureURL := "data:text/html;charset=utf-8," + url.PathEscape(deterministicHTML)
+	doc, err := d.crawlWithBrowser(ctx, b, fixtureURL)
 	require.NoError(t, err)
 
-	assert.True(t, strings.Contains(doc.Content, "points"))
+	assert.Equal(t, 200, doc.StatusCode)
+	assert.Contains(t, doc.Content, "browser-backed markdown")
 }

--- a/api/pkg/org/application/lifecycle/agent_links_test.go
+++ b/api/pkg/org/application/lifecycle/agent_links_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
@@ -21,16 +23,79 @@ type lifecycleRuntime struct {
 	store            *store.Store
 	linkedErr        error
 	deleteAppErr     error
+	deleteProjectErr error
 	projectDeleted   bool
+	deletedProjects  []string
 	deletedApps      []string
 	cleanupCancelled bool
 	linkedCancelled  bool
 	stoppedSessions  []string
 }
 
-func (r *lifecycleRuntime) DeleteProject(context.Context, string) error {
-	r.projectDeleted = true
+type interleavedDeleteRuntime struct {
+	store   *store.Store
+	started chan struct{}
+	resume  chan struct{}
+	mu      sync.Mutex
+	calls   int
+}
+
+type olderSuccessfulDeleteRuntime struct {
+	store   *store.Store
+	started chan struct{}
+	resume  chan struct{}
+	mu      sync.Mutex
+	calls   int
+}
+
+func (r *olderSuccessfulDeleteRuntime) DeleteProject(context.Context, string) error {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+	if call == 1 {
+		close(r.started)
+		<-r.resume
+		return nil
+	}
+	return errors.New("newer project delete failed")
+}
+
+func (*olderSuccessfulDeleteRuntime) DeleteApp(context.Context, string) error { return nil }
+
+func (r *olderSuccessfulDeleteRuntime) DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.NodeID, _, _ string) error {
+	if err := r.store.NodeRuntimeState.Clear(ctx, orgID, botID, runtimehelix.Backend); err != nil {
+		return err
+	}
+	return r.store.Nodes.Delete(ctx, orgID, botID)
+}
+
+func (r *interleavedDeleteRuntime) DeleteProject(context.Context, string) error {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+	if call == 1 {
+		close(r.started)
+		<-r.resume
+		return errors.New("project delete failed")
+	}
 	return nil
+}
+
+func (*interleavedDeleteRuntime) DeleteApp(context.Context, string) error { return nil }
+
+func (r *interleavedDeleteRuntime) DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.NodeID, _, _ string) error {
+	if err := r.store.NodeRuntimeState.Clear(ctx, orgID, botID, runtimehelix.Backend); err != nil {
+		return err
+	}
+	return r.store.Nodes.Delete(ctx, orgID, botID)
+}
+
+func (r *lifecycleRuntime) DeleteProject(_ context.Context, id string) error {
+	r.projectDeleted = true
+	r.deletedProjects = append(r.deletedProjects, id)
+	return r.deleteProjectErr
 }
 
 func (r *lifecycleRuntime) DeleteApp(ctx context.Context, id string) error {
@@ -169,20 +234,21 @@ func TestReconcileAgentLinksReportsClaimAndCleanupFailures(t *testing.T) {
 	}
 }
 
-func TestDeletePreservesConfiguredProject(t *testing.T) {
+func TestDeleteArchivesOwnedProjectAndPreservesAllowedProjects(t *testing.T) {
 	st := memory.New()
 	ctx := context.Background()
 	bot, err := orgchart.NewNode("b-agent", "instructions", nil, time.Now().UTC(), "org-test")
 	require.NoError(t, err)
 	bot = bot.WithAgentID("app-agent")
+	bot = bot.WithProjectIDs([]string{"project-configured"})
 	require.NoError(t, st.Nodes.Create(ctx, bot))
-	require.NoError(t, runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-configured", "app-agent", "repo-configured"))
+	require.NoError(t, runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-owned", "app-agent", "repo-owned"))
 	require.NoError(t, runtimehelix.SaveSession(ctx, st, "org-test", bot.ID, "session-agent"))
 	runtime := &lifecycleRuntime{store: st}
 	svc := &lifecycle.Service{Store: st, Helix: runtime}
 
 	require.NoError(t, svc.Delete(ctx, "org-test", bot.ID))
-	require.False(t, runtime.projectDeleted, "configured project was deleted")
+	require.Equal(t, []string{"project-owned"}, runtime.deletedProjects)
 	require.Equal(t, []string{"session-agent"}, runtime.stoppedSessions)
 	if _, err := st.Nodes.Get(ctx, "org-test", bot.ID); err == nil {
 		t.Fatal("node still exists")
@@ -192,10 +258,12 @@ func TestDeletePreservesConfiguredProject(t *testing.T) {
 
 func TestDeleteFailurePreservesGraphAnchorAndRetry(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		linkedErr error
+		name             string
+		linkedErr        error
+		deleteProjectErr error
 	}{
 		{name: "app", linkedErr: errors.New("app delete failed")},
+		{name: "project", deleteProjectErr: errors.New("project delete failed")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st := memory.New()
@@ -211,7 +279,7 @@ func TestDeleteFailurePreservesGraphAnchorAndRetry(t *testing.T) {
 			if err := runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-agent", "app-agent", "repo-agent"); err != nil {
 				t.Fatal(err)
 			}
-			runtime := &lifecycleRuntime{store: st, linkedErr: tc.linkedErr}
+			runtime := &lifecycleRuntime{store: st, linkedErr: tc.linkedErr, deleteProjectErr: tc.deleteProjectErr}
 			svc := &lifecycle.Service{Store: st, Helix: runtime}
 
 			if err := svc.Delete(ctx, "org-test", bot.ID); err == nil {
@@ -233,6 +301,7 @@ func TestDeleteFailurePreservesGraphAnchorAndRetry(t *testing.T) {
 			}
 
 			runtime.linkedErr = nil
+			runtime.deleteProjectErr = nil
 			if err := svc.Delete(ctx, "org-test", bot.ID); err != nil {
 				t.Fatalf("retry delete: %v", err)
 			}
@@ -242,6 +311,68 @@ func TestDeleteFailurePreservesGraphAnchorAndRetry(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteChiefOfStaffFailureRollsBackDeletionMarker(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	bot, err := orgchart.NewNode(seedprompts.ChiefOfStaffBotID, "instructions", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	bot = bot.WithAgentID("app-agent")
+	require.NoError(t, st.Nodes.Create(ctx, bot))
+	require.NoError(t, runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-agent", "app-agent", "repo-agent"))
+	svc := &lifecycle.Service{Store: st, Helix: &lifecycleRuntime{deleteProjectErr: errors.New("project delete failed")}}
+
+	require.Error(t, svc.Delete(ctx, "org-test", bot.ID))
+	marked, err := svc.ChiefOfStaffDeletionMarked(ctx, "org-test")
+	require.NoError(t, err)
+	require.False(t, marked)
+	_, err = st.Nodes.Get(ctx, "org-test", bot.ID)
+	require.NoError(t, err)
+}
+
+func TestConcurrentChiefOfStaffDeleteFailurePreservesSuccessfulMarker(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	bot, err := orgchart.NewNode(seedprompts.ChiefOfStaffBotID, "instructions", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	bot = bot.WithAgentID("app-agent")
+	require.NoError(t, st.Nodes.Create(ctx, bot))
+	require.NoError(t, runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-agent", "app-agent", "repo-agent"))
+	runtime := &interleavedDeleteRuntime{store: st, started: make(chan struct{}), resume: make(chan struct{})}
+	svc := &lifecycle.Service{Store: st, Helix: runtime}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- svc.Delete(ctx, "org-test", bot.ID) }()
+	<-runtime.started
+
+	require.NoError(t, svc.Delete(ctx, "org-test", bot.ID))
+	close(runtime.resume)
+	require.Error(t, <-firstDone)
+	marked, err := svc.ChiefOfStaffDeletionMarked(ctx, "org-test")
+	require.NoError(t, err)
+	require.True(t, marked)
+}
+
+func TestOlderSuccessfulChiefOfStaffDeleteRestoresMarkerAfterNewerFailure(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	bot, err := orgchart.NewNode(seedprompts.ChiefOfStaffBotID, "instructions", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	bot = bot.WithAgentID("app-agent")
+	require.NoError(t, st.Nodes.Create(ctx, bot))
+	require.NoError(t, runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-agent", "app-agent", "repo-agent"))
+	runtime := &olderSuccessfulDeleteRuntime{store: st, started: make(chan struct{}), resume: make(chan struct{})}
+	svc := &lifecycle.Service{Store: st, Helix: runtime}
+	olderDone := make(chan error, 1)
+	go func() { olderDone <- svc.Delete(ctx, "org-test", bot.ID) }()
+	<-runtime.started
+
+	require.Error(t, svc.Delete(ctx, "org-test", bot.ID))
+	close(runtime.resume)
+	require.NoError(t, <-olderDone)
+	marked, err := svc.ChiefOfStaffDeletionMarked(ctx, "org-test")
+	require.NoError(t, err)
+	require.True(t, marked)
 }
 
 func TestCreateCleanupIgnoresCancelledRequestContext(t *testing.T) {

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -19,9 +19,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/config"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
@@ -47,14 +50,17 @@ type TopicSubscriber interface {
 }
 
 // HelixRuntime is the slice of runtime/helix.ProjectService that the
-// Delete cascade needs to tear down a Node's Helix-side agent app.
-// The configured project is deliberately preserved. Production wiring
+// Delete cascade needs to tear down a Node's Helix-side project and agent app.
+// Repositories are deliberately preserved. Production wiring
 // satisfies this with the in-process adapter used everywhere else; the
 // interface exists so tests can stub.
 type HelixRuntime interface {
+	DeleteProject(ctx context.Context, id string) error
 	DeleteApp(ctx context.Context, id string) error
 	DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.NodeID, appID, sessionID string) error
 }
+
+const chiefOfStaffDeletedConfigKey = "lifecycle.chief_of_staff_deleted"
 
 type AgentCreator interface {
 	CreateAgent(ctx context.Context, orgID, name, instructions string, config AgentConfig) (string, error)
@@ -257,10 +263,19 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	rollback := func(createErr error) (CreateResult, error) {
 		cleanupCtx, cancel := cleanupContext(ctx)
 		defer cancel()
-		if err := s.Delete(cleanupCtx, orgID, id); err != nil {
+		if err := s.delete(cleanupCtx, orgID, id, false); err != nil {
 			return CreateResult{}, fmt.Errorf("%w; rollback failed: %v", createErr, err)
 		}
 		return CreateResult{}, createErr
+	}
+	clearChiefOfStaffDeletionMarker := func() error {
+		if id != seedprompts.ChiefOfStaffBotID || s.Store.Configs == nil {
+			return nil
+		}
+		if err := s.Store.Configs.Delete(ctx, orgID, chiefOfStaffDeletedConfigKey); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("clear chief of staff deletion marker: %w", err)
+		}
+		return nil
 	}
 
 	// Wire the initial reporting line now that both node rows exist.
@@ -310,11 +325,13 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 			return rollback(fmt.Errorf("create handler: %w", err))
 		}
 	}
-
 	if s.AgentDelivery != nil {
 		s.AgentDelivery.RestoreAgent(orgID, id)
 	}
 	if p.DeferActivation {
+		if err := clearChiefOfStaffDeletionMarker(); err != nil {
+			return rollback(err)
+		}
 		return CreateResult{Node: node}, nil
 	}
 
@@ -332,6 +349,9 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		if err := s.Store.Activations.Create(ctx, act); err != nil {
 			return rollback(fmt.Errorf("persist create activation: %w", err))
 		}
+	}
+	if err := clearChiefOfStaffDeletionMarker(); err != nil {
+		return rollback(err)
 	}
 	if s.Dispatcher != nil {
 		s.Dispatcher.DispatchHire(ctx, orgID, id, actID)
@@ -399,9 +419,13 @@ func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
 //
 // Subscriptions are node-anchored, so they die with the node. Activation
 // events themselves are intentionally left behind as an audit trail; only
-// the Topic row is dropped. A configured Helix project is not node-owned and
-// survives deletion; only its reference to the deleted default agent is unset.
+// the Topic row is dropped. The runtime-owned Helix project is archived;
+// repositories and explicitly allowed other projects survive deletion.
 func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) (err error) {
+	return s.delete(ctx, orgID, id, true)
+}
+
+func (s *Service) delete(ctx context.Context, orgID string, id orgchart.NodeID, explicit bool) (err error) {
 	if id == "" {
 		return errors.New("node id is empty")
 	}
@@ -411,6 +435,35 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 	node, err := s.Store.Nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return fmt.Errorf("get node %q: %w", id, err)
+	}
+	deleteSucceeded := false
+	var chiefOfStaffDeletionMarker config.Config
+	if explicit && id == seedprompts.ChiefOfStaffBotID && s.Store.Configs != nil {
+		markerValue := `"` + uuid.NewString() + `"`
+		marker, err := config.New(chiefOfStaffDeletedConfigKey, markerValue, time.Now().UTC(), orgID)
+		if err != nil {
+			return fmt.Errorf("build chief of staff deletion marker: %w", err)
+		}
+		if err := s.Store.Configs.Set(ctx, marker); err != nil {
+			return fmt.Errorf("persist chief of staff deletion marker: %w", err)
+		}
+		chiefOfStaffDeletionMarker = marker
+		defer func() {
+			if deleteSucceeded {
+				return
+			}
+			cleanupCtx, cancel := cleanupContext(ctx)
+			defer cancel()
+			if _, nodeErr := s.Store.Nodes.Get(cleanupCtx, orgID, id); errors.Is(nodeErr, store.ErrNotFound) {
+				return
+			} else if nodeErr != nil {
+				err = fmt.Errorf("%w; verify chief of staff before marker rollback: %v", err, nodeErr)
+				return
+			}
+			if rollbackErr := s.Store.Configs.DeleteIfValue(cleanupCtx, orgID, chiefOfStaffDeletedConfigKey, markerValue); rollbackErr != nil {
+				err = fmt.Errorf("%w; rollback chief of staff deletion marker: %v", err, rollbackErr)
+			}
+		}()
 	}
 	if s.AgentDelivery != nil {
 		if err := s.AgentDelivery.CleanupAgent(ctx, orgID, id); err != nil {
@@ -438,6 +491,11 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 	}
 
 	state, _ := helix.LoadState(ctx, s.Store, orgID, id)
+	if s.Helix != nil && state.ProjectID != "" {
+		if err := s.Helix.DeleteProject(ctx, state.ProjectID); err != nil && !errors.Is(err, helix.ErrProjectNotFound) {
+			return fmt.Errorf("delete project %s: %w", state.ProjectID, err)
+		}
+	}
 
 	agentAppID := node.AgentID
 	if agentAppID == "" {
@@ -478,7 +536,29 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 	// Run the whole-org reconcilers so the deleted Node's Slack auto-route is
 	// GC'd. Best-effort, like topology above.
 	s.runOrgReconcilers(ctx, orgID, "delete", id)
+	if chiefOfStaffDeletionMarker.Key != "" {
+		cleanupCtx, cancel := cleanupContext(ctx)
+		defer cancel()
+		if err := s.Store.Configs.Set(cleanupCtx, chiefOfStaffDeletionMarker); err != nil {
+			return fmt.Errorf("confirm chief of staff deletion marker: %w", err)
+		}
+	}
+	deleteSucceeded = true
 	return nil
+}
+
+func (s *Service) ChiefOfStaffDeletionMarked(ctx context.Context, orgID string) (bool, error) {
+	if s == nil || s.Store == nil || s.Store.Configs == nil {
+		return false, nil
+	}
+	_, err := s.Store.Configs.Get(ctx, orgID, chiefOfStaffDeletedConfigKey)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		return false, nil
+	}
+	return false, fmt.Errorf("read chief of staff deletion marker: %w", err)
 }
 
 // runOrgReconcilers runs every whole-org reconciler best-effort, logging (not

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -211,6 +211,7 @@ type Configs interface {
 	Get(ctx context.Context, orgID, key string) (config.Config, error)
 	List(ctx context.Context, orgID, prefix string) ([]config.Config, error)
 	Delete(ctx context.Context, orgID, key string) error
+	DeleteIfValue(ctx context.Context, orgID, key, value string) error
 }
 
 // ChartPositions persists free-placed (x, y) canvas coordinates for

--- a/api/pkg/org/infrastructure/persistence/gorm/config.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/config.go
@@ -78,3 +78,9 @@ func (r *configsRepo) Delete(ctx context.Context, orgID, key string) error {
 		store.WithCondition("key", key),
 	)
 }
+
+func (r *configsRepo) DeleteIfValue(ctx context.Context, orgID, key, value string) error {
+	return r.db.WithContext(ctx).
+		Where("org_id = ? AND key = ? AND value = ?", orgID, key, value).
+		Delete(&configRow{}).Error
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/config_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/config_test.go
@@ -109,3 +109,27 @@ func TestConfigsDelete(t *testing.T) {
 		t.Fatalf("Delete again = %v, want ErrNotFound", err)
 	}
 }
+
+func TestConfigsDeleteIfValue(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+	cfg, err := config.New("delete.if-value", `"new"`, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Configs.Set(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Configs.DeleteIfValue(ctx, "org-test", cfg.Key, `"old"`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Configs.Get(ctx, "org-test", cfg.Key); err != nil {
+		t.Fatalf("mismatched value deleted config: %v", err)
+	}
+	if err := s.Configs.DeleteIfValue(ctx, "org-test", cfg.Key, cfg.Value); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Configs.Get(ctx, "org-test", cfg.Key); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("matching value was not deleted: %v", err)
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -856,6 +856,16 @@ func (c *configsRepo) Delete(_ context.Context, orgID, key string) error {
 	return nil
 }
 
+func (c *configsRepo) DeleteIfValue(_ context.Context, orgID, key, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := orgKey{OrgID: orgID, ID: key}
+	if cfg, ok := c.rows[k]; ok && cfg.Value == value {
+		delete(c.rows, k)
+	}
+	return nil
+}
+
 // ---- Activations -------------------------------------------------------
 
 type activationsRepo struct {

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -474,8 +474,9 @@ func (a *WorkerProject) ensureWorkerRepo(ctx context.Context, projectID, orgID s
 	if ownerID == "" {
 		return "", fmt.Errorf("cannot create per-Worker repo — WhoAmI returned empty owner id (host wiring forgot to supply a service user?)")
 	}
+	repoName := fmt.Sprintf("%s-%s", workerID, projectID)
 	repo, err := a.Service.CreateGitRepo(ctx, types.GitRepositoryCreateRequest{
-		Name:           string(workerID),
+		Name:           repoName,
 		OwnerID:        ownerID,
 		OrganizationID: orgID,
 		InitialFiles: map[string]string{
@@ -491,11 +492,11 @@ func (a *WorkerProject) ensureWorkerRepo(ctx context.Context, projectID, orgID s
 	// replica, which repoEnsureMu can't serialise) won the create race. Don't
 	// keep the duplicate: delete it and error, so the caller retries and the
 	// outer re-check picks up the winner's now-attached repo.
-	if repo.Name != string(workerID) {
+	if repo.Name != repoName {
 		if derr := a.Service.DeleteGitRepo(ctx, repo.ID); derr != nil && a.Logger != nil {
 			a.Logger.Warn("delete raced duplicate repo", "worker", workerID, "repo", repo.ID, "err", derr)
 		}
-		return "", fmt.Errorf("per-Worker repo %q already exists (create race); retrying", string(workerID))
+		return "", fmt.Errorf("per-Worker repo %q was created concurrently; retry activation", repoName)
 	}
 	if err := a.Service.AttachRepoToProject(ctx, projectID, repo.ID, true); err != nil {
 		// The repo was created but couldn't be attached — it's an orphan with

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -316,7 +316,10 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 		t.Fatalf("Ensure: %v", err)
 	}
 	if projectID != "prj_test" || agentAppID != "app_test" {
-		t.Fatalf("ids = (%q,%q,%q); want (prj_test, app_test, repo-w-eng)", projectID, agentAppID, repoID)
+		t.Fatalf("ids = (%q,%q,%q); want (prj_test, app_test, repo-w-eng-prj_test)", projectID, agentAppID, repoID)
+	}
+	if repoID != "repo-w-eng-prj_test" {
+		t.Fatalf("repo = %q, want project-specific repo-w-eng-prj_test", repoID)
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
@@ -486,8 +489,8 @@ func TestEnsureDeletesOrphanRepoOnAttachFailure(t *testing.T) {
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
-	if len(svc.deleteGitRepoIDs) != 1 || svc.deleteGitRepoIDs[0] != "repo-w-eng" {
-		t.Fatalf("orphan repo not deleted: deleteGitRepoIDs = %v, want [repo-w-eng]", svc.deleteGitRepoIDs)
+	if len(svc.deleteGitRepoIDs) != 1 || svc.deleteGitRepoIDs[0] != "repo-w-eng-prj_test" {
+		t.Fatalf("orphan repo not deleted: deleteGitRepoIDs = %v, want [repo-w-eng-prj_test]", svc.deleteGitRepoIDs)
 	}
 }
 
@@ -499,7 +502,7 @@ func TestEnsureDeletesRacedDuplicateRepo(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role: engineer")
 	svc := newFakeProjectService()
-	svc.createGitRepoNameReturn = "w-eng-2" // simulate auto-increment on collision
+	svc.createGitRepoNameReturn = "w-eng-prj_test-2" // simulate auto-increment on collision
 	git := newFakeGitForProject()
 	a := newApplierGit(svc, git, st)
 
@@ -508,8 +511,8 @@ func TestEnsureDeletesRacedDuplicateRepo(t *testing.T) {
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
-	if len(svc.deleteGitRepoIDs) != 1 || svc.deleteGitRepoIDs[0] != "repo-w-eng-2" {
-		t.Fatalf("raced duplicate not deleted: deleteGitRepoIDs = %v, want [repo-w-eng-2]", svc.deleteGitRepoIDs)
+	if len(svc.deleteGitRepoIDs) != 1 || svc.deleteGitRepoIDs[0] != "repo-w-eng-prj_test-2" {
+		t.Fatalf("raced duplicate not deleted: deleteGitRepoIDs = %v, want [repo-w-eng-prj_test-2]", svc.deleteGitRepoIDs)
 	}
 	if svc.attachRepoCalls != 0 {
 		t.Errorf("must not attach a raced duplicate; attachRepoCalls = %d", svc.attachRepoCalls)
@@ -535,8 +538,8 @@ func TestEnsureFastPathReprovisionsDeletedRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ensure: %v", err)
 	}
-	if rid != "repo-w-eng" {
-		t.Fatalf("fast path did not re-provision the deleted repo: rid = %q, want repo-w-eng", rid)
+	if rid != "repo-w-eng-prj_existing" {
+		t.Fatalf("fast path did not re-provision the deleted repo: rid = %q, want repo-w-eng-prj_existing", rid)
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
@@ -548,8 +551,8 @@ func TestEnsureFastPathReprovisionsDeletedRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
-	if state.RepoID != "repo-w-eng" {
-		t.Errorf("re-provisioned repo id not persisted: state.RepoID = %q, want repo-w-eng", state.RepoID)
+	if state.RepoID != "repo-w-eng-prj_existing" {
+		t.Errorf("re-provisioned repo id not persisted: state.RepoID = %q, want repo-w-eng-prj_existing", state.RepoID)
 	}
 }
 

--- a/api/pkg/org/interfaces/mcptools/delete_bot.go
+++ b/api/pkg/org/interfaces/mcptools/delete_bot.go
@@ -13,9 +13,9 @@ import (
 
 // DeleteBot tears a Bot down via the lifecycle service — the same use
 // case the REST DELETE /bots/{id} handler drives. It cascades: stops the
-// Bot's sessions, deletes its Helix project + agent app, clears runtime
+// Bot's sessions, archives its Helix project, deletes its agent app, clears runtime
 // state, drops its subscriptions and reporting lines, deletes the bot
-// row, and reconciles team/DM topics. Activations are preserved as audit.
+// row, and reconciles team/DM topics. Repositories and activations are preserved.
 // Owner-only.
 type DeleteBot struct {
 	deps Deps
@@ -32,9 +32,9 @@ type deleteBotArgs struct {
 func (t *DeleteBot) Name() tool.Name                 { return DeleteBotName }
 func (t *DeleteBot) InputSchema() *jsonschema.Schema { return deleteBotSchema }
 func (t *DeleteBot) Description() string {
-	return "Delete a Bot. Cascades: stops its sessions, deletes its Helix project + agent " +
-		"app, clears runtime state, drops its subscriptions and reporting lines, then the " +
-		"bot row. Nodes that reported to it become parentless. Owner-only."
+	return "Delete a Bot. Cascades: stops its sessions, archives its Helix project, deletes its " +
+		"agent app, clears runtime state, drops its subscriptions and reporting lines, then the " +
+		"bot row. Repositories are preserved. Nodes that reported to it become parentless. Owner-only."
 }
 
 func (t *DeleteBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {

--- a/api/pkg/org/interfaces/server/api/agents_openapi.go
+++ b/api/pkg/org/interfaces/server/api/agents_openapi.go
@@ -46,7 +46,7 @@ func (a *apiHandler) updateAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Summary Helix-org: delete an agent
-// @Description Delete an Agent after atomically detaching and deleting its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row. Only the project's default agent ID is unset; the configured project, repositories, tasks, and other project configuration are preserved.
+// @Description Delete an Agent after archiving its runtime-owned project and deleting its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row. Repositories are preserved.
 // @Tags HelixOrg
 // @Param org path string true "Organization slug or ID"
 // @Param id path string true "Agent ID"

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -358,10 +358,10 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 
 // deleteBot tears down a Bot via the lifecycle service. Cascades the
 // Helix app, runtime state, subscriptions, reporting lines, then the bot
-// row. The configured project is preserved.
+// row. Its runtime-owned project is archived and repositories are preserved.
 //
 // @Summary Helix-org: delete a bot
-// @Description Delete a Bot. Cascades: detaches and deletes the Helix agent app, clears runtime state, drops subscriptions + reporting lines, then the bot row. Only the project's default agent ID is unset; the configured project, repositories, tasks, other project configuration, and activations are preserved.
+// @Description Delete a Bot. Cascades: archives its runtime-owned project, detaches and deletes the Helix agent app, clears runtime state, drops subscriptions + reporting lines, then the bot row. Repositories and activations are preserved.
 // @Tags HelixOrg
 // @Param id path string true "Bot ID"
 // @Success 204

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -24,6 +24,8 @@ import (
 	"github.com/helixml/helix/api/pkg/controller/knowledge"
 	"github.com/helixml/helix/api/pkg/filestore"
 	"github.com/helixml/helix/api/pkg/oauth"
+	orgdomainstore "github.com/helixml/helix/api/pkg/org/domain/store"
+	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/tools"
@@ -1263,7 +1265,15 @@ func (s *HelixAPIServer) deleteAgent(_ http.ResponseWriter, r *http.Request) (*t
 			return nil, system.NewHTTPError500(listErr.Error())
 		}
 		for _, bot := range bots {
-			if bot.AgentID == id {
+			linked := bot.AgentID == id
+			if !linked && bot.AgentID == "" {
+				state, stateErr := runtimehelix.LoadState(r.Context(), s.helixOrg.store, existing.OrganizationID, bot.ID)
+				if stateErr != nil && !errors.Is(stateErr, orgdomainstore.ErrNotFound) {
+					return nil, system.NewHTTPError500(stateErr.Error())
+				}
+				linked = stateErr == nil && state.AgentID == id
+			}
+			if linked {
 				if keepKnowledge {
 					return nil, system.NewHTTPError400("keep_knowledge is not supported when deleting an org-linked agent")
 				}

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	orgbots "github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -25,8 +27,109 @@ import (
 
 type failingAgentCreator struct{}
 
+type stateLinkedDeleteRuntime struct {
+	store *orgstore.Store
+}
+
+type missingRuntimeState struct{}
+
+func (missingRuntimeState) Get(context.Context, string, orgchart.NodeID, string) (map[string]string, error) {
+	return nil, orgstore.ErrNotFound
+}
+func (missingRuntimeState) Set(context.Context, string, orgchart.NodeID, string, string, string) error {
+	return nil
+}
+func (missingRuntimeState) SetMany(context.Context, string, orgchart.NodeID, string, map[string]string) error {
+	return nil
+}
+func (missingRuntimeState) Clear(context.Context, string, orgchart.NodeID, string) error { return nil }
+
+func (*stateLinkedDeleteRuntime) DeleteProject(context.Context, string) error { return nil }
+func (*stateLinkedDeleteRuntime) DeleteApp(context.Context, string) error     { return nil }
+func (r *stateLinkedDeleteRuntime) DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.NodeID, _, _ string) error {
+	if err := r.store.NodeRuntimeState.Clear(ctx, orgID, botID, runtimehelix.Backend); err != nil {
+		return err
+	}
+	return r.store.Nodes.Delete(ctx, orgID, botID)
+}
+
 func (failingAgentCreator) CreateAgent(context.Context, string, string, string, lifecycle.AgentConfig) (string, error) {
 	return "", fmt.Errorf("reconcile failed")
+}
+
+func TestDeleteAppUsesStateOnlyOrgAgentLifecycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	orgStore := orgmemory.New()
+	ctx := context.Background()
+	node, err := orgchart.NewNode("b-linked", "# Linked", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.Empty(t, node.AgentID)
+	require.NoError(t, orgStore.Nodes.Create(ctx, node))
+	require.NoError(t, runtimehelix.SaveProject(ctx, orgStore, "org-test", node.ID, "", "app-linked", ""))
+	existing := &types.App{ID: "app-linked", Owner: "user-test", OrganizationID: "org-test"}
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID:         existing.Owner,
+		OrganizationID: existing.OrganizationID,
+		Role:           types.OrganizationRoleOwner,
+	}, nil)
+	runtime := &stateLinkedDeleteRuntime{store: orgStore}
+	server := &HelixAPIServer{
+		Store: helixStore,
+		helixOrg: &helixOrgHandlers{
+			store:     orgStore,
+			lifecycle: &lifecycle.Service{Store: orgStore, Helix: runtime},
+		},
+	}
+	req, err := http.NewRequest(http.MethodDelete, "/api/v1/agents/"+existing.ID, nil)
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
+
+	deleted, httpErr := server.deleteAgent(nil, req)
+
+	require.Nil(t, httpErr)
+	require.Equal(t, existing, deleted)
+	_, err = orgStore.Nodes.Get(ctx, "org-test", node.ID)
+	require.ErrorIs(t, err, orgstore.ErrNotFound)
+}
+
+func TestDeleteStandaloneAppIgnoresUnlinkedNodeWithoutRuntimeState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	baseOrgStore := orgmemory.New()
+	ctx := context.Background()
+	node, err := orgchart.NewNode("b-unprovisioned", "# Unprovisioned", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.NoError(t, baseOrgStore.Nodes.Create(ctx, node))
+	orgStore := *baseOrgStore
+	orgStore.NodeRuntimeState = missingRuntimeState{}
+	existing := &types.App{ID: "app-standalone", Owner: "user-test", OrganizationID: "org-test"}
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID: existing.Owner, OrganizationID: existing.OrganizationID, Role: types.OrganizationRoleOwner,
+	}, nil)
+	helixStore.EXPECT().ListKnowledge(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().DeleteApp(gomock.Any(), existing.ID).Return(nil)
+	server := &HelixAPIServer{
+		Store: helixStore,
+		helixOrg: &helixOrgHandlers{
+			store:     &orgStore,
+			lifecycle: &lifecycle.Service{Store: &orgStore},
+		},
+	}
+	req, err := http.NewRequest(http.MethodDelete, "/api/v1/agents/"+existing.ID, nil)
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
+
+	deleted, httpErr := server.deleteAgent(nil, req)
+
+	require.Nil(t, httpErr)
+	require.Equal(t, existing, deleted)
+	_, err = orgStore.Nodes.Get(ctx, "org-test", node.ID)
+	require.NoError(t, err)
 }
 
 func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -764,8 +764,8 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	// chat-driven hire both call the same workers.Hire service (wired
 	// into apiDeps.Workers below) — one implementation, no drift.
 
-	// Fire (DELETE /workers/{id}) cascades Helix-side agent teardown
-	// while preserving its project, plus full org-store cleanup. The Helix
+	// Delete cascades Helix-side Agent teardown, archives its runtime-owned
+	// project, preserves repositories, and performs full org-store cleanup. The Helix
 	// runtime port is satisfied by the same in-process adapter every
 	// other Helix call goes through.
 	lifecycleSvc := &lifecycle.Service{

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -829,8 +829,8 @@ func (c *inProcHelixClient) DeleteLinkedAgent(ctx context.Context, orgID string,
 		return fmt.Errorf("delete linked agent: store %T has no shared database", c.server.Store)
 	}
 	return accessor.GormDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Projects outlive org agents. Clear only the deleted app's default-agent
-		// link; repositories, tasks, secrets, and all other project state remain.
+		// The lifecycle archives the runtime-owned project first. Detach the app
+		// from any other configured projects without touching their repositories.
 		if err := tx.Model(&types.Project{}).
 			Where("default_helix_app_id = ?", appID).
 			Update("default_helix_app_id", "").Error; err != nil {

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -101,7 +101,14 @@ func (s *orgGraphSeeder) RemoveHumanNode(ctx context.Context, orgID, userID stri
 // When CoS already exists, OwnerBotTools is unioned onto its tool list so
 // upgrades (e.g. new repository tools) land without recreating the bot.
 func (s *orgGraphSeeder) SeedChiefOfStaff(ctx context.Context, orgID string) error {
-	if s == nil {
+	if s == nil || s.lifecycle == nil {
+		return nil
+	}
+	deleted, err := s.lifecycle.ChiefOfStaffDeletionMarked(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	if deleted {
 		return nil
 	}
 	existing, err := s.botStore.Get(ctx, orgID, chiefOfStaffBotID)

--- a/api/pkg/server/org_graph_seed_test.go
+++ b/api/pkg/server/org_graph_seed_test.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
@@ -15,6 +16,45 @@ import (
 type seedDispatcher struct {
 	ids           []orgchart.NodeID
 	activationIDs []activation.ID
+}
+
+func TestSeedChiefOfStaffRespectsDeletionAndExplicitRecreation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orggorm.GetOrgTestDB(t)
+	deps := mcptools.DefaultDeps(st).Build()
+	seeder := &orgGraphSeeder{lifecycle: deps.Lifecycle, bots: deps.Nodes, botStore: st.Nodes}
+	const orgID = "org-chief-deletion"
+
+	if err := seeder.SeedChiefOfStaff(ctx, orgID); err != nil {
+		t.Fatalf("seed chief of staff: %v", err)
+	}
+	if err := deps.Lifecycle.Delete(ctx, orgID, chiefOfStaffBotID); err != nil {
+		t.Fatalf("delete chief of staff: %v", err)
+	}
+	if err := seeder.SeedChiefOfStaff(ctx, orgID); err != nil {
+		t.Fatalf("bootstrap after deletion: %v", err)
+	}
+	if _, err := st.Nodes.Get(ctx, orgID, chiefOfStaffBotID); err == nil {
+		t.Fatal("bootstrap recreated explicitly deleted chief of staff")
+	}
+
+	if _, err := deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
+		ID:              string(chiefOfStaffBotID),
+		Name:            "Chief of Staff",
+		Content:         chiefOfStaffContent,
+		PreserveContext: true,
+		DeferActivation: true,
+	}); err != nil {
+		t.Fatalf("explicitly recreate chief of staff: %v", err)
+	}
+	marked, err := deps.Lifecycle.ChiefOfStaffDeletionMarked(ctx, orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if marked {
+		t.Fatal("explicit recreation did not clear chief of staff deletion marker")
+	}
 }
 
 func (d *seedDispatcher) DispatchHire(_ context.Context, _ string, id orgchart.NodeID, activationID activation.ID) {

--- a/api/pkg/store/store_projects.go
+++ b/api/pkg/store/store_projects.go
@@ -249,7 +249,8 @@ func (s *PostgresStore) populateProjectStats(ctx context.Context, projects []*ty
 	return nil
 }
 
-// DeleteProject deletes a project by ID
+// DeleteProject soft-deletes a project by ID. Repository rows and their
+// project attachments are retained as restore metadata.
 func (s *PostgresStore) DeleteProject(ctx context.Context, projectID string) error {
 	if projectID == "" {
 		return fmt.Errorf("project ID is required")

--- a/api/pkg/store/store_projects_test.go
+++ b/api/pkg/store/store_projects_test.go
@@ -2,11 +2,33 @@ package store
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+func TestDeleteProjectPreservesRepositoryAndAttachment(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.Project{}, &types.GitRepository{}, &types.ProjectRepository{}))
+	project := &types.Project{ID: "project-agent", Name: "Agent Project"}
+	repository := &types.GitRepository{ID: "repo-agent", Name: "agent-repo"}
+	attachment := &types.ProjectRepository{ProjectID: project.ID, RepositoryID: repository.ID, OrganizationID: "org-test"}
+	require.NoError(t, db.Create(project).Error)
+	require.NoError(t, db.Create(repository).Error)
+	require.NoError(t, db.Create(attachment).Error)
+	store := &PostgresStore{gdb: db}
+
+	require.NoError(t, store.DeleteProject(context.Background(), project.ID))
+	require.ErrorIs(t, db.First(&types.Project{}, "id = ?", project.ID).Error, gorm.ErrRecordNotFound)
+	require.NoError(t, db.First(&types.GitRepository{}, "id = ?", repository.ID).Error)
+	require.NoError(t, db.First(&types.ProjectRepository{}, "project_id = ? AND repository_id = ?", project.ID, repository.ID).Error)
+}
 
 func (suite *PostgresStoreTestSuite) TestListProjects_WithStats_EmptyProject() {
 	project := &types.Project{


### PR DESCRIPTION
## Summary

- respect explicit Chief of Staff deletion across bootstrap while allowing explicit recreation
- archive runtime-owned projects on Agent deletion but preserve repositories and project-repository restore metadata
- avoid stale repository name collisions during Agent recreation
- route state-only linked App deletion through the unified Agent lifecycle

## Testing

- `CGO_ENABLED=1 go test ./pkg/org/application/lifecycle ./pkg/org/infrastructure/runtime/helix ./pkg/org/infrastructure/persistence/gorm ./pkg/server -count=1`
- `CGO_ENABLED=1 go test ./pkg/store -run "^TestDeleteProjectPreservesRepositoryAndAttachment$" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`

## Validation

- reviewed independently by explorer and implementer agents
- no live Meta mutation performed
- NOT tested: live delete then recreate E2E