### PR TITLE
fix(api): initialize interaction request mapping

### DIFF
--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -379,6 +379,7 @@ func NewServer(
 		contextMappings:            make(map[string]string),
 
 		requestToSessionMapping:     make(map[string]string),
+		requestToInteractionMapping: make(map[string]string),
 		interactionDispatchClaims:   make(map[string]dispatchClaim),
 		credentialTokens:            make(map[string]map[string]struct{}),
 		pendingCancelChannels:       make(map[string]chan string),


### PR DESCRIPTION
## Summary
- initialize the production request-to-interaction map in `NewServer`
- prevent external-agent cancellation from panicking after API startup

## Root cause
PR #3026 added a cancellation path that writes to `requestToInteractionMapping`. Test fixtures initialized the map, but the production server constructor did not, so Meta panicked with `assignment to entry in nil map`.

## Verification
- `CGO_ENABLED=1 go test ./pkg/server -run '^TestWebSocketSyncSuite$/^TestCancelActiveTurn_AfterRestartUsesDurableRequestAndWaitsForAck$' -count=1`\n- `CGO_ENABLED=1 go build ./pkg/server/ ./pkg/store/ ./pkg/types/`\n- `git diff --check`