### PR TITLE
feat(tasks): support headless spec task sandboxes

### DIFF
--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -1318,6 +1318,7 @@ ADD desktop/shared/helix-git-hooks.sh /usr/local/bin/helix-git-hooks.sh
 ADD desktop/shared/helix-workspace-setup.sh /usr/local/bin/helix-workspace-setup.sh
 ADD desktop/shared/helix-run-startup-script.sh /usr/local/bin/helix-run-startup-script.sh
 ADD desktop/shared/start-desktop-bridge.sh /usr/local/bin/start-desktop-bridge.sh
+ADD desktop/shared/start-headless-workspace-bridge.sh /usr/local/bin/start-headless-workspace-bridge.sh
 ADD desktop/shared/start-settings-sync-daemon.sh /usr/local/bin/start-settings-sync-daemon.sh
 ADD desktop/shared/start-zed-headless.sh /usr/local/bin/start-zed-headless.sh
 # D-Bus policy for logind-stub (macOS ARM scanout mode)
@@ -1330,7 +1331,8 @@ ADD desktop/shared/start-zed-core.sh /usr/local/bin/start-zed-core.sh
 RUN chmod 755 /usr/local/bin/start-zed-helix.sh /usr/local/bin/start-gnome-bridge.sh \
     /usr/local/bin/helix-specs-create.sh /usr/local/bin/helix-git-hooks.sh \
     /usr/local/bin/helix-workspace-setup.sh /usr/local/bin/helix-run-startup-script.sh \
-    /usr/local/bin/start-desktop-bridge.sh /usr/local/bin/start-settings-sync-daemon.sh \
+    /usr/local/bin/start-desktop-bridge.sh /usr/local/bin/start-headless-workspace-bridge.sh \
+    /usr/local/bin/start-settings-sync-daemon.sh \
     /usr/local/bin/start-zed-headless.sh /usr/local/bin/detect-render-node.sh /usr/local/bin/start-zed-core.sh
 
 # Ubuntu desktop theming (includes cursor-size=48 for fingerprinting)

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -564,6 +564,11 @@ _USER_INIT
 # 2. Create udev rule for Mutter primary GPU selection on multi-GPU systems
 COPY <<'_GPU_INIT' /etc/cont-init.d/15-detect-gpu.sh
 #!/bin/bash
+if [ "${HELIX_HEADLESS}" = "1" ]; then
+    echo "Headless mode: skipping GPU detection and udev setup"
+    return 0
+fi
+
 echo "**** Fixing GPU device permissions ****"
 # In Docker-in-Docker setups, GPU devices may be mounted as root:root
 # We need to make them accessible to non-root users for Vulkan/CUDA/EGL
@@ -1314,6 +1319,7 @@ ADD desktop/shared/helix-workspace-setup.sh /usr/local/bin/helix-workspace-setup
 ADD desktop/shared/helix-run-startup-script.sh /usr/local/bin/helix-run-startup-script.sh
 ADD desktop/shared/start-desktop-bridge.sh /usr/local/bin/start-desktop-bridge.sh
 ADD desktop/shared/start-settings-sync-daemon.sh /usr/local/bin/start-settings-sync-daemon.sh
+ADD desktop/shared/start-zed-headless.sh /usr/local/bin/start-zed-headless.sh
 # D-Bus policy for logind-stub (macOS ARM scanout mode)
 ADD desktop/shared/helix-logind.conf /etc/dbus-1/system.d/helix-logind.conf
 # Scanout mode init script (starts system D-Bus for logind-stub)
@@ -1325,7 +1331,7 @@ RUN chmod 755 /usr/local/bin/start-zed-helix.sh /usr/local/bin/start-gnome-bridg
     /usr/local/bin/helix-specs-create.sh /usr/local/bin/helix-git-hooks.sh \
     /usr/local/bin/helix-workspace-setup.sh /usr/local/bin/helix-run-startup-script.sh \
     /usr/local/bin/start-desktop-bridge.sh /usr/local/bin/start-settings-sync-daemon.sh \
-    /usr/local/bin/detect-render-node.sh /usr/local/bin/start-zed-core.sh
+    /usr/local/bin/start-zed-headless.sh /usr/local/bin/detect-render-node.sh /usr/local/bin/start-zed-core.sh
 
 # Ubuntu desktop theming (includes cursor-size=48 for fingerprinting)
 ADD desktop/ubuntu-config/dconf-settings.ini /opt/gow/dconf-settings.ini

--- a/api/cmd/desktop-bridge/main.go
+++ b/api/cmd/desktop-bridge/main.go
@@ -31,6 +31,7 @@ func main() {
 		HTTPPort:      os.Getenv("SCREENSHOT_PORT"),
 		XDGRuntimeDir: os.Getenv("XDG_RUNTIME_DIR"),
 		SessionID:     os.Getenv("HELIX_SESSION_ID"),
+		WorkspaceOnly: os.Getenv("HELIX_HEADLESS") == "1",
 	}
 
 	// Apply defaults
@@ -65,7 +66,7 @@ func main() {
 	// Mount MCP handler on the desktop HTTP server so it's reachable via RevDial.
 	// RevDial tunnels to port 9876 (this server), so the API gateway proxy
 	// sends MCP requests to /mcp on this server.
-	if mcpEnabled {
+	if mcpEnabled && !cfg.WorkspaceOnly {
 		mcpCfg := desktop.MCPConfig{
 			ScreenshotURL: fmt.Sprintf("http://localhost:%s/screenshot", cfg.HTTPPort),
 		}

--- a/api/pkg/desktop/desktop.go
+++ b/api/pkg/desktop/desktop.go
@@ -24,6 +24,7 @@ type Config struct {
 	HTTPPort      string // HTTP server port (default: 9876)
 	XDGRuntimeDir string // XDG_RUNTIME_DIR for sockets
 	SessionID     string // HELIX_SESSION_ID for session identification
+	WorkspaceOnly bool   // Serve workspace APIs without compositor/video initialization
 }
 
 // Server is the main desktop integration server.
@@ -226,6 +227,10 @@ func (s *Server) GetCursorState() (x, y int32, cursorName string) {
 
 // Run starts the server and blocks until context is cancelled.
 func (s *Server) Run(ctx context.Context) error {
+	if s.config.WorkspaceOnly {
+		return s.runWorkspaceServer(ctx)
+	}
+
 	s.logger.Info("starting desktop server",
 		"port", s.config.HTTPPort,
 		"session_id", s.config.SessionID,
@@ -476,6 +481,42 @@ func (s *Server) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// runWorkspaceServer serves the git/file APIs needed by headless tasks without
+// initializing GStreamer, D-Bus, a compositor, or any input/video resources.
+func (s *Server) runWorkspaceServer(ctx context.Context) error {
+	s.logger.Info("starting headless workspace server",
+		"port", s.config.HTTPPort,
+		"session_id", s.config.SessionID,
+	)
+	s.running.Store(true)
+	defer s.running.Store(false)
+
+	httpServer := &http.Server{
+		Addr:    ":" + s.config.HTTPPort,
+		Handler: s.workspaceHTTPHandler(),
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("http: %w", err)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		s.logger.Info("shutting down headless workspace server")
+	case err := <-errCh:
+		return err
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutdown workspace server: %w", err)
+	}
+	return ctx.Err()
+}
+
 // httpHandler returns the HTTP handler with all routes.
 func (s *Server) httpHandler() http.Handler {
 	mux := http.NewServeMux()
@@ -484,27 +525,10 @@ func (s *Server) httpHandler() http.Handler {
 	mux.HandleFunc("/clipboard", s.handleClipboard)
 	mux.HandleFunc("/upload", s.handleUpload)
 	mux.HandleFunc("/file", s.handleFile)
-	mux.HandleFunc("/ws/input", s.handleWSInput)      // Direct WebSocket input
-	mux.HandleFunc("/ws/stream", s.handleWSStream)    // Direct WebSocket video streaming
-	mux.HandleFunc("/exec", s.handleExec)             // Execute command in container (for benchmarking)
-	mux.HandleFunc("/workspaces", s.handleWorkspaces) // List git workspaces
-	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)
-	mux.HandleFunc("/workspace/files", s.handleWorkspaceFiles)
-	mux.HandleFunc("/workspace/file", s.handleWorkspaceFile)
-	mux.HandleFunc("/workspace/skills", s.handleWorkspaceSkills)
-	mux.HandleFunc("/workspace/checkpoints/capture", s.handleWorkspaceCheckpointCapture)
-	mux.HandleFunc("/workspace/checkpoints/diff", s.handleWorkspaceCheckpointDiff)
-	// Workspace git plumbing used by the fork-and-pause safety net.
-	// Kept as dedicated endpoints (not /exec) because /exec is
-	// allowlist-restricted by design — adding git status/add/commit/push
-	// to the allowlist would weaken that gate. These run trusted, fixed
-	// command sequences with no caller-controlled command strings.
-	mux.HandleFunc("/workspace/status", s.handleWorkspaceStatus)
-	mux.HandleFunc("/workspace/commit-and-push", s.handleWorkspaceCommitAndPush)
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	})
+	mux.HandleFunc("/ws/input", s.handleWSInput)   // Direct WebSocket input
+	mux.HandleFunc("/ws/stream", s.handleWSStream) // Direct WebSocket video streaming
+	mux.HandleFunc("/exec", s.handleExec)          // Execute command in container (for benchmarking)
+	s.registerWorkspaceRoutes(mux)
 	mux.HandleFunc("/clients", s.handleClients)
 	mux.HandleFunc("/video/stats", s.handleVideoStats)
 
@@ -514,6 +538,33 @@ func (s *Server) httpHandler() http.Handler {
 	}
 
 	return mux
+}
+
+// workspaceHTTPHandler is the complete HTTP surface exposed by a headless
+// task. Desktop-only screenshot, clipboard, input, video, and MCP routes are
+// intentionally absent.
+func (s *Server) workspaceHTTPHandler() http.Handler {
+	mux := http.NewServeMux()
+	s.registerWorkspaceRoutes(mux)
+	return mux
+}
+
+func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/workspaces", s.handleWorkspaces)
+	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)
+	mux.HandleFunc("/workspace/files", s.handleWorkspaceFiles)
+	mux.HandleFunc("/workspace/file", s.handleWorkspaceFile)
+	mux.HandleFunc("/workspace/skills", s.handleWorkspaceSkills)
+	mux.HandleFunc("/workspace/checkpoints/capture", s.handleWorkspaceCheckpointCapture)
+	mux.HandleFunc("/workspace/checkpoints/diff", s.handleWorkspaceCheckpointDiff)
+	// Git plumbing used by the fork-and-pause safety net stays on fixed,
+	// dedicated endpoints rather than weakening the generic /exec allowlist.
+	mux.HandleFunc("/workspace/status", s.handleWorkspaceStatus)
+	mux.HandleFunc("/workspace/commit-and-push", s.handleWorkspaceCommitAndPush)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
 }
 
 // isRunning returns whether the server is still running.

--- a/api/pkg/desktop/workspace_test.go
+++ b/api/pkg/desktop/workspace_test.go
@@ -2,7 +2,11 @@ package desktop
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,6 +94,58 @@ func TestHandleWorkspacesIncludesAgentPath(t *testing.T) {
 	assert.Equal(t, "/home/retro/work/testproj", resp.Workspaces[0].AgentPath)
 	assert.Contains(t, rec.Body.String(), `"path":`)
 	assert.NotContains(t, rec.Body.String(), workspaceDir)
+}
+
+// TestWorkspaceOnlyServerServesFilesAndDiffsWithoutDesktop proves the headless
+// runtime can browse its live workspace without starting any compositor,
+// streaming, or input services.
+func TestWorkspaceOnlyServerServesFilesAndDiffsWithoutDesktop(t *testing.T) {
+	workspaceDir, _, _ := setupTestRepoWithRemote(t, "testproj", true)
+	t.Setenv("WORKSPACE_DIR", workspaceDir)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	server := NewServer(Config{
+		HTTPPort:      fmt.Sprintf("%d", port),
+		SessionID:     "ses_headless",
+		WorkspaceOnly: true,
+	}, slog.Default())
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Run(ctx) }()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	require.Eventually(t, func() bool {
+		response, requestErr := http.Get(baseURL + "/health")
+		if requestErr != nil {
+			return false
+		}
+		_ = response.Body.Close()
+		return response.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond)
+
+	for _, path := range []string{
+		"/workspaces",
+		"/workspace/files",
+		"/workspace/review?base=main",
+	} {
+		response, requestErr := http.Get(baseURL + path)
+		require.NoError(t, requestErr)
+		_ = response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode, path)
+	}
+
+	response, err := http.Get(baseURL + "/screenshot")
+	require.NoError(t, err)
+	_ = response.Body.Close()
+	require.Equal(t, http.StatusNotFound, response.StatusCode)
+
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
 }
 
 // TestHandleWorkspaceStatus_Dirty covers the happy path of the modal-

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -553,24 +553,23 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	// No bridging needed - desktop runs its own dockerd, so all containers
 	// are on the same Docker network inside the desktop container.
 
-	// Wait for desktop-bridge to be ready before returning.
-	// Desktop-bridge takes time to start: waits for D-Bus, Wayland, portal, GStreamer init.
+	// Wait for the container bridge to be ready before returning. Desktop
+	// runtimes initialize D-Bus, Wayland, portals, and GStreamer first; headless
+	// runtimes expose only the workspace API from the same bridge binary.
 	// Uses RevDial for health check since container IP is inside sandbox's DinD network.
 	//
 	// IMPORTANT: use an independent context here (issue #1 from ZFS deployment).
 	// The caller's ctx may have been partially consumed by the ZFS clone (which can take
 	// 10-90s). If we reuse it, the bridge wait budget is whatever is left over, which may
 	// be far less than the 90s we need. Using context.Background() gives the full 90s.
-	if containerType != "headless" {
-		bridgeCtx, bridgeCancel := context.WithTimeout(context.Background(), 90*time.Second)
-		defer bridgeCancel()
-		if err := h.waitForDesktopBridge(bridgeCtx, agent.SessionID); err != nil {
-			log.Warn().Err(err).
-				Str("session_id", agent.SessionID).
-				Msg("Desktop bridge not ready (continuing anyway, frontend may need to retry)")
-			// Don't fail - container is running, just not fully ready yet.
-			// Frontend should handle this gracefully with retry logic.
-		}
+	bridgeCtx, bridgeCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer bridgeCancel()
+	if err := h.waitForDesktopBridge(bridgeCtx, agent.SessionID); err != nil {
+		log.Warn().Err(err).
+			Str("session_id", agent.SessionID).
+			Msg("Container bridge not ready (continuing anyway, frontend may need to retry)")
+		// Don't fail - the container is running, just not fully ready yet.
+		// Frontend callers retry once the service becomes reachable.
 	}
 
 	// Track session
@@ -1637,9 +1636,9 @@ func (h *HydraExecutor) buildMounts(agent *types.DesktopAgent, workspaceDir stri
 	return mounts
 }
 
-// waitForDesktopBridge polls the desktop-bridge health endpoint via RevDial until it's ready.
-// Desktop-bridge startup includes: D-Bus wait, Wayland socket wait, portal wait, GStreamer init.
-// This can take 10-30 seconds depending on the compositor and GPU.
+// waitForDesktopBridge polls the bridge health endpoint via RevDial until it's ready.
+// Desktop startup includes D-Bus, Wayland, portal, and GStreamer initialization;
+// headless startup serves the workspace APIs without those dependencies.
 // Uses RevDial connection because the container IP is inside the sandbox's DinD network
 // and not directly reachable from the API container.
 func (h *HydraExecutor) waitForDesktopBridge(ctx context.Context, sessionID string) error {

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -240,23 +240,21 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		}
 	}
 
-	// Check limits for the user/org
+	// Resolve immutable task launch settings before quota checks and placement.
+	// Resume, fork, and design-review paths rebuild DesktopAgent from session
+	// metadata, so the owning task remains the source of truth.
+	if err := h.resolveSpecTaskLaunchConfig(ctx, agent); err != nil {
+		return nil, err
+	}
+
+	// Check legacy external-agent desktop limits for full desktops. Headless
+	// tasks are enforced by the headless sandbox limit in beginSandboxMetering.
 	limitReached, err := h.checkLimits(ctx, agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check limits: %w", err)
 	}
 	if limitReached != nil && limitReached.LimitReached {
 		return nil, fmt.Errorf("desktop limit reached (%d). Stop some of the existing sessions or upgrade your plan", limitReached.Limit)
-	}
-
-	// A spec task owns a sandbox size the user picked. Only the three launch
-	// paths in spec_driven_task_service set it on the agent; resume, fork and
-	// design-review rebuild the agent from the session and would otherwise
-	// start the desktop uncapped — running bigger than the user asked for and
-	// billing at the default. Resolve it here so every spec-task desktop honours
-	// the task's preset.
-	if err := h.resolveSpecTaskResources(ctx, agent); err != nil {
-		return nil, err
 	}
 
 	// Open the sandbox row that bills and quota-checks this desktop. This
@@ -288,8 +286,14 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	// Determine sandbox ID - use agent's preference or find an available one
 	sandboxID := agent.SandboxID
 	if sandboxID == "" {
-		// Find an available sandbox with the required desktop image
-		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, containerType)
+		// Headless agents use the helix-ubuntu toolchain image, so placement must
+		// select a host advertising that image even though the created container
+		// itself has no compositor or display devices.
+		placementImage := containerType
+		if containerType == "headless" {
+			placementImage = "ubuntu"
+		}
+		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find available sandbox: %w", err)
 		}
@@ -557,14 +561,16 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	// The caller's ctx may have been partially consumed by the ZFS clone (which can take
 	// 10-90s). If we reuse it, the bridge wait budget is whatever is left over, which may
 	// be far less than the 90s we need. Using context.Background() gives the full 90s.
-	bridgeCtx, bridgeCancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer bridgeCancel()
-	if err := h.waitForDesktopBridge(bridgeCtx, agent.SessionID); err != nil {
-		log.Warn().Err(err).
-			Str("session_id", agent.SessionID).
-			Msg("Desktop bridge not ready (continuing anyway, frontend may need to retry)")
-		// Don't fail - container is running, just not fully ready yet.
-		// Frontend should handle this gracefully with retry logic.
+	if containerType != "headless" {
+		bridgeCtx, bridgeCancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer bridgeCancel()
+		if err := h.waitForDesktopBridge(bridgeCtx, agent.SessionID); err != nil {
+			log.Warn().Err(err).
+				Str("session_id", agent.SessionID).
+				Msg("Desktop bridge not ready (continuing anyway, frontend may need to retry)")
+			// Don't fail - container is running, just not fully ready yet.
+			// Frontend should handle this gracefully with retry logic.
+		}
 	}
 
 	// Track session
@@ -660,20 +666,25 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	}, nil
 }
 
-// resolveSpecTaskResources fills in the sandbox size from the owning spec task
-// when the caller didn't supply one. A caller that set resources explicitly
-// wins — it already knows what it wants.
-func (h *HydraExecutor) resolveSpecTaskResources(ctx context.Context, agent *types.DesktopAgent) error {
-	if agent.SpecTaskID == "" || (agent.VCPUs > 0 && agent.MemoryMB > 0) {
+// resolveSpecTaskLaunchConfig applies the immutable runtime and fills a missing
+// resource preset from the owning task. It is deliberately centralized here so
+// every start path, including forks and reconciler resumes, behaves identically.
+func (h *HydraExecutor) resolveSpecTaskLaunchConfig(ctx context.Context, agent *types.DesktopAgent) error {
+	if agent.SpecTaskID == "" {
 		return nil
 	}
 	task, err := h.store.GetSpecTask(ctx, agent.SpecTaskID)
 	if err != nil {
-		return fmt.Errorf("load spec task %s for sandbox sizing: %w", agent.SpecTaskID, err)
+		return fmt.Errorf("load spec task %s for sandbox configuration: %w", agent.SpecTaskID, err)
 	}
-	resources := types.EffectiveSpecTaskSandboxResources(task.SandboxResourceOverrides)
-	agent.VCPUs = resources.VCPUs
-	agent.MemoryMB = resources.MemoryMB
+	if agent.VCPUs <= 0 || agent.MemoryMB <= 0 {
+		resources := types.EffectiveSpecTaskSandboxResources(task.SandboxResourceOverrides)
+		agent.VCPUs = resources.VCPUs
+		agent.MemoryMB = resources.MemoryMB
+	}
+	if types.EffectiveSpecTaskSandboxRuntime(task.SandboxRuntime) == types.SandboxRuntimeHeadlessUbuntu {
+		agent.DesktopType = "headless"
+	}
 	return nil
 }
 
@@ -685,6 +696,10 @@ func (h *HydraExecutor) beginSandboxMetering(ctx context.Context, agent *types.D
 		return false, nil
 	}
 	vcpus, memoryMB := desktopBillingResources(agent)
+	runtime := types.SandboxRuntimeUbuntuDesktop
+	if h.parseContainerType(agent.DesktopType) == "headless" {
+		runtime = types.SandboxRuntimeHeadlessUbuntu
+	}
 	sb, err := h.sandboxMeter.BeginSession(ctx, &types.BeginSandboxSessionRequest{
 		SessionID:      agent.SessionID,
 		OrganizationID: agent.OrganizationID,
@@ -692,7 +707,7 @@ func (h *HydraExecutor) beginSandboxMetering(ctx context.Context, agent *types.D
 		ProjectID:      agent.ProjectID,
 		SpecTaskID:     agent.SpecTaskID,
 		Name:           h.desktopSandboxName(ctx, agent),
-		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Runtime:        runtime,
 		VCPUs:          vcpus,
 		MemoryMB:       memoryMB,
 		DisplayWidth:   agent.DisplayWidth,
@@ -1298,6 +1313,11 @@ func (h *HydraExecutor) getContainerImage(ctx context.Context, containerType str
 	case "ubuntu":
 		imageName = "helix-ubuntu"
 		versionKey = "ubuntu"
+	case "headless":
+		// Headless spec tasks still need the Helix agent toolchain baked into
+		// helix-ubuntu; the container type suppresses the compositor and GPU path.
+		imageName = "helix-ubuntu"
+		versionKey = "ubuntu"
 	default:
 		imageName = "helix-sway"
 		versionKey = "sway"
@@ -1334,9 +1354,6 @@ func (h *HydraExecutor) getContainerImage(ctx context.Context, containerType str
 
 // buildEnvVars builds environment variables for the container
 func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, workspaceDir string) []string {
-	// Build GPU devices string
-	gpuDevices := "/dev/dri/card*:/dev/dri/renderD*:/dev/uinput:/dev/input/event*:/dev/input/js*:/dev/input/mice"
-
 	// Determine Helix URL for Zed's WebSocket connection
 	zedHelixURL := strings.TrimPrefix(h.helixAPIURL, "https://")
 	zedHelixURL = strings.TrimPrefix(zedHelixURL, "http://")
@@ -1359,9 +1376,6 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 		// RevDial connection - startup-app.sh expects these specific names
 		fmt.Sprintf("HELIX_API_BASE_URL=%s", h.helixAPIURL),
 
-		// GPU/input device passthrough
-		fmt.Sprintf("GOW_REQUIRED_DEVICES=%s", gpuDevices),
-
 		// LLM proxy configuration for Zed's built-in agents
 		// SECURITY: ANTHROPIC_API_KEY, OPENAI_API_KEY are set via agent.Env with session-scoped token
 		// (see addUserAPITokenToAgent). Only set the base URLs here - NOT the runner token.
@@ -1370,14 +1384,12 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 
 		// Zed sync configuration
 		"ZED_EXTERNAL_SYNC_ENABLED=true",
-		"ZED_ALLOW_EMULATED_GPU=1", // Allow software rendering with llvmpipe
 		fmt.Sprintf("ZED_HELIX_URL=%s", zedHelixURL),
 		fmt.Sprintf("ZED_HELIX_TLS=%t", zedHelixTLS),
 		"ZED_HELIX_SKIP_TLS_VERIFY=true", // Enterprise internal CAs
 
 		// Debug logging
-		"RUST_LOG=info,gst_wayland_display=debug",
-		"GST_DEBUG=vsockenc:5", // TODO: Remove after fixing vsockenc receive thread
+		"RUST_LOG=info",
 		"SHOW_ACP_DEBUG_LOGS=true",
 
 		// Settings sync daemon port
@@ -1449,7 +1461,11 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 	// Display settings for non-headless containers
 	if containerType != "headless" {
 		width, height, refreshRate := agent.GetEffectiveResolution()
+		env = setContainerEnv(env, "RUST_LOG", "info,gst_wayland_display=debug")
 		env = append(env,
+			"GOW_REQUIRED_DEVICES=/dev/dri/card*:/dev/dri/renderD*:/dev/uinput:/dev/input/event*:/dev/input/js*:/dev/input/mice",
+			"GST_DEBUG=vsockenc:5",
+			"ZED_ALLOW_EMULATED_GPU=1",
 			fmt.Sprintf("GAMESCOPE_WIDTH=%d", width),
 			fmt.Sprintf("GAMESCOPE_HEIGHT=%d", height),
 			fmt.Sprintf("GAMESCOPE_REFRESH=%d", refreshRate),
@@ -1467,18 +1483,18 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 		if agent.DisplayScale > 0 {
 			env = append(env, fmt.Sprintf("HELIX_DISPLAY_SCALE=%d", agent.DisplayScale))
 		}
-	}
 
-	// Add GPU-specific environment variables
-	switch h.gpuVendor {
-	case "nvidia":
-		env = append(env, "NVIDIA_VISIBLE_DEVICES=all")
-		// Use explicit capabilities instead of "all" for GKE/cloud compatibility
-		env = append(env, "NVIDIA_DRIVER_CAPABILITIES=compute,utility,video,graphics,display")
-	case "amd":
-		env = append(env, "GOW_REQUIRED_DEVICES=/dev/dri/card*:/dev/dri/renderD*")
-	case "intel":
-		env = append(env, "GOW_REQUIRED_DEVICES=/dev/dri/card*:/dev/dri/renderD*")
+		// Add GPU-specific environment variables.
+		switch h.gpuVendor {
+		case "nvidia":
+			env = append(env, "NVIDIA_VISIBLE_DEVICES=all")
+			// Use explicit capabilities instead of "all" for GKE/cloud compatibility
+			env = append(env, "NVIDIA_DRIVER_CAPABILITIES=compute,utility,video,graphics,display")
+		case "amd":
+			env = append(env, "GOW_REQUIRED_DEVICES=/dev/dri/card*:/dev/dri/renderD*")
+		case "intel":
+			env = append(env, "GOW_REQUIRED_DEVICES=/dev/dri/card*:/dev/dri/renderD*")
+		}
 	}
 
 	// NOTE: BUILDKIT_HOST env var is injected by Hydra server side (devcontainer.go buildEnv)
@@ -1495,15 +1511,17 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 	//                       explicitly for the macOS QEMU virtio-gpu path.
 	//   HELIX_GOP_SIZE    - GOP size in frames (default 120 = 2s at 60fps)
 	//   HELIX_RENDER_NODE - VA-API render device (e.g. /dev/dri/renderD129)
-	for _, name := range []string{"HELIX_ENCODER", "HELIX_VIDEO_MODE", "HELIX_GOP_SIZE", "HELIX_RENDER_NODE"} {
-		val := os.Getenv(name)
-		if val == "" {
-			continue
+	if containerType != "headless" {
+		for _, name := range []string{"HELIX_ENCODER", "HELIX_VIDEO_MODE", "HELIX_GOP_SIZE", "HELIX_RENDER_NODE"} {
+			val := os.Getenv(name)
+			if val == "" {
+				continue
+			}
+			if name == "HELIX_VIDEO_MODE" && val == "scanout" {
+				continue
+			}
+			env = append(env, fmt.Sprintf("%s=%s", name, val))
 		}
-		if name == "HELIX_VIDEO_MODE" && val == "scanout" {
-			continue
-		}
-		env = append(env, fmt.Sprintf("%s=%s", name, val))
 	}
 
 	// These come LAST so they can override defaults (e.g., use user's token instead of runner token)
@@ -1521,8 +1539,22 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 		Msg("buildEnvVars: Appending agent.Env (USER_API_TOKEN should be present for RevDial)")
 
 	env = append(env, agent.Env...)
+	if containerType == "headless" {
+		env = setContainerEnv(env, "HELIX_HEADLESS", "1")
+	}
 
 	return env
+}
+
+func setContainerEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
 }
 
 // buildMounts builds volume mounts for the container.
@@ -2008,6 +2040,9 @@ func (h *HydraExecutor) ReconcileSandboxResources(ctx context.Context, sandboxID
 
 // checkLimits checks desktop limits for the user/org
 func (h *HydraExecutor) checkLimits(ctx context.Context, agent *types.DesktopAgent) (*types.QuotaLimitReachedResponse, error) {
+	if h.parseContainerType(agent.DesktopType) == "headless" {
+		return &types.QuotaLimitReachedResponse{LimitReached: false}, nil
+	}
 	// Get system settings
 	systemSettings, err := h.store.GetSystemSettings(ctx)
 	if err != nil {

--- a/api/pkg/external-agent/sandbox_metering_test.go
+++ b/api/pkg/external-agent/sandbox_metering_test.go
@@ -2,19 +2,19 @@ package external_agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"gorm.io/datatypes"
 )
 
-// Only the three spec_driven_task_service launch paths put resources on the
-// agent. Resume, fork and design-review rebuild it from the session, so without
-// this resolution a resumed 8 vCPU task would come back uncapped and be billed
-// at the default preset.
-func TestResolveSpecTaskResourcesAppliesTaskPreset(t *testing.T) {
+// Resume, fork and design-review rebuild the agent from session state. The task
+// remains authoritative for both its resource preset and immutable runtime.
+func TestResolveSpecTaskLaunchConfigAppliesTaskPreset(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStore := store.NewMockStore(ctrl)
@@ -26,14 +26,14 @@ func TestResolveSpecTaskResourcesAppliesTaskPreset(t *testing.T) {
 	}, nil)
 
 	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_1"}
-	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.NoError(t, executor.resolveSpecTaskLaunchConfig(context.Background(), agent))
 	require.Equal(t, 8, agent.VCPUs)
 	require.Equal(t, 16384, agent.MemoryMB)
 }
 
 // A legacy task with no explicit override resolves to the same default the
 // task UI displays, so the billed size matches what the user is shown.
-func TestResolveSpecTaskResourcesFallsBackToTaskDefault(t *testing.T) {
+func TestResolveSpecTaskLaunchConfigFallsBackToTaskDefault(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStore := store.NewMockStore(ctrl)
@@ -42,37 +42,97 @@ func TestResolveSpecTaskResourcesFallsBackToTaskDefault(t *testing.T) {
 	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_legacy").Return(&types.SpecTask{ID: "spt_legacy"}, nil)
 
 	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_legacy"}
-	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.NoError(t, executor.resolveSpecTaskLaunchConfig(context.Background(), agent))
 
 	expected := types.EffectiveSpecTaskSandboxResources(nil)
 	require.Equal(t, expected.VCPUs, agent.VCPUs)
 	require.Equal(t, expected.MemoryMB, agent.MemoryMB)
 }
 
-// An explicit caller-supplied size wins — it already knows what it wants, and
-// re-reading the task would undo an in-flight resize.
-func TestResolveSpecTaskResourcesLeavesExplicitSizeAlone(t *testing.T) {
+// An explicit caller-supplied size wins. The task is still read because its
+// runtime remains authoritative, but an in-flight resize is not undone.
+func TestResolveSpecTaskLaunchConfigLeavesExplicitSizeAlone(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStore := store.NewMockStore(ctrl)
 	executor := newTestExecutor(mockStore)
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(&types.SpecTask{ID: "spt_1"}, nil)
 
 	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_1", VCPUs: 1, MemoryMB: 2048}
-	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.NoError(t, executor.resolveSpecTaskLaunchConfig(context.Background(), agent))
 	require.Equal(t, 1, agent.VCPUs)
 	require.Equal(t, 2048, agent.MemoryMB)
 }
 
-func TestResolveSpecTaskResourcesIgnoresNonTaskDesktops(t *testing.T) {
+func TestResolveSpecTaskLaunchConfigIgnoresNonTaskDesktops(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStore := store.NewMockStore(ctrl)
 	executor := newTestExecutor(mockStore)
 
 	agent := &types.DesktopAgent{SessionID: "ses_1"}
-	require.NoError(t, executor.resolveSpecTaskResources(context.Background(), agent))
+	require.NoError(t, executor.resolveSpecTaskLaunchConfig(context.Background(), agent))
 	require.Zero(t, agent.VCPUs)
 	require.Zero(t, agent.MemoryMB)
+}
+
+func TestResolveSpecTaskLaunchConfigForcesHeadlessRuntime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_headless").Return(&types.SpecTask{
+		ID:             "spt_headless",
+		SandboxRuntime: types.SandboxRuntimeHeadlessUbuntu,
+	}, nil)
+
+	agent := &types.DesktopAgent{SessionID: "ses_1", SpecTaskID: "spt_headless", DesktopType: "ubuntu"}
+	require.NoError(t, executor.resolveSpecTaskLaunchConfig(context.Background(), agent))
+	require.Equal(t, "headless", agent.DesktopType)
+}
+
+func TestGetContainerImageUsesUbuntuToolchainForHeadlessTask(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	executor := newTestExecutor(mockStore)
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "runner-1").Return(&types.SandboxInstance{
+		ID:              "runner-1",
+		DesktopVersions: datatypes.JSON([]byte(`{"ubuntu":"image-123"}`)),
+	}, nil)
+
+	image, err := executor.getContainerImage(context.Background(), "headless", "runner-1", &types.DesktopAgent{})
+	require.NoError(t, err)
+	require.Equal(t, "helix-ubuntu:image-123", image)
+}
+
+func TestBuildEnvVarsForcesHeadlessStartup(t *testing.T) {
+	executor := newTestExecutor(nil)
+	executor.gpuVendor = "nvidia"
+	env := executor.buildEnvVars(&types.DesktopAgent{
+		SessionID: "ses_1",
+		Env:       []string{"HELIX_HEADLESS=0"},
+	}, "headless", "/workspace")
+
+	require.Equal(t, 1, countEnvKey(env, "HELIX_HEADLESS"))
+	require.Contains(t, env, "HELIX_HEADLESS=1")
+	for _, entry := range env {
+		require.False(t, strings.HasPrefix(entry, "GAMESCOPE_"), entry)
+		require.False(t, strings.HasPrefix(entry, "GOW_REQUIRED_DEVICES="), entry)
+		require.False(t, strings.HasPrefix(entry, "GST_DEBUG="), entry)
+		require.False(t, strings.HasPrefix(entry, "NVIDIA_"), entry)
+		require.False(t, strings.HasPrefix(entry, "ZED_ALLOW_EMULATED_GPU="), entry)
+	}
+}
+
+func countEnvKey(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, key+"=") {
+			count++
+		}
+	}
+	return count
 }
 
 // Desktops with no cap (exploratory sessions, subscription logins) can use the

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -491,8 +491,9 @@ func (dm *DevContainerManager) CreateDevContainer(ctx context.Context, req *Crea
 		return nil, fmt.Errorf("failed to build host config: %w", err)
 	}
 
-	// Configure GPU passthrough
-	dm.configureGPU(hostConfig, req.GPUVendor, req.GPUIndex)
+	if req.ContainerType != DevContainerTypeHeadless {
+		dm.configureGPU(hostConfig, req.GPUVendor, req.GPUIndex)
+	}
 
 	// Network configuration is nil for host network mode
 	// (host network mode shares the sandbox's network namespace, so no separate network config needed)
@@ -856,99 +857,103 @@ func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string
 		}
 	}
 
-	// Add GPU_VENDOR for detect-render-node.sh inside the container
-	// This tells the container which GPU to look for in /sys/class/drm
-	if req.GPUVendor != "" {
-		env = append(env, fmt.Sprintf("GPU_VENDOR=%s", req.GPUVendor))
-	}
+	if req.ContainerType != DevContainerTypeHeadless {
+		// Add GPU_VENDOR for detect-render-node.sh inside the container
+		// This tells the container which GPU to look for in /sys/class/drm
+		if req.GPUVendor != "" {
+			env = append(env, fmt.Sprintf("GPU_VENDOR=%s", req.GPUVendor))
+		}
 
-	// Enable GStreamer debug logging for vsockenc debugging
-	// TODO: Remove this after vsockenc receive thread issue is fixed
-	env = append(env, "GST_DEBUG=vsockenc:5")
+		// Enable GStreamer debug logging for vsockenc debugging
+		// TODO: Remove this after vsockenc receive thread issue is fixed
+		env = append(env, "GST_DEBUG=vsockenc:5")
+	}
 
 	// Tell claude-code-acp that we're in a sandbox environment.
 	// The ACP checks (!IS_ROOT || IS_SANDBOX) to allow bypassPermissions mode.
 	// Our containers run as root, so without this Claude Code prompts for every tool use.
 	env = append(env, "IS_SANDBOX=1")
 
-	// Add GPU-specific environment variables
-	switch req.GPUVendor {
-	case "nvidia":
-		// Check if already set
-		hasVisibleDevices := false
-		hasDriverCaps := false
-		for _, e := range env {
-			if strings.HasPrefix(e, "NVIDIA_VISIBLE_DEVICES=") {
-				hasVisibleDevices = true
+	if req.ContainerType != DevContainerTypeHeadless {
+		// Add GPU-specific environment variables
+		switch req.GPUVendor {
+		case "nvidia":
+			// Check if already set
+			hasVisibleDevices := false
+			hasDriverCaps := false
+			for _, e := range env {
+				if strings.HasPrefix(e, "NVIDIA_VISIBLE_DEVICES=") {
+					hasVisibleDevices = true
+				}
+				if strings.HasPrefix(e, "NVIDIA_DRIVER_CAPABILITIES=") {
+					hasDriverCaps = true
+				}
 			}
-			if strings.HasPrefix(e, "NVIDIA_DRIVER_CAPABILITIES=") {
-				hasDriverCaps = true
+			if !hasVisibleDevices {
+				// Decision 15: per-session GPU pinning on multi-GPU hosts.
+				// If the request specifies GPUIndex, expose only that GPU.
+				// Otherwise default to "all" (legacy behaviour).
+				//
+				// IMPORTANT: in nested-DinD setups (sandbox -> inner dockerd
+				// -> desktop container) the cgroup-level device restriction
+				// from NVIDIA_VISIBLE_DEVICES does NOT actually take effect
+				// because the outer sandbox container was launched with
+				// `--gpus all` so all /dev/nvidia* nodes are inherited.
+				// Verified live on a 2x Blackwell box: nvidia-smi inside
+				// pin-0 still saw GPU 1. The DRM device pinning (PCI walk)
+				// IS effective (Mutter+GStreamer get the right card), but
+				// CUDA visibility leaks. We set both NVIDIA_VISIBLE_DEVICES
+				// AND CUDA_VISIBLE_DEVICES to the index so CUDA workloads
+				// inside the desktop respect the pin even if /dev/nvidia*
+				// nodes leak. Real cgroup-level restriction in nested DinD
+				// is a separate problem documented in Decision 15 follow-ups.
+				if req.GPUIndex != nil {
+					env = append(env, fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%d", *req.GPUIndex))
+					env = append(env, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%d", *req.GPUIndex))
+				} else {
+					env = append(env, "NVIDIA_VISIBLE_DEVICES=all")
+				}
+			}
+			if !hasDriverCaps {
+				// Use explicit capabilities instead of "all" for GKE/cloud compatibility
+				env = append(env, "NVIDIA_DRIVER_CAPABILITIES=compute,utility,video,graphics,display")
 			}
 		}
-		if !hasVisibleDevices {
-			// Decision 15: per-session GPU pinning on multi-GPU hosts.
-			// If the request specifies GPUIndex, expose only that GPU.
-			// Otherwise default to "all" (legacy behaviour).
-			//
-			// IMPORTANT: in nested-DinD setups (sandbox -> inner dockerd
-			// -> desktop container) the cgroup-level device restriction
-			// from NVIDIA_VISIBLE_DEVICES does NOT actually take effect
-			// because the outer sandbox container was launched with
-			// `--gpus all` so all /dev/nvidia* nodes are inherited.
-			// Verified live on a 2x Blackwell box: nvidia-smi inside
-			// pin-0 still saw GPU 1. The DRM device pinning (PCI walk)
-			// IS effective (Mutter+GStreamer get the right card), but
-			// CUDA visibility leaks. We set both NVIDIA_VISIBLE_DEVICES
-			// AND CUDA_VISIBLE_DEVICES to the index so CUDA workloads
-			// inside the desktop respect the pin even if /dev/nvidia*
-			// nodes leak. Real cgroup-level restriction in nested DinD
-			// is a separate problem documented in Decision 15 follow-ups.
-			if req.GPUIndex != nil {
-				env = append(env, fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%d", *req.GPUIndex))
-				env = append(env, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%d", *req.GPUIndex))
-			} else {
-				env = append(env, "NVIDIA_VISIBLE_DEVICES=all")
-			}
-		}
-		if !hasDriverCaps {
-			// Use explicit capabilities instead of "all" for GKE/cloud compatibility
-			env = append(env, "NVIDIA_DRIVER_CAPABILITIES=compute,utility,video,graphics,display")
-		}
-	}
 
-	// Decision 15: tell detect-render-node.sh which GPU to pick. This drives
-	// Mutter via udev tags + the GStreamer encoder via HELIX_RENDER_NODE.
-	// Set for all vendors so AMD/Intel paths also pin via the script's
-	// PCI walk fast-path. Live-tested on 2x Blackwell box: each desktop
-	// correctly picked its assigned card via PCI BDF (not by index suffix).
-	if req.GPUIndex != nil {
-		env = append(env, fmt.Sprintf("HELIX_GPU_INDEX=%d", *req.GPUIndex))
-		// AMD equivalent of CUDA_VISIBLE_DEVICES — ROCm honours this for
-		// HIP workloads even when /dev/dri leaks (same nested-DinD caveat).
-		if req.GPUVendor == "amd" {
-			env = append(env, fmt.Sprintf("HIP_VISIBLE_DEVICES=%d", *req.GPUIndex))
-			env = append(env, fmt.Sprintf("ROCR_VISIBLE_DEVICES=%d", *req.GPUIndex))
+		// Decision 15: tell detect-render-node.sh which GPU to pick. This drives
+		// Mutter via udev tags + the GStreamer encoder via HELIX_RENDER_NODE.
+		// Set for all vendors so AMD/Intel paths also pin via the script's
+		// PCI walk fast-path. Live-tested on 2x Blackwell box: each desktop
+		// correctly picked its assigned card via PCI BDF (not by index suffix).
+		if req.GPUIndex != nil {
+			env = append(env, fmt.Sprintf("HELIX_GPU_INDEX=%d", *req.GPUIndex))
+			// AMD equivalent of CUDA_VISIBLE_DEVICES — ROCm honours this for
+			// HIP workloads even when /dev/dri leaks (same nested-DinD caveat).
+			if req.GPUVendor == "amd" {
+				env = append(env, fmt.Sprintf("HIP_VISIBLE_DEVICES=%d", *req.GPUIndex))
+				env = append(env, fmt.Sprintf("ROCR_VISIBLE_DEVICES=%d", *req.GPUIndex))
+			}
 		}
-	}
 
-	// For virtio-gpu (macOS ARM): set scanout mode environment variables
-	// These tell detect-render-node.sh and desktop-bridge to use the
-	// DRM lease → QEMU VideoToolbox H.264 pipeline instead of PipeWire.
-	drmSock := "/run/helix-drm/drm.sock"
-	if _, err := os.Stat(drmSock); err == nil {
-		env = append(env,
-			"GPU_VENDOR=virtio",
-			"HELIX_SCANOUT_MODE=1",
-			"HELIX_VIDEO_MODE=scanout",
-			"XDG_RUNTIME_DIR=/run/user/1000",
-		)
-		log.Debug().Str("socket", drmSock).Msg("DRM manager socket found, setting scanout env vars")
-	}
-	// Pass QEMU frame export port unconditionally — detect-render-node.sh can
-	// independently trigger scanout mode (GPU_VENDOR=virtio) even without the
-	// DRM socket, and desktop-bridge needs the correct port either way.
-	if fePort := os.Getenv("HELIX_FRAME_EXPORT_PORT"); fePort != "" {
-		env = append(env, "HELIX_FRAME_EXPORT_PORT="+fePort)
+		// For virtio-gpu (macOS ARM): set scanout mode environment variables
+		// These tell detect-render-node.sh and desktop-bridge to use the
+		// DRM lease → QEMU VideoToolbox H.264 pipeline instead of PipeWire.
+		drmSock := "/run/helix-drm/drm.sock"
+		if _, err := os.Stat(drmSock); err == nil {
+			env = append(env,
+				"GPU_VENDOR=virtio",
+				"HELIX_SCANOUT_MODE=1",
+				"HELIX_VIDEO_MODE=scanout",
+				"XDG_RUNTIME_DIR=/run/user/1000",
+			)
+			log.Debug().Str("socket", drmSock).Msg("DRM manager socket found, setting scanout env vars")
+		}
+		// Pass QEMU frame export port unconditionally — detect-render-node.sh can
+		// independently trigger scanout mode (GPU_VENDOR=virtio) even without the
+		// DRM socket, and desktop-bridge needs the correct port either way.
+		if fePort := os.Getenv("HELIX_FRAME_EXPORT_PORT"); fePort != "" {
+			env = append(env, "HELIX_FRAME_EXPORT_PORT="+fePort)
+		}
 	}
 
 	// Pass Docker nesting depth for address pool isolation.
@@ -1032,10 +1037,12 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 	}
 
 	resources := container.Resources{
-		DeviceCgroupRules: dm.getDeviceCgroupRules(),
 		Ulimits: []*units.Ulimit{
 			{Name: "nofile", Soft: 65536, Hard: 65536},
 		},
+	}
+	if req.ContainerType != DevContainerTypeHeadless {
+		resources.DeviceCgroupRules = dm.getDeviceCgroupRules()
 	}
 	// Apply CPU and memory limits when requested. NanoCPUs uses 10^9 units per CPU.
 	resources.NanoCPUs, resources.Memory, resources.MemorySwap = sandboxResourceLimits(req.VCPUs, req.MemoryMB)

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -46,6 +46,37 @@ func TestSandboxResourceLimits(t *testing.T) {
 	}
 }
 
+func TestBuildEnvHeadlessOmitsDisplayAndGPU(t *testing.T) {
+	t.Setenv("HELIX_FRAME_EXPORT_PORT", "19000")
+	gpuIndex := 0
+	env := (&DevContainerManager{}).buildEnv(&CreateDevContainerRequest{
+		ContainerType: DevContainerTypeHeadless,
+		DisplayWidth:  1920,
+		DisplayHeight: 1080,
+		DisplayFPS:    60,
+		GPUVendor:     "nvidia",
+		GPUIndex:      &gpuIndex,
+	})
+
+	for _, entry := range env {
+		for _, prefix := range []string{
+			"GAMESCOPE_",
+			"NVIDIA_",
+			"GPU_VENDOR=",
+			"GST_DEBUG=",
+			"CUDA_VISIBLE_DEVICES=",
+			"HELIX_GPU_INDEX=",
+			"HELIX_SCANOUT_MODE=",
+			"HELIX_VIDEO_MODE=",
+			"HELIX_FRAME_EXPORT_PORT=",
+		} {
+			if strings.HasPrefix(entry, prefix) {
+				t.Fatalf("headless environment contains display/GPU setting %q", entry)
+			}
+		}
+	}
+}
+
 func TestResolveRegistryImage(t *testing.T) {
 	// Create a temp dir to act as /opt/images for tests
 	tmpDir := t.TempDir()

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -34,7 +34,7 @@ type DevContainerType string
 const (
 	DevContainerTypeSway     DevContainerType = "sway"     // Sway compositor with Zed
 	DevContainerTypeUbuntu   DevContainerType = "ubuntu"   // GNOME with Zed
-	DevContainerTypeHeadless DevContainerType = "headless" // No GUI, just agent (future)
+	DevContainerTypeHeadless DevContainerType = "headless" // No GUI, agent-only runtime
 )
 
 // DevContainerStatus represents the current status of a dev container

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -24456,7 +24456,7 @@ const docTemplate = `{
                 "headless"
             ],
             "x-enum-comments": {
-                "DevContainerTypeHeadless": "No GUI, just agent (future)",
+                "DevContainerTypeHeadless": "No GUI, agent-only runtime",
                 "DevContainerTypeSway": "Sway compositor with Zed",
                 "DevContainerTypeUbuntu": "GNOME with Zed"
             },
@@ -30372,6 +30372,9 @@ const docTemplate = `{
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "type": {
                     "type": "string"
@@ -37374,6 +37377,9 @@ const docTemplate = `{
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",
                     "type": "string"
@@ -38216,6 +38222,9 @@ const docTemplate = `{
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -33867,6 +33867,14 @@ const docTemplate = `{
                     "description": "Project-level repository management\nDefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo",
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for new spec tasks. Empty values from legacy\nprojects resolve to the full desktop runtime.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "deleted_at": {
                     "description": "Soft delete timestamp",
                     "allOf": [
@@ -34173,6 +34181,14 @@ const docTemplate = `{
                 "default_repo_id": {
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },
@@ -34385,6 +34401,14 @@ const docTemplate = `{
                 },
                 "default_repo_id": {
                     "type": "string"
+                },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -402,6 +402,9 @@ func (s *HelixAPIServer) createProject(_ http.ResponseWriter, r *http.Request) (
 	if req.DefaultHelixAppID == "" {
 		return nil, system.NewHTTPError400("default helix app ID is required")
 	}
+	if !types.ValidSpecTaskSandboxRuntime(req.DefaultSandboxRuntime) {
+		return nil, system.NewHTTPError400(fmt.Sprintf("invalid default sandbox runtime %q", req.DefaultSandboxRuntime))
+	}
 
 	if req.OrganizationID != "" {
 		org, err := s.lookupOrg(r.Context(), req.OrganizationID)
@@ -469,19 +472,20 @@ func (s *HelixAPIServer) createProject(_ http.ResponseWriter, r *http.Request) (
 	}
 
 	project := &types.Project{
-		OrganizationID:    req.OrganizationID,
-		ID:                system.GenerateProjectID(),
-		Name:              req.Name,
-		Description:       req.Description,
-		UserID:            user.ID,
-		GitHubRepoURL:     req.GitHubRepoURL,
-		DefaultBranch:     req.DefaultBranch,
-		Technologies:      req.Technologies,
-		Status:            "active",
-		DefaultRepoID:     req.DefaultRepoID,
-		StartupScript:     req.StartupScript,
-		DefaultHelixAppID: req.DefaultHelixAppID,
-		Guidelines:        req.Guidelines,
+		OrganizationID:        req.OrganizationID,
+		ID:                    system.GenerateProjectID(),
+		Name:                  req.Name,
+		Description:           req.Description,
+		UserID:                user.ID,
+		GitHubRepoURL:         req.GitHubRepoURL,
+		DefaultBranch:         req.DefaultBranch,
+		Technologies:          req.Technologies,
+		Status:                "active",
+		DefaultRepoID:         req.DefaultRepoID,
+		StartupScript:         req.StartupScript,
+		DefaultHelixAppID:     req.DefaultHelixAppID,
+		DefaultSandboxRuntime: types.EffectiveSpecTaskSandboxRuntime(req.DefaultSandboxRuntime),
+		Guidelines:            req.Guidelines,
 	}
 
 	created, err := s.Store.CreateProject(r.Context(), project)
@@ -702,6 +706,12 @@ func (s *HelixAPIServer) updateProject(_ http.ResponseWriter, r *http.Request) (
 	if req.DefaultHelixAppID != nil {
 		project.DefaultHelixAppID = *req.DefaultHelixAppID
 	}
+	if req.DefaultSandboxRuntime != nil {
+		if !types.ValidSpecTaskSandboxRuntime(*req.DefaultSandboxRuntime) {
+			return nil, system.NewHTTPError400(fmt.Sprintf("invalid default sandbox runtime %q", *req.DefaultSandboxRuntime))
+		}
+		project.DefaultSandboxRuntime = types.EffectiveSpecTaskSandboxRuntime(*req.DefaultSandboxRuntime)
+	}
 	if req.ProjectManagerHelixAppID != nil {
 		project.ProjectManagerHelixAppID = *req.ProjectManagerHelixAppID
 	}
@@ -861,6 +871,9 @@ func (s *HelixAPIServer) updateProject(_ http.ResponseWriter, r *http.Request) (
 		}
 		if req.DefaultHelixAppID != nil {
 			changedFields = append(changedFields, "default_helix_app_id")
+		}
+		if req.DefaultSandboxRuntime != nil {
+			changedFields = append(changedFields, "default_sandbox_runtime")
 		}
 		if req.ProjectManagerHelixAppID != nil {
 			changedFields = append(changedFields, "project_manager_helix_app_id")

--- a/api/pkg/server/project_handlers_test.go
+++ b/api/pkg/server/project_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -85,6 +86,43 @@ func (s *ProjectRepositoryHandlersSuite) detachRequest(projectID, repoID string)
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/projects/"+projectID+"/repositories/"+repoID+"/detach", http.NoBody)
 	req = req.WithContext(s.authCtx)
 	return mux.SetURLVars(req, map[string]string{"id": projectID, "repo_id": repoID})
+}
+
+func (s *ProjectRepositoryHandlersSuite) updateRequest(projectID, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/projects/"+projectID, strings.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	return mux.SetURLVars(req, map[string]string{"id": projectID})
+}
+
+func (s *ProjectRepositoryHandlersSuite) TestUpdateProjectSetsDefaultSandboxRuntime() {
+	project := s.makeProject("proj-runtime", "repo-1")
+	s.store.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil)
+	s.store.EXPECT().UpdateProject(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.Project) error {
+			s.Equal(types.SandboxRuntimeHeadlessUbuntu, updated.DefaultSandboxRuntime)
+			return nil
+		},
+	)
+
+	resp, httpErr := s.server.updateProject(
+		httptest.NewRecorder(),
+		s.updateRequest(project.ID, `{"default_sandbox_runtime":"headless-ubuntu"}`),
+	)
+	s.Nil(httpErr)
+	s.Equal(types.SandboxRuntimeHeadlessUbuntu, resp.DefaultSandboxRuntime)
+}
+
+func (s *ProjectRepositoryHandlersSuite) TestUpdateProjectRejectsInvalidDefaultSandboxRuntime() {
+	project := s.makeProject("proj-runtime-invalid", "repo-1")
+	s.store.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil)
+
+	resp, httpErr := s.server.updateProject(
+		httptest.NewRecorder(),
+		s.updateRequest(project.ID, `{"default_sandbox_runtime":"windows"}`),
+	)
+	s.Nil(resp)
+	s.NotNil(httpErr)
+	s.Equal(http.StatusBadRequest, httpErr.StatusCode)
 }
 
 // ---------------------------------------------------------------------------

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -190,6 +190,10 @@ func (s *HelixAPIServer) createTaskFromPrompt(w http.ResponseWriter, r *http.Req
 		http.Error(w, "sandbox size must be 1 CPU/2 GB, 4 CPU/8 GB, or 8 CPU/16 GB", http.StatusBadRequest)
 		return
 	}
+	if !types.ValidSpecTaskSandboxRuntime(req.SandboxRuntime) {
+		http.Error(w, "sandbox runtime must be ubuntu-desktop or headless-ubuntu", http.StatusBadRequest)
+		return
+	}
 	if req.CodeAgentOverrides != nil {
 		if err := s.validateCodeAgentOverrides(ctx, req.AppID, req.CodeAgentOverrides, user.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/pkg/server/spec_task_clone_handlers.go
+++ b/api/pkg/server/spec_task_clone_handlers.go
@@ -200,6 +200,7 @@ func (s *HelixAPIServer) cloneTaskToProject(ctx context.Context, source *types.S
 		TechnicalDesign:     technicalDesign,
 		ImplementationPlan:  implementationPlan,
 		JustDoItMode:        source.JustDoItMode,
+		SandboxRuntime:      types.EffectiveSpecTaskSandboxRuntime(source.SandboxRuntime),
 		ClonedFromID:        source.ID,
 		ClonedFromProjectID: source.ProjectID,
 		CloneGroupID:        cloneGroupID,

--- a/api/pkg/server/spec_task_clone_handlers_test.go
+++ b/api/pkg/server/spec_task_clone_handlers_test.go
@@ -29,6 +29,7 @@ func TestCloneTaskToProject_WithSpecs_GoesToSpecGeneration(t *testing.T) {
 		TechnicalDesign:    "# Technical Design\nSome design",
 		ImplementationPlan: "# Implementation Plan\nSome plan",
 		JustDoItMode:       false,
+		SandboxRuntime:     types.SandboxRuntimeHeadlessUbuntu,
 	}
 
 	targetProjectID := "target-project-id"
@@ -76,6 +77,7 @@ func TestCloneTaskToProject_WithSpecs_GoesToSpecGeneration(t *testing.T) {
 	assert.Equal(t, sourceTask.RequirementsSpec, createdTask.RequirementsSpec)
 	assert.Equal(t, sourceTask.TechnicalDesign, createdTask.TechnicalDesign)
 	assert.Equal(t, sourceTask.ImplementationPlan, createdTask.ImplementationPlan)
+	assert.Equal(t, types.SandboxRuntimeHeadlessUbuntu, createdTask.SandboxRuntime)
 
 	// Verify UserID and OrganizationID are set correctly
 	assert.Equal(t, userID, createdTask.UserID, "UserID should be set from the user creating the clone")

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -33863,6 +33863,14 @@
                     "description": "Project-level repository management\nDefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo",
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for new spec tasks. Empty values from legacy\nprojects resolve to the full desktop runtime.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "deleted_at": {
                     "description": "Soft delete timestamp",
                     "allOf": [
@@ -34169,6 +34177,14 @@
                 "default_repo_id": {
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },
@@ -34381,6 +34397,14 @@
                 },
                 "default_repo_id": {
                     "type": "string"
+                },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -24452,7 +24452,7 @@
                 "headless"
             ],
             "x-enum-comments": {
-                "DevContainerTypeHeadless": "No GUI, just agent (future)",
+                "DevContainerTypeHeadless": "No GUI, agent-only runtime",
                 "DevContainerTypeSway": "Sway compositor with Zed",
                 "DevContainerTypeUbuntu": "GNOME with Zed"
             },
@@ -30368,6 +30368,9 @@
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "type": {
                     "type": "string"
@@ -37370,6 +37373,9 @@
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",
                     "type": "string"
@@ -38212,6 +38218,9 @@
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -7894,6 +7894,12 @@ definitions:
           Project-level repository management
           DefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          Default sandbox environment for new spec tasks. Empty values from legacy
+          projects resolve to the full desktop runtime.
       deleted_at:
         allOf:
         - $ref: '#/definitions/gorm.DeletedAt'
@@ -8111,6 +8117,10 @@ definitions:
         type: string
       default_repo_id:
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: Default sandbox environment for spec tasks
       description:
         type: string
       github_repo_url:
@@ -8251,6 +8261,10 @@ definitions:
         type: string
       default_repo_id:
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: Default sandbox environment for spec tasks
       description:
         type: string
       github_repo_url:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1117,7 +1117,7 @@ definitions:
     - headless
     type: string
     x-enum-comments:
-      DevContainerTypeHeadless: No GUI, just agent (future)
+      DevContainerTypeHeadless: No GUI, agent-only runtime
       DevContainerTypeSway: Sway compositor with Zed
       DevContainerTypeUbuntu: GNOME with Zed
     x-enum-varnames:
@@ -5379,6 +5379,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       type:
         type: string
       user_email:
@@ -10586,6 +10588,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       sandbox_state:
         description: '"absent", "running", "starting" — derived from session config
           in listTasks'
@@ -11236,6 +11240,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       sandbox_state:
         description: '"absent", "running", "starting" — derived from session config
           in listTasks'

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -136,6 +136,9 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 	if req.SandboxResourceOverrides != nil && !req.SandboxResourceOverrides.ValidPreset() {
 		return nil, fmt.Errorf("invalid sandbox resource preset")
 	}
+	if !types.ValidSpecTaskSandboxRuntime(req.SandboxRuntime) {
+		return nil, fmt.Errorf("invalid spec task sandbox runtime %q", req.SandboxRuntime)
+	}
 	sandboxResources := req.SandboxResourceOverrides
 	if sandboxResources == nil {
 		sandboxResources = types.DefaultSpecTaskSandboxResources()
@@ -221,6 +224,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		HelixAppID:               helixAppID, // Helix agent used for entire workflow
 		CodeAgentOverrides:       req.CodeAgentOverrides,
 		SandboxResourceOverrides: sandboxResources,
+		SandboxRuntime:           types.EffectiveSpecTaskSandboxRuntime(req.SandboxRuntime),
 		JustDoItMode:             req.JustDoItMode, // Set Just Do It mode from request
 		// Credential-only override: whose Claude subscription authenticates this
 		// task's agent. Enforced at resolution time against the named user's

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -152,6 +152,11 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 			return nil, fmt.Errorf("failed to get project: %w", err)
 		}
 	}
+	sandboxRuntime := req.SandboxRuntime
+	if sandboxRuntime == "" && project != nil {
+		sandboxRuntime = project.DefaultSandboxRuntime
+	}
+	sandboxRuntime = types.EffectiveSpecTaskSandboxRuntime(sandboxRuntime)
 
 	// Determine which agent to use (single agent for entire workflow)
 	// Priority: request.AppID > project.DefaultHelixAppID > error if not found
@@ -224,7 +229,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		HelixAppID:               helixAppID, // Helix agent used for entire workflow
 		CodeAgentOverrides:       req.CodeAgentOverrides,
 		SandboxResourceOverrides: sandboxResources,
-		SandboxRuntime:           types.EffectiveSpecTaskSandboxRuntime(req.SandboxRuntime),
+		SandboxRuntime:           sandboxRuntime,
 		JustDoItMode:             req.JustDoItMode, // Set Just Do It mode from request
 		// Credential-only override: whose Claude subscription authenticates this
 		// task's agent. Enforced at resolution time against the named user's

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -136,14 +136,17 @@ func TestSpecDrivenTaskService_AutoStartAssignsStarter(t *testing.T) {
 	service.SetTestMode(true)
 
 	ctx := context.Background()
-	mockStore.EXPECT().GetProject(ctx, "test-project").Return(&types.Project{ID: "test-project"}, nil)
+	mockStore.EXPECT().GetProject(ctx, "test-project").Return(&types.Project{
+		ID:                    "test-project",
+		DefaultSandboxRuntime: types.SandboxRuntimeHeadlessUbuntu,
+	}, nil)
 	mockStore.EXPECT().IncrementGlobalTaskNumber(ctx).Return(1, nil)
 	mockStore.EXPECT().CreateSpecTask(ctx, gomock.Any()).DoAndReturn(
 		func(_ context.Context, task *types.SpecTask) error {
 			require.Equal(t, "starter", task.AssigneeID)
 			require.Equal(t, "starter", task.PlanningStartedBy)
 			require.Equal(t, types.DefaultSpecTaskSandboxResources(), task.SandboxResourceOverrides)
-			require.Equal(t, types.SandboxRuntimeUbuntuDesktop, task.SandboxRuntime)
+			require.Equal(t, types.SandboxRuntimeHeadlessUbuntu, task.SandboxRuntime)
 			return nil
 		},
 	)

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -47,6 +47,7 @@ func TestSpecDrivenTaskService_CreateTaskFromPrompt(t *testing.T) {
 		UserID:                   "test-user",
 		CodeAgentOverrides:       &types.CodeAgentOverrides{Model: "gpt-5.6-sol", ReasoningEffort: "high"},
 		SandboxResourceOverrides: &types.SandboxResourceOverrides{VCPUs: 4, MemoryMB: 8192},
+		SandboxRuntime:           types.SandboxRuntimeHeadlessUbuntu,
 	}
 
 	// Mock expectations
@@ -68,6 +69,7 @@ func TestSpecDrivenTaskService_CreateTaskFromPrompt(t *testing.T) {
 			assert.Equal(t, types.SpecTaskPriorityHigh, task.Priority)
 			assert.Equal(t, req.CodeAgentOverrides, task.CodeAgentOverrides)
 			assert.Equal(t, req.SandboxResourceOverrides, task.SandboxResourceOverrides)
+			assert.Equal(t, types.SandboxRuntimeHeadlessUbuntu, task.SandboxRuntime)
 			// Task number and design doc path should be assigned at creation
 			assert.Equal(t, 1, task.TaskNumber)
 			assert.NotEmpty(t, task.DesignDocPath)
@@ -93,6 +95,17 @@ func TestSpecDrivenTaskService_CreateTaskFromPrompt(t *testing.T) {
 	assert.NotEmpty(t, task.DesignDocPath)
 
 	// Note: Goroutine will fail gracefully, we only test the synchronous part
+}
+
+func TestSpecDrivenTaskService_CreateTaskFromPromptRejectsInvalidSandboxRuntime(t *testing.T) {
+	service := NewSpecDrivenTaskService(
+		nil, nil, "test-helix-agent", nil, nil, nil, nil, nil, NewDisabledKoditService(),
+	)
+	task, err := service.CreateTaskFromPrompt(context.Background(), &types.CreateTaskRequest{
+		SandboxRuntime: types.SandboxRuntime("windows-desktop"),
+	})
+	require.EqualError(t, err, `invalid spec task sandbox runtime "windows-desktop"`)
+	require.Nil(t, task)
 }
 
 func TestSpecDrivenTaskService_CreateTaskFromPromptRejectsInvalidSandboxPreset(t *testing.T) {
@@ -130,6 +143,7 @@ func TestSpecDrivenTaskService_AutoStartAssignsStarter(t *testing.T) {
 			require.Equal(t, "starter", task.AssigneeID)
 			require.Equal(t, "starter", task.PlanningStartedBy)
 			require.Equal(t, types.DefaultSpecTaskSandboxResources(), task.SandboxResourceOverrides)
+			require.Equal(t, types.SandboxRuntimeUbuntuDesktop, task.SandboxRuntime)
 			return nil
 		},
 	)

--- a/api/pkg/types/project.go
+++ b/api/pkg/types/project.go
@@ -236,6 +236,9 @@ type Project struct {
 	// Default agent for spec tasks in this project (App ID)
 	// New spec tasks inherit this agent; can be overridden per-task
 	DefaultHelixAppID string `json:"default_helix_app_id"`
+	// Default sandbox environment for new spec tasks. Empty values from legacy
+	// projects resolve to the full desktop runtime.
+	DefaultSandboxRuntime SandboxRuntime `json:"default_sandbox_runtime,omitempty" gorm:"size:64"`
 
 	ProjectManagerHelixAppID string `json:"project_manager_helix_app_id"`
 
@@ -363,17 +366,18 @@ type ProjectTasksResponse struct {
 
 // ProjectCreateRequest represents a request to create a new project
 type ProjectCreateRequest struct {
-	OrganizationID    string           `json:"organization_id"`
-	Name              string           `json:"name"`
-	Description       string           `json:"description"`
-	GitHubRepoURL     string           `json:"github_repo_url,omitempty"`
-	DefaultBranch     string           `json:"default_branch,omitempty"`
-	Technologies      []string         `json:"technologies,omitempty"`
-	DefaultRepoID     string           `json:"default_repo_id,omitempty"`
-	StartupScript     string           `json:"startup_script,omitempty"`
-	DefaultHelixAppID string           `json:"default_helix_app_id,omitempty"` // Default agent for spec tasks
-	Guidelines        string           `json:"guidelines,omitempty"`           // Project-specific AI agent guidelines
-	Skills            *AssistantSkills `json:"skills,omitempty"`               // Project-level skills
+	OrganizationID        string           `json:"organization_id"`
+	Name                  string           `json:"name"`
+	Description           string           `json:"description"`
+	GitHubRepoURL         string           `json:"github_repo_url,omitempty"`
+	DefaultBranch         string           `json:"default_branch,omitempty"`
+	Technologies          []string         `json:"technologies,omitempty"`
+	DefaultRepoID         string           `json:"default_repo_id,omitempty"`
+	StartupScript         string           `json:"startup_script,omitempty"`
+	DefaultHelixAppID     string           `json:"default_helix_app_id,omitempty"`    // Default agent for spec tasks
+	DefaultSandboxRuntime SandboxRuntime   `json:"default_sandbox_runtime,omitempty"` // Default sandbox environment for spec tasks
+	Guidelines            string           `json:"guidelines,omitempty"`              // Project-specific AI agent guidelines
+	Skills                *AssistantSkills `json:"skills,omitempty"`                  // Project-level skills
 }
 
 // ProjectUpdateRequest represents a request to update a project
@@ -388,6 +392,7 @@ type ProjectUpdateRequest struct {
 	StartupScript                 *string          `json:"startup_script,omitempty"`
 	AutoStartBacklogTasks         *bool            `json:"auto_start_backlog_tasks,omitempty"`
 	DefaultHelixAppID             *string          `json:"default_helix_app_id,omitempty"`               // Default agent for spec tasks
+	DefaultSandboxRuntime         *SandboxRuntime  `json:"default_sandbox_runtime,omitempty"`            // Default sandbox environment for spec tasks
 	ProjectManagerHelixAppID      *string          `json:"project_manager_helix_app_id,omitempty"`       // Project manager agent
 	PullRequestReviewerHelixAppID *string          `json:"pull_request_reviewer_helix_app_id,omitempty"` // Pull request reviewer agent
 	PullRequestReviewsEnabled     *bool            `json:"pull_request_reviews_enabled,omitempty"`       // Whether pull request reviews are enabled

--- a/api/pkg/types/sandbox.go
+++ b/api/pkg/types/sandbox.go
@@ -7,8 +7,6 @@ import (
 )
 
 // SandboxRuntime identifies the type of sandbox to create.
-// Today only ubuntu-desktop is implemented; later runtimes will spin up
-// lightweight Docker containers.
 type SandboxRuntime string
 
 const (
@@ -17,9 +15,9 @@ const (
 	// user can stream into and exec commands inside.
 	SandboxRuntimeUbuntuDesktop SandboxRuntime = "ubuntu-desktop"
 
-	// SandboxRuntimeHeadlessUbuntu spins up a plain `ubuntu:22.04` container
-	// running `sleep infinity` — no GUI, no agent, just a long-lived shell
-	// to exec into. Useful for CI-style scripted workloads.
+	// SandboxRuntimeHeadlessUbuntu selects an Ubuntu runtime without a GUI.
+	// Standalone sandboxes use the configured lightweight image; spec tasks use
+	// the Helix agent toolchain image without compositor or streaming services.
 	SandboxRuntimeHeadlessUbuntu SandboxRuntime = "headless-ubuntu"
 )
 

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -122,6 +122,24 @@ func (r SandboxResourceOverrides) ValidPreset() bool {
 	}
 }
 
+// EffectiveSpecTaskSandboxRuntime keeps legacy tasks on the full desktop while
+// allowing newly-created tasks to opt into the headless agent runtime.
+func EffectiveSpecTaskSandboxRuntime(runtime SandboxRuntime) SandboxRuntime {
+	if runtime == "" {
+		return SandboxRuntimeUbuntuDesktop
+	}
+	return runtime
+}
+
+func ValidSpecTaskSandboxRuntime(runtime SandboxRuntime) bool {
+	switch runtime {
+	case "", SandboxRuntimeUbuntuDesktop, SandboxRuntimeHeadlessUbuntu:
+		return true
+	default:
+		return false
+	}
+}
+
 // Request types
 type CreateTaskRequest struct {
 	ProjectID string `json:"project_id"`
@@ -140,6 +158,7 @@ type CreateTaskRequest struct {
 
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
+	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty"`
 
 	// CredentialOwnerID optionally names the user whose Claude subscription should
 	// authenticate this task's agent, for orchestrators dispatching work on a
@@ -198,6 +217,7 @@ type SpecTask struct {
 
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
+	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty" gorm:"size:64"`
 
 	// Git repository attachments: REMOVED - now inherited from parent Project
 	// Repos are managed at the project level. Access via project.DefaultRepoID and GetProjectRepositories(project_id)
@@ -457,7 +477,6 @@ type SpecTaskExecutionConfigUpdateRequest struct {
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
 }
-
 
 type SpecTaskExecutionConfigUpdateResponse struct {
 	Task                    *SpecTask `json:"task"`

--- a/design/2026-08-14-headless-spec-tasks.md
+++ b/design/2026-08-14-headless-spec-tasks.md
@@ -30,3 +30,9 @@ views omit the Desktop tab and initially collapse the task panel; users can
 expand it to inspect changes and task details. The environment remains visible
 in that menu after launch but is locked, with a tooltip directing users to
 start a new task if they need a different runtime.
+
+The last environment a user selects is stored per project in the browser and
+becomes that user's next-task default. A project owner can also set the shared
+baseline in Project Settings → Sandbox. The personal preference wins once a
+user makes an explicit choice; otherwise the project default is used. API
+clients that omit `sandbox_runtime` inherit the project default on the server.

--- a/design/2026-08-14-headless-spec-tasks.md
+++ b/design/2026-08-14-headless-spec-tasks.md
@@ -12,10 +12,13 @@ and nested Docker toolchain. `HELIX_HEADLESS=1` selects an agent-only startup
 path in that image:
 
 - Zed starts with `--headless`.
-- GNOME, desktop-bridge, streaming, render-node detection, scanout setup, and
-  NVIDIA runtime configuration do not start.
-- Hydra does not inject display or GPU configuration and does not wait for the
-  desktop bridge.
+- GNOME, streaming, render-node detection, scanout setup, and NVIDIA runtime
+  configuration do not start.
+- The desktop bridge runs in workspace-only mode. It exposes the file, diff,
+  checkpoint, and fixed git-plumbing APIs through RevDial without initializing
+  GStreamer, D-Bus, a compositor, input, video, screenshots, or desktop MCP.
+- Hydra does not inject display or GPU configuration. It waits for the
+  workspace-only bridge before declaring the headless sandbox ready.
 - Workspace setup, settings sync, and nested Docker remain available.
 
 The owning task is the source of truth for runtime on every launch path,

--- a/design/2026-08-14-headless-spec-tasks.md
+++ b/design/2026-08-14-headless-spec-tasks.md
@@ -1,0 +1,32 @@
+# Headless spec tasks
+
+Spec tasks can be created with either `ubuntu-desktop` or `headless-ubuntu` as
+an immutable sandbox runtime. Existing tasks with no stored runtime continue to
+use the full desktop.
+
+## Runtime
+
+Headless spec tasks use the versioned `helix-ubuntu` image because the agent
+requires the bundled Zed binary, ACP harnesses, workspace setup, settings sync,
+and nested Docker toolchain. `HELIX_HEADLESS=1` selects an agent-only startup
+path in that image:
+
+- Zed starts with `--headless`.
+- GNOME, desktop-bridge, streaming, render-node detection, scanout setup, and
+  NVIDIA runtime configuration do not start.
+- Hydra does not inject display or GPU configuration and does not wait for the
+  desktop bridge.
+- Workspace setup, settings sync, and nested Docker remain available.
+
+The owning task is the source of truth for runtime on every launch path,
+including resume, fork, and reconciliation. This prevents a headless task from
+being restarted as a desktop later.
+
+## UI
+
+Task creation exposes compute and environment in one compact sectioned menu
+on both the home chat composer and board form. Headless task detail
+views omit the Desktop tab and initially collapse the task panel; users can
+expand it to inspect changes and task details. The environment remains visible
+in that menu after launch but is locked, with a tooltip directing users to
+start a new task if they need a different runtime.

--- a/desktop/shared/17-scanout-setup.sh
+++ b/desktop/shared/17-scanout-setup.sh
@@ -2,7 +2,7 @@
 # Start system D-Bus daemon for scanout mode (macOS ARM).
 # logind-stub needs the system bus to register org.freedesktop.login1.
 # This script runs as root during container init (before gosu).
-if [ "${GPU_VENDOR}" = "virtio" ] && [ ! -S /var/run/dbus/system_bus_socket ]; then
+if [ "${HELIX_HEADLESS}" != "1" ] && [ "${GPU_VENDOR}" = "virtio" ] && [ ! -S /var/run/dbus/system_bus_socket ]; then
     echo "**** Starting system D-Bus for scanout mode ****"
     mkdir -p /var/run/dbus
     dbus-daemon --system --fork 2>/dev/null && echo "System D-Bus started" || { echo "FATAL: Failed to start system D-Bus"; exit 1; }

--- a/desktop/shared/17-start-dockerd.sh
+++ b/desktop/shared/17-start-dockerd.sh
@@ -80,7 +80,7 @@ echo "[dockerd] /var/lib/docker is a volume mount - starting dockerd"
 EOF
 
     # Add NVIDIA runtime if GPU available
-    if [ -e /dev/nvidia0 ] && command -v nvidia-container-runtime &>/dev/null; then
+    if [ "${HELIX_HEADLESS}" != "1" ] && [ -e /dev/nvidia0 ] && command -v nvidia-container-runtime &>/dev/null; then
         echo "[dockerd] NVIDIA GPU detected - adding nvidia runtime"
         cat > /etc/docker/daemon.json <<EOF
 {

--- a/desktop/shared/start-headless-workspace-bridge.sh
+++ b/desktop/shared/start-headless-workspace-bridge.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SERVICE_NAME="headless-workspace-bridge"
+
+while true; do
+    /usr/local/bin/desktop-bridge 2>&1 | sed -u "s/^/[${SERVICE_NAME}] /"
+    exit_code=$?
+    echo "[${SERVICE_NAME}] Process exited with code ${exit_code}, restarting in 2s..."
+    sleep 2
+done

--- a/desktop/shared/start-settings-sync-daemon.sh
+++ b/desktop/shared/start-settings-sync-daemon.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Shared init script for settings-sync-daemon
 # Used by both Ubuntu and Sway startup scripts
-# Waits for Wayland socket, then starts settings-sync-daemon with log prefix
+# Waits for Wayland when a desktop is present, then starts settings-sync-daemon
+# with a log prefix. Headless sessions only require D-Bus.
 # Must be launched from within dbus-run-session (inherits DBUS_SESSION_BUS_ADDRESS)
 
 set -e
@@ -36,33 +37,36 @@ if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
 fi
 log "D-Bus session: ${DBUS_SESSION_BUS_ADDRESS}"
 
-# Wait for Wayland socket (settings-sync-daemon may need display access)
-# Sway uses wayland-1, GNOME uses wayland-0
 WAYLAND_SOCKET=""
-log "Waiting for Wayland socket..."
-for i in $(seq 1 60); do
-    if [ -S "${XDG_RUNTIME_DIR}/wayland-1" ]; then
-        WAYLAND_SOCKET="wayland-1"
-        break
-    elif [ -S "${XDG_RUNTIME_DIR}/wayland-0" ]; then
-        WAYLAND_SOCKET="wayland-0"
-        break
-    fi
-    sleep 0.5
-done
+if [ "${HELIX_HEADLESS}" = "1" ]; then
+    log "Headless mode: no Wayland socket required"
+else
+    # Sway uses wayland-1, GNOME uses wayland-0.
+    log "Waiting for Wayland socket..."
+    for i in $(seq 1 60); do
+        if [ -S "${XDG_RUNTIME_DIR}/wayland-1" ]; then
+            WAYLAND_SOCKET="wayland-1"
+            break
+        elif [ -S "${XDG_RUNTIME_DIR}/wayland-0" ]; then
+            WAYLAND_SOCKET="wayland-0"
+            break
+        fi
+        sleep 0.5
+    done
 
-if [ -z "$WAYLAND_SOCKET" ]; then
-    log "ERROR: No Wayland socket found after 30 seconds"
-    exit 1
+    if [ -z "$WAYLAND_SOCKET" ]; then
+        log "ERROR: No Wayland socket found after 30 seconds"
+        exit 1
+    fi
+    log "Wayland socket: ${WAYLAND_SOCKET}"
+    export WAYLAND_DISPLAY="$WAYLAND_SOCKET"
 fi
-log "Wayland socket: ${WAYLAND_SOCKET}"
 
 # Export environment for settings-sync-daemon
-export WAYLAND_DISPLAY="$WAYLAND_SOCKET"
 export DBUS_SESSION_BUS_ADDRESS
 
 # Set XDG_CURRENT_DESKTOP if not already set
-if [ -z "$XDG_CURRENT_DESKTOP" ]; then
+if [ -z "$XDG_CURRENT_DESKTOP" ] && [ -n "$WAYLAND_SOCKET" ]; then
     if [ "$WAYLAND_SOCKET" = "wayland-1" ]; then
         export XDG_CURRENT_DESKTOP="sway"
     else

--- a/desktop/shared/start-zed-core.sh
+++ b/desktop/shared/start-zed-core.sh
@@ -188,7 +188,11 @@ run_zed_restart_loop() {
     while true; do
         echo "Launching Zed..."
         # ZED_EXTRA_FILES can be set by desktop-specific script (e.g., user guide)
-        /zed-build/zed "${ZED_FOLDERS[@]}" "${ZED_EXTRA_FILES[@]}" || true
+        if [ "${HELIX_HEADLESS}" = "1" ]; then
+            /zed-build/zed --headless "${ZED_FOLDERS[@]}" "${ZED_EXTRA_FILES[@]}" || true
+        else
+            /zed-build/zed "${ZED_FOLDERS[@]}" "${ZED_EXTRA_FILES[@]}" || true
+        fi
         echo "Zed exited, restarting in 2 seconds..."
         sleep 2
     done

--- a/desktop/shared/start-zed-headless.sh
+++ b/desktop/shared/start-zed-headless.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+HELIX_DESKTOP_NAME="Headless"
+
+launch_terminal() {
+    local title="$1"
+    local working_dir="$2"
+    shift 2
+    (
+        cd "$working_dir"
+        "$@"
+        sleep infinity
+    ) >>"/tmp/helix-${title// /-}.log" 2>&1 &
+}
+
+source /usr/local/bin/start-zed-core.sh
+start_zed_helix

--- a/desktop/ubuntu-config/startup-app.sh
+++ b/desktop/ubuntu-config/startup-app.sh
@@ -87,6 +87,7 @@ gow_log "[start] Codex state directory set: $CODEX_STATE_DIR"
 if [ "${HELIX_HEADLESS}" = "1" ]; then
     gow_log "[start] Starting headless Zed agent without GNOME or streaming services"
     exec dbus-run-session -- bash -c '
+        /usr/local/bin/start-headless-workspace-bridge.sh &
         /usr/local/bin/start-settings-sync-daemon.sh &
         exec /usr/local/bin/start-zed-headless.sh
     '

--- a/desktop/ubuntu-config/startup-app.sh
+++ b/desktop/ubuntu-config/startup-app.sh
@@ -3,12 +3,16 @@
 # Extracted from Dockerfile.ubuntu-helix for consistency with Sway's startup-app.sh
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "[start] Starting Helix Desktop (Ubuntu GNOME Wayland)..."
+if [ "${HELIX_HEADLESS}" = "1" ]; then
+    gow_log "[start] Starting Helix headless agent..."
+else
+    gow_log "[start] Starting Helix Desktop (Ubuntu GNOME Wayland)..."
+fi
 
 # GPU detection - export HELIX_RENDER_NODE and LIBVA_DRIVER_NAME for GStreamer
 # The udev rule for Mutter was already created by the root init script,
 # but we need the env vars for the GStreamer pipelines in desktop-bridge
-if [ -f /usr/local/bin/detect-render-node.sh ]; then
+if [ "${HELIX_HEADLESS}" != "1" ] && [ -f /usr/local/bin/detect-render-node.sh ]; then
     source /usr/local/bin/detect-render-node.sh
     gow_log "[start] GPU: HELIX_RENDER_NODE=${HELIX_RENDER_NODE:-not set}, LIBVA_DRIVER_NAME=${LIBVA_DRIVER_NAME:-not set}"
 fi
@@ -79,6 +83,14 @@ if [ -d ~/.codex ] && [ ! -L ~/.codex ]; then
 fi
 rm -rf ~/.codex && ln -sf $CODEX_STATE_DIR ~/.codex
 gow_log "[start] Codex state directory set: $CODEX_STATE_DIR"
+
+if [ "${HELIX_HEADLESS}" = "1" ]; then
+    gow_log "[start] Starting headless Zed agent without GNOME or streaming services"
+    exec dbus-run-session -- bash -c '
+        /usr/local/bin/start-settings-sync-daemon.sh &
+        exec /usr/local/bin/start-zed-headless.sh
+    '
+fi
 
 # Note: RevDial client is now integrated into desktop-bridge
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3429,6 +3429,7 @@ export interface TypesCreateTaskRequest {
   project_id?: string;
   prompt?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  sandbox_runtime?: TypesSandboxRuntime;
   type?: string;
   /** Optional: User email for audit trail */
   user_email?: string;
@@ -6697,6 +6698,7 @@ export interface TypesSpecTask {
   /** User stories + EARS acceptance criteria (markdown) */
   requirements_spec?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  sandbox_runtime?: TypesSandboxRuntime;
   /** "absent", "running", "starting" — derived from session config in listTasks */
   sandbox_state?: string;
   /** Transient startup message e.g. "Unpacking build cache" */
@@ -7078,6 +7080,7 @@ export interface TypesSpecTaskWithProject {
   /** User stories + EARS acceptance criteria (markdown) */
   requirements_spec?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  sandbox_runtime?: TypesSandboxRuntime;
   /** "absent", "running", "starting" — derived from session config in listTasks */
   sandbox_state?: string;
   /** Transient startup message e.g. "Unpacking build cache" */

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4944,6 +4944,11 @@ export interface TypesProject {
    * DefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo
    */
   default_repo_id?: string;
+  /**
+   * Default sandbox environment for new spec tasks. Empty values from legacy
+   * projects resolve to the full desktop runtime.
+   */
+  default_sandbox_runtime?: TypesSandboxRuntime;
   /** Soft delete timestamp */
   deleted_at?: GormDeletedAt;
   description?: string;
@@ -5085,6 +5090,8 @@ export interface TypesProjectCreateRequest {
   /** Default agent for spec tasks */
   default_helix_app_id?: string;
   default_repo_id?: string;
+  /** Default sandbox environment for spec tasks */
+  default_sandbox_runtime?: TypesSandboxRuntime;
   description?: string;
   github_repo_url?: string;
   /** Project-specific AI agent guidelines */
@@ -5169,6 +5176,8 @@ export interface TypesProjectUpdateRequest {
   /** Default agent for spec tasks */
   default_helix_app_id?: string;
   default_repo_id?: string;
+  /** Default sandbox environment for spec tasks */
+  default_sandbox_runtime?: TypesSandboxRuntime;
   description?: string;
   github_repo_url?: string;
   /** Project-specific AI agent guidelines */

--- a/frontend/src/components/session/ProjectChatItemTooltip.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemTooltip.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { TypesCodeAgentRuntime } from '../../api/api'
+import { TypesCodeAgentRuntime, TypesSandboxRuntime } from '../../api/api'
 import { AppsContext, IAppsContext } from '../../contexts/apps'
 import type { IApp } from '../../types'
 import ProjectChatItemTooltip from './ProjectChatItemTooltip'
@@ -47,7 +47,7 @@ describe('ProjectChatItemTooltip', () => {
     expect(screen.getByText('claude-opus-4-6')).toBeInTheDocument()
   })
 
-  it('uses the agent configured on a spec task when no session summary is available', async () => {
+  it('uses the task configuration for agent, compute, and environment details', async () => {
     const agent = {
       id: 'app-codex',
       config: { helix: { assistants: [{ code_agent_runtime: 'codex_cli', model: 'gpt-5.6-sol' }] } },
@@ -59,7 +59,12 @@ describe('ProjectChatItemTooltip', () => {
             id: 'task-codex',
             kind: 'spec-task',
             title: 'Fix CI',
-            task: { id: 'task-codex', helix_app_id: agent.id },
+            task: {
+              id: 'task-codex',
+              helix_app_id: agent.id,
+              sandbox_resource_overrides: { vcpus: 8, memory_mb: 16384 },
+              sandbox_runtime: TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
+            },
           }}
         >
           <button>Spec task row</button>
@@ -71,5 +76,27 @@ describe('ProjectChatItemTooltip', () => {
 
     expect(await screen.findByText('Codex')).toBeInTheDocument()
     expect(screen.getByText('gpt-5.6-sol')).toBeInTheDocument()
+    expect(screen.getByText('8 vCPU · 16 GB RAM')).toBeInTheDocument()
+    expect(screen.getByText('Headless')).toBeInTheDocument()
+  })
+
+  it('shows legacy spec tasks with the default compute and desktop environment', async () => {
+    render(
+      <ProjectChatItemTooltip
+        item={{
+          id: 'task-defaults',
+          kind: 'spec-task',
+          title: 'Legacy task',
+          task: { id: 'task-defaults' },
+        }}
+      >
+        <button>Legacy task row</button>
+      </ProjectChatItemTooltip>,
+    )
+
+    fireEvent.mouseOver(screen.getByRole('button', { name: 'Legacy task row' }))
+
+    expect(await screen.findByText('4 vCPU · 8 GB RAM')).toBeInTheDocument()
+    expect(screen.getByText('Full Desktop')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/session/ProjectChatItemTooltip.tsx
+++ b/frontend/src/components/session/ProjectChatItemTooltip.tsx
@@ -2,9 +2,11 @@ import type { FC, ReactElement } from 'react'
 import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { BrainCircuit, FolderGit2, GitBranch } from 'lucide-react'
+import { BrainCircuit, Cpu, FolderGit2, GitBranch, Monitor, SquareTerminal } from 'lucide-react'
 
+import { TypesSandboxRuntime } from '../../api/api'
 import useApps from '../../hooks/useApps'
+import { effectiveSpecTaskSandboxRuntime } from '../../utils/specTaskSandboxRuntime'
 import AgentHarness, { getAgentHarnessModel, getAgentHarnessRuntime } from '../agent/AgentHarness'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
 
@@ -29,6 +31,22 @@ const runtimeLabel = (runtime?: string): string => {
   }
 }
 
+const sandboxDetails = (item: SidebarItem): { compute?: string; environment?: string } => {
+  if (item.kind !== 'spec-task' || !item.task) return {}
+
+  const vcpus = item.task.sandbox_resource_overrides?.vcpus || 4
+  const memoryMb = item.task.sandbox_resource_overrides?.memory_mb || 8192
+  const memory = memoryMb % 1024 === 0
+    ? `${memoryMb / 1024} GB RAM`
+    : `${memoryMb} MB RAM`
+  const environment = effectiveSpecTaskSandboxRuntime(item.task.sandbox_runtime)
+    === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
+    ? 'Headless'
+    : 'Full Desktop'
+
+  return { compute: `${vcpus} vCPU · ${memory}`, environment }
+}
+
 const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
   item,
   repository,
@@ -45,6 +63,7 @@ const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
   const model = configuredApp
     ? getAgentHarnessModel(configuredApp)
     : item.session?.model_name
+  const { compute, environment } = sandboxDetails(item)
   const rows = [
     repository && { icon: <FolderGit2 size={13} />, value: repository },
     branch && { icon: <GitBranch size={13} />, value: branch },
@@ -55,6 +74,11 @@ const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
       value: harness,
     },
     model && { icon: <BrainCircuit size={13} />, value: model },
+    compute && { icon: <Cpu size={13} />, value: compute },
+    environment && {
+      icon: environment === 'Headless' ? <SquareTerminal size={13} /> : <Monitor size={13} />,
+      value: environment,
+    },
   ].filter(Boolean) as Array<{ icon: ReactElement; value: string }>
 
   return (

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -42,6 +42,7 @@ import {
   TypesSpecTaskPriority,
   TypesBranchMode,
   TypesSandboxResourceOverrides,
+  TypesSandboxRuntime,
   TypesSpecTask,
   TypesSpecTaskStatus,
 } from "../../api/api";
@@ -146,6 +147,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     vcpus: 4,
     memory_mb: 8192,
   });
+  const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(
+    TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+  );
   // Goose recipe selection — only meaningful when the selected agent's runtime
   // is goose_code. Empty selectedRecipeName means "use vanilla goose"; the
   // backend skips baking and the agent's declared recipes are still available
@@ -432,6 +436,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     setSelectedHelixAgent("");
     setCodeAgentOverrides({});
     setSandboxResourceOverrides({ vcpus: 4, memory_mb: 8192 });
+    setSandboxRuntime(TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop);
     setSelectedRecipeName("");
     setRecipeParams({});
     // justDoItMode and autoStart intentionally kept — they persist to the next
@@ -511,6 +516,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
           ? codeAgentOverrides
           : undefined,
         sandbox_resource_overrides: sandboxResourceOverrides,
+        sandbox_runtime: sandboxRuntime,
       };
 
       const response = await api
@@ -1134,11 +1140,13 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                   selectedAgentId={selectedHelixAgent}
                   codeAgentOverrides={codeAgentOverrides}
                   sandboxResourceOverrides={sandboxResourceOverrides}
+                  sandboxRuntime={sandboxRuntime}
                   onAgentModelChange={(agentId, overrides) => {
                     setSelectedHelixAgent(agentId);
                     setCodeAgentOverrides(overrides);
                   }}
                   onSandboxResourceOverridesChange={setSandboxResourceOverrides}
+                  onSandboxRuntimeChange={setSandboxRuntime}
                 />
                 {selectedAgentIsGoose && (
                   <GooseRecipeSelector
@@ -1215,8 +1223,10 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                   agents={[]}
                   selectedAgentId=""
                   sandboxResourceOverrides={sandboxResourceOverrides}
+                  sandboxRuntime={sandboxRuntime}
                   onAgentModelChange={() => undefined}
                   onSandboxResourceOverridesChange={setSandboxResourceOverrides}
+                  onSandboxRuntimeChange={setSandboxRuntime}
                 />
               )}
             </Box>

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -62,6 +62,10 @@ import {
   useUploadSpecTaskAttachments,
 } from "../../services/specTaskAttachmentsService";
 import SpecTaskExecutionControls from "./SpecTaskExecutionControls";
+import {
+  preferredSpecTaskSandboxRuntime,
+  saveSpecTaskSandboxRuntimePreference,
+} from "../../utils/specTaskSandboxRuntime";
 
 const ATTACHMENT_ACCEPT_ATTR = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
   .flatMap(([mime, exts]) => [mime, ...exts])
@@ -147,8 +151,8 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     vcpus: 4,
     memory_mb: 8192,
   });
-  const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(
-    TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+  const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
+    preferredSpecTaskSandboxRuntime(projectId),
   );
   // Goose recipe selection — only meaningful when the selected agent's runtime
   // is goose_code. Empty selectedRecipeName means "use vanilla goose"; the
@@ -369,6 +373,18 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     setSelectedRecipeName("");
     setRecipeParams({});
   }, [selectedHelixAgent]);
+
+  useEffect(() => {
+    setSandboxRuntime(preferredSpecTaskSandboxRuntime(
+      projectId,
+      project?.default_sandbox_runtime,
+    ));
+  }, [projectId, project?.default_sandbox_runtime]);
+
+  const handleSandboxRuntimeChange = (runtime: TypesSandboxRuntime) => {
+    setSandboxRuntime(runtime);
+    saveSpecTaskSandboxRuntimePreference(projectId, runtime);
+  };
 
   // Load apps on mount
   useEffect(() => {
@@ -1146,7 +1162,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                     setCodeAgentOverrides(overrides);
                   }}
                   onSandboxResourceOverridesChange={setSandboxResourceOverrides}
-                  onSandboxRuntimeChange={setSandboxRuntime}
+                  onSandboxRuntimeChange={handleSandboxRuntimeChange}
                 />
                 {selectedAgentIsGoose && (
                   <GooseRecipeSelector
@@ -1226,7 +1242,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                   sandboxRuntime={sandboxRuntime}
                   onAgentModelChange={() => undefined}
                   onSandboxResourceOverridesChange={setSandboxResourceOverrides}
-                  onSandboxRuntimeChange={setSandboxRuntime}
+                  onSandboxRuntimeChange={handleSandboxRuntimeChange}
                 />
               )}
             </Box>

--- a/frontend/src/components/tasks/SandboxStatusIndicator.test.tsx
+++ b/frontend/src/components/tasks/SandboxStatusIndicator.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SandboxStatusIndicator from "./SandboxStatusIndicator";
+
+describe("SandboxStatusIndicator", () => {
+  it("identifies a running sandbox", () => {
+    render(<SandboxStatusIndicator state="running" />);
+
+    const indicator = screen.getByRole("status", { name: "Sandbox running" });
+    expect(indicator).toHaveAttribute(
+      "data-state",
+      "running",
+    );
+    expect(indicator.firstChild).toHaveStyle({ backgroundColor: "#34d399" });
+  });
+
+  it.each([
+    ["starting", "Sandbox starting"],
+    ["stopped", "Sandbox stopped"],
+  ] as const)("keeps the %s state distinct from running", (state, label) => {
+    render(<SandboxStatusIndicator state={state} />);
+
+    const indicator = screen.getByRole("status", { name: label });
+    expect(indicator).toHaveAttribute(
+      "data-state",
+      state,
+    );
+    expect(indicator.firstChild).toHaveStyle({ backgroundColor: "#a1a1aa" });
+  });
+});

--- a/frontend/src/components/tasks/SandboxStatusIndicator.tsx
+++ b/frontend/src/components/tasks/SandboxStatusIndicator.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "react";
+import Box from "@mui/material/Box";
+import Tooltip from "@mui/material/Tooltip";
+
+export type SandboxIndicatorState = "running" | "starting" | "stopped";
+
+const statusMeta: Record<SandboxIndicatorState, { color: string; label: string }> = {
+  running: { color: "#34d399", label: "Sandbox running" },
+  starting: { color: "#a1a1aa", label: "Sandbox starting" },
+  stopped: { color: "#a1a1aa", label: "Sandbox stopped" },
+};
+
+const SandboxStatusIndicator: FC<{ state: SandboxIndicatorState }> = ({ state }) => {
+  const status = statusMeta[state];
+
+  return (
+    <Tooltip title={status.label}>
+      <Box
+        role="status"
+        aria-label={status.label}
+        data-state={state}
+        sx={{
+          width: 30,
+          height: 30,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          sx={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            backgroundColor: status.color,
+          }}
+        />
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default SandboxStatusIndicator;

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -108,6 +108,9 @@ import AgentChat from "../session/AgentChat";
 import { getChatColors } from "../session/chatStyles";
 import type { WorkspaceReviewComment } from "../workspace-inspector/workspaceReviewComments";
 import SpecTaskExecutionControls from "./SpecTaskExecutionControls";
+import SandboxStatusIndicator, {
+  type SandboxIndicatorState,
+} from "./SandboxStatusIndicator";
 import SharePreviewSection from "./SharePreviewSection";
 import SandboxBrowser from "./SandboxBrowser";
 import SpecTaskLaunchWindow, {
@@ -700,6 +703,11 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // immediately after clicking "Start Planning" rather than a confusing flash of the stopped state.
   const isQueuedForPlanning = task?.status === "queued_spec_generation";
   const effectiveIsDesktopPaused = isDesktopPaused && !isQueuedForPlanning;
+  const sandboxIndicatorState: SandboxIndicatorState = isDesktopRunning
+    ? "running"
+    : isDesktopStarting
+      ? "starting"
+      : "stopped";
 
   // Subscribe to WebSocket updates for the active session when chat is visible
   // On big screens: chat is visible unless collapsed
@@ -2530,6 +2538,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       );
                     })()}
                   </Box>
+                  <SandboxStatusIndicator state={sandboxIndicatorState} />
                   {contentCollapsed ? (
                     <Tooltip title="Show task panel">
                       <IconButton

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -142,6 +142,7 @@ import SpecTaskViewToolbar, {
 import { getAutoOpenedSpecTasks, addAutoOpenedSpecTask } from "../../lib/specTaskAutoOpen";
 import { loadPanelLayout, savePanelLayout } from "../../lib/panelLayoutStorage";
 import SpecTaskTerminalDrawer from "./SpecTaskTerminalDrawer";
+import { resolveSpecTaskChatDefaultLayout } from "./specTaskPanelLayout";
 import {
   isSpecTaskTerminalToggleShortcut,
   loadSpecTaskTerminalDrawerState,
@@ -358,15 +359,12 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [contentCollapsed, setContentCollapsed] = useState(false);
   const contentPanelRef = useRef<PanelImperativeHandle>(null);
   const collapseContentAfterSplitRef = useRef(false);
-  const headlessInitialCollapseAppliedRef = useRef(false);
-
-  useEffect(() => {
-    headlessInitialCollapseAppliedRef.current = false;
-  }, [taskId]);
+  const headlessInitialCollapseTaskRef = useRef<string | null>(null);
 
   const collapseContentPanel = useCallback(() => {
     if (chatCollapsed) {
       collapseContentAfterSplitRef.current = true;
+      setContentCollapsed(true);
       setChatCollapsed(false);
       return;
     }
@@ -384,12 +382,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     panel.expand();
     panel.resize(`${restoredSize}%`);
   }, []);
-
-  useEffect(() => {
-    if (chatCollapsed || !collapseContentAfterSplitRef.current) return;
-    collapseContentAfterSplitRef.current = false;
-    contentPanelRef.current?.collapse();
-  }, [chatCollapsed]);
 
   const [terminalDrawerState, setTerminalDrawerState] = useState(() =>
     loadSpecTaskTerminalDrawerState(taskId),
@@ -756,14 +748,20 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       !isHeadless
       || !allowContentCollapse
       || !isBigScreen
+      || !activeSessionId
       || launchPhase
-      || headlessInitialCollapseAppliedRef.current
+      || chatCollapsed
     ) return;
-    const panel = contentPanelRef.current;
-    if (!panel) return;
-    headlessInitialCollapseAppliedRef.current = true;
-    panel.collapse();
-  }, [activeSessionId, allowContentCollapse, isBigScreen, isHeadless, launchPhase]);
+    headlessInitialCollapseTaskRef.current = taskId;
+  }, [
+    activeSessionId,
+    allowContentCollapse,
+    chatCollapsed,
+    isBigScreen,
+    isHeadless,
+    launchPhase,
+    taskId,
+  ]);
 
   // Fetch session data
   const { data: sessionResponse } = useGetSession(activeSessionId || "", {
@@ -2402,10 +2400,21 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           />
         ) : activeSessionId && isBigScreen && !chatCollapsed ? (
           <PanelGroup
-            key="spec-task-chat-layout"
+            id={`spec-task-chat-layout-${taskId}`}
+            key={`spec-task-chat-layout-${taskId}-${isHeadless ? "headless" : "desktop"}`}
             orientation="horizontal"
-            defaultLayout={savedSpecTaskChatLayout ?? { "spec-task-chat": 50, "spec-task-content": 50 }}
+            defaultLayout={resolveSpecTaskChatDefaultLayout(
+              savedSpecTaskChatLayout,
+              allowContentCollapse && (
+                collapseContentAfterSplitRef.current
+                || (isHeadless && headlessInitialCollapseTaskRef.current !== taskId)
+              ),
+            )}
             onLayoutChange={(layout) => {
+              if (layout["spec-task-content"] === 0) {
+                collapseContentAfterSplitRef.current = false;
+                if (isHeadless) headlessInitialCollapseTaskRef.current = taskId;
+              }
               // A collapsed panel is transient UI state; retain the last useful
               // split so restoring or reloading does not produce a zero-width pane.
               if (layout["spec-task-chat"] > 0 && layout["spec-task-content"] > 0) {

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -46,6 +46,7 @@ import UndoIcon from "@mui/icons-material/Undo";
 import {
   TypesCodeAgentOverrides,
   TypesSandboxResourceOverrides,
+  TypesSandboxRuntime,
   TypesSpecTaskStatus,
 } from "../../api/api";
 import ExternalAgentDesktopViewer, {
@@ -265,6 +266,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     enabled: !!taskId,
     refetchInterval: 2300, // 2.3s - prime to avoid sync with other polling
   });
+  const isHeadless = task?.sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu;
   const { data: currentExecutionConfig } = useGetSpecTaskExecutionConfig(
     taskId,
     !!task?.helix_app_id || !!task?.planning_session_id,
@@ -356,6 +358,11 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [contentCollapsed, setContentCollapsed] = useState(false);
   const contentPanelRef = useRef<PanelImperativeHandle>(null);
   const collapseContentAfterSplitRef = useRef(false);
+  const headlessInitialCollapseAppliedRef = useRef(false);
+
+  useEffect(() => {
+    headlessInitialCollapseAppliedRef.current = false;
+  }, [taskId]);
 
   const collapseContentPanel = useCallback(() => {
     if (chatCollapsed) {
@@ -630,6 +637,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
   // Get the active session ID - keep it available for chat history even when task is completed
   const activeSessionId = selectedThreadSessionId || task?.planning_session_id;
+
+  useEffect(() => {
+    if (!isHeadless || currentView !== "desktop") return;
+    const nextView: TaskView = activeSessionId ? "changes" : "details";
+    setCurrentView(nextView);
+    if (syncViewWithUrl) router.mergeParams({ view: nextView });
+  }, [activeSessionId, currentView, isHeadless, syncViewWithUrl]);
   const [workspaceCommentsBySession, setWorkspaceCommentsBySession] = useState<
     Record<string, WorkspaceReviewComment[]>
   >({});
@@ -723,7 +737,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     if (activeSessionId && currentView === "details") {
       // If there's an active session and we're on details, switch to appropriate view
       // On mobile, default to chat; on desktop, default to desktop (chat is always visible)
-      const newView = isBigScreen ? "desktop" : "chat";
+      const newView = isBigScreen ? (isHeadless ? "changes" : "desktop") : "chat";
       setCurrentView(newView);
       if (syncViewWithUrl) {
         router.mergeParams({ view: newView });
@@ -735,7 +749,21 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         router.mergeParams({ view: "details" });
       }
     }
-  }, [activeSessionId, isBigScreen]);
+  }, [activeSessionId, isBigScreen, isHeadless]);
+
+  useEffect(() => {
+    if (
+      !isHeadless
+      || !allowContentCollapse
+      || !isBigScreen
+      || launchPhase
+      || headlessInitialCollapseAppliedRef.current
+    ) return;
+    const panel = contentPanelRef.current;
+    if (!panel) return;
+    headlessInitialCollapseAppliedRef.current = true;
+    panel.collapse();
+  }, [activeSessionId, allowContentCollapse, isBigScreen, isHeadless, launchPhase]);
 
   // Fetch session data
   const { data: sessionResponse } = useGetSession(activeSessionId || "", {
@@ -899,7 +927,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       }
 
       snackbar.success("Planning started! Agent session will begin shortly.");
-      handleViewChange("desktop");
+      handleViewChange(isHeadless ? "changes" : "desktop");
     } catch (err: any) {
       console.error("Failed to start planning:", err);
       snackbar.error(
@@ -1870,6 +1898,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           codeAgentOverrides={task?.code_agent_overrides}
           currentExecutionConfig={currentExecutionConfig}
           sandboxResourceOverrides={task?.sandbox_resource_overrides}
+          sandboxRuntime={task?.sandbox_runtime}
           onAgentModelChange={handleAgentModelChange}
           onSandboxResourceOverridesChange={handleSandboxResourcesChange}
           disabled={updateExecutionConfig.isPending || !!task?.archived}
@@ -2512,7 +2541,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                           setChatCollapsed(true);
                           // Switch to desktop view when collapsing chat
                           if (currentView === "chat") {
-                            handleViewChange("desktop");
+                            handleViewChange(isHeadless ? "changes" : "desktop");
                           }
                         }}
                         sx={taskToolbarIconButtonSx}
@@ -2535,6 +2564,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       codeAgentOverrides={task.code_agent_overrides}
                       currentExecutionConfig={currentExecutionConfig}
                       sandboxResourceOverrides={task.sandbox_resource_overrides}
+                      sandboxRuntime={task.sandbox_runtime}
                       onAgentModelChange={handleAgentModelChange}
                       onSandboxResourceOverridesChange={handleSandboxResourcesChange}
                       disabled={updateExecutionConfig.isPending}
@@ -2600,6 +2630,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   currentView={currentView}
                   onViewChange={handleViewChange}
                   hasSession
+                  showDesktop={!isHeadless}
                   renderActions={(density) =>
                     renderTaskActions("inline", density)
                   }
@@ -2630,7 +2661,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
                 {/* In split-view layout, "chat" falls through to desktop since chat
                     is already visible in the left panel */}
-                {(currentView === "desktop" || currentView === "chat") &&
+                {!isHeadless && (currentView === "desktop" || currentView === "chat") &&
                   (isTaskCompleted && isDesktopPaused ? (
                     <TaskSessionPlaceholder
                       tone="finished"
@@ -2731,6 +2762,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 onViewChange={handleViewChange}
                 hasSession
                 showChatTab
+                showDesktop={!isHeadless}
                 renderActions={(density) =>
                   renderTaskActions("inline", density)
                 }
@@ -2847,6 +2879,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       codeAgentOverrides={task.code_agent_overrides}
                       currentExecutionConfig={currentExecutionConfig}
                       sandboxResourceOverrides={task.sandbox_resource_overrides}
+                      sandboxRuntime={task.sandbox_runtime}
                       onAgentModelChange={handleAgentModelChange}
                       onSandboxResourceOverridesChange={handleSandboxResourcesChange}
                       disabled={updateExecutionConfig.isPending}
@@ -2868,7 +2901,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             )}
 
             {/* Desktop View - mobile */}
-            {activeSessionId && currentView === "desktop" && (
+            {activeSessionId && !isHeadless && currentView === "desktop" && (
               <Box
                 sx={{
                   flex: 1,

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { TypesCodeAgentRuntime } from "../../api/api";
+import { TypesCodeAgentRuntime, TypesSandboxRuntime } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
 import SpecTaskExecutionControls from "./SpecTaskExecutionControls";
 
@@ -192,6 +192,51 @@ describe("SpecTaskExecutionControls", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: /8 vCPU.*16 GB RAM/ }));
 
     await waitFor(() => expect(resize).toHaveBeenCalledWith({ vcpus: 8, memory_mb: 16384 }));
+  });
+
+  it("offers full desktop and headless environments when creating a task", async () => {
+    const setRuntime = vi.fn();
+    render(
+      <SpecTaskExecutionControls
+        agents={[codexAgent]}
+        selectedAgentId={codexAgent.id}
+        sandboxResourceOverrides={{ vcpus: 4, memory_mb: 8192 }}
+        sandboxRuntime={TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop}
+        onAgentModelChange={vi.fn()}
+        onSandboxResourceOverridesChange={vi.fn()}
+        onSandboxRuntimeChange={setRuntime}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Change sandbox size" }));
+    expect(screen.getByRole("menuitem", { name: /Full Desktop.*Selected/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Headless" }));
+
+    await waitFor(() => expect(setRuntime).toHaveBeenCalledWith(
+      TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
+    ));
+  });
+
+  it("shows a locked environment with guidance after task creation", async () => {
+    render(
+      <SpecTaskExecutionControls
+        agents={[codexAgent]}
+        selectedAgentId={codexAgent.id}
+        sandboxResourceOverrides={{ vcpus: 4, memory_mb: 8192 }}
+        sandboxRuntime={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}
+        onAgentModelChange={vi.fn()}
+        onSandboxResourceOverridesChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Change sandbox size" }));
+    const lockedRuntime = screen.getByRole("menuitem", { name: /Headless.*Selected/ });
+    expect(lockedRuntime).toHaveAttribute("aria-disabled", "true");
+    fireEvent.mouseOver(lockedRuntime);
+
+    expect(await screen.findByText(
+      "Sandbox environment can't be changed after the task starts. Start a new task to use a different environment.",
+    )).toBeInTheDocument();
   });
 
   it("shows the effective 4 vCPU default for legacy tasks without an override", () => {

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
@@ -208,13 +208,33 @@ describe("SpecTaskExecutionControls", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Change sandbox size" }));
+    const computeButton = screen.getByRole("button", { name: "Change sandbox size" });
+    expect(computeButton.querySelector(".lucide-monitor"))
+      .toBeInTheDocument();
+    fireEvent.click(computeButton);
     expect(screen.getByRole("menuitem", { name: /Full Desktop.*Selected/ })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Headless" }));
 
     await waitFor(() => expect(setRuntime).toHaveBeenCalledWith(
       TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
     ));
+  });
+
+  it("omits the desktop icon from the collapsed control for headless tasks", () => {
+    render(
+      <SpecTaskExecutionControls
+        agents={[codexAgent]}
+        selectedAgentId={codexAgent.id}
+        sandboxResourceOverrides={{ vcpus: 4, memory_mb: 8192 }}
+        sandboxRuntime={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}
+        onAgentModelChange={vi.fn()}
+        onSandboxResourceOverridesChange={vi.fn()}
+        onSandboxRuntimeChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Change sandbox size" }).querySelector(".lucide-monitor"))
+      .not.toBeInTheDocument();
   });
 
   it("shows a locked environment with guidance after task creation", async () => {

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { ChevronDown, Cpu } from "lucide-react";
+import { ChevronDown, Cpu, Monitor } from "lucide-react";
 import {
   TypesCodeAgentOverrides,
   TypesSandboxResourceOverrides,
@@ -250,7 +250,14 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
           disabled={controlsDisabled}
           aria-label="Change sandbox size"
           onClick={(event) => setCpuAnchor(event.currentTarget)}
-          startIcon={<Cpu size={15} />}
+          startIcon={(
+            <Stack direction="row" spacing={0.375} alignItems="center">
+              <Cpu size={15} />
+              {effectiveSandboxRuntime === TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop && (
+                <Monitor size={15} />
+              )}
+            </Stack>
+          )}
           endIcon={<ChevronDown size={13} />}
           sx={compactButtonSx}
         >
@@ -377,9 +384,10 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
             selected={preset.vcpus === effectiveSandboxResources.vcpus}
             disabled={controlsDisabled}
             onClick={() => void selectSandbox(preset)}
+            sx={{ columnGap: 2 }}
           >
-            <Typography variant="body2" sx={{ flex: 1 }}>{preset.vcpus} vCPU</Typography>
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="body2" sx={{ flex: 1, whiteSpace: "nowrap" }}>{preset.vcpus} vCPU</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>
               {preset.description}
               {preset.vcpus === DEFAULT_SANDBOX_PRESET.vcpus ? " · Default" : ""}
             </Typography>
@@ -409,7 +417,10 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
                 onClick={sandboxRuntimeLocked
                   ? undefined
                   : () => void selectSandboxRuntime(option.value)}
-                sx={sandboxRuntimeLocked ? { cursor: "not-allowed" } : undefined}
+                sx={{
+                  columnGap: 2,
+                  ...(sandboxRuntimeLocked ? { cursor: "not-allowed" } : {}),
+                }}
               >
                 <Typography variant="body2" sx={{ flex: 1 }}>{option.label}</Typography>
                 {selected && (

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -15,6 +15,7 @@ import {
   TypesCodeAgentOverrides,
   TypesSandboxResourceOverrides,
   TypesAgentExecutionConfig,
+  TypesSandboxRuntime,
 } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAssistantConfig } from "../../types";
 import useSnackbar from "../../hooks/useSnackbar";
@@ -34,10 +35,12 @@ interface SpecTaskExecutionControlsProps {
   codeAgentOverrides?: TypesCodeAgentOverrides;
   currentExecutionConfig?: TypesAgentExecutionConfig;
   sandboxResourceOverrides?: TypesSandboxResourceOverrides;
+  sandboxRuntime?: TypesSandboxRuntime;
   onAgentModelChange: (agentId: string, value: TypesCodeAgentOverrides) => MaybePromise;
   // Omitted by surfaces that don't own a resizable sandbox (plain chat
   // sessions); the compute control is then hidden rather than inert.
   onSandboxResourceOverridesChange?: (value: TypesSandboxResourceOverrides) => MaybePromise;
+  onSandboxRuntimeChange?: (value: TypesSandboxRuntime) => MaybePromise;
   disabled?: boolean;
   compact?: boolean;
   grouped?: boolean;
@@ -107,8 +110,10 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
   codeAgentOverrides = {},
   currentExecutionConfig,
   sandboxResourceOverrides,
+  sandboxRuntime,
   onAgentModelChange,
   onSandboxResourceOverridesChange,
+  onSandboxRuntimeChange,
   disabled = false,
   compact = false,
   grouped = false,
@@ -136,6 +141,10 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
     ? sandboxResourceOverrides
     : DEFAULT_SANDBOX_PRESET;
   const sandboxLabel = `${effectiveSandboxResources.vcpus} vCPU`;
+  const effectiveSandboxRuntime = sandboxRuntime
+    || TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop;
+  const showSandboxRuntime = sandboxRuntime !== undefined || !!onSandboxRuntimeChange;
+  const sandboxRuntimeLocked = showSandboxRuntime && !onSandboxRuntimeChange;
   const effortLabel = effortOptions.find((option) => option.value === effectiveEffort)?.label || effectiveEffort;
   const agentSettingsLabel = runtime === "codex_cli" && effectiveTier === "fast"
     ? `${effortLabel} · Fast`
@@ -168,8 +177,8 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
   };
 
   const selectSandbox = async (preset: typeof SANDBOX_PRESETS[number]) => {
-    setCpuAnchor(null);
     if (!onSandboxResourceOverridesChange) return;
+    setCpuAnchor(null);
     setIsSaving(true);
     try {
       await onSandboxResourceOverridesChange({
@@ -178,6 +187,19 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
       });
     } catch (err) {
       snackbar.error(err instanceof Error ? err.message : "Failed to resize sandbox");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const selectSandboxRuntime = async (runtime: TypesSandboxRuntime) => {
+    if (!onSandboxRuntimeChange) return;
+    setCpuAnchor(null);
+    setIsSaving(true);
+    try {
+      await onSandboxRuntimeChange(runtime);
+    } catch (err) {
+      snackbar.error(err instanceof Error ? err.message : "Failed to update sandbox runtime");
     } finally {
       setIsSaving(false);
     }
@@ -348,20 +370,66 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
         anchorOrigin={{ vertical: "top", horizontal: "left" }}
         transformOrigin={{ vertical: "bottom", horizontal: "left" }}
       >
+        <ListSubheader disableSticky>Compute</ListSubheader>
         {SANDBOX_PRESETS.map((preset) => (
           <MenuItem
             key={preset.vcpus}
             selected={preset.vcpus === effectiveSandboxResources.vcpus}
+            disabled={controlsDisabled}
             onClick={() => void selectSandbox(preset)}
           >
-            <Box>
-              <Typography variant="body2">{preset.vcpus} vCPU</Typography>
-              <Typography variant="caption" color="text.secondary">
-                {preset.description}{preset.vcpus === DEFAULT_SANDBOX_PRESET.vcpus ? " · Default" : ""}
-              </Typography>
-            </Box>
+            <Typography variant="body2" sx={{ flex: 1 }}>{preset.vcpus} vCPU</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {preset.description}
+              {preset.vcpus === DEFAULT_SANDBOX_PRESET.vcpus ? " · Default" : ""}
+            </Typography>
           </MenuItem>
         ))}
+
+        {showSandboxRuntime && [
+          <Divider key="runtime-divider" sx={{ my: 0.5 }} />,
+          <ListSubheader key="runtime-heading" disableSticky>Environment</ListSubheader>,
+          ...[
+            {
+              value: TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+              label: "Full Desktop",
+            },
+            {
+              value: TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
+              label: "Headless",
+            },
+          ].map((option) => {
+            const selected = option.value === effectiveSandboxRuntime;
+            const item = (
+              <MenuItem
+                key={option.value}
+                selected={selected}
+                disabled={controlsDisabled}
+                aria-disabled={sandboxRuntimeLocked || undefined}
+                onClick={sandboxRuntimeLocked
+                  ? undefined
+                  : () => void selectSandboxRuntime(option.value)}
+                sx={sandboxRuntimeLocked ? { cursor: "not-allowed" } : undefined}
+              >
+                <Typography variant="body2" sx={{ flex: 1 }}>{option.label}</Typography>
+                {selected && (
+                  <Typography variant="caption" color="text.secondary">Selected</Typography>
+                )}
+              </MenuItem>
+            );
+            if (!sandboxRuntimeLocked) return item;
+            return (
+              <Tooltip
+                key={option.value}
+                title="Sandbox environment can't be changed after the task starts. Start a new task to use a different environment."
+                placement="right"
+                describeChild
+              >
+                {item}
+              </Tooltip>
+            );
+          }),
+        ]}
       </Menu>
     </>
   );

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SpecTaskViewToolbar from "./SpecTaskViewToolbar";
+
+vi.mock("../../hooks/useElementWidth", () => ({
+  useElementWidth: () => [{ current: null }, 800],
+}));
+
+describe("SpecTaskViewToolbar", () => {
+  it("hides the desktop view for a headless task and keeps panel collapse available", () => {
+    const collapse = vi.fn();
+    render(
+      <SpecTaskViewToolbar
+        currentView="changes"
+        onViewChange={vi.fn()}
+        hasSession
+        showDesktop={false}
+        onCollapsePanel={collapse}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Desktop view" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Collapse task panel" }));
+    expect(collapse).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
@@ -151,6 +151,8 @@ export interface SpecTaskViewToolbarProps {
   hasSession: boolean;
   /** Show the Chat tab (single-column layouts where chat has no panel). */
   showChatTab?: boolean;
+  /** Headless tasks have no stream and cannot be converted to a desktop. */
+  showDesktop?: boolean;
   /** Status-specific action buttons (Reject / Open PR / …). */
   renderActions?: (density: ToolbarDensity) => ReactNode;
 
@@ -201,6 +203,7 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   onViewChange,
   hasSession,
   showChatTab = false,
+  showDesktop = true,
   renderActions,
   onToggleTerminal,
   terminalOpen,
@@ -238,7 +241,9 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   const controlIconSize = ICON_BUTTON_METRICS[density].icon;
 
   const tabs = VIEW_TABS.filter(
-    (t) => (!t.sessionOnly || hasSession) && (!t.chatOnly || showChatTab),
+    (t) => (!t.sessionOnly || hasSession)
+      && (!t.chatOnly || showChatTab)
+      && (t.value !== "desktop" || showDesktop),
   );
 
   const controls: SecondaryControl[] = [];

--- a/frontend/src/components/tasks/specTaskPanelLayout.test.ts
+++ b/frontend/src/components/tasks/specTaskPanelLayout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveSpecTaskChatDefaultLayout } from "./specTaskPanelLayout";
+
+describe("resolveSpecTaskChatDefaultLayout", () => {
+  it("starts headless content collapsed without an imperative panel call", () => {
+    expect(resolveSpecTaskChatDefaultLayout({
+      "spec-task-chat": 40,
+      "spec-task-content": 60,
+    }, true)).toEqual({
+      "spec-task-chat": 100,
+      "spec-task-content": 0,
+    });
+  });
+
+  it("restores the saved expanded split otherwise", () => {
+    expect(resolveSpecTaskChatDefaultLayout({
+      "spec-task-chat": 40,
+      "spec-task-content": 60,
+    }, false)).toEqual({
+      "spec-task-chat": 40,
+      "spec-task-content": 60,
+    });
+  });
+});

--- a/frontend/src/components/tasks/specTaskPanelLayout.ts
+++ b/frontend/src/components/tasks/specTaskPanelLayout.ts
@@ -1,0 +1,22 @@
+export type SpecTaskChatLayout = {
+  "spec-task-chat": number;
+  "spec-task-content": number;
+};
+
+const DEFAULT_LAYOUT: SpecTaskChatLayout = {
+  "spec-task-chat": 50,
+  "spec-task-content": 50,
+};
+
+const COLLAPSED_CONTENT_LAYOUT: SpecTaskChatLayout = {
+  "spec-task-chat": 100,
+  "spec-task-content": 0,
+};
+
+export function resolveSpecTaskChatDefaultLayout(
+  savedLayout: Record<string, number> | null,
+  collapseContent: boolean,
+): Record<string, number> {
+  if (collapseContent) return COLLAPSED_CONTENT_LAYOUT;
+  return savedLayout || DEFAULT_LAYOUT;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, Folder, FolderPlus, Hammer, ListTodo, MessageCircle } from
 import {
   TypesCodeAgentOverrides,
   TypesSandboxResourceOverrides,
+  TypesSandboxRuntime,
 } from '../api/api'
 import AdvancedModelPicker from '../components/create/AdvancedModelPicker'
 import RobustPromptInput from '../components/common/RobustPromptInput'
@@ -137,6 +138,9 @@ const Home: FC = () => {
     vcpus: 4,
     memory_mb: 8192,
   })
+  const [taskSandboxRuntime, setTaskSandboxRuntime] = useState<TypesSandboxRuntime>(
+    TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+  )
   const [taskMode, setTaskMode] = useState<NewChatTaskMode>('build')
   const [modeMenuAnchor, setModeMenuAnchor] = useState<HTMLElement | null>(null)
   const [effortMenuAnchor, setEffortMenuAnchor] = useState<HTMLElement | null>(null)
@@ -179,6 +183,7 @@ const Home: FC = () => {
   useEffect(() => {
     setTaskCodeAgentOverrides({})
     setTaskSandboxResources({ vcpus: 4, memory_mb: 8192 })
+    setTaskSandboxRuntime(TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop)
   }, [selectedProjectId])
 
   const taskAgents = codingAgents.flatMap((summary) => {
@@ -250,6 +255,7 @@ const Home: FC = () => {
         prompt: message,
         codeAgentOverrides: taskCodeAgentOverrides,
         sandboxResourceOverrides: taskSandboxResources,
+        sandboxRuntime: taskSandboxRuntime,
       }))
       taskId = task?.id || ''
       if (!taskId) throw new Error('Task creation returned no task ID')
@@ -332,11 +338,13 @@ const Home: FC = () => {
         selectedAgentId={selectedAgentId}
         codeAgentOverrides={taskCodeAgentOverrides}
         sandboxResourceOverrides={taskSandboxResources}
+        sandboxRuntime={taskSandboxRuntime}
         onAgentModelChange={(agentId, overrides) => {
           setSelectedAgentId(agentId)
           setTaskCodeAgentOverrides(overrides)
         }}
         onSandboxResourceOverridesChange={setTaskSandboxResources}
+        onSandboxRuntimeChange={setTaskSandboxRuntime}
         disabled={submitting}
         compact
       />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -55,6 +55,10 @@ import {
   projectChatAgentStorageKey,
   readNewChatReasoningEffort,
 } from './newChatLogic'
+import {
+  preferredSpecTaskSandboxRuntime,
+  saveSpecTaskSandboxRuntimePreference,
+} from '../utils/specTaskSandboxRuntime'
 
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
 const TASK_ATTACHMENT_ACCEPT = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
@@ -138,8 +142,8 @@ const Home: FC = () => {
     vcpus: 4,
     memory_mb: 8192,
   })
-  const [taskSandboxRuntime, setTaskSandboxRuntime] = useState<TypesSandboxRuntime>(
-    TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+  const [taskSandboxRuntime, setTaskSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
+    preferredSpecTaskSandboxRuntime(requestedProjectId),
   )
   const [taskMode, setTaskMode] = useState<NewChatTaskMode>('build')
   const [modeMenuAnchor, setModeMenuAnchor] = useState<HTMLElement | null>(null)
@@ -183,8 +187,16 @@ const Home: FC = () => {
   useEffect(() => {
     setTaskCodeAgentOverrides({})
     setTaskSandboxResources({ vcpus: 4, memory_mb: 8192 })
-    setTaskSandboxRuntime(TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop)
-  }, [selectedProjectId])
+    setTaskSandboxRuntime(preferredSpecTaskSandboxRuntime(
+      selectedProjectId,
+      selectedProject?.default_sandbox_runtime,
+    ))
+  }, [selectedProjectId, selectedProject?.default_sandbox_runtime])
+
+  const handleTaskSandboxRuntimeChange = (runtime: TypesSandboxRuntime) => {
+    setTaskSandboxRuntime(runtime)
+    saveSpecTaskSandboxRuntimePreference(selectedProjectId, runtime)
+  }
 
   const taskAgents = codingAgents.flatMap((summary) => {
     const app = apps.apps.find((candidate) => candidate.id === summary.id)
@@ -344,7 +356,7 @@ const Home: FC = () => {
           setTaskCodeAgentOverrides(overrides)
         }}
         onSandboxResourceOverridesChange={setTaskSandboxResources}
-        onSandboxRuntimeChange={setTaskSandboxRuntime}
+        onSandboxRuntimeChange={handleTaskSandboxRuntimeChange}
         disabled={submitting}
         compact
       />

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -50,7 +50,7 @@ import HubIcon from "@mui/icons-material/Hub";
 import SettingsIcon from "@mui/icons-material/Settings";
 
 import Skills from "../components/app/Skills";
-import { TypesAssistantSkills, TypesCreateAccessGrantRequest, TypesProject, TypesSecretScope, TypesZFSTree, TypesZFSTreeNode } from "../api/api";
+import { TypesAssistantSkills, TypesCreateAccessGrantRequest, TypesProject, TypesSandboxRuntime, TypesSecretScope, TypesZFSTree, TypesZFSTreeNode } from "../api/api";
 import SavingToast from "../components/widgets/SavingToast";
 import StartupScriptEditor from "../components/project/StartupScriptEditor";
 import WebServiceTab from "../components/project/WebServiceTab";
@@ -98,6 +98,10 @@ import {
   useGetProjectGuidelinesHistory,
 } from "../services";
 import { isProjectAccessDeniedError } from "../services/projectService";
+import {
+  effectiveSpecTaskSandboxRuntime,
+  saveSpecTaskSandboxRuntimePreference,
+} from "../utils/specTaskSandboxRuntime";
 
 interface ProjectSettingsProps {
   projectId: string;
@@ -1009,6 +1013,37 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
 
   const renderSandboxTab = () => (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box>
+        <Typography variant="h6" gutterBottom>
+          Default Task Environment
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Choose the sandbox environment selected by default for new tasks in
+          this project. It can still be changed before a task starts.
+        </Typography>
+        <Divider sx={{ mb: 3 }} />
+        <FormControl size="small" sx={{ minWidth: 240 }}>
+          <InputLabel id="default-task-environment-label">Environment</InputLabel>
+          <Select
+            labelId="default-task-environment-label"
+            label="Environment"
+            value={effectiveSpecTaskSandboxRuntime(project.default_sandbox_runtime)}
+            onChange={(event) => {
+              const runtime = event.target.value as TypesSandboxRuntime;
+              saveSpecTaskSandboxRuntimePreference(projectId, runtime);
+              updateProjectMutation.mutate({ default_sandbox_runtime: runtime });
+            }}
+          >
+            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop}>
+              Full Desktop
+            </MenuItem>
+            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}>
+              Headless
+            </MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+
       {/* Startup Script */}
       <Box sx={{ display: "flex", gap: 3, alignItems: "flex-start" }}>
         <Box sx={{ flex: showTestSession ? undefined : 1, width: showTestSession ? 600 : undefined, flexShrink: 0 }}>

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -1022,26 +1022,35 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
           this project. It can still be changed before a task starts.
         </Typography>
         <Divider sx={{ mb: 3 }} />
-        <FormControl size="small" sx={{ minWidth: 240 }}>
-          <InputLabel id="default-task-environment-label">Environment</InputLabel>
-          <Select
-            labelId="default-task-environment-label"
-            label="Environment"
-            value={effectiveSpecTaskSandboxRuntime(project.default_sandbox_runtime)}
-            onChange={(event) => {
-              const runtime = event.target.value as TypesSandboxRuntime;
-              saveSpecTaskSandboxRuntimePreference(projectId, runtime);
-              updateProjectMutation.mutate({ default_sandbox_runtime: runtime });
-            }}
-          >
-            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop}>
-              Full Desktop
-            </MenuItem>
-            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}>
-              Headless
-            </MenuItem>
-          </Select>
-        </FormControl>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <Typography variant="body2">Environment:</Typography>
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <Select
+              value={effectiveSpecTaskSandboxRuntime(
+                project.default_sandbox_runtime,
+              )}
+              inputProps={{ "aria-label": "Default task environment" }}
+              onChange={(event) => {
+                const runtime = event.target.value as TypesSandboxRuntime;
+                saveSpecTaskSandboxRuntimePreference(projectId, runtime);
+                updateProjectMutation.mutate({
+                  default_sandbox_runtime: runtime,
+                });
+              }}
+            >
+              <MenuItem
+                value={TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop}
+              >
+                Full Desktop
+              </MenuItem>
+              <MenuItem
+                value={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}
+              >
+                Headless
+              </MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
       </Box>
 
       {/* Startup Script */}

--- a/frontend/src/pages/newChatLogic.test.ts
+++ b/frontend/src/pages/newChatLogic.test.ts
@@ -7,6 +7,7 @@ import {
   projectChatAgentStorageKey,
   readNewChatReasoningEffort,
 } from './newChatLogic'
+import { TypesSandboxRuntime } from '../api/api'
 
 describe('new chat project mode', () => {
   it('uses the normal-chat heading without project context', () => {
@@ -53,6 +54,7 @@ describe('new chat project mode', () => {
       projectId: 'prj_1',
       prompt: 'Fix the tests',
       sandboxResourceOverrides: { vcpus: 8, memory_mb: 16384 },
+      sandboxRuntime: TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
     })).toMatchObject({
       app_id: 'app_codex',
       code_agent_overrides: {
@@ -61,6 +63,7 @@ describe('new chat project mode', () => {
         service_tier: 'fast',
       },
       sandbox_resource_overrides: { vcpus: 8, memory_mb: 16384 },
+      sandbox_runtime: TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
     })
   })
 

--- a/frontend/src/pages/newChatLogic.ts
+++ b/frontend/src/pages/newChatLogic.ts
@@ -3,6 +3,7 @@ import {
   TypesCreateTaskRequest,
   TypesProviderEndpoint,
   TypesSandboxResourceOverrides,
+  TypesSandboxRuntime,
   TypesSpecTaskPriority,
 } from '../api/api'
 
@@ -71,6 +72,7 @@ export function buildNewChatTaskRequest({
   prompt,
   codeAgentOverrides,
   sandboxResourceOverrides,
+  sandboxRuntime,
 }: {
   appId?: string
   codeAgentOverrides?: TypesCodeAgentOverrides
@@ -78,6 +80,7 @@ export function buildNewChatTaskRequest({
   projectId: string
   prompt: string
   sandboxResourceOverrides?: TypesSandboxResourceOverrides
+  sandboxRuntime?: TypesSandboxRuntime
 }): TypesCreateTaskRequest {
   return {
     app_id: appId || undefined,
@@ -92,5 +95,6 @@ export function buildNewChatTaskRequest({
     ...(sandboxResourceOverrides
       ? { sandbox_resource_overrides: sandboxResourceOverrides }
       : {}),
+    ...(sandboxRuntime ? { sandbox_runtime: sandboxRuntime } : {}),
   }
 }

--- a/frontend/src/utils/specTaskSandboxRuntime.test.ts
+++ b/frontend/src/utils/specTaskSandboxRuntime.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TypesSandboxRuntime } from "../api/api";
+import {
+  preferredSpecTaskSandboxRuntime,
+  saveSpecTaskSandboxRuntimePreference,
+} from "./specTaskSandboxRuntime";
+
+describe("spec task sandbox runtime preferences", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("uses the project default until the user chooses a preference", () => {
+    expect(preferredSpecTaskSandboxRuntime(
+      "prj_1",
+      TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
+    )).toBe(TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu);
+  });
+
+  it("keeps the user's last choice for that project", () => {
+    saveSpecTaskSandboxRuntimePreference(
+      "prj_1",
+      TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu,
+    );
+
+    expect(preferredSpecTaskSandboxRuntime(
+      "prj_1",
+      TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+    )).toBe(TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu);
+    expect(preferredSpecTaskSandboxRuntime(
+      "prj_2",
+      TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+    )).toBe(TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop);
+  });
+});

--- a/frontend/src/utils/specTaskSandboxRuntime.ts
+++ b/frontend/src/utils/specTaskSandboxRuntime.ts
@@ -1,0 +1,42 @@
+import { TypesSandboxRuntime } from "../api/api";
+
+const STORAGE_PREFIX = "helix_spec_task_sandbox_runtime_";
+
+export const DEFAULT_SPEC_TASK_SANDBOX_RUNTIME =
+  TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop;
+
+export function effectiveSpecTaskSandboxRuntime(
+  runtime?: TypesSandboxRuntime,
+): TypesSandboxRuntime {
+  return runtime || DEFAULT_SPEC_TASK_SANDBOX_RUNTIME;
+}
+
+export function readSpecTaskSandboxRuntimePreference(
+  projectId: string,
+): TypesSandboxRuntime | undefined {
+  if (!projectId) return undefined;
+  const value = localStorage.getItem(`${STORAGE_PREFIX}${projectId}`);
+  if (
+    value === TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop
+    || value === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+export function saveSpecTaskSandboxRuntimePreference(
+  projectId: string,
+  runtime: TypesSandboxRuntime,
+): void {
+  if (!projectId) return;
+  localStorage.setItem(`${STORAGE_PREFIX}${projectId}`, runtime);
+}
+
+export function preferredSpecTaskSandboxRuntime(
+  projectId: string,
+  projectDefault?: TypesSandboxRuntime,
+): TypesSandboxRuntime {
+  return readSpecTaskSandboxRuntimePreference(projectId)
+    || effectiveSpecTaskSandboxRuntime(projectDefault);
+}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -7894,6 +7894,12 @@ definitions:
           Project-level repository management
           DefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          Default sandbox environment for new spec tasks. Empty values from legacy
+          projects resolve to the full desktop runtime.
       deleted_at:
         allOf:
         - $ref: '#/definitions/gorm.DeletedAt'
@@ -8111,6 +8117,10 @@ definitions:
         type: string
       default_repo_id:
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: Default sandbox environment for spec tasks
       description:
         type: string
       github_repo_url:
@@ -8251,6 +8261,10 @@ definitions:
         type: string
       default_repo_id:
         type: string
+      default_sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: Default sandbox environment for spec tasks
       description:
         type: string
       github_repo_url:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1117,7 +1117,7 @@ definitions:
     - headless
     type: string
     x-enum-comments:
-      DevContainerTypeHeadless: No GUI, just agent (future)
+      DevContainerTypeHeadless: No GUI, agent-only runtime
       DevContainerTypeSway: Sway compositor with Zed
       DevContainerTypeUbuntu: GNOME with Zed
     x-enum-varnames:
@@ -5379,6 +5379,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       type:
         type: string
       user_email:
@@ -10586,6 +10588,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       sandbox_state:
         description: '"absent", "running", "starting" — derived from session config
           in listTasks'
@@ -11236,6 +11240,8 @@ definitions:
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       sandbox_state:
         description: '"absent", "running", "starting" — derived from session config
           in listTasks'

--- a/openapi.json
+++ b/openapi.json
@@ -29026,7 +29026,7 @@
                     "headless"
                 ],
                 "x-enum-comments": {
-                    "DevContainerTypeHeadless": "No GUI, just agent (future)",
+                    "DevContainerTypeHeadless": "No GUI, agent-only runtime",
                     "DevContainerTypeSway": "Sway compositor with Zed",
                     "DevContainerTypeUbuntu": "GNOME with Zed"
                 },
@@ -34942,6 +34942,9 @@
                     },
                     "sandbox_resource_overrides": {
                         "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "$ref": "#/components/schemas/types.SandboxRuntime"
                     },
                     "type": {
                         "type": "string"
@@ -41944,6 +41947,9 @@
                     "sandbox_resource_overrides": {
                         "$ref": "#/components/schemas/types.SandboxResourceOverrides"
                     },
+                    "sandbox_runtime": {
+                        "$ref": "#/components/schemas/types.SandboxRuntime"
+                    },
                     "sandbox_state": {
                         "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",
                         "type": "string"
@@ -42786,6 +42792,9 @@
                     },
                     "sandbox_resource_overrides": {
                         "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "$ref": "#/components/schemas/types.SandboxRuntime"
                     },
                     "sandbox_state": {
                         "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",

--- a/openapi.json
+++ b/openapi.json
@@ -38437,6 +38437,14 @@
                         "description": "Project-level repository management\nDefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo",
                         "type": "string"
                     },
+                    "default_sandbox_runtime": {
+                        "description": "Default sandbox environment for new spec tasks. Empty values from legacy\nprojects resolve to the full desktop runtime.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
+                    },
                     "deleted_at": {
                         "description": "Soft delete timestamp",
                         "allOf": [
@@ -38743,6 +38751,14 @@
                     "default_repo_id": {
                         "type": "string"
                     },
+                    "default_sandbox_runtime": {
+                        "description": "Default sandbox environment for spec tasks",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
+                    },
                     "description": {
                         "type": "string"
                     },
@@ -38955,6 +38971,14 @@
                     },
                     "default_repo_id": {
                         "type": "string"
+                    },
+                    "default_sandbox_runtime": {
+                        "description": "Default sandbox environment for spec tasks",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
                     },
                     "description": {
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -33863,6 +33863,14 @@
                     "description": "Project-level repository management\nDefaultRepoID is the PRIMARY repository - startup script lives at .helix/startup.sh in this repo",
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for new spec tasks. Empty values from legacy\nprojects resolve to the full desktop runtime.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "deleted_at": {
                     "description": "Soft delete timestamp",
                     "allOf": [
@@ -34169,6 +34177,14 @@
                 "default_repo_id": {
                     "type": "string"
                 },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },
@@ -34381,6 +34397,14 @@
                 },
                 "default_repo_id": {
                     "type": "string"
+                },
+                "default_sandbox_runtime": {
+                    "description": "Default sandbox environment for spec tasks",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -24452,7 +24452,7 @@
                 "headless"
             ],
             "x-enum-comments": {
-                "DevContainerTypeHeadless": "No GUI, just agent (future)",
+                "DevContainerTypeHeadless": "No GUI, agent-only runtime",
                 "DevContainerTypeSway": "Sway compositor with Zed",
                 "DevContainerTypeUbuntu": "GNOME with Zed"
             },
@@ -30368,6 +30368,9 @@
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "type": {
                     "type": "string"
@@ -37370,6 +37373,9 @@
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",
                     "type": "string"
@@ -38212,6 +38218,9 @@
                 },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
                 },
                 "sandbox_state": {
                     "description": "\"absent\", \"running\", \"starting\" — derived from session config in listTasks",


### PR DESCRIPTION
## Summary

- Add an immutable Full Desktop / Headless sandbox runtime choice to spec-task creation from Home chat and the task board.
- Persist each user’s last environment choice per project and add the shared default to Project Settings → Sandbox; API-created tasks inherit the project default when they omit a runtime.
- Run headless tasks with the normal Zed/toolchain image while omitting GNOME, streaming, display, GPU, screenshot, input, video, and desktop MCP setup.
- Run the bridge in workspace-only mode for headless tasks so Files, Diff, checkpoints, and fixed git operations remain available through RevDial.
- Use the compact sectioned execution menu, keep compute labels spaced correctly, show a Monitor icon only for Full Desktop, lock the environment after creation, and hide the unavailable Desktop view.
- Present the project default as one inline `Environment: <menu>` row.
- Start the headless task panel collapsed declaratively, avoiding stale resizable-panel handles during launch transitions.
- Persist the runtime through create, clone, start, resume, fork, and reconciliation paths.

## Root cause

Headless startup intentionally skipped the desktop bridge, but Files and Diff are served by workspace routes on that same process. The API therefore could not dial the task through RevDial and the frontend interpreted the 503 as a stopped desktop even while the headless sandbox and terminal were running.

## Validation

- `go test ./api/pkg/types ./api/pkg/external-agent ./api/pkg/services ./api/pkg/server -count=1`
- `go test ./api/pkg/desktop ./api/pkg/external-agent -count=1`
- `go test ./api/pkg/hydra -run TestBuildEnvHeadlessOmitsDisplayAndGPU -count=1`
- `go test ./api/pkg/hydra -run TestSandboxResourceLimits -count=1`
- `go build ./api/pkg/server ./api/pkg/store ./api/pkg/types`
- Targeted frontend tests: 26 passed
- `cd frontend && yarn build`
- Shell syntax checks and `git diff --check`
- Live project-default inheritance: updating a project to `headless-ubuntu` and creating a task without `sandbox_runtime` persisted `headless-ubuntu` on the task.
- Live inner-Helix headless task on image `0815f3`: Zed and the workspace-only bridge were running with no GNOME or Mutter processes.
- Live workspace E2E: `/workspaces`, `/workspace-files`, and `/workspace-review` returned 200; saving a real README edit through `/workspace-file` was then visible in Files and reported as a modified file in Diff.
- Project Settings selector was verified in the live frontend as one inline `Environment: Full Desktop` row, with both runtime choices available.

## Test environment note

The earlier stop/resume task reached a connected Zed ACP thread. Its sample agent prompt did not complete because the local test provider rejected `MaxTokens` in favor of `MaxCompletionTokens`; sandbox startup and the stop/resume lifecycle were verified independently.

## Follow-up UI

- Add a green/grey sandbox running indicator immediately before the task chat collapse control, backed by the existing live session-state poll.
- Add CPU, memory, and Full Desktop/Headless details to the project chat task tooltip.
- Validate running/starting/stopped colors and explicit/default task execution details with focused component tests.
