### PR TITLE
fix(frontend): show merged PR metadata

### DIFF
--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -1118,6 +1118,14 @@ func (o *SpecTaskOrchestrator) processExternalPullRequestStatus(ctx context.Cont
 			task.RepoPullRequests[i].PRState = newState
 			updated = true
 		}
+		if pr.Number > 0 && task.RepoPullRequests[i].PRNumber != pr.Number {
+			task.RepoPullRequests[i].PRNumber = pr.Number
+			updated = true
+		}
+		if pr.URL != "" && task.RepoPullRequests[i].PRURL != pr.URL {
+			task.RepoPullRequests[i].PRURL = pr.URL
+			updated = true
+		}
 
 		// CI status: poll the provider for the PR's head SHA, fire
 		// transition notifications, persist if anything changed.

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -987,6 +987,33 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_All
 	assert.NotNil(s.T(), task.MergedAt)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_BackfillsPRMetadata() {
+	ctx := context.Background()
+	task := makePullRequestTask(2)
+	task.RepoPullRequests[1].PRNumber = 0
+	task.RepoPullRequests[1].PRURL = ""
+
+	s.gitService.EXPECT().
+		GetPullRequest(ctx, "repo-1", "1").
+		Return(&types.PullRequest{Number: 1, State: types.PullRequestStateOpen}, nil)
+	s.gitService.EXPECT().
+		GetPullRequest(ctx, "repo-2", "2").
+		Return(&types.PullRequest{
+			Number: 42,
+			URL:    "https://github.com/helixml/helix/pull/42",
+			State:  types.PullRequestStateMerged,
+		}, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, task).Return(nil)
+
+	err := s.orchestrator.processExternalPullRequestStatus(ctx, task)
+	s.Require().NoError(err)
+
+	assert.Equal(s.T(), 42, task.RepoPullRequests[1].PRNumber)
+	assert.Equal(s.T(), "https://github.com/helixml/helix/pull/42", task.RepoPullRequests[1].PRURL)
+	assert.Equal(s.T(), "merged", task.RepoPullRequests[1].PRState)
+	assert.Equal(s.T(), types.TaskStatusPullRequest, task.Status)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestCheckTaskForExternalPRActivity_NoPRDoesNotTreatBranchAsMerged() {
 	ctx := context.Background()
 	task := &types.SpecTask{

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -53,11 +53,13 @@ function normalizePRState(state?: string): PRStateKind {
   return "open";
 }
 
-const PR_STATE_CHIP_COLOR: Record<PRStateKind, "info" | "success" | "default"> = {
+const PR_STATE_CHIP_COLOR: Record<PRStateKind, "info" | "default"> = {
   open: "info",
-  merged: "success",
+  merged: "default",
   closed: "default",
 };
+
+const MERGED_PR_COLOR = "#8b5cf6";
 
 const PRStateBadge: React.FC<{ state?: string }> = ({ state }) => {
   const kind = normalizePRState(state);
@@ -67,14 +69,22 @@ const PRStateBadge: React.FC<{ state?: string }> = ({ state }) => {
       size="small"
       variant="outlined"
       color={PR_STATE_CHIP_COLOR[kind]}
-      sx={{ height: 20, fontSize: "0.7rem", flexShrink: 0 }}
+      sx={{
+        height: 20,
+        fontSize: "0.7rem",
+        flexShrink: 0,
+        ...(kind === "merged" && {
+          color: MERGED_PR_COLOR,
+          borderColor: MERGED_PR_COLOR,
+        }),
+      }}
     />
   );
 };
 
 const PR_STATE_ICON_COLOR: Record<PRStateKind, string> = {
   open: "#10b981",
-  merged: "#8b5cf6",
+  merged: MERGED_PR_COLOR,
   closed: "#6b7280",
 };
 


### PR DESCRIPTION
## Summary
- render merged PR state badges in the canonical purple
- backfill missing PR numbers and URLs during provider polling
- add regression coverage for mixed open and merged PRs

## Tests
- `CGO_ENABLED=1 go test ./pkg/services -run 'TestSpecTaskOrchestratorTestSuite/TestProcessExternalPullRequestStatus_(BackfillsPRMetadata|AllMerged_TransitionsToDone)$' -count=1`\n- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`\n- `cd frontend && yarn build`