### PR TITLE
fix(providers): migrate legacy personal providers

### DIFF
--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -515,13 +515,16 @@ func (c *Controller) getClient(ctx context.Context, organizationID, userID, prov
 		Msg("getting OpenAI API client")
 
 	owner := userID
+	ownerType := types.OwnerTypeUser
 	if organizationID != "" {
 		owner = organizationID
+		ownerType = types.OwnerTypeOrg
 	}
 
 	client, err := c.providerManager.GetClient(ctx, &manager.GetClientRequest{
-		Provider: provider,
-		Owner:    owner,
+		Provider:  provider,
+		Owner:     owner,
+		OwnerType: ownerType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %v", err)

--- a/api/pkg/controller/inference_agent.go
+++ b/api/pkg/controller/inference_agent.go
@@ -67,8 +67,10 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 	}
 
 	ownerID := req.User.ID
+	ownerType := types.OwnerTypeUser
 	if req.OrganizationID != "" {
 		ownerID = req.OrganizationID
+		ownerType = types.OwnerTypeOrg
 	}
 
 	log.Info().
@@ -85,6 +87,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	reasoningModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		ownerType,
 		withFallbackProvider(req.Assistant.ReasoningModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.ReasoningModel)
 	if err != nil {
@@ -100,6 +103,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	generationModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		ownerType,
 		withFallbackProvider(req.Assistant.GenerationModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.GenerationModel)
 	if err != nil {
@@ -123,6 +127,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	smallReasoningModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		ownerType,
 		withFallbackProvider(req.Assistant.SmallReasoningModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.SmallReasoningModel)
 	if err != nil {
@@ -132,6 +137,7 @@ func (c *Controller) runAgent(ctx context.Context, req *runAgentRequest) (*agent
 
 	smallGenerationModel, err := c.getLLMModelConfig(ctx,
 		ownerID,
+		ownerType,
 		withFallbackProvider(req.Assistant.SmallGenerationModelProvider, req.Assistant), // Defaults to top level assistant provider
 		req.Assistant.SmallGenerationModel)
 	if err != nil {
@@ -338,10 +344,11 @@ func withFallbackProvider(provider string, assistant *types.AssistantConfig) str
 	return provider
 }
 
-func (c *Controller) getLLMModelConfig(ctx context.Context, owner, provider, model string) (*agent.LLMModelConfig, error) {
+func (c *Controller) getLLMModelConfig(ctx context.Context, owner string, ownerType types.OwnerType, provider, model string) (*agent.LLMModelConfig, error) {
 	client, err := c.providerManager.GetClient(ctx, &manager.GetClientRequest{
-		Provider: provider,
-		Owner:    owner,
+		Provider:  provider,
+		Owner:     owner,
+		OwnerType: ownerType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)

--- a/api/pkg/openai/manager/manager_mocks.go
+++ b/api/pkg/openai/manager/manager_mocks.go
@@ -110,6 +110,21 @@ func (mr *MockProviderManagerMockRecorder) ListProviderEndpoints(ctx, owner any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProviderEndpoints", reflect.TypeOf((*MockProviderManager)(nil).ListProviderEndpoints), ctx, owner)
 }
 
+// ListProviderEndpointsForOwner mocks base method.
+func (m *MockProviderManager) ListProviderEndpointsForOwner(ctx context.Context, owner string, ownerType types.OwnerType) ([]*types.ProviderEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProviderEndpointsForOwner", ctx, owner, ownerType)
+	ret0, _ := ret[0].([]*types.ProviderEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProviderEndpointsForOwner indicates an expected call of ListProviderEndpointsForOwner.
+func (mr *MockProviderManagerMockRecorder) ListProviderEndpointsForOwner(ctx, owner, ownerType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProviderEndpointsForOwner", reflect.TypeOf((*MockProviderManager)(nil).ListProviderEndpointsForOwner), ctx, owner, ownerType)
+}
+
 // ListProviders mocks base method.
 func (m *MockProviderManager) ListProviders(ctx context.Context, owner string) ([]types.Provider, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -20,9 +20,10 @@ import (
 )
 
 type GetClientRequest struct {
-	Provider string
-	Owner    string
-	AppID    string
+	Provider  string
+	Owner     string
+	OwnerType types.OwnerType
+	AppID     string
 }
 
 // RunnerControllerStatus defines the minimum interface needed to check runner status
@@ -45,6 +46,8 @@ type ProviderManager interface {
 	// provider reference (an immutable ID for DB-backed, the canonical name
 	// for globals) to the current canonical name.
 	ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error)
+	// ListProviderEndpointsForOwner uses the explicit owner scope required for organization providers.
+	ListProviderEndpointsForOwner(ctx context.Context, owner string, ownerType types.OwnerType) ([]*types.ProviderEndpoint, error)
 	// SetRunnerController sets the runner controller for checking runner availability
 	SetRunnerController(controller RunnerControllerStatus)
 }
@@ -348,6 +351,11 @@ func (m *MultiClientManager) ListProviders(ctx context.Context, owner string) ([
 // — the agent record stores the immutable ID, settings.json carries the
 // current name. Renames flow into running sessions on the next sync poll.
 func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error) {
+	return m.ListProviderEndpointsForOwner(ctx, owner, types.OwnerTypeUser)
+}
+
+// ListProviderEndpointsForOwner returns global endpoints plus DB endpoints in exactly the requested owner scope.
+func (m *MultiClientManager) ListProviderEndpointsForOwner(ctx context.Context, owner string, ownerType types.OwnerType) ([]*types.ProviderEndpoint, error) {
 	// Always list global providers including Helix — runner availability is
 	// checked by the inferencerouter at request-routing time post sandbox-
 	// absorbs-runner pivot, not at provider-listing time. Matches
@@ -368,6 +376,7 @@ func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner st
 
 	userProviders, err := m.store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 		Owner:      owner,
+		OwnerType:  ownerType,
 		WithGlobal: true,
 	})
 	if err != nil {
@@ -377,7 +386,7 @@ func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner st
 	return endpoints, nil
 }
 
-func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest) (openai.Client, error) {
+func (m *MultiClientManager) GetClient(ctx context.Context, req *GetClientRequest) (openai.Client, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -401,8 +410,9 @@ func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest)
 		return client.client, nil
 	}
 
-	userProviders, err := m.store.ListProviderEndpoints(context.Background(), &store.ListProviderEndpointsQuery{
+	userProviders, err := m.store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 		Owner:      req.Owner,
+		OwnerType:  req.OwnerType,
 		WithGlobal: true,
 	})
 	if err != nil {

--- a/api/pkg/openai/manager/provider_manager_test.go
+++ b/api/pkg/openai/manager/provider_manager_test.go
@@ -56,6 +56,36 @@ func (suite *MultiClientManagerTestSuite) Test_VLLM() {
 	suite.NotNil(client)
 }
 
+func (suite *MultiClientManagerTestSuite) Test_ListProviderEndpointsForOwner_UsesOrgScope() {
+	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner:      "org_123",
+		OwnerType:  types.OwnerTypeOrg,
+		WithGlobal: true,
+	}).Return([]*types.ProviderEndpoint{{ID: "pe_org", Name: "org-provider"}}, nil)
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	endpoints, err := manager.ListProviderEndpointsForOwner(context.Background(), "org_123", types.OwnerTypeOrg)
+	suite.NoError(err)
+	suite.Contains(endpoints, &types.ProviderEndpoint{ID: "pe_org", Name: "org-provider"})
+}
+
+func (suite *MultiClientManagerTestSuite) Test_GetClient_UsesOrgScope() {
+	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner:      "org_123",
+		OwnerType:  types.OwnerTypeOrg,
+		WithGlobal: true,
+	}).Return([]*types.ProviderEndpoint{{
+		ID: "pe_org", Name: "org-provider", BaseURL: "https://example.com/v1", APIKey: "key",
+	}}, nil)
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	client, err := manager.GetClient(context.Background(), &GetClientRequest{
+		Provider: "pe_org", Owner: "org_123", OwnerType: types.OwnerTypeOrg,
+	})
+	suite.NoError(err)
+	suite.NotNil(client)
+}
+
 func (suite *MultiClientManagerTestSuite) Test_WatchAndUpdateClient() {
 	// Create a temporary file for testing
 	tmpDir := suite.T().TempDir()

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -276,6 +276,7 @@ func (s *HelixAPIServer) listAgents(_ http.ResponseWriter, r *http.Request) ([]*
 		}
 
 		orgApps = s.populateAppOwner(ctx, orgApps)
+		s.populateAgentConfigurationWarnings(ctx, user, orgApps)
 
 		return orgApps, nil
 	}
@@ -306,6 +307,7 @@ func (s *HelixAPIServer) listAgents(_ http.ResponseWriter, r *http.Request) ([]*
 	allApps := append(nonGlobalUserApps, globalApps...)
 
 	filteredApps := s.populateAppOwner(ctx, allApps)
+	s.populateAgentConfigurationWarnings(ctx, user, filteredApps)
 
 	return filteredApps, nil
 }
@@ -683,12 +685,6 @@ func applyDefaultNewProjectAgentConfig(settings *types.SystemSettings, app *type
 // validateProvidersAndModels checks if the provider and model are valid. Provider
 // can be empty, however model is required
 func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *types.User, app *types.Agent) error {
-	for _, assistant := range app.Config.Helix.Assistants {
-		if err := types.ValidateCodeAgentModelCompatibility(assistant); err != nil {
-			return fmt.Errorf("assistant %q: %w", assistant.Name, err)
-		}
-	}
-
 	endpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
 	if err != nil {
 		log.Error().
@@ -696,6 +692,15 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 			Str("user_id", user.ID).
 			Msg("Failed to get available providers during validation")
 		return fmt.Errorf("failed to get available providers: %w", err)
+	}
+	return validateProvidersAndModelsWithEndpoints(user, app, endpoints)
+}
+
+func validateProvidersAndModelsWithEndpoints(user *types.User, app *types.Agent, endpoints []*types.ProviderEndpoint) error {
+	for _, assistant := range app.Config.Helix.Assistants {
+		if err := types.ValidateCodeAgentModelCompatibility(assistant); err != nil {
+			return fmt.Errorf("assistant %q: %w", assistant.Name, err)
+		}
 	}
 
 	// Provider references are IDs for DB-backed providers, canonical names
@@ -1097,6 +1102,7 @@ func (s *HelixAPIServer) getAgent(_ http.ResponseWriter, r *http.Request) (*type
 	if err != nil {
 		return nil, system.NewHTTPError403(err.Error())
 	}
+	s.populateAgentConfigurationWarnings(r.Context(), user, []*types.Agent{app})
 	return app, nil
 }
 
@@ -2349,6 +2355,45 @@ func newSafeFetchClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
+	}
+}
+
+func (s *HelixAPIServer) populateAgentConfigurationWarnings(ctx context.Context, user *types.User, apps []*types.Agent) {
+	for _, app := range apps {
+		app.ConfigurationWarning = ""
+		endpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
+		if err != nil {
+			log.Warn().Err(err).Str("app_id", app.ID).Msg("failed to populate agent configuration warning")
+			continue
+		}
+		if err := validateProvidersAndModelsWithEndpoints(user, app, endpoints); err != nil {
+			app.ConfigurationWarning = err.Error()
+			continue
+		}
+		personalIDs := make(map[string]struct{})
+		for _, endpoint := range endpoints {
+			if endpoint.OwnerType == types.OwnerTypeUser && endpoint.EndpointType == types.ProviderEndpointTypeUser {
+				personalIDs[endpoint.ID] = struct{}{}
+			}
+		}
+		for _, assistant := range app.Config.Helix.Assistants {
+			refs := []string{
+				assistant.Provider,
+				assistant.ReasoningModelProvider,
+				assistant.GenerationModelProvider,
+				assistant.SmallReasoningModelProvider,
+				assistant.SmallGenerationModelProvider,
+			}
+			for _, ref := range refs {
+				if _, ok := personalIDs[ref]; ok {
+					app.ConfigurationWarning = "This agent uses a legacy personal inference provider. Select an organization or global provider in agent settings."
+					break
+				}
+			}
+			if app.ConfigurationWarning != "" {
+				break
+			}
+		}
 	}
 }
 

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -643,7 +643,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("substitutes model when provider unavailable", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, user.ID).
+			ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		app := &types.App{
@@ -676,7 +676,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 
 	t.Run("leaves unavailable provider ID for organization validation", func(t *testing.T) {
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "org1").
+			ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).
 			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil).
 			Times(2)
 
@@ -705,7 +705,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 
 	t.Run("substitutes unavailable provider ID for personal app", func(t *testing.T) {
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, user.ID).
+			ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		app := &types.App{
@@ -729,7 +729,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("preserves all other fields during substitution", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, user.ID).
+			ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		// Create an assistant with all possible fields populated
@@ -803,7 +803,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("preserves original values when no substitution needed", func(t *testing.T) {
 		// Mock provider manager to return "together" as available
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, user.ID).
+			ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{Name: "together"}}, nil)
 
 		originalAssistant := types.AssistantConfig{
@@ -838,7 +838,7 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("handles multiple assistants independently", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, user.ID).
+			ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		app := &types.App{
@@ -908,7 +908,7 @@ func TestCreateAppWithModelSubstitutions(t *testing.T) {
 
 	// Mock provider manager to return only "helix" as available (forcing substitution)
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 	app := &types.App{
@@ -976,7 +976,7 @@ func TestApplyModelSubstitutions_AgentMode(t *testing.T) {
 
 	// Mock provider manager to return only "helix" as available
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 	app := &types.App{
@@ -1067,7 +1067,7 @@ func TestApplyModelSubstitutions_AgentModePartialSubstitution(t *testing.T) {
 
 	// Mock provider manager to return "helix" and "anthropic" as available
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "helix"}, {Name: "anthropic"}}, nil)
 
 	app := &types.App{
@@ -1171,7 +1171,7 @@ func TestO3MiniSubstitution(t *testing.T) {
 
 	// Mock provider manager to return only "helix" and "anthropic" as available (no openai)
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "helix"}, {Name: "anthropic"}}, nil)
 
 	app := &types.App{
@@ -1308,7 +1308,7 @@ func TestValidateProvidersAndModels_HelixAgentRejectsTopLevelProviderModel(t *te
 	user := &types.User{ID: "user1"}
 
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "openai"}}, nil)
 
 	app := &types.App{
@@ -1362,7 +1362,7 @@ func TestValidateProvidersAndModels_HelixAgentRequiresModelProviders(t *testing.
 	user := &types.User{ID: "user1"}
 
 	mockProviderManager.EXPECT().
-		ListProviderEndpoints(ctx, user.ID).
+		ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).
 		Return([]*types.ProviderEndpoint{{Name: "openai"}}, nil)
 
 	app := &types.App{
@@ -1406,11 +1406,11 @@ func TestValidateProvidersAndModels_UnavailableProviderMessage(t *testing.T) {
 		}
 	}
 
-	mockProviderManager.EXPECT().ListProviderEndpoints(ctx, "org1").Return([]*types.ProviderEndpoint{}, nil)
+	mockProviderManager.EXPECT().ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).Return([]*types.ProviderEndpoint{}, nil)
 	err := server.validateProvidersAndModels(ctx, user, app("org1"))
 	require.EqualError(t, err, types.OrganizationProviderUnavailableMessage)
 
-	mockProviderManager.EXPECT().ListProviderEndpoints(ctx, user.ID).Return([]*types.ProviderEndpoint{}, nil)
+	mockProviderManager.EXPECT().ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).Return([]*types.ProviderEndpoint{}, nil)
 	err = server.validateProvidersAndModels(ctx, user, app(""))
 	require.ErrorContains(t, err, "provider 'pe_provider' is not available")
 }
@@ -1426,7 +1426,7 @@ func TestListEndpointsForApp(t *testing.T) {
 
 	t.Run("personal app uses user owner only", func(t *testing.T) {
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "user1").
+			ListProviderEndpointsForOwner(ctx, "user1", types.OwnerTypeUser).
 			Return([]*types.ProviderEndpoint{{ID: "pe_user_01", Name: "user-prov"}}, nil)
 		app := &types.App{ID: "app1"}
 		eps, err := server.listEndpointsForApp(ctx, "user1", app)
@@ -1437,7 +1437,7 @@ func TestListEndpointsForApp(t *testing.T) {
 
 	t.Run("org app excludes personal bucket", func(t *testing.T) {
 		mockProviderManager.EXPECT().
-			ListProviderEndpoints(ctx, "org1").
+			ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).
 			Return([]*types.ProviderEndpoint{
 				{ID: "pe_org_01", Name: "org-prov"},
 				{Name: "openai"},
@@ -1450,4 +1450,37 @@ func TestListEndpointsForApp(t *testing.T) {
 		require.Equal(t, "pe_org_01", eps[0].ID)
 		require.Equal(t, "openai", eps[1].Name)
 	})
+}
+
+func TestPopulateAgentConfigurationWarnings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+	user := &types.User{ID: "user1"}
+
+	personal := &types.App{ID: "personal", Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+		Provider: "pe_personal", Model: "model",
+	}}}}}
+	mockProviderManager.EXPECT().ListProviderEndpointsForOwner(ctx, user.ID, types.OwnerTypeUser).Return([]*types.ProviderEndpoint{{
+		ID: "pe_personal", OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser,
+	}}, nil)
+	server.populateAgentConfigurationWarnings(ctx, user, []*types.App{personal})
+	require.Contains(t, personal.ConfigurationWarning, "legacy personal inference provider")
+
+	orphan := &types.App{ID: "orphan", OrganizationID: "org1", Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+		Provider: "pe_missing", Model: "model",
+	}}}}}
+	mockProviderManager.EXPECT().ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).Return(nil, nil)
+	server.populateAgentConfigurationWarnings(ctx, user, []*types.App{orphan})
+	require.Equal(t, types.OrganizationProviderUnavailableMessage, orphan.ConfigurationWarning)
+
+	valid := &types.App{ID: "valid", OrganizationID: "org1", Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+		Provider: "pe_org", Model: "model",
+	}}}}}
+	mockProviderManager.EXPECT().ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).Return([]*types.ProviderEndpoint{{
+		ID: "pe_org", OwnerType: types.OwnerTypeOrg, EndpointType: types.ProviderEndpointTypeOrg,
+	}}, nil)
+	server.populateAgentConfigurationWarnings(ctx, user, []*types.App{valid})
+	require.Empty(t, valid.ConfigurationWarning)
 }

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -25400,6 +25400,9 @@ const docTemplate = `{
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
                 },
+                "configuration_warning": {
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -27976,6 +27979,9 @@ const docTemplate = `{
                 },
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
+                },
+                "configuration_warning": {
+                    "type": "string"
                 },
                 "created": {
                     "type": "string"

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -461,8 +461,9 @@ func (s *HelixAPIServer) refreshProviderModels(ctx context.Context, providerEndp
 		}
 
 		provider, err := s.providerManager.GetClient(ctx, &manager.GetClientRequest{
-			Provider: providerEndpoint.Name,
-			Owner:    providerEndpoint.Owner,
+			Provider:  providerEndpoint.Name,
+			Owner:     providerEndpoint.Owner,
+			OwnerType: providerEndpoint.OwnerType,
 		})
 		if err != nil {
 			log.Err(err).
@@ -610,11 +611,6 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
-	if !isAdmin && !s.Cfg.Providers.EnableCustomUserProviders {
-		http.Error(rw, "Custom user providers are not enabled", http.StatusForbidden)
-		return
-	}
-
 	var endpoint types.ProviderEndpoint
 	if err := json.NewDecoder(r.Body).Decode(&endpoint); err != nil {
 		log.Err(err).Msg("error decoding request body")
@@ -636,8 +632,22 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		endpoint.Owner = user.ID
 	}
 
+	// Default endpoint type from the requested owner scope.
+	if endpoint.EndpointType == "" {
+		if endpoint.OwnerType == types.OwnerTypeOrg {
+			endpoint.EndpointType = types.ProviderEndpointTypeOrg
+		} else {
+			endpoint.EndpointType = types.ProviderEndpointTypeUser
+		}
+	}
+
+	if endpoint.OwnerType == types.OwnerTypeUser && endpoint.EndpointType == types.ProviderEndpointTypeUser {
+		http.Error(rw, "Personal inference providers are no longer supported; create an organization provider instead", http.StatusBadRequest)
+		return
+	}
+
 	// Check for duplicate names
-	existingProviders, err := s.providerManager.ListProviders(r.Context(), endpoint.Owner)
+	existingProviders, err := s.providerManager.ListProviderEndpointsForOwner(r.Context(), endpoint.Owner, endpoint.OwnerType)
 	if err != nil {
 		log.Err(err).Msg("error listing providers")
 		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
@@ -645,15 +655,10 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 	}
 
 	for _, provider := range existingProviders {
-		if string(provider) == endpoint.Name {
+		if provider.Name == endpoint.Name {
 			http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", endpoint.Name), http.StatusBadRequest)
 			return
 		}
-	}
-
-	// Default to user endpoint type if not specified
-	if endpoint.EndpointType == "" {
-		endpoint.EndpointType = types.ProviderEndpointTypeUser
 	}
 
 	// Only admins can add global endpoints
@@ -806,14 +811,14 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	if updatedEndpoint.Name != "" && updatedEndpoint.Name != existingEndpoint.Name {
 		newName := strings.TrimSpace(updatedEndpoint.Name)
 		// Check for duplicate names with other providers
-		existingProviders, err := s.providerManager.ListProviders(ctx, existingEndpoint.Owner)
+		existingProviders, err := s.providerManager.ListProviderEndpointsForOwner(ctx, existingEndpoint.Owner, existingEndpoint.OwnerType)
 		if err != nil {
 			log.Err(err).Msg("error listing providers for name validation")
 			http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		for _, provider := range existingProviders {
-			if string(provider) == newName {
+			if provider.Name == newName {
 				http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", newName), http.StatusBadRequest)
 				return
 			}

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -287,7 +287,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		Name:         "my-ollama",
 		BaseURL:      "http://localhost:11434",
 		APIKey:       "real-secret-key",
-		EndpointType: types.ProviderEndpointTypeUser,
+		EndpointType: types.ProviderEndpointTypeGlobal,
 	}
 
 	body, err := json.Marshal(endpoint)
@@ -298,7 +298,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		ProvidersManagementEnabled: true,
 	}, nil)
 
-	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.manager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), "user_id", types.OwnerTypeUser).Return([]*types.ProviderEndpoint{}, nil)
 
 	createdEndpoint := &types.ProviderEndpoint{
 		ID:           "ep_123",
@@ -307,7 +307,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		APIKey:       "real-secret-key",
 		Owner:        "user_id",
 		OwnerType:    types.OwnerTypeUser,
-		EndpointType: types.ProviderEndpointTypeUser,
+		EndpointType: types.ProviderEndpointTypeGlobal,
 	}
 	s.store.EXPECT().CreateProviderEndpoint(gomock.Any(), gomock.Any()).Return(createdEndpoint, nil)
 
@@ -316,8 +316,9 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 	warmDone := make(chan struct{})
 
 	s.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "my-ollama",
-		Owner:    "user_id",
+		Provider:  "my-ollama",
+		Owner:     "user_id",
+		OwnerType: types.OwnerTypeUser,
 	}).DoAndReturn(func(_ context.Context, req *manager.GetClientRequest) (openai.Client, error) {
 		defer close(warmDone)
 		// The warm goroutine shouldn't see "*****" — it should use the copy with the real key.
@@ -352,6 +353,34 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 	case <-time.After(5 * time.Second):
 		s.Fail("cache warm goroutine did not complete in time")
 	}
+}
+
+func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_RejectsPersonalProvider() {
+	s.server.authMiddleware = &authMiddleware{
+		store: s.store,
+		cfg: authMiddlewareConfig{
+			adminUserIDs: []string{"user_id"},
+		},
+	}
+
+	body, err := json.Marshal(types.ProviderEndpoint{
+		Name: "personal-provider",
+	})
+	s.Require().NoError(err)
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+
+	req, err := http.NewRequest("POST", "/v1/provider-endpoints", bytes.NewReader(body))
+	s.Require().NoError(err)
+	req = req.WithContext(s.authCtx)
+
+	rr := httptest.NewRecorder()
+	s.server.createProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), "Personal inference providers are no longer supported")
 }
 
 // When a custom endpoint has a static Models list and upstream /v1/models
@@ -791,7 +820,7 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_AdminUpdatesPresentat
 			s.True(ep.BillingEnabled)
 			return ep, nil
 		})
-	s.manager.EXPECT().ListProviders(gomock.Any(), "admin_id").Return([]types.Provider{}, nil)
+	s.manager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), "admin_id", types.OwnerTypeUser).Return([]*types.ProviderEndpoint{}, nil)
 
 	update := types.UpdateProviderEndpoint{
 		Name:           "DeepSeek Production",
@@ -975,7 +1004,7 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_RenameInvalidatesOldK
 	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
 		ID: endpointID,
 	}).Return(existing, nil)
-	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.manager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), "user_id", types.OwnerTypeUser).Return([]*types.ProviderEndpoint{}, nil)
 	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
 			s.Equal("new-name", ep.Name)

--- a/api/pkg/server/spec_driven_task_handlers_test.go
+++ b/api/pkg/server/spec_driven_task_handlers_test.go
@@ -69,7 +69,7 @@ func TestSpecTaskProviderPreflightHandlers(t *testing.T) {
 			mockStore.EXPECT().GetSpecTask(gomock.Any(), task.ID).Return(task, nil)
 			mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil).Times(2)
 			mockStore.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
-			mockProviderManager.EXPECT().ListProviderEndpoints(gomock.Any(), app.OrganizationID).Return([]*types.ProviderEndpoint{{Name: "anthropic"}}, nil)
+			mockProviderManager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), app.OrganizationID, types.OwnerTypeOrg).Return([]*types.ProviderEndpoint{{Name: "anthropic"}}, nil)
 
 			req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(tt.body))
 			req = mux.SetURLVars(req, map[string]string{"taskId": task.ID})

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -25396,6 +25396,9 @@
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
                 },
+                "configuration_warning": {
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -27972,6 +27975,9 @@
                 },
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
+                },
+                "configuration_warning": {
+                    "type": "string"
                 },
                 "created": {
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1819,6 +1819,8 @@ definitions:
         type: string
       config:
         $ref: '#/definitions/types.AgentConfig'
+      configuration_warning:
+        type: string
       created:
         type: string
       global:
@@ -3601,6 +3603,8 @@ definitions:
         type: string
       config:
         $ref: '#/definitions/types.AgentConfig'
+      configuration_warning:
+        type: string
       created:
         type: string
       global:

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -1087,10 +1087,12 @@ func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorI
 		return nil, nil
 	}
 	owner := actorID
+	ownerType := types.OwnerTypeUser
 	if app != nil && app.OrganizationID != "" {
 		owner = app.OrganizationID
+		ownerType = types.OwnerTypeOrg
 	}
-	return apiServer.providerManager.ListProviderEndpoints(ctx, owner)
+	return apiServer.providerManager.ListProviderEndpointsForOwner(ctx, owner, ownerType)
 }
 
 // validateSpecTaskAgentConfig pre-flights the agent's provider/model snapshot

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -498,7 +498,7 @@ func TestBuildCodeAgentConfigProviderAdvertisedContextLength(t *testing.T) {
 			}
 
 			providerManager.EXPECT().
-				ListProviderEndpoints(gomock.Any(), "user-1").
+				ListProviderEndpointsForOwner(gomock.Any(), "user-1", types.OwnerTypeUser).
 				Return(func() []*types.ProviderEndpoint {
 					if tt.providerListErr != nil {
 						return nil

--- a/api/pkg/store/migrations/0009_cleanup_legacy_personal_providers.down.sql
+++ b/api/pkg/store/migrations/0009_cleanup_legacy_personal_providers.down.sql
@@ -1,0 +1,1 @@
+-- No-op rollback. Deleted unused personal provider credentials cannot be restored.

--- a/api/pkg/store/migrations/0009_cleanup_legacy_personal_providers.up.sql
+++ b/api/pkg/store/migrations/0009_cleanup_legacy_personal_providers.up.sql
@@ -1,0 +1,101 @@
+CREATE TEMP TABLE IF NOT EXISTS cleanup_provider_refs (
+    provider_ref text NOT NULL,
+    source text NOT NULL,
+    organization_id text NOT NULL DEFAULT '',
+    app_owner text NOT NULL DEFAULT ''
+) ON COMMIT DROP;
+
+TRUNCATE cleanup_provider_refs;
+
+DO $$
+BEGIN
+    IF to_regclass('apps') IS NOT NULL THEN
+        INSERT INTO cleanup_provider_refs (provider_ref, source, organization_id, app_owner)
+        SELECT refs.provider_ref, 'app', COALESCE(apps.organization_id, ''), COALESCE(apps.owner, '')
+        FROM apps
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(config::jsonb #> '{helix,assistants}') = 'array'
+                THEN config::jsonb #> '{helix,assistants}'
+                ELSE '[]'::jsonb
+            END
+        ) AS assistants(assistant)
+        CROSS JOIN LATERAL (VALUES
+            (assistant ->> 'provider'),
+            (assistant ->> 'reasoning_model_provider'),
+            (assistant ->> 'generation_model_provider'),
+            (assistant ->> 'small_reasoning_model_provider'),
+            (assistant ->> 'small_generation_model_provider')
+        ) AS refs(provider_ref)
+        WHERE COALESCE(refs.provider_ref, '') <> '';
+    END IF;
+
+    IF to_regclass('sessions') IS NOT NULL THEN
+        INSERT INTO cleanup_provider_refs (provider_ref, source, organization_id)
+        SELECT refs.provider_ref, 'session', COALESCE(sessions.organization_id, '')
+        FROM sessions
+        CROSS JOIN LATERAL (VALUES
+            (provider),
+            (config::jsonb #>> '{code_agent_overrides,provider_ref}')
+        ) AS refs(provider_ref)
+        WHERE COALESCE(refs.provider_ref, '') <> '';
+    END IF;
+
+    IF to_regclass('spec_tasks') IS NOT NULL THEN
+        INSERT INTO cleanup_provider_refs (provider_ref, source, organization_id)
+        SELECT code_agent_overrides::jsonb ->> 'provider_ref', 'spec_task', COALESCE(organization_id, '')
+        FROM spec_tasks
+        WHERE COALESCE(code_agent_overrides::jsonb ->> 'provider_ref', '') <> '';
+    END IF;
+
+    IF to_regclass('provider_endpoints') IS NOT NULL THEN
+        UPDATE provider_endpoints endpoint
+        SET owner = (
+                SELECT MIN(refs.organization_id)
+                FROM cleanup_provider_refs refs
+                WHERE refs.provider_ref = endpoint.id AND refs.source = 'app'
+            ),
+            owner_type = 'org',
+            endpoint_type = 'org'
+        WHERE endpoint.owner_type = 'user'
+          AND endpoint.endpoint_type = 'user'
+          AND 1 = (
+              SELECT COUNT(DISTINCT refs.organization_id)
+              FROM cleanup_provider_refs refs
+              WHERE refs.provider_ref = endpoint.id
+                AND refs.source = 'app'
+                AND refs.organization_id <> ''
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM cleanup_provider_refs refs
+              WHERE refs.provider_ref = endpoint.id
+                AND refs.source = 'app'
+                AND (
+                    refs.organization_id = ''
+                    OR refs.app_owner <> endpoint.owner
+                )
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM cleanup_provider_refs refs
+              WHERE refs.provider_ref = endpoint.id
+                AND refs.source <> 'app'
+                AND refs.organization_id IS DISTINCT FROM (
+                    SELECT MIN(app_refs.organization_id)
+                    FROM cleanup_provider_refs app_refs
+                    WHERE app_refs.provider_ref = endpoint.id
+                      AND app_refs.source = 'app'
+                      AND app_refs.organization_id <> ''
+                )
+          );
+
+        DELETE FROM provider_endpoints endpoint
+        WHERE endpoint.owner_type = 'user'
+          AND endpoint.endpoint_type = 'user'
+          AND NOT EXISTS (
+              SELECT 1 FROM cleanup_provider_refs refs WHERE refs.provider_ref = endpoint.id
+          );
+    END IF;
+
+END $$;

--- a/api/pkg/store/migrations_test.go
+++ b/api/pkg/store/migrations_test.go
@@ -1,0 +1,198 @@
+package store
+
+import (
+	"encoding/json"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *PostgresStoreTestSuite) TestCleanupLegacyPersonalProvidersMigration() {
+	t := suite.T()
+	owner := "user-" + system.GenerateUUID()
+	orgOne := "org-" + system.GenerateUUID()
+	orgTwo := "org-" + system.GenerateUUID()
+	unusedID := "pe_unused_" + system.GenerateUUID()
+	movedID := "pe_moved_" + system.GenerateUUID()
+	ambiguousID := "pe_ambiguous_" + system.GenerateUUID()
+	personalID := "pe_personal_" + system.GenerateUUID()
+	crossOrgID := "pe_cross_org_" + system.GenerateUUID()
+	orphanID := "pe_orphan_" + system.GenerateUUID()
+	validOrgID := "pe_org_" + system.GenerateUUID()
+	validGlobalID := "pe_global_" + system.GenerateUUID()
+
+	for _, endpoint := range []*types.ProviderEndpoint{
+		{ID: unusedID, Name: "unused", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser},
+		{ID: movedID, Name: "moved", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser, APIKey: "preserved-key"},
+		{ID: ambiguousID, Name: "ambiguous", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser},
+		{ID: personalID, Name: "personal", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser},
+		{ID: crossOrgID, Name: "cross-org", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeUser},
+		{ID: validOrgID, Name: "org", Owner: orgOne, OwnerType: types.OwnerTypeOrg, EndpointType: types.ProviderEndpointTypeOrg},
+		{ID: validGlobalID, Name: "global", Owner: owner, OwnerType: types.OwnerTypeUser, EndpointType: types.ProviderEndpointTypeGlobal},
+	} {
+		_, err := suite.db.CreateProviderEndpoint(suite.ctx, endpoint)
+		require.NoError(t, err)
+	}
+
+	appOne := suite.createMigrationTestApp(owner, orgOne, map[string]any{
+		"unrelated": "preserved",
+		"helix": map[string]any{"assistants": []any{
+			map[string]any{"name": "moved", "provider": movedID, "model": "moved-model", "custom": map[string]any{"preserved": true}},
+			map[string]any{"name": "ambiguous", "provider": ambiguousID, "model": "ambiguous-model"},
+			map[string]any{"name": "cross-org", "provider": crossOrgID, "model": "cross-org-model"},
+			map[string]any{"name": "valid-org", "provider": validOrgID, "model": "org-model"},
+			map[string]any{"name": "valid-global", "provider": validGlobalID, "model": "global-model"},
+			map[string]any{
+				"name":                            "orphan",
+				"provider":                        orphanID,
+				"model":                           "model",
+				"reasoning_model_provider":        orphanID,
+				"reasoning_model":                 "reasoning",
+				"generation_model_provider":       orphanID,
+				"generation_model":                "generation",
+				"small_reasoning_model_provider":  orphanID,
+				"small_reasoning_model":           "small-reasoning",
+				"small_generation_model_provider": orphanID,
+				"small_generation_model":          "small-generation",
+			},
+		}},
+	})
+	appTwo := suite.createMigrationTestApp(owner, orgTwo, map[string]any{
+		"helix": map[string]any{"assistants": []any{
+			map[string]any{"name": "ambiguous", "provider": ambiguousID, "model": "ambiguous-model"},
+		}},
+	})
+	personalApp := suite.createMigrationTestApp(owner, "", map[string]any{
+		"helix": map[string]any{"assistants": []any{
+			map[string]any{"name": "personal", "provider": personalID, "model": "personal-model"},
+		}},
+	})
+	malformedApp := suite.createMigrationTestApp(owner, orgOne, map[string]any{
+		"helix": map[string]any{"assistants": map[string]any{"not": "an array"}},
+	})
+
+	sessionID := "ses_" + system.GenerateUUID()
+	_, err := suite.db.CreateSession(suite.ctx, types.Session{
+		ID: sessionID, OrganizationID: orgOne, Provider: orphanID, ModelName: "orphan-model",
+		Metadata: types.SessionMetadata{CodeAgentOverrides: &types.CodeAgentOverrides{
+			ProviderRef: movedID, Model: "moved-model", ServiceTier: "priority",
+		}},
+	})
+	require.NoError(t, err)
+	crossOrgSessionID := "ses_" + system.GenerateUUID()
+	_, err = suite.db.CreateSession(suite.ctx, types.Session{
+		ID: crossOrgSessionID, OrganizationID: orgTwo, Provider: crossOrgID, ModelName: "cross-org-model",
+	})
+	require.NoError(t, err)
+
+	movedTask := &types.SpecTask{
+		ID: "task_" + system.GenerateUUID(), ProjectID: "project_" + system.GenerateUUID(), OrganizationID: orgOne,
+		CodeAgentOverrides: &types.CodeAgentOverrides{ProviderRef: movedID, Model: "moved-model", ReasoningEffort: "high"},
+	}
+	orphanTask := &types.SpecTask{
+		ID: "task_" + system.GenerateUUID(), ProjectID: "project_" + system.GenerateUUID(), OrganizationID: orgOne,
+		CodeAgentOverrides: &types.CodeAgentOverrides{ProviderRef: orphanID, Model: "orphan-model", ReasoningEffort: "low"},
+	}
+	require.NoError(t, suite.db.gdb.Create(movedTask).Error)
+	require.NoError(t, suite.db.gdb.Create(orphanTask).Error)
+
+	interaction := &types.Interaction{
+		ID: "int_" + system.GenerateUUID(), SessionID: sessionID,
+		CodeAgentConfigSnapshot: &types.InteractionCodeAgentConfigSnapshot{Provider: orphanID, Model: "historical-model"},
+	}
+	require.NoError(t, suite.db.gdb.Create(interaction).Error)
+
+	t.Cleanup(func() {
+		suite.db.gdb.Delete(&types.Interaction{}, "id = ?", interaction.ID)
+		suite.db.gdb.Delete(&types.Session{}, "id IN ?", []string{sessionID, crossOrgSessionID})
+		suite.db.gdb.Delete(&types.SpecTask{}, "id IN ?", []string{movedTask.ID, orphanTask.ID})
+		suite.db.gdb.Delete(&types.App{}, "id IN ?", []string{appOne.ID, appTwo.ID, personalApp.ID, malformedApp.ID})
+		suite.db.gdb.Delete(&types.ProviderEndpoint{}, "id IN ?", []string{unusedID, movedID, ambiguousID, personalID, crossOrgID, validOrgID, validGlobalID})
+	})
+
+	migration, err := fs.ReadFile("migrations/0009_cleanup_legacy_personal_providers.up.sql")
+	require.NoError(t, err)
+	require.NoError(t, suite.db.gdb.Exec(string(migration)).Error)
+	require.NoError(t, suite.db.gdb.Exec(string(migration)).Error)
+
+	var count int64
+	require.NoError(t, suite.db.gdb.Model(&types.ProviderEndpoint{}).Where("id = ?", unusedID).Count(&count).Error)
+	require.Zero(t, count)
+
+	moved, err := suite.db.GetProviderEndpoint(suite.ctx, &GetProviderEndpointsQuery{ID: movedID})
+	require.NoError(t, err)
+	require.Equal(t, orgOne, moved.Owner)
+	require.Equal(t, types.OwnerTypeOrg, moved.OwnerType)
+	require.Equal(t, types.ProviderEndpointTypeOrg, moved.EndpointType)
+	require.Equal(t, "preserved-key", moved.APIKey)
+
+	for _, id := range []string{ambiguousID, personalID, crossOrgID} {
+		endpoint, err := suite.db.GetProviderEndpoint(suite.ctx, &GetProviderEndpointsQuery{ID: id})
+		require.NoError(t, err)
+		require.Equal(t, owner, endpoint.Owner)
+		require.Equal(t, types.OwnerTypeUser, endpoint.OwnerType)
+		require.Equal(t, types.ProviderEndpointTypeUser, endpoint.EndpointType)
+	}
+	for _, id := range []string{validOrgID, validGlobalID} {
+		require.NoError(t, suite.db.gdb.Model(&types.ProviderEndpoint{}).Where("id = ?", id).Count(&count).Error)
+		require.EqualValues(t, 1, count)
+	}
+
+	config := suite.getMigrationTestAppConfig(appOne.ID)
+	require.Equal(t, "preserved", config["unrelated"])
+	assistants := config["helix"].(map[string]any)["assistants"].([]any)
+	require.Equal(t, movedID, assistants[0].(map[string]any)["provider"])
+	require.Equal(t, true, assistants[0].(map[string]any)["custom"].(map[string]any)["preserved"])
+	require.Equal(t, ambiguousID, assistants[1].(map[string]any)["provider"])
+	require.Equal(t, crossOrgID, assistants[2].(map[string]any)["provider"])
+	require.Equal(t, validOrgID, assistants[3].(map[string]any)["provider"])
+	require.Equal(t, validGlobalID, assistants[4].(map[string]any)["provider"])
+	require.Equal(t, orphanID, assistants[5].(map[string]any)["provider"])
+	require.Equal(t, "model", assistants[5].(map[string]any)["model"])
+	require.Equal(t, orphanID, assistants[5].(map[string]any)["reasoning_model_provider"])
+	require.Equal(t, orphanID, assistants[5].(map[string]any)["generation_model_provider"])
+	require.Equal(t, orphanID, assistants[5].(map[string]any)["small_reasoning_model_provider"])
+	require.Equal(t, orphanID, assistants[5].(map[string]any)["small_generation_model_provider"])
+
+	storedSession, err := suite.db.GetSession(suite.ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, orphanID, storedSession.Provider)
+	require.Equal(t, "orphan-model", storedSession.ModelName)
+	require.Equal(t, movedID, storedSession.Metadata.CodeAgentOverrides.ProviderRef)
+	require.Equal(t, "moved-model", storedSession.Metadata.CodeAgentOverrides.Model)
+	require.Equal(t, "priority", storedSession.Metadata.CodeAgentOverrides.ServiceTier)
+
+	var storedMovedTask, storedOrphanTask types.SpecTask
+	require.NoError(t, suite.db.gdb.First(&storedMovedTask, "id = ?", movedTask.ID).Error)
+	require.Equal(t, movedID, storedMovedTask.CodeAgentOverrides.ProviderRef)
+	require.Equal(t, "moved-model", storedMovedTask.CodeAgentOverrides.Model)
+	require.NoError(t, suite.db.gdb.First(&storedOrphanTask, "id = ?", orphanTask.ID).Error)
+	require.Equal(t, orphanID, storedOrphanTask.CodeAgentOverrides.ProviderRef)
+	require.Equal(t, "orphan-model", storedOrphanTask.CodeAgentOverrides.Model)
+	require.Equal(t, "low", storedOrphanTask.CodeAgentOverrides.ReasoningEffort)
+
+	var storedInteraction types.Interaction
+	require.NoError(t, suite.db.gdb.First(&storedInteraction, "id = ?", interaction.ID).Error)
+	require.Equal(t, orphanID, storedInteraction.CodeAgentConfigSnapshot.Provider)
+	require.Equal(t, "historical-model", storedInteraction.CodeAgentConfigSnapshot.Model)
+}
+
+func (suite *PostgresStoreTestSuite) createMigrationTestApp(owner, organizationID string, config map[string]any) *types.App {
+	app, err := suite.db.CreateApp(suite.ctx, &types.App{
+		Owner: owner, OwnerType: types.OwnerTypeUser, OrganizationID: organizationID, Config: types.AppConfig{},
+	})
+	suite.Require().NoError(err)
+	encoded, err := json.Marshal(config)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.db.gdb.Exec("UPDATE apps SET config = ?::jsonb WHERE id = ?", string(encoded), app.ID).Error)
+	return app
+}
+
+func (suite *PostgresStoreTestSuite) getMigrationTestAppConfig(id string) map[string]any {
+	var stored string
+	suite.Require().NoError(suite.db.gdb.Raw("SELECT config FROM apps WHERE id = ?", id).Scan(&stored).Error)
+	var config map[string]any
+	suite.Require().NoError(json.Unmarshal([]byte(stored), &config))
+	return config
+}

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -154,8 +154,9 @@ func (suite *CronTestSuite) TestExecuteCronTask() {
 	)
 
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "togetherai",
-		Owner:    "test-user",
+		Provider:  "togetherai",
+		Owner:     "test-user",
+		OwnerType: types.OwnerTypeUser,
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -284,8 +285,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_Organization() {
 	)
 
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "togetherai",
-		Owner:    "test-org",
+		Provider:  "togetherai",
+		Owner:     "test-org",
+		OwnerType: types.OwnerTypeOrg,
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -408,8 +410,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_WithEmails() {
 	)
 
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "togetherai",
-		Owner:    "test-user",
+		Provider:  "togetherai",
+		Owner:     "test-user",
+		OwnerType: types.OwnerTypeUser,
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -516,8 +519,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_FailureNotification_WithEmails()
 	)
 
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "togetherai",
-		Owner:    "test-user",
+		Provider:  "togetherai",
+		Owner:     "test-user",
+		OwnerType: types.OwnerTypeUser,
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()
@@ -606,8 +610,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_NoEmails_FallsBackToOwner() {
 	)
 
 	suite.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "togetherai",
-		Owner:    "test-user",
+		Provider:  "togetherai",
+		Owner:     "test-user",
+		OwnerType: types.OwnerTypeUser,
 	}).Return(suite.openAiClient, nil).Times(1)
 
 	suite.openAiClient.EXPECT().BillingEnabled().Return(true).AnyTimes()

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2010,6 +2010,8 @@ type Agent struct {
 
 	// AgentKind classifies where an agent belongs in the product.
 	AgentKind string `json:"agent_kind" gorm:"not null;default:helix_agent;index"`
+
+	ConfigurationWarning string `json:"configuration_warning,omitempty" gorm:"-"`
 }
 
 func (Agent) TableName() string { return "apps" }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1191,6 +1191,7 @@ export interface ServerAgentCreateResponse {
   /** AgentKind classifies where an agent belongs in the product. */
   agent_kind?: string;
   config?: TypesAgentConfig;
+  configuration_warning?: string;
   created?: string;
   global?: boolean;
   id?: string;
@@ -2313,6 +2314,7 @@ export interface TypesAgent {
   /** AgentKind classifies where an agent belongs in the product. */
   agent_kind?: string;
   config?: TypesAgentConfig;
+  configuration_warning?: string;
   created?: string;
   global?: boolean;
   id?: string;

--- a/frontend/src/components/apps/AppsTable.test.tsx
+++ b/frontend/src/components/apps/AppsTable.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { ConfigurationWarningAlert, ConfigurationWarningChip } from './ConfigurationWarning'
+
+describe('agent configuration warnings', () => {
+  it('shows the compact list warning and detail alert', () => {
+    render(
+      <>
+        <ConfigurationWarningChip warning="Select a valid provider" />
+        <ConfigurationWarningAlert warning="Select a valid provider" />
+      </>,
+    )
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Select a valid provider')
+  })
+
+  it('renders nothing when the server sends no warning', () => {
+    const { container } = render(
+      <>
+        <ConfigurationWarningChip />
+        <ConfigurationWarningAlert />
+      </>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/components/apps/AppsTable.tsx
+++ b/frontend/src/components/apps/AppsTable.tsx
@@ -33,6 +33,7 @@ import {
 // Import DuplicateDialog
 import DuplicateDialog from '../app/DuplicateDialog'
 import AgentHarness, { getAgentHarnessRuntime } from '../agent/AgentHarness'
+import { ConfigurationWarningChip } from './ConfigurationWarning'
 
 const AppsDataGrid: FC<React.PropsWithChildren<{
   authenticated: boolean,
@@ -254,6 +255,7 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
                 {description}
               </Typography>
             )}
+            <ConfigurationWarningChip warning={app.configuration_warning} />
           </Box>
         ),
         skills: (

--- a/frontend/src/components/apps/ConfigurationWarning.tsx
+++ b/frontend/src/components/apps/ConfigurationWarning.tsx
@@ -1,0 +1,25 @@
+import Alert from '@mui/material/Alert'
+import Chip from '@mui/material/Chip'
+import Tooltip from '@mui/material/Tooltip'
+import { TriangleAlert } from 'lucide-react'
+import { FC } from 'react'
+
+export const ConfigurationWarningChip: FC<{ warning?: string }> = ({ warning }) => {
+  if (!warning) return null
+  return (
+    <Tooltip title={warning} arrow>
+      <Chip
+        icon={<TriangleAlert size={14} />}
+        label="Needs attention"
+        color="warning"
+        size="small"
+        variant="outlined"
+      />
+    </Tooltip>
+  )
+}
+
+export const ConfigurationWarningAlert: FC<{ warning?: string }> = ({ warning }) => {
+  if (!warning) return null
+  return <Alert severity="warning" sx={{ mb: 2 }}>{warning}</Alert>
+}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -46,6 +46,7 @@ import {
 } from '../services/helixOrgService'
 import { AGENT_TYPE_ZED_EXTERNAL } from '../types'
 import { isOrgAgent, usesFocusedAgentDetails } from '../utils/apps'
+import { ConfigurationWarningAlert } from '../components/apps/ConfigurationWarning'
 
 const App: FC = () => {
   const account = useAccount()  
@@ -172,6 +173,7 @@ const App: FC = () => {
         }}
       >
         <Box sx={{ width: '100%', pl: 2, pr: 2, mt: 2 }}>
+          <ConfigurationWarningAlert warning={appTools.app.configuration_warning} />
           <Grid container>
             <Grid item xs={12} sx={{
               p: 0,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -776,6 +776,7 @@ export interface IApp {
   owner_type: IOwnerType;
   user?: IUser;
   agent_kind: string;
+  configuration_warning?: string;
 }
 
 export interface IAppUpdate {

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1819,6 +1819,8 @@ definitions:
         type: string
       config:
         $ref: '#/definitions/types.AgentConfig'
+      configuration_warning:
+        type: string
       created:
         type: string
       global:
@@ -3601,6 +3603,8 @@ definitions:
         type: string
       config:
         $ref: '#/definitions/types.AgentConfig'
+      configuration_warning:
+        type: string
       created:
         type: string
       global:

--- a/openapi.json
+++ b/openapi.json
@@ -29970,6 +29970,9 @@
                     "config": {
                         "$ref": "#/components/schemas/types.AgentConfig"
                     },
+                    "configuration_warning": {
+                        "type": "string"
+                    },
                     "created": {
                         "type": "string"
                     },
@@ -32546,6 +32549,9 @@
                     },
                     "config": {
                         "$ref": "#/components/schemas/types.AgentConfig"
+                    },
+                    "configuration_warning": {
+                        "type": "string"
                     },
                     "created": {
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -25396,6 +25396,9 @@
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
                 },
+                "configuration_warning": {
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -27972,6 +27975,9 @@
                 },
                 "config": {
                     "$ref": "#/definitions/types.AgentConfig"
+                },
+                "configuration_warning": {
+                    "type": "string"
                 },
                 "created": {
                     "type": "string"


### PR DESCRIPTION
## Summary

- migrate unambiguous legacy personal providers to the organization that uses them while preserving provider IDs and credentials
- delete only unused personal providers and retain ambiguous or orphaned references so agents are not silently broken
- route organization-scoped provider IDs correctly and reject creation of new personal providers
- expose provider configuration warnings on agent list and detail views

## Upgrade behavior

- agents using a provider owned by exactly one organization continue working after that provider is re-scoped
- ambiguous, personal-app, and cross-organization providers remain unchanged and affected agents show "Needs attention"
- already-deleted provider references remain visible so users are told to select an organization or global provider

## Tests

- `go test ./pkg/openai/manager -count=1`
- focused server provider, validation, routing, and warning tests
- `go test ./pkg/controller ./pkg/trigger/cron -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- PostgreSQL migration integration test, including two consecutive migration runs
- `yarn vitest run src/components/apps/AppsTable.test.tsx`
- `git diff --check`

## Not tested

- browser E2E: standalone Playwright MCP was unavailable
- full frontend build is blocked on macOS by the pre-existing `WorkspaceReviewMessage.ts` / `workspaceReviewMessage.ts` case collision