### PR TITLE
fix(api): populate sandbox_state on GET /spec-tasks/{id}

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -274,9 +274,12 @@ func (s *HelixAPIServer) getTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Surface why a queued task hasn't started yet. getTask does not run the
-	// listTasks enrichment, so compute it explicitly here for the detail page.
+	// getTask does not go through the listTasks read path, so compute the same
+	// derived fields explicitly: why a queued task hasn't started yet, and the
+	// live sandbox/agent state. Without the second call sandbox_state comes back
+	// null here while the board reports "running" for the same task.
 	s.populateQueueReasons(ctx, task.ProjectID, []*types.SpecTask{task})
+	s.populateSessionState(ctx, []*types.SpecTask{task})
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(task)
@@ -419,7 +422,37 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 	// Recomputed each read so it clears as the queue drains.
 	s.populateQueueReasons(ctx, projectID, tasks)
 
-	// Populate SessionUpdatedAt and AgentWorkState for agent activity detection
+	s.populateSessionState(ctx, tasks)
+
+	// ETag support: hash the response to avoid sending unchanged data
+	jsonBytes, err := json.Marshal(tasks)
+	if err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	h := fnv.New64a()
+	h.Write(jsonBytes)
+	etag := fmt.Sprintf(`"%x"`, h.Sum64())
+
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "private, no-cache, must-revalidate")
+
+	if match := r.Header.Get("If-None-Match"); match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonBytes) //nolint:errcheck
+}
+
+// populateSessionState fills the computed, non-persisted session fields on each
+// task: SessionUpdatedAt, SandboxState, SandboxStatusMessage and AgentWorkState.
+// Shared by listTasks and getTask so a single-task fetch reports the same
+// sandbox state the board does — callers polling GET /spec-tasks/{id} for
+// sandbox_state used to see null forever while the container was running.
+func (s *HelixAPIServer) populateSessionState(ctx context.Context, tasks []*types.SpecTask) {
 	// Collect all session IDs and batch query for efficiency
 	sessionIDs := make([]string, 0)
 	for _, task := range tasks {
@@ -495,28 +528,6 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-
-	// ETag support: hash the response to avoid sending unchanged data
-	jsonBytes, err := json.Marshal(tasks)
-	if err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-		return
-	}
-
-	h := fnv.New64a()
-	h.Write(jsonBytes)
-	etag := fmt.Sprintf(`"%x"`, h.Sum64())
-
-	w.Header().Set("ETag", etag)
-	w.Header().Set("Cache-Control", "private, no-cache, must-revalidate")
-
-	if match := r.Header.Get("If-None-Match"); match == etag {
-		w.WriteHeader(http.StatusNotModified)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(jsonBytes) //nolint:errcheck
 }
 
 // approveSpecs godoc


### PR DESCRIPTION
## The bug

`sandbox_state`, `sandbox_status_message`, `session_updated_at` and `agent_work_state` are `gorm:"-"` fields computed at read time. That computation lived inline in `listTasks`. `getTask` never ran it.

So the same task, at the same moment, reports two different things:

```bash
$ helix spectask board --project prj_… --json | jq -r '.[] | .sandbox_state'
running

$ helix spectask get spt_… --json | jq -r .sandbox_state
null
```

Which makes the obvious wait loop silently never terminate, while the container is up the entire time:

```bash
until [ "$(helix spectask get $T --json | jq -r .sandbox_state)" = running ]; do sleep 10; done
```

I hit this writing a documented "wait for the sandbox" recipe and watching it spin for ten minutes against a healthy, running desktop.

## The fix

Extract the enrichment block into `populateSessionState(ctx, tasks)` and call it from both handlers — right next to the `populateQueueReasons` call `getTask` already makes for exactly the same reason (its comment even says "getTask does not run the listTasks enrichment").

The moved code is verbatim; only the ETag/response-writing tail stays behind in `listTasks`. No behaviour change for the list path.

## Cost

One extra `GetSessionsByIDs` + `GetLatestInteractionsForSessions` + one executor live-check per `getTask`, for a single session. `listTasks` already does this for every task on the board on every poll, so a single-task fetch doing it once is not a new class of load.

## Testing

- `go build ./pkg/server/` and `gofmt` clean. `go vet ./pkg/server/` reports only pre-existing findings in `mcp_backend_external.go` and `start_dev_container_test.go`.
- The divergence was reproduced against a live control plane (board `running` vs get `null`, task `spt_01m0227…`).
- **Not** runtime-verified after the fix: the only deployment available was running real work and I wasn't willing to restart its API to test. The extracted code is unchanged and the call site mirrors `populateQueueReasons`, but it deserves a run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)