### PR TITLE
feat(sandbox): headless workloads no longer require a GPU

### DIFF
--- a/api/pkg/cli/sandbox/sandbox.go
+++ b/api/pkg/cli/sandbox/sandbox.go
@@ -58,12 +58,31 @@ func newRuntimesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			runtimes, err := c.ListSandboxRuntimes(ctx)
+			details, desktopCapable, err := c.ListSandboxRuntimeDetails(ctx)
 			if err != nil {
 				return err
 			}
-			for _, r := range runtimes {
-				fmt.Println(r)
+			if len(details) == 0 {
+				// Older server: no availability information published.
+				runtimes, err := c.ListSandboxRuntimes(ctx)
+				if err != nil {
+					return err
+				}
+				for _, r := range runtimes {
+					fmt.Println(r)
+				}
+				return nil
+			}
+			for _, r := range details {
+				if r.Available {
+					fmt.Println(r.Name)
+					continue
+				}
+				fmt.Printf("%s  (unavailable: %s)\n", r.Name, r.Reason)
+			}
+			if !desktopCapable {
+				fmt.Println("\nNo sandbox host on this deployment has a display/render node, so desktop")
+				fmt.Println("runtimes cannot run. Headless runtimes are unaffected — they need no GPU.")
 			}
 			return nil
 		},

--- a/api/pkg/client/sandbox.go
+++ b/api/pkg/client/sandbox.go
@@ -30,6 +30,16 @@ type SandboxListFilter struct {
 	ProjectID string
 }
 
+// SandboxRuntimeInfo describes one runtime and whether this deployment can
+// actually run it. Desktop runtimes are unavailable on a fleet whose sandbox
+// hosts have no render node.
+type SandboxRuntimeInfo struct {
+	Name            string `json:"name"`
+	RequiresDisplay bool   `json:"requires_display"`
+	Available       bool   `json:"available"`
+	Reason          string `json:"reason,omitempty"`
+}
+
 // ListSandboxRuntimes returns the runtime names this server is configured to
 // expose. The UI uses it to populate the runtime dropdown; the CLI uses it
 // for tab-completion and validation.
@@ -41,6 +51,21 @@ func (c *HelixClient) ListSandboxRuntimes(ctx context.Context) ([]string, error)
 		return nil, err
 	}
 	return resp.Runtimes, nil
+}
+
+// ListSandboxRuntimeDetails returns per-runtime availability alongside whether
+// the deployment has any display-capable sandbox host at all. Servers older
+// than this field return an empty slice, in which case callers should fall
+// back to ListSandboxRuntimes.
+func (c *HelixClient) ListSandboxRuntimeDetails(ctx context.Context) ([]SandboxRuntimeInfo, bool, error) {
+	var resp struct {
+		RuntimeDetails []SandboxRuntimeInfo `json:"runtime_details"`
+		DesktopCapable bool                 `json:"desktop_capable"`
+	}
+	if err := c.makeRequest(ctx, http.MethodGet, "/sandbox-runtimes", nil, &resp); err != nil {
+		return nil, false, err
+	}
+	return resp.RuntimeDetails, resp.DesktopCapable, nil
 }
 
 // ListSandboxes returns the sandboxes belonging to an organization.

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -290,10 +290,14 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		// select a host advertising that image even though the created container
 		// itself has no compositor or display devices.
 		placementImage := containerType
+		requiresDisplay := true
 		if containerType == "headless" {
 			placementImage = "ubuntu"
+			// No compositor, no encoder — a CPU-only host is fine, it just
+			// has to advertise the toolchain image.
+			requiresDisplay = false
 		}
-		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage)
+		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find available sandbox: %w", err)
 		}

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -418,7 +418,7 @@ func (m *Manager) demandPressureExists(rows []*types.SandboxInstance) bool {
 		// can't run sandboxes at all, so they never contribute sandbox
 		// capacity or absorb demand - exclude them so a neuron fleet
 		// never masks real desktop demand nor scales up to "meet" it.
-		if !isReadyAndOnline(r) || !r.CanHostSandbox() {
+		if !isReadyAndOnline(r) || !r.CanHostDesktop() {
 			continue
 		}
 		readyAny = true
@@ -485,7 +485,7 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		}
 		readyByID[r.ID] = r
 		readyCount++
-		if isReadyAndOnline(r) && r.CanHostSandbox() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+		if isReadyAndOnline(r) && r.CanHostDesktop() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
 			fleetAtCap = true
 		}
 	}
@@ -759,7 +759,7 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 		// capacity/demand or it would suppress real scale-up. Floor
 		// counting above (isAliveForFloor) stays vendor-blind so a neuron
 		// floor runner is still kept alive.
-		if isReadyAndOnline(r) && r.CanHostSandbox() {
+		if isReadyAndOnline(r) && r.CanHostDesktop() {
 			readyOnlineCount++
 			readyCapacity += int(r.MaxSandboxes)
 			readyDemand += int(r.ActiveSandboxes)

--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -31,6 +31,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ErrNoDisplayCapableHost is returned when a runtime that streams a desktop
+// is requested but no online sandbox host has a render node. Only the desktop
+// runtime hits this: headless containers run no compositor and no encoder, so
+// they place on CPU-only hosts happily. Callers should surface it as a 4xx —
+// it is a property of the deployment's hardware, not a transient failure.
+var ErrNoDisplayCapableHost = errors.New(
+	"this deployment has no sandbox host with a display/render node, so desktop runtimes are unavailable; " +
+		"use a headless runtime, or add a sandbox host with a GPU")
+
 // recoverGoroutine turns a panic in a detached goroutine into a logged error
 // instead of a process-wide crash (a panic in ANY goroutine kills the whole
 // API binary — every sandbox and web service with it). Guard every fire-and-
@@ -124,6 +133,19 @@ func (c *Controller) Create(ctx context.Context, orgID, owner string, req *types
 	}
 	if err := c.ensureSandboxCredits(ctx, orgID, spec, settings, vcpus); err != nil {
 		return nil, err
+	}
+	// Reject desktop runtimes when the fleet has no render-capable host,
+	// rather than letting placement fail later with a generic "no available
+	// host". Deliberately after the quota and credit checks so those keep
+	// precedence — this only adds a rejection, it never masks one.
+	if spec.RequiresDisplay {
+		hasDisplay, err := c.HasDisplayCapableHost(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !hasDisplay {
+			return nil, ErrNoDisplayCapableHost
+		}
 	}
 	// Stamp the row with the resolved runtime name and image so the UI/CLI
 	// can show what's actually running, even when the caller used a custom

--- a/api/pkg/sandbox/controller_placement_test.go
+++ b/api/pkg/sandbox/controller_placement_test.go
@@ -59,10 +59,11 @@ func (s *ControllerPlacementSuite) headlessSpec() *RuntimeSpec {
 // desktopSpec returns the heartbeat-versioned ubuntu-desktop spec.
 func (s *ControllerPlacementSuite) desktopSpec() *RuntimeSpec {
 	return &RuntimeSpec{
-		Name:          string(types.SandboxRuntimeUbuntuDesktop),
-		ContainerType: hydra.DevContainerTypeUbuntu,
-		Privileged:    true,
-		VersionKey:    "ubuntu",
+		Name:            string(types.SandboxRuntimeUbuntuDesktop),
+		ContainerType:   hydra.DevContainerTypeUbuntu,
+		Privileged:      true,
+		VersionKey:      "ubuntu",
+		RequiresDisplay: true,
 	}
 }
 
@@ -164,7 +165,7 @@ func (s *ControllerPlacementSuite) TestFirstTimePlacementHeadless() {
 func (s *ControllerPlacementSuite) TestFirstTimePlacementDesktopRequiresVersionMatch() {
 	sb := &types.Sandbox{ID: "sbx_new_desktop"}
 	hostA := &types.SandboxInstance{ID: "host-a", Status: "online"}
-	s.store.EXPECT().FindAvailableSandboxInstance(s.ctx, "ubuntu").Return(hostA, nil)
+	s.store.EXPECT().FindAvailableSandboxInstance(s.ctx, "ubuntu", true).Return(hostA, nil)
 
 	host, err := s.controller.pickHostForSandbox(s.ctx, sb, s.desktopSpec())
 	s.Require().NoError(err)
@@ -231,4 +232,69 @@ func (s *ControllerPlacementSuite) TestNoHostsAvailable() {
 	host, err := s.controller.pickHostForSandbox(s.ctx, sb, s.headlessSpec())
 	s.Require().Error(err)
 	s.Require().Nil(host)
+}
+
+// TestHeadlessPlacesOnHostWithoutRenderNode — headless containers run no
+// compositor and no encoder, so a CPU-only host (gpu_vendor "none",
+// render_node "SOFTWARE") is a perfectly good home for them. Before this,
+// headless placement shared the desktop capability check and such a host was
+// skipped entirely, leaving it online but permanently idle.
+func (s *ControllerPlacementSuite) TestHeadlessPlacesOnHostWithoutRenderNode() {
+	sb := &types.Sandbox{ID: "sbx_headless_cpu"}
+	cpuOnly := &types.SandboxInstance{
+		ID:         "host-cpu",
+		Status:     "online",
+		GPUVendor:  "none",
+		RenderNode: "SOFTWARE",
+	}
+	s.store.EXPECT().ListSandboxInstances(s.ctx).Return([]*types.SandboxInstance{cpuOnly}, nil)
+
+	host, err := s.controller.pickHostForSandbox(s.ctx, sb, s.headlessSpec())
+	s.Require().NoError(err)
+	s.Require().Equal("host-cpu", host.ID)
+}
+
+// TestHeadlessPlacesOnNeuronHost — same for inference accelerators, which
+// also have no render node.
+func (s *ControllerPlacementSuite) TestHeadlessPlacesOnNeuronHost() {
+	sb := &types.Sandbox{ID: "sbx_headless_neuron"}
+	neuron := &types.SandboxInstance{ID: "host-inf2", Status: "online", GPUVendor: "neuron"}
+	s.store.EXPECT().ListSandboxInstances(s.ctx).Return([]*types.SandboxInstance{neuron}, nil)
+
+	host, err := s.controller.pickHostForSandbox(s.ctx, sb, s.headlessSpec())
+	s.Require().NoError(err)
+	s.Require().Equal("host-inf2", host.ID)
+}
+
+// TestDesktopWithoutDisplayHostReturnsTypedError — when the store finds no
+// render-capable host for a desktop runtime, callers get ErrNoDisplayCapableHost
+// so the API can explain that this deployment cannot stream desktops at all,
+// rather than a generic "no host advertises image".
+func (s *ControllerPlacementSuite) TestDesktopWithoutDisplayHostReturnsTypedError() {
+	sb := &types.Sandbox{ID: "sbx_desktop_nogpu"}
+	s.store.EXPECT().FindAvailableSandboxInstance(s.ctx, "ubuntu", true).Return(nil, nil)
+
+	host, err := s.controller.pickHostForSandbox(s.ctx, sb, s.desktopSpec())
+	s.Require().Nil(host)
+	s.Require().ErrorIs(err, ErrNoDisplayCapableHost)
+}
+
+// TestHasDisplayCapableHost distinguishes a fleet that can stream desktops
+// from one that cannot.
+func (s *ControllerPlacementSuite) TestHasDisplayCapableHost() {
+	s.store.EXPECT().ListSandboxInstances(s.ctx).Return([]*types.SandboxInstance{
+		{ID: "host-cpu", Status: "online", GPUVendor: "none", RenderNode: "SOFTWARE"},
+		{ID: "host-inf2", Status: "online", GPUVendor: "neuron"},
+	}, nil)
+	ok, err := s.controller.HasDisplayCapableHost(s.ctx)
+	s.Require().NoError(err)
+	s.Require().False(ok)
+
+	s.store.EXPECT().ListSandboxInstances(s.ctx).Return([]*types.SandboxInstance{
+		{ID: "host-cpu", Status: "online", GPUVendor: "none", RenderNode: "SOFTWARE"},
+		{ID: "host-gpu", Status: "online", GPUVendor: "nvidia", RenderNode: "/dev/dri/renderD128"},
+	}, nil)
+	ok, err = s.controller.HasDisplayCapableHost(s.ctx)
+	s.Require().NoError(err)
+	s.Require().True(ok)
 }

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -368,6 +368,23 @@ func (c *Controller) specForSandbox(sandbox *types.Sandbox) (*RuntimeSpec, error
 	return spec, nil
 }
 
+// HasDisplayCapableHost reports whether any online sandbox host can run a
+// streamed desktop. Used to reject desktop runtimes at create time and to
+// advertise per-runtime availability, so a CPU-only deployment tells callers
+// what it can do instead of failing at placement.
+func (c *Controller) HasDisplayCapableHost(ctx context.Context) (bool, error) {
+	hosts, err := c.store.ListSandboxInstances(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list hosts: %w", err)
+	}
+	for _, h := range hosts {
+		if h.Status == "online" && h.CanHostDesktop() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // instanceAdvertisesVersion mirrors the version-matching logic in
 // store.FindAvailableSandboxInstance — it returns true iff the host's
 // heartbeat blob lists a non-empty image tag for desktopType. Used when
@@ -424,11 +441,14 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 
 	// First-time placement (or non-persistent reschedule).
 	if spec.VersionKey != "" {
-		host, err := c.store.FindAvailableSandboxInstance(ctx, spec.VersionKey)
+		host, err := c.store.FindAvailableSandboxInstance(ctx, spec.VersionKey, spec.RequiresDisplay)
 		if err != nil {
 			return nil, fmt.Errorf("find available host: %w", err)
 		}
 		if host == nil {
+			if spec.RequiresDisplay {
+				return nil, ErrNoDisplayCapableHost
+			}
 			return nil, fmt.Errorf("no online sandbox host advertises image for runtime %s", spec.Name)
 		}
 		return host, nil
@@ -438,10 +458,10 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 		return nil, fmt.Errorf("list hosts: %w", err)
 	}
 	for _, h := range hosts {
-		// Headless sandboxes are still sandboxes - keep them off
-		// non-render-capable (e.g. neuron/inf2) hosts, which are
-		// inference-only.
-		if h.Status == "online" && h.CanHostSandbox() {
+		// Headless containers run no compositor and no encoder, so any
+		// online host will do - including CPU-only and inference
+		// accelerator hosts that cannot stream a desktop.
+		if h.Status == "online" {
 			return h, nil
 		}
 	}

--- a/api/pkg/sandbox/controller_provision_test.go
+++ b/api/pkg/sandbox/controller_provision_test.go
@@ -162,6 +162,14 @@ func (s *ProvisionSuite) expectCreateOK(orgID string, sb *types.Sandbox) {
 	)
 }
 
+// expectDisplayCapableFleet satisfies the display-capability probe Create()
+// runs before accepting a desktop runtime.
+func (s *ProvisionSuite) expectDisplayCapableFleet() {
+	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{
+		{ID: "host-a", Status: "online", GPUVendor: "nvidia", RenderNode: "/dev/dri/renderD128"},
+	}, nil)
+}
+
 // expectProvisionStoreCalls wires up the store sequence inside provision()
 // for a successful run targeting host-a.
 func (s *ProvisionSuite) expectProvisionStoreCalls(sb *types.Sandbox, host *types.SandboxInstance, hostListed bool) {
@@ -170,7 +178,7 @@ func (s *ProvisionSuite) expectProvisionStoreCalls(sb *types.Sandbox, host *type
 		s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{host}, nil)
 	} else {
 		// Heartbeat-versioned (desktop) path.
-		s.store.EXPECT().FindAvailableSandboxInstance(gomock.Any(), gomock.Any()).Return(host, nil)
+		s.store.EXPECT().FindAvailableSandboxInstance(gomock.Any(), gomock.Any(), gomock.Any()).Return(host, nil)
 	}
 	// IncrementSandboxContainerCount is called after CreateDevContainer
 	// succeeds so the autoscaler sees user-facing sandbox API load.
@@ -376,6 +384,7 @@ func (s *ProvisionSuite) TestProvisionDesktopBuildsFullEnvAndMounts() {
 	versions := mustMarshal(map[string]string{"ubuntu": "abc123"})
 	host := &types.SandboxInstance{ID: "host-a", Status: "online", DesktopVersions: versions}
 
+	s.expectDisplayCapableFleet() // Create() rejects desktop runtimes on a fleet with no render node
 	s.expectCreateOK("org_1", sb)
 	s.expectProvisionStoreCalls(sb, host, false) // versioned -> FindAvailable path
 	// Desktop runtime mints an API token.

--- a/api/pkg/sandbox/runtimes.go
+++ b/api/pkg/sandbox/runtimes.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/config"
@@ -32,6 +33,11 @@ type RuntimeSpec struct {
 	// hydra heartbeat (e.g. ubuntu-desktop -> "ubuntu"). Empty for
 	// fixed-image runtimes.
 	VersionKey string
+	// RequiresDisplay is true for runtimes that run a compositor and are
+	// streamed, and therefore need a host with a real render node. Headless
+	// runtimes leave it false and place on any online host, including
+	// CPU-only ones.
+	RequiresDisplay bool
 }
 
 // RuntimeRegistry is the lookup table of all runtimes available on this
@@ -46,10 +52,11 @@ type RuntimeRegistry struct {
 // config) because its image is heartbeat-versioned and it has special
 // container-type/privileged handling.
 var builtinDesktop = &RuntimeSpec{
-	Name:          string(types.SandboxRuntimeUbuntuDesktop),
-	ContainerType: hydra.DevContainerTypeUbuntu,
-	Privileged:    true,
-	VersionKey:    "ubuntu",
+	Name:            string(types.SandboxRuntimeUbuntuDesktop),
+	ContainerType:   hydra.DevContainerTypeUbuntu,
+	Privileged:      true,
+	VersionKey:      "ubuntu",
+	RequiresDisplay: true,
 }
 
 // NewRuntimeRegistry parses cfg.Runtimes and builds the lookup. The format is
@@ -167,5 +174,37 @@ func (r *RuntimeRegistry) Names() []string {
 	for name := range r.specs {
 		out = append(out, name)
 	}
+	return out
+}
+
+// RuntimeAvailability describes one runtime to API callers: whether it needs a
+// display-capable host, and whether this deployment currently has one. A UI can
+// grey out unavailable runtimes instead of letting the user pick one that will
+// be rejected.
+type RuntimeAvailability struct {
+	Name            string `json:"name"`
+	RequiresDisplay bool   `json:"requires_display"`
+	Available       bool   `json:"available"`
+	// Reason is set only when Available is false.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Availability describes every registered runtime given whether the fleet has
+// a display-capable host right now.
+func (r *RuntimeRegistry) Availability(hasDisplayHost bool) []RuntimeAvailability {
+	out := make([]RuntimeAvailability, 0, len(r.specs))
+	for name, spec := range r.specs {
+		entry := RuntimeAvailability{
+			Name:            name,
+			RequiresDisplay: spec.RequiresDisplay,
+			Available:       true,
+		}
+		if spec.RequiresDisplay && !hasDisplayHost {
+			entry.Available = false
+			entry.Reason = "no online sandbox host has a display/render node"
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }

--- a/api/pkg/sandbox/runtimes_availability_test.go
+++ b/api/pkg/sandbox/runtimes_availability_test.go
@@ -1,0 +1,74 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func testRegistry(t *testing.T) *RuntimeRegistry {
+	t.Helper()
+	r, err := NewRuntimeRegistry(config.Sandboxes{
+		Runtimes:       "headless-ubuntu=ubuntu:22.04|sleep infinity,node22=node:22-bookworm-slim",
+		DefaultRuntime: "headless-ubuntu",
+	})
+	require.NoError(t, err)
+	return r
+}
+
+// The desktop runtime is the only one that needs display hardware; everything
+// configured through HELIX_SANDBOX_RUNTIMES is headless and runs anywhere.
+func TestRuntimeAvailabilityWithoutDisplayHost(t *testing.T) {
+	got := testRegistry(t).Availability(false)
+
+	byName := map[string]RuntimeAvailability{}
+	for _, r := range got {
+		byName[r.Name] = r
+	}
+
+	desktop := byName[string(types.SandboxRuntimeUbuntuDesktop)]
+	require.True(t, desktop.RequiresDisplay)
+	require.False(t, desktop.Available, "desktop must be unavailable with no render-capable host")
+	require.NotEmpty(t, desktop.Reason, "an unavailable runtime must say why")
+
+	for _, name := range []string{"headless-ubuntu", "node22"} {
+		r := byName[name]
+		require.False(t, r.RequiresDisplay, "%s should not require a display", name)
+		require.True(t, r.Available, "%s must stay available on a CPU-only fleet", name)
+		require.Empty(t, r.Reason)
+	}
+}
+
+func TestRuntimeAvailabilityWithDisplayHost(t *testing.T) {
+	for _, r := range testRegistry(t).Availability(true) {
+		require.True(t, r.Available, "%s should be available when a render-capable host exists", r.Name)
+		require.Empty(t, r.Reason)
+	}
+}
+
+// Availability is sorted so CLI and UI output is stable across calls; the
+// registry itself is a map and would otherwise iterate in random order.
+func TestRuntimeAvailabilityIsSorted(t *testing.T) {
+	got := testRegistry(t).Availability(true)
+	require.Len(t, got, 3)
+	for i := 1; i < len(got); i++ {
+		require.Less(t, got[i-1].Name, got[i].Name)
+	}
+}
+
+// The built-in desktop spec must carry RequiresDisplay, otherwise placement
+// would silently schedule a compositor onto a host with no render node.
+func TestBuiltinDesktopRequiresDisplay(t *testing.T) {
+	spec, err := testRegistry(t).Resolve(&types.CreateSandboxRequest{
+		Runtime: types.SandboxRuntimeUbuntuDesktop,
+	})
+	require.NoError(t, err)
+	require.True(t, spec.RequiresDisplay)
+
+	headless, err := testRegistry(t).Resolve(&types.CreateSandboxRequest{Runtime: "headless-ubuntu"})
+	require.NoError(t, err)
+	require.False(t, headless.RequiresDisplay)
+}

--- a/api/pkg/server/sandboxes_api_handlers.go
+++ b/api/pkg/server/sandboxes_api_handlers.go
@@ -45,9 +45,19 @@ var sandboxTerminalUpgrader = websocket.Upgrader{
 // @Success 200 {object} map[string][]string
 // @Security ApiKeyAuth
 // @Router /api/v1/sandbox-runtimes [get]
-func (s *HelixAPIServer) listSandboxRuntimes(rw http.ResponseWriter, _ *http.Request) {
+func (s *HelixAPIServer) listSandboxRuntimes(rw http.ResponseWriter, r *http.Request) {
+	// A deployment with no display-capable sandbox host cannot run desktop
+	// runtimes at all. Report that alongside the names so callers can grey the
+	// option out rather than discovering it when creation is rejected.
+	hasDisplayHost, err := s.sandboxController.HasDisplayCapableHost(r.Context())
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to determine display-capable host availability; reporting desktop runtimes as available")
+		hasDisplayHost = true
+	}
 	writeJSON(rw, http.StatusOK, map[string]any{
-		"runtimes": s.sandboxController.Runtimes().Names(),
+		"runtimes":        s.sandboxController.Runtimes().Names(),
+		"runtime_details": s.sandboxController.Runtimes().Availability(hasDisplayHost),
+		"desktop_capable": hasDisplayHost,
 	})
 }
 

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/sandbox"
 	"github.com/helixml/helix/api/pkg/services"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -193,6 +194,20 @@ func (s *HelixAPIServer) createTaskFromPrompt(w http.ResponseWriter, r *http.Req
 	if !types.ValidSpecTaskSandboxRuntime(req.SandboxRuntime) {
 		http.Error(w, "sandbox runtime must be ubuntu-desktop or headless-ubuntu", http.StatusBadRequest)
 		return
+	}
+	// A task pinned to the streamed desktop can never start on a fleet with no
+	// render node. Say so now rather than letting it sit in the backlog and
+	// fail at placement. The runtime is immutable once the task exists, so
+	// this is the only chance to catch it.
+	if types.EffectiveSpecTaskSandboxRuntime(req.SandboxRuntime) == types.SandboxRuntimeUbuntuDesktop {
+		hasDisplay, err := s.sandboxController.HasDisplayCapableHost(ctx)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to check display-capable hosts; allowing desktop spec task")
+		} else if !hasDisplay {
+			http.Error(w, sandbox.ErrNoDisplayCapableHost.Error()+
+				" — create the task with sandbox_runtime \"headless-ubuntu\"", http.StatusBadRequest)
+			return
+		}
 	}
 	if req.CodeAgentOverrides != nil {
 		if err := s.validateCodeAgentOverrides(ctx, req.AppID, req.CodeAgentOverrides, user.ID); err != nil {

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -833,7 +833,7 @@ type Store interface {
 	BackfillSandboxMaxSandboxes(ctx context.Context, value int) (int64, error)
 	ResetSandboxOnReconnect(ctx context.Context, id string) error
 	GetSandboxInstancesOlderThanHeartbeat(ctx context.Context, olderThan time.Time) ([]*types.SandboxInstance, error)
-	FindAvailableSandboxInstance(ctx context.Context, desktopType string) (*types.SandboxInstance, error)
+	FindAvailableSandboxInstance(ctx context.Context, desktopType string, requiresDisplay bool) (*types.SandboxInstance, error)
 
 	// User Sandbox methods (Sandboxes API — POST /organizations/{org}/sandboxes etc.)
 	CreateSandbox(ctx context.Context, sandbox *types.Sandbox) (*types.Sandbox, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -2301,18 +2301,18 @@ func (mr *MockStoreMockRecorder) FailInFlightWebServiceDeploys(ctx any) *gomock.
 }
 
 // FindAvailableSandboxInstance mocks base method.
-func (m *MockStore) FindAvailableSandboxInstance(ctx context.Context, desktopType string) (*types.SandboxInstance, error) {
+func (m *MockStore) FindAvailableSandboxInstance(ctx context.Context, desktopType string, requiresDisplay bool) (*types.SandboxInstance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAvailableSandboxInstance", ctx, desktopType)
+	ret := m.ctrl.Call(m, "FindAvailableSandboxInstance", ctx, desktopType, requiresDisplay)
 	ret0, _ := ret[0].(*types.SandboxInstance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAvailableSandboxInstance indicates an expected call of FindAvailableSandboxInstance.
-func (mr *MockStoreMockRecorder) FindAvailableSandboxInstance(ctx, desktopType any) *gomock.Call {
+func (mr *MockStoreMockRecorder) FindAvailableSandboxInstance(ctx, desktopType, requiresDisplay any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAvailableSandboxInstance", reflect.TypeOf((*MockStore)(nil).FindAvailableSandboxInstance), ctx, desktopType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAvailableSandboxInstance", reflect.TypeOf((*MockStore)(nil).FindAvailableSandboxInstance), ctx, desktopType, requiresDisplay)
 }
 
 // FinishTriggerExecution mocks base method.

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -282,13 +282,20 @@ func (s *PostgresStore) GetSandboxInstancesOlderThanHeartbeat(ctx context.Contex
 // FindAvailableSandboxInstance finds a sandbox host that is online, has recent heartbeat, and has the required desktop version.
 // Returns nil if no suitable sandbox host is found.
 //
+// requiresDisplay narrows the search to render-capable hosts. Pass true when
+// the container will run a compositor and be streamed; pass false for
+// headless containers, which still need the versioned toolchain image named
+// by desktopType but have no display or encoder to satisfy. A CPU-only host
+// (gpu_vendor "none" / render_node "SOFTWARE") is a perfectly good home for
+// headless work and is only excluded when requiresDisplay is true.
+//
 // Uses config.DefaultSandboxDispatchStaleThreshold (90s) as the dispatch
 // staleness filter. The Runner-side heartbeat cadence is 30s (see
 // cmd/sandbox-heartbeat/main.go:27 `HeartbeatInterval`), so 90s = 3
 // heartbeat intervals: a Runner that misses one beat stays selectable;
 // missing two-or-more excludes it from new dispatch. The reaper uses the
 // looser SandboxStaleThreshold for UI/reporting state.
-func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, desktopType string) (*types.SandboxInstance, error) {
+func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, desktopType string, requiresDisplay bool) (*types.SandboxInstance, error) {
 	staleThreshold := time.Now().Add(-config.DefaultSandboxDispatchStaleThreshold)
 	var instances []*types.SandboxInstance
 	err := s.gdb.WithContext(ctx).
@@ -301,10 +308,11 @@ func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, deskto
 
 	// Find one with the required desktop version
 	for _, instance := range instances {
-		// Sandboxes only run on render-capable hosts. A neuron/inf2 host
-		// (no /dev/dri render node) would otherwise be picked on load
-		// alone, then the desktop container FATALs at startup.
-		if !instance.CanHostSandbox() {
+		// Streamed desktops only run on render-capable hosts. A neuron/inf2
+		// host (no /dev/dri render node) would otherwise be picked on load
+		// alone, then the desktop container FATALs at startup. Headless
+		// containers have no such constraint.
+		if requiresDisplay && !instance.CanHostDesktop() {
 			continue
 		}
 		if len(instance.DesktopVersions) > 0 {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3604,14 +3604,18 @@ func (SandboxInstance) TableName() string {
 	return "sandbox_instances"
 }
 
-// CanHostSandbox reports whether this host can run a sandbox (desktop or
-// headless dev container). Sandboxes need display/encode hardware, so we
-// exclude the accelerators that lack it: AWS Inferentia/Trainium
-// (GPUVendor "neuron") has no /dev/dri render node - its desktop startup
-// FATALs - and "none" is a CPU-only host. A SOFTWARE render node has no
-// hardware encoder for streaming. Everything else (nvidia / amd / intel,
-// and not-yet-reported hosts) is treated as capable.
-func (s *SandboxInstance) CanHostSandbox() bool {
+// CanHostDesktop reports whether this host can run a *streamed desktop*
+// container. Desktops need display and encode hardware, so we exclude the
+// hosts that lack it: AWS Inferentia/Trainium (GPUVendor "neuron") has no
+// /dev/dri render node - its desktop startup FATALs - and "none" is a
+// CPU-only host. A SOFTWARE render node has no hardware encoder for
+// streaming. Everything else (nvidia / amd / intel, and not-yet-reported
+// hosts) is treated as capable.
+//
+// This gates desktop placement and desktop capacity accounting ONLY.
+// Headless containers run no compositor and no encoder, so they place on any
+// online host regardless of what this returns - see pickHostForSandbox.
+func (s *SandboxInstance) CanHostDesktop() bool {
 	switch s.GPUVendor {
 	case "neuron", "none":
 		return false

--- a/api/pkg/types/types_test.go
+++ b/api/pkg/types/types_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSandboxInstanceCanHostSandbox(t *testing.T) {
+func TestSandboxInstanceCanHostDesktop(t *testing.T) {
 	cases := []struct {
 		name   string
 		vendor string
@@ -24,8 +24,8 @@ func TestSandboxInstanceCanHostSandbox(t *testing.T) {
 	}
 	for _, tc := range cases {
 		s := &SandboxInstance{GPUVendor: tc.vendor, RenderNode: tc.render}
-		if got := s.CanHostSandbox(); got != tc.want {
-			t.Errorf("%s: CanHostSandbox()=%v want %v", tc.name, got, tc.want)
+		if got := s.CanHostDesktop(); got != tc.want {
+			t.Errorf("%s: CanHostDesktop()=%v want %v", tc.name, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## The problem

A GPU is only needed to render and encode a **streamed desktop**. A headless sandbox is a plain image running a keep-alive command — no compositor, no encoder, nothing that touches `/dev/dri`.

But placement didn't distinguish them. Every path went through `SandboxInstance.CanHostSandbox()`:

```go
func (s *SandboxInstance) CanHostSandbox() bool {
	switch s.GPUVendor {
	case "neuron", "none":
		return false
	}
	return s.RenderNode != "SOFTWARE"
}
```

So a CPU-only sandbox host registers, heartbeats, and reports `status: "online"` in `helix api /sandboxes` — while nothing is ever scheduled onto it, including headless work it could run perfectly well. There's no error anywhere; the host just sits idle and sandboxes fail to place.

The exclusion was written to keep desktops off inference-only inf2/Neuron hosts (whose desktop startup FATALs — see the comment in `FindAvailableSandboxInstance`). CPU-only hosts were collateral.

## What changes

**Split the capability.** `CanHostSandbox()` → `CanHostDesktop()` — same predicate, honest name, and it now gates only desktop placement and desktop capacity accounting.

- `RuntimeSpec` gains `RequiresDisplay`; only the built-in `ubuntu-desktop` sets it. Everything configured through `HELIX_SANDBOX_RUNTIMES` is headless.
- `FindAvailableSandboxInstance(ctx, desktopType, requiresDisplay)` applies the render-node filter only when asked. Headless spec tasks still need the host to advertise the versioned toolchain image — that's an image concern, not a hardware one — so they keep the version match and drop the GPU check.
- Headless placement in `pickHostForSandbox` accepts any online host, including CPU-only and Neuron.
- **Autoscaler behaviour is deliberately unchanged**: the three capacity/demand sites in `compute/manager.go` now say `CanHostDesktop()`, which is exactly what they meant. Desktop demand is still only satisfiable by render-capable hosts, so a Neuron fleet can't mask real desktop scale-up.

**Make the limitation visible** rather than a late placement failure:

- `GET /sandbox-runtimes` gains `runtime_details` (per-runtime `requires_display` / `available` / `reason`) and `desktop_capable`.
- `helix sandbox runtimes` marks unavailable runtimes and explains why, falling back to the plain list on older servers.
- Creating a sandbox on a desktop runtime, or a spec task pinned to `ubuntu-desktop`, is rejected up front with `ErrNoDisplayCapableHost` and a message pointing at headless. The sandbox-side check runs *after* the quota and credit checks so their precedence is untouched.

## Testing

- `go build ./...`, `go vet ./pkg/...` (only pre-existing findings in `pkg/hydra` and `pkg/desktop`) and `gofmt` clean.
- `go test ./pkg/sandbox/... ./pkg/types/...` pass, including new coverage: CPU-only and Neuron hosts taking headless work, the typed desktop error, `HasDisplayCapableHost`, and runtime availability reporting.
- `pkg/store` needs Postgres and was not run locally, per CONTRIBUTING/CLAUDE guidance.
- The CLI's older-server fallback was verified against a live 2.12.3 control plane: `helix sandbox runtimes` still prints the plain list when `runtime_details` is absent.
- **Not** verified against a server running this branch — the only deployment available had real work on it and I wasn't willing to restart its API. The behaviour worth exercising before merge is a genuinely CPU-only sandbox host: confirm a headless sandbox places on it, and that `ubuntu-desktop` is rejected with the new message rather than hanging.

## Note for reviewers

The one judgement call is that Neuron/inf2 hosts can now take headless sandboxes. That was chosen deliberately over keeping them reserved for inference — if you'd rather inf2 stayed inference-only, the change is a single condition in `pickHostForSandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)