### PR TITLE
feat(cli): select spec task sandbox environment

### DIFF
--- a/api/pkg/cli/project/inspect.go
+++ b/api/pkg/cli/project/inspect.go
@@ -75,7 +75,9 @@ func newInspectCommand() *cobra.Command {
 			if len(project.Technologies) > 0 {
 				fmt.Printf("Technologies: %v\n", project.Technologies)
 			}
-			fmt.Printf("Status: %s\n\n", project.Status)
+			fmt.Printf("Status: %s\n", project.Status)
+			fmt.Printf("Default task environment: %s\n\n",
+				types.EffectiveSpecTaskSandboxRuntime(project.DefaultSandboxRuntime))
 
 			// Group tasks by status
 			backlog := []types.SpecTask{}
@@ -182,6 +184,7 @@ func displayTask(task types.SpecTask) {
 	if task.Type != "" {
 		fmt.Printf(" | Type: %s", task.Type)
 	}
+	fmt.Printf(" | Env: %s", types.EffectiveSpecTaskSandboxRuntime(task.SandboxRuntime))
 	fmt.Println()
 	if task.Description != "" && task.Description != task.Name {
 		fmt.Printf("    Description: %s\n", task.Description)

--- a/api/pkg/cli/project/list.go
+++ b/api/pkg/cli/project/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 func newListCommand() *cobra.Command {
@@ -93,10 +94,11 @@ prompted. The HELIX_ORG environment variable is also honoured.`,
 }
 
 type Project struct {
-	ID            string   `json:"id"`
-	Name          string   `json:"name"`
-	Description   string   `json:"description"`
-	Technologies  []string `json:"technologies"`
-	Status        string   `json:"status"`
-	StartupScript string   `json:"startup_script"`
+	ID                    string               `json:"id"`
+	Name                  string               `json:"name"`
+	Description           string               `json:"description"`
+	Technologies          []string             `json:"technologies"`
+	Status                string               `json:"status"`
+	StartupScript         string               `json:"startup_script"`
+	DefaultSandboxRuntime types.SandboxRuntime `json:"default_sandbox_runtime"`
 }

--- a/api/pkg/cli/spectask/mcp_cmd.go
+++ b/api/pkg/cli/spectask/mcp_cmd.go
@@ -607,7 +607,10 @@ Examples:
 			taskPrompt = "E2E cancellation probe: immediately run the shell command `sleep 60` before doing any other work. " +
 				"After it finishes, continue with this request: " + taskPrompt
 
-			task, err := createSpecTask(apiURL, token, "E2E Test Task", taskPrompt, projectID, agentID)
+			// Pinned to the desktop runtime: step 5 screenshots the session, which
+			// a headless project default would not provide.
+			task, err := createSpecTask(apiURL, token, "E2E Test Task", taskPrompt, projectID, agentID,
+				string(types.SandboxRuntimeUbuntuDesktop))
 			if err != nil {
 				return fmt.Errorf("failed to create task: %w", err)
 			}

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -79,6 +79,7 @@ func newStartCommand() *cobra.Command {
 	var prompt string
 	var promptFile string
 	var attachFiles []string
+	var runtime string
 	var quiet bool
 	var wait bool
 	var noWait bool
@@ -86,11 +87,16 @@ func newStartCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start [task-id]",
 		Short: "Start a spec task planning session (creates sandbox)",
-		Long: `Start a spec task planning session which creates a sandbox desktop.
+		Long: `Start a spec task planning session which creates a sandbox.
 
 If no task-id is provided, a new spec task will be created.
 Use --project to specify which project to create the task in.
 Use --agent to specify which Helix agent/app to use (e.g., app_01xxx).
+Use --runtime to pick the sandbox environment:
+  ubuntu-desktop   full GNOME desktop you can stream and screenshot (default)
+  headless-ubuntu  agent-only, no compositor or streaming — faster and cheaper
+The runtime is fixed for the life of the task; omit --runtime to inherit the
+project default.
 
 Example workflow:
   1. Fork a sample project:  helix project fork modern-todo-app --name "My Project"
@@ -101,9 +107,20 @@ Example workflow:
 			apiURL := getAPIURL()
 			token := getToken()
 
+			if !types.ValidSpecTaskSandboxRuntime(types.SandboxRuntime(runtime)) {
+				return fmt.Errorf("invalid --runtime %q: must be %s or %s",
+					runtime, types.SandboxRuntimeUbuntuDesktop, types.SandboxRuntimeHeadlessUbuntu)
+			}
+
 			var taskID string
 			if len(args) > 0 {
 				taskID = args[0]
+				// The runtime is chosen at creation and is immutable — the
+				// owning task is the source of truth on every launch path, so
+				// silently ignoring it here would be misleading.
+				if runtime != "" {
+					return fmt.Errorf("--runtime can only be set when creating a task; %s already has a fixed runtime", taskID)
+				}
 			} else {
 				// Create a new spec task
 				if projectID == "" {
@@ -130,7 +147,7 @@ Example workflow:
 				if taskPrompt == "" {
 					taskPrompt = "Testing RevDial connectivity"
 				}
-				task, err := createSpecTask(apiURL, token, taskName, taskPrompt, projectID, agentID)
+				task, err := createSpecTask(apiURL, token, taskName, taskPrompt, projectID, agentID, runtime)
 				if err != nil {
 					return fmt.Errorf("failed to create spec task: %w", err)
 				}
@@ -140,6 +157,7 @@ Example workflow:
 					if agentID != "" {
 						fmt.Printf("   Agent: %s\n", agentID)
 					}
+					fmt.Printf("   Environment: %s\n", types.EffectiveSpecTaskSandboxRuntime(task.SandboxRuntime))
 				}
 				// Attach files (e.g. logfiles) — the agent reads them at
 				// design/tasks/<task>/attachments/<name>, keeping large context
@@ -217,12 +235,23 @@ Example workflow:
 				fmt.Printf("\n✅ Sandbox is running!\n")
 				fmt.Printf("   Session ID: %s\n", session.ID)
 
-				// Show connection instructions
-				fmt.Printf("\n📺 Connect to Desktop:\n")
-				fmt.Printf("   Open in browser: %s/sessions/%s\n", apiURL, session.ID)
+				// Show connection instructions. Headless sandboxes run no
+				// compositor or streaming stack, so the desktop/screenshot
+				// hints don't apply to them.
+				if types.EffectiveSpecTaskSandboxRuntime(task.SandboxRuntime) == types.SandboxRuntimeHeadlessUbuntu {
+					fmt.Printf("\n🤖 Headless sandbox — no desktop to stream.\n")
+					if taskURL := buildTaskURL(apiURL, task, projectID); taskURL != "" {
+						fmt.Printf("   Follow the agent: %s\n", taskURL)
+					}
+					fmt.Printf("\n💬 Interact from the CLI:\n")
+					fmt.Printf("   helix spectask interact %s\n", session.ID)
+				} else {
+					fmt.Printf("\n📺 Connect to Desktop:\n")
+					fmt.Printf("   Open in browser: %s/sessions/%s\n", apiURL, session.ID)
 
-				fmt.Printf("\n📷 Test screenshot:\n")
-				fmt.Printf("   helix spectask screenshot %s\n", session.ID)
+					fmt.Printf("\n📷 Test screenshot:\n")
+					fmt.Printf("   helix spectask screenshot %s\n", session.ID)
+				}
 			}
 
 			return nil
@@ -235,6 +264,7 @@ Example workflow:
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Task prompt/description")
 	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "Read the task prompt from a file (e.g. a design doc) — dispatch a full brief without committing it to the repo. Appended after --prompt if both are set.")
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file(s) to the task (repeatable). Uploaded as spec-task attachments the agent reads at design/tasks/<task>/attachments/<name> — good for logs/large context without bloating the prompt.")
+	cmd.Flags().StringVar(&runtime, "runtime", "", "Sandbox environment for the new task: ubuntu-desktop (streamable GNOME desktop) or headless-ubuntu (agent only, no desktop). Empty = project default. Immutable once the task exists.")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output the task ID (session ID with --wait)")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Block until the sandbox has booted, then print session-level connect info (default: return immediately with the task URL — the browser page shows it loading)")
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Deprecated: no-wait is now the default; kept as a no-op for back-compat")
@@ -470,13 +500,14 @@ func getToken() string {
 }
 
 type SpecTask struct {
-	ID                string `json:"id"`
-	Name              string `json:"name"`
-	Description       string `json:"description"`
-	Status            string `json:"status"`
-	OrganizationID    string `json:"organization_id"`
-	ProjectID         string `json:"project_id"`
-	PlanningSessionID string `json:"planning_session_id"`
+	ID                string               `json:"id"`
+	Name              string               `json:"name"`
+	Description       string               `json:"description"`
+	Status            string               `json:"status"`
+	OrganizationID    string               `json:"organization_id"`
+	ProjectID         string               `json:"project_id"`
+	PlanningSessionID string               `json:"planning_session_id"`
+	SandboxRuntime    types.SandboxRuntime `json:"sandbox_runtime"`
 }
 
 // buildTaskURL returns the frontend task-detail page URL, which is known the
@@ -513,7 +544,7 @@ type SessionMetadata struct {
 	StatusMessage   string `json:"status_message"`
 }
 
-func createSpecTask(apiURL, token, name, prompt, projectID, agentID string) (*SpecTask, error) {
+func createSpecTask(apiURL, token, name, prompt, projectID, agentID, runtime string) (*SpecTask, error) {
 	payload := map[string]string{
 		"name":   name,
 		"prompt": prompt, // API expects "prompt" not "description"
@@ -523,6 +554,10 @@ func createSpecTask(apiURL, token, name, prompt, projectID, agentID string) (*Sp
 	}
 	if agentID != "" {
 		payload["app_id"] = agentID // API expects "app_id" not "helix_app_id"
+	}
+	// Omitted means "inherit the project default" — the server resolves it.
+	if runtime != "" {
+		payload["sandbox_runtime"] = runtime
 	}
 	jsonData, _ := json.Marshal(payload)
 


### PR DESCRIPTION
Follow-up to https://github.com/helixml/helix/pull/3030 — exposes the headless spec task runtime in the CLI.

## Changes

- **`helix spectask start --runtime <ubuntu-desktop|headless-ubuntu>`** — validated client-side against `types.ValidSpecTaskSandboxRuntime`, sent as `sandbox_runtime` on `/spec-tasks/from-prompt`. Omitting it keeps the server's project-default resolution.
- The flag is **rejected alongside an existing task-id**: the runtime is fixed at creation, and the owning task is the source of truth on every launch path, so silently ignoring it would mislead.
- `start` echoes the server-resolved `Environment:`, and its `--wait` connect block drops the desktop/screenshot hints for headless sandboxes (no compositor or streaming stack to connect to).
- `helix project tasks` shows the project's default environment plus a per-task `Env:` field. Empty legacy values render as `ubuntu-desktop` via `EffectiveSpecTaskSandboxRuntime`.
- `spectask mcp e2e` pins its task to `ubuntu-desktop` — step 5 screenshots the session, which a headless project default would break.

## Testing

Run end-to-end against a local dev stack:

| Check | Result |
|---|---|
| `--runtime bogus` | `invalid --runtime "bogus": must be ubuntu-desktop or headless-ubuntu`, exit 1 |
| `--runtime` + task-id | rejected, exit 1 |
| `--runtime headless-ubuntu` create | task row `sandbox_runtime=headless-ubuntu`; container `headless-external-*` with `HELIX_HEADLESS=1`; Zed connected over the sync WebSocket |
| queued-then-started path | second task also provisioned as `headless-external-*` once planning capacity freed |
| `project tasks` | headless task shows `Env: headless-ubuntu`, legacy tasks `Env: ubuntu-desktop` |

**Not exercised live:** the headless branch of the `--wait` connect output. The test project hit its 3-task planning cap, so `--wait` took the (correct) soft-timeout path instead. The field that branch reads was verified separately — `POST /start-planning` returns `sandbox_runtime: headless-ubuntu` — but the printf itself is unrun.

## Not included

There is still no CLI way to *set* a project's `default_sandbox_runtime` (the CLI has no `project create`/`update` command at all). That remains the Project Settings UI or `helix api -X PUT /projects/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)