### PR TITLE
fix(sandbox): reconcile dev containers that exit on their own

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -96,6 +96,15 @@ type ServerConfig struct {
 	// reap a healthy Runner.
 	SandboxStaleThreshold time.Duration `envconfig:"HELIX_SANDBOX_STALE_THRESHOLD" default:"5m"`
 
+	// SandboxContainerReconcileInterval is how often the control plane asks
+	// every online sandbox which dev containers are actually running, so
+	// sessions whose container died on its own (workspace-setup FATAL, OOM
+	// kill, crashed compositor) stop being reported as running. Container
+	// discovery otherwise only happens when a sandbox registers or its
+	// RevDial connection is (re)established, which never fires for a
+	// container that dies while its sandbox stays connected.
+	SandboxContainerReconcileInterval time.Duration `envconfig:"HELIX_SANDBOX_CONTAINER_RECONCILE_INTERVAL" default:"30s"`
+
 	// SandboxDispatchStaleThreshold is the tighter freshness filter
 	// applied by FindAvailableSandboxInstance when selecting a Runner
 	// for new work. Set lower than SandboxStaleThreshold so freshly-dead
@@ -748,9 +757,10 @@ const RAGProviderName = "kodit"
 // the field was never explicitly configured and envconfig left it
 // unparsed). Keep in sync with the `default:` tags above.
 var (
-	DefaultSandboxReaperInterval         = time.Minute
-	DefaultSandboxStaleThreshold         = 5 * time.Minute
-	DefaultSandboxDispatchStaleThreshold = 90 * time.Second
+	DefaultSandboxReaperInterval             = time.Minute
+	DefaultSandboxStaleThreshold             = 5 * time.Minute
+	DefaultSandboxDispatchStaleThreshold     = 90 * time.Second
+	DefaultSandboxContainerReconcileInterval = 30 * time.Second
 )
 
 type RAG struct {

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1772,28 +1772,36 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 		}
 	}
 
+	runningContainers := filterRunningContainers(containerList.Containers)
+	if exited := len(containerList.Containers) - len(runningContainers); exited > 0 {
+		log.Info().
+			Str("sandbox_id", sandboxID).
+			Int("exited_containers", exited).
+			Msg("Sandbox reports containers that are no longer running; excluding them from the live set")
+	}
+
 	// Reconcile the inverse of discovery: any session this control-plane still
-	// believes is "running" on this sandbox but that hydra no longer reports is
-	// stale (e.g. a CD redeploy restarted the sandbox and destroyed its dev
-	// containers). Mark those sessions stopped so the Kanban / task page stop
-	// showing a dead container as running. This MUST run even when hydra reports
-	// zero containers (the full-wipe case), so it sits before the empty-list
-	// early return below.
-	liveSessionIDs := make(map[string]bool, len(containerList.Containers))
-	for _, container := range containerList.Containers {
+	// believes is "running" on this sandbox but that hydra no longer reports as
+	// running is stale (e.g. a CD redeploy destroyed its dev containers, or the
+	// container's entrypoint exited on its own). Mark those sessions stopped so
+	// the Kanban / task page stop showing a dead container as running. This MUST
+	// run even when hydra reports zero running containers (the full-wipe case),
+	// so it sits before the empty-list early return below.
+	liveSessionIDs := make(map[string]bool, len(runningContainers))
+	for _, container := range runningContainers {
 		if container.SessionID != "" {
 			liveSessionIDs[container.SessionID] = true
 		}
 	}
 	h.markMissingSessionsStopped(ctx, sandboxID, liveSessionIDs, hydraClient)
 
-	if len(containerList.Containers) == 0 {
+	if len(runningContainers) == 0 {
 		return nil
 	}
 
 	log.Info().
 		Str("sandbox_id", sandboxID).
-		Int("container_count", len(containerList.Containers)).
+		Int("container_count", len(runningContainers)).
 		Msg("Discovered running containers from sandbox")
 
 	// Collect containers that need to be added to our map
@@ -1809,7 +1817,7 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 
 	// Phase 1: Check which containers we don't have tracked (short lock)
 	h.mutex.RLock()
-	for _, container := range containerList.Containers {
+	for _, container := range runningContainers {
 		sessionID := container.SessionID
 		if _, exists := h.sessions[sessionID]; !exists {
 			containerType := "ubuntu" // Default to Ubuntu
@@ -1918,16 +1926,47 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 	return nil
 }
 
+// filterRunningContainers keeps only the containers Docker currently reports as
+// running.
+//
+// hydra tracks a container until it is explicitly removed, so its list includes
+// containers that have exited (workspace-setup FATAL, OOM kill, crashed
+// compositor). Everything downstream of discovery — the "did this session die"
+// reconcile, the recovery of untracked containers into the in-memory map, the
+// `external_agent_status = "running"` DB write — keys off this set. Treating
+// "hydra still tracks it" as "alive" is what left dead sessions showing a green
+// "Sandbox running" dot indefinitely, and what let a reconnect resurrect a
+// session whose container had already exited.
+func filterRunningContainers(containers []hydra.DevContainerResponse) []hydra.DevContainerResponse {
+	running := make([]hydra.DevContainerResponse, 0, len(containers))
+	for _, container := range containers {
+		if container.Status == hydra.DevContainerStatusRunning {
+			running = append(running, container)
+		}
+	}
+	return running
+}
+
+// devContainerProber is the slice of the hydra client that
+// markMissingSessionsStopped needs: an authoritative, per-session liveness
+// check. Narrowing it to an interface lets the reconcile tests exercise the
+// "hydra still tracks the container but Docker says it exited" case, which is
+// exactly the state a crashed sandbox leaves behind.
+type devContainerProber interface {
+	GetDevContainer(ctx context.Context, sessionID string) (*hydra.DevContainerResponse, error)
+}
+
 // markMissingSessionsStopped downgrades sessions on the given sandbox that this
 // control-plane still marks "running" but that are absent from hydra's live set
-// (liveSessionIDs). For each candidate it authoritatively confirms the container
-// is gone with a per-session GetDevContainer probe — taken under the session's
-// creation lock so a concurrent StartDesktop that (re)created the container after
-// hydra's snapshot can't be wrongly torn down. Confirmed-dead sessions have their
-// container metadata cleared, status set to "stopped", and their stale in-memory
-// entry evicted, so the derived SandboxState becomes "absent" instead of showing
-// a dead container as running.
-func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxID string, liveSessionIDs map[string]bool, hydraClient *hydra.RevDialClient) {
+// (liveSessionIDs — containers Docker currently reports as running). For each
+// candidate it authoritatively confirms the container is not running with a
+// per-session GetDevContainer probe — taken under the session's creation lock so
+// a concurrent StartDesktop that (re)created the container after hydra's snapshot
+// can't be wrongly torn down. Confirmed-dead sessions have their container
+// metadata cleared, status set to "stopped", and their stale in-memory entry
+// evicted, so the derived SandboxState becomes "absent" instead of showing a dead
+// container as running.
+func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxID string, liveSessionIDs map[string]bool, prober devContainerProber) {
 	// Unlike the active_sandboxes counter (a multi-tenant autoscaler concern that
 	// skips "local"), session-status reconciliation applies to every sandbox
 	// including the single-node "local" one — a self-hosted CD redeploy destroys
@@ -1976,13 +2015,20 @@ func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxI
 			continue
 		}
 
-		// Authoritatively confirm the container is gone before downgrading.
-		// hydra's list snapshot may pre-date a just-started container, so a
-		// direct live probe is the source of truth for the decision.
-		if hydraClient != nil {
-			if _, err := hydraClient.GetDevContainer(ctx, session.ID); err == nil {
+		// Authoritatively confirm the container is not running before
+		// downgrading. hydra's list snapshot may pre-date a just-started
+		// container, so a direct live probe is the source of truth for the
+		// decision.
+		//
+		// The probe must check the reported status, not merely that the call
+		// succeeded: GetDevContainer returns a container hydra still tracks even
+		// when Docker reports it exited, so an `err == nil` check here treated a
+		// dead container as alive and skipped the downgrade forever.
+		if prober != nil {
+			if container, err := prober.GetDevContainer(ctx, session.ID); err == nil &&
+				container != nil && container.Status == hydra.DevContainerStatusRunning {
 				sessionLock.Unlock()
-				continue // container actually exists; snapshot was just stale
+				continue // container really is running; snapshot was just stale
 			}
 		}
 

--- a/api/pkg/external-agent/reconcile_exited_containers_test.go
+++ b/api/pkg/external-agent/reconcile_exited_containers_test.go
@@ -1,0 +1,155 @@
+package external_agent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/hydra"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// stubProber is a devContainerProber that answers from a fixture map. A session
+// absent from the map is reported as "not found", mirroring a container hydra
+// has forgotten entirely.
+type stubProber struct {
+	containers map[string]*hydra.DevContainerResponse
+	calls      []string
+}
+
+func (s *stubProber) GetDevContainer(_ context.Context, sessionID string) (*hydra.DevContainerResponse, error) {
+	s.calls = append(s.calls, sessionID)
+	container, ok := s.containers[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("dev container not found for session: %s", sessionID)
+	}
+	return container, nil
+}
+
+func TestFilterRunningContainers(t *testing.T) {
+	containers := []hydra.DevContainerResponse{
+		{SessionID: "ses_running", Status: hydra.DevContainerStatusRunning},
+		{SessionID: "ses_exited", Status: hydra.DevContainerStatusStopped},
+		{SessionID: "ses_also_running", Status: hydra.DevContainerStatusRunning},
+		// An unset status must not be optimistically treated as running.
+		{SessionID: "ses_unknown"},
+	}
+
+	running := filterRunningContainers(containers)
+
+	require.Len(t, running, 2)
+	assert.Equal(t, "ses_running", running[0].SessionID)
+	assert.Equal(t, "ses_also_running", running[1].SessionID)
+}
+
+func TestFilterRunningContainers_Empty(t *testing.T) {
+	assert.Empty(t, filterRunningContainers(nil))
+	assert.Empty(t, filterRunningContainers([]hydra.DevContainerResponse{
+		{SessionID: "ses_exited", Status: hydra.DevContainerStatusStopped},
+	}))
+}
+
+// The regression this whole change exists for: hydra still tracks the container
+// (so GetDevContainer succeeds) but Docker reports it exited. Before the fix the
+// probe only checked `err == nil`, treated the dead container as alive, and left
+// the session pinned at external_agent_status="running" forever — which is what
+// rendered a green "Sandbox running" dot and a ticking "Working for…" timer
+// against a container whose entrypoint had died.
+func TestMarkMissingSessionsStopped_DowngradesTrackedButExitedContainer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	h.sessions["ses_exited"] = &ZedSession{SessionID: "ses_exited", Status: "running"}
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{runningSession("ses_exited")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_exited").
+		Return(runningSession("ses_exited"), nil)
+
+	var downgraded *types.Session
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			downgraded = &s
+			return &s, nil
+		})
+
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{
+		"ses_exited": {SessionID: "ses_exited", Status: hydra.DevContainerStatusStopped},
+	}}
+
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", map[string]bool{}, prober)
+
+	require.NotNil(t, downgraded, "an exited-but-tracked container must be downgraded")
+	assert.Equal(t, "stopped", downgraded.Metadata.ExternalAgentStatus)
+	assert.Empty(t, downgraded.Metadata.ContainerName)
+	assert.Equal(t, []string{"ses_exited"}, prober.calls)
+
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_exited"]
+	h.mutex.RUnlock()
+	assert.False(t, stillTracked, "stale in-memory session should be evicted")
+}
+
+// The probe is what protects a container started between hydra's list snapshot
+// and this sweep. A genuinely running container must survive even though the
+// snapshot did not include it.
+func TestMarkMissingSessionsStopped_KeepsRunningContainerMissingFromSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{runningSession("ses_fresh")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_fresh").
+		Return(runningSession("ses_fresh"), nil)
+	// No UpdateSession expectation: downgrading here would tear down a live session.
+
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{
+		"ses_fresh": {SessionID: "ses_fresh", Status: hydra.DevContainerStatusRunning},
+	}}
+
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", map[string]bool{}, prober)
+}
+
+// A container hydra has forgotten entirely (probe errors) is also dead.
+func TestMarkMissingSessionsStopped_DowngradesUnknownContainer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{runningSession("ses_removed")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_removed").
+		Return(runningSession("ses_removed"), nil)
+
+	downgraded := false
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			assert.Equal(t, "stopped", s.Metadata.ExternalAgentStatus)
+			downgraded = true
+			return &s, nil
+		})
+
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{}}
+
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", map[string]bool{}, prober)
+	assert.True(t, downgraded)
+}

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -2141,49 +2141,16 @@ func (dm *DevContainerManager) GetDevContainer(ctx context.Context, sessionID st
 		return nil, fmt.Errorf("dev container not found for session: %s", sessionID)
 	}
 
-	// Refresh status AND IP from Docker. The container's IP can change across
-	// a container restart; a stale cached IP causes "no route to host" 502s on
-	// the proxy path. Since the proxy calls GetDevContainer on every request,
-	// refreshing the IP here keeps routing correct without any retry logic.
-	var vcpus, memoryMB int
-	dockerClient, err := dm.getDockerClient(dc.DockerSocket)
-	if err == nil {
-		defer dockerClient.Close()
-		inspect, err := dockerClient.ContainerInspect(ctx, dc.ContainerID)
-		if err == nil {
-			status := DevContainerStatusStopped
-			if inspect.State.Running {
-				status = DevContainerStatusRunning
-			}
-			ip := ""
-			for _, network := range inspect.NetworkSettings.Networks {
-				if network.IPAddress != "" {
-					ip = network.IPAddress
-					break
-				}
-			}
-			if ip == "" {
-				ip = inspect.NetworkSettings.IPAddress
-			}
-			dm.mu.Lock()
-			dc.Status = status
-			if ip != "" {
-				dc.IPAddress = ip
-			}
-			dm.mu.Unlock()
-			if inspect.HostConfig != nil {
-				vcpus = int(inspect.HostConfig.NanoCPUs / 1_000_000_000)
-				memoryMB = int(inspect.HostConfig.Memory / (1024 * 1024))
-			}
-		}
-	}
+	// Since the proxy calls GetDevContainer on every request, refreshing the
+	// status and IP here keeps routing correct without any retry logic.
+	status, ipAddress, vcpus, memoryMB := dm.inspectContainerState(ctx, dc)
 
 	return &DevContainerResponse{
 		SessionID:     dc.SessionID,
 		ContainerID:   dc.ContainerID,
 		ContainerName: dc.ContainerName,
-		Status:        dc.Status,
-		IPAddress:     dc.IPAddress,
+		Status:        status,
+		IPAddress:     ipAddress,
 		ContainerType: dc.ContainerType,
 		VCPUs:         vcpus,
 		MemoryMB:      memoryMB,
@@ -2252,19 +2219,36 @@ func (dm *DevContainerManager) UpdateDevContainerResources(ctx context.Context, 
 	}, nil
 }
 
-// ListDevContainers returns all active dev containers
-func (dm *DevContainerManager) ListDevContainers() *ListDevContainersResponse {
+// ListDevContainers returns all tracked dev containers with a status refreshed
+// from Docker.
+//
+// The cached `dc.Status` is only written when hydra itself stops a container
+// (StopDevContainer) or lazily by GetDevContainer. A container whose entrypoint
+// exits on its own — a workspace-setup FATAL, an OOM kill, a crashed compositor —
+// leaves the cached value at "running" indefinitely. The control plane treats
+// this list as its live-set when reconciling session status, so a stale
+// "running" here resurrects dead sessions and the UI shows a green "Sandbox
+// running" dot for a container that exited hours ago.
+//
+// One ContainerInspect per tracked container is local to the sandbox host and
+// cheap relative to the RevDial round-trip that carries the response.
+func (dm *DevContainerManager) ListDevContainers(ctx context.Context) *ListDevContainersResponse {
 	dm.mu.RLock()
-	defer dm.mu.RUnlock()
-
-	containers := make([]DevContainerResponse, 0, len(dm.containers))
+	tracked := make([]*DevContainer, 0, len(dm.containers))
 	for _, dc := range dm.containers {
+		tracked = append(tracked, dc)
+	}
+	dm.mu.RUnlock()
+
+	containers := make([]DevContainerResponse, 0, len(tracked))
+	for _, dc := range tracked {
+		status, ip, _, _ := dm.inspectContainerState(ctx, dc)
 		containers = append(containers, DevContainerResponse{
 			SessionID:     dc.SessionID,
 			ContainerID:   dc.ContainerID,
 			ContainerName: dc.ContainerName,
-			Status:        dc.Status,
-			IPAddress:     dc.IPAddress,
+			Status:        status,
+			IPAddress:     ip,
 			ContainerType: dc.ContainerType,
 		})
 	}
@@ -2272,6 +2256,57 @@ func (dm *DevContainerManager) ListDevContainers() *ListDevContainersResponse {
 	return &ListDevContainersResponse{
 		Containers: containers,
 	}
+}
+
+// inspectContainerState refreshes a tracked container's status and IP from
+// Docker and writes them back to the cached entry, also returning its current
+// cgroup limits. If Docker can't be reached or the container has been removed
+// the container is reported stopped — a container we cannot confirm is running
+// must never be advertised as running, because the control plane uses this to
+// decide whether a session is alive.
+//
+// The IP is refreshed because it can change across a container restart, and a
+// stale cached IP causes "no route to host" 502s on the proxy path.
+func (dm *DevContainerManager) inspectContainerState(ctx context.Context, dc *DevContainer) (status DevContainerStatus, ipAddress string, vcpus int, memoryMB int) {
+	// Default to stopped and only upgrade on a successful inspect that reports
+	// the container running. The write-back below therefore also clears a stale
+	// cached "running" when Docker is unreachable, so a caller reading dc.Status
+	// directly can't be handed a status we failed to confirm.
+	status = DevContainerStatusStopped
+	ip := ""
+
+	if dockerClient, err := dm.getDockerClient(dc.DockerSocket); err == nil {
+		defer dockerClient.Close()
+
+		if inspect, err := dockerClient.ContainerInspect(ctx, dc.ContainerID); err == nil {
+			if inspect.State.Running {
+				status = DevContainerStatusRunning
+			}
+			for _, network := range inspect.NetworkSettings.Networks {
+				if network.IPAddress != "" {
+					ip = network.IPAddress
+					break
+				}
+			}
+			if ip == "" {
+				ip = inspect.NetworkSettings.IPAddress
+			}
+			if inspect.HostConfig != nil {
+				vcpus = int(inspect.HostConfig.NanoCPUs / 1_000_000_000)
+				memoryMB = int(inspect.HostConfig.Memory / (1024 * 1024))
+			}
+		}
+	}
+
+	dm.mu.Lock()
+	dc.Status = status
+	if ip != "" {
+		dc.IPAddress = ip
+	}
+	ipAddress = dc.IPAddress
+	dm.mu.Unlock()
+
+	return status, ipAddress, vcpus, memoryMB
 }
 
 // FindDevContainerBySessionID finds a dev container by session ID

--- a/api/pkg/hydra/devcontainer_list_status_test.go
+++ b/api/pkg/hydra/devcontainer_list_status_test.go
@@ -1,0 +1,87 @@
+package hydra
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// newListTestManager builds a DevContainerManager whose tracked containers point
+// at a Docker socket that does not exist, so every ContainerInspect fails. That
+// is the "cannot confirm" case the status contract is about.
+func newListTestManager(containers map[string]*DevContainer) *DevContainerManager {
+	return &DevContainerManager{containers: containers}
+}
+
+// The bug: dc.Status is only written when hydra itself stops a container or
+// lazily by GetDevContainer, so a container whose entrypoint exited on its own
+// keeps a cached "running" forever. ListDevContainers is the control plane's
+// live-set, so that stale value resurrected dead sessions on every reconnect.
+// A status that cannot be confirmed against Docker must be reported stopped.
+func TestListDevContainers_UnconfirmableContainerIsNotReportedRunning(t *testing.T) {
+	missingSocket := filepath.Join(t.TempDir(), "does-not-exist.sock")
+	dm := newListTestManager(map[string]*DevContainer{
+		"ses_dead": {
+			SessionID:     "ses_dead",
+			ContainerID:   "cid_dead",
+			ContainerName: "headless-external-ses_dead",
+			// Stale cached value, exactly as a self-exited container leaves it.
+			Status:       DevContainerStatusRunning,
+			IPAddress:    "10.213.0.5",
+			DockerSocket: missingSocket,
+		},
+	})
+
+	resp := dm.ListDevContainers(context.Background())
+
+	if len(resp.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(resp.Containers))
+	}
+	if got := resp.Containers[0].Status; got != DevContainerStatusStopped {
+		t.Errorf("unconfirmable container reported as %q, want %q", got, DevContainerStatusStopped)
+	}
+	// The cached entry must be corrected too, so a later GetDevContainer that
+	// also fails to reach Docker doesn't hand back the stale "running".
+	if got := dm.containers["ses_dead"].Status; got == DevContainerStatusRunning {
+		t.Errorf("cached status left at %q after a failed inspect", got)
+	}
+}
+
+// The same contract on the single-container path used by HasRunningContainer and
+// the reconcile probe.
+func TestGetDevContainer_UnconfirmableContainerIsNotReportedRunning(t *testing.T) {
+	missingSocket := filepath.Join(t.TempDir(), "does-not-exist.sock")
+	dm := newListTestManager(map[string]*DevContainer{
+		"ses_dead": {
+			SessionID:    "ses_dead",
+			ContainerID:  "cid_dead",
+			Status:       DevContainerStatusRunning,
+			DockerSocket: missingSocket,
+		},
+	})
+
+	resp, err := dm.GetDevContainer(context.Background(), "ses_dead")
+	if err != nil {
+		t.Fatalf("GetDevContainer returned error: %v", err)
+	}
+	if resp.Status != DevContainerStatusStopped {
+		t.Errorf("unconfirmable container reported as %q, want %q", resp.Status, DevContainerStatusStopped)
+	}
+}
+
+func TestGetDevContainer_UnknownSessionErrors(t *testing.T) {
+	dm := newListTestManager(map[string]*DevContainer{})
+
+	if _, err := dm.GetDevContainer(context.Background(), "ses_missing"); err == nil {
+		t.Fatal("expected an error for an untracked session")
+	}
+}
+
+func TestListDevContainers_EmptyManager(t *testing.T) {
+	dm := newListTestManager(map[string]*DevContainer{})
+
+	resp := dm.ListDevContainers(context.Background())
+	if len(resp.Containers) != 0 {
+		t.Fatalf("expected no containers, got %d", len(resp.Containers))
+	}
+}

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -308,7 +308,7 @@ func (s *Server) handleCreateDevContainer(w http.ResponseWriter, r *http.Request
 
 // handleListDevContainers lists all active dev containers
 func (s *Server) handleListDevContainers(w http.ResponseWriter, r *http.Request) {
-	resp := s.devContainerManager.ListDevContainers()
+	resp := s.devContainerManager.ListDevContainers(r.Context())
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
@@ -773,7 +773,7 @@ func (s *Server) handleGCReconcile(w http.ResponseWriter, r *http.Request) {
 // handleSystemStats returns GPU stats and session counts
 func (s *Server) handleSystemStats(w http.ResponseWriter, r *http.Request) {
 	gpus := getGPUInfo()
-	containers := s.devContainerManager.ListDevContainers()
+	containers := s.devContainerManager.ListDevContainers(r.Context())
 
 	resp := &SystemStatsResponse{
 		GPUs:             gpus,

--- a/api/pkg/server/sandbox_container_reconciler.go
+++ b/api/pkg/server/sandbox_container_reconciler.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/config"
+)
+
+// perSandboxReconcileTimeout bounds one sandbox's discovery round trip so a
+// wedged RevDial connection can't stall the whole sweep. Discovery is a list
+// call plus a bounded number of per-session probes; 30s is generous for both.
+const perSandboxReconcileTimeout = 30 * time.Second
+
+// startSandboxContainerReconciler periodically asks every online sandbox which
+// dev containers are actually running and reconciles session state against the
+// answer.
+//
+// Container discovery previously ran in exactly two places: when a sandbox
+// POSTs to /sandboxes/register, and when its RevDial control connection is
+// established. Both are *sandbox* lifecycle events. A dev container that dies
+// while its sandbox stays happily connected — the dominant failure mode, e.g.
+// helix-workspace-setup hanging on a git fetch until start-zed-core's 300s
+// timeout kills the container's PID 1 — fires neither. Nothing then downgraded
+// the session, so `external_agent_status` stayed "running" indefinitely: the
+// task chat showed a green "Sandbox running" dot and a ticking "Working for…"
+// timer against a container that had exited hours earlier, and the billing row
+// stayed open.
+//
+// This loop closes that gap by making reconciliation time-driven rather than
+// connection-driven. It reuses DiscoverContainersFromSandbox, which is already
+// idempotent and correctly locked (per-session creation locks, authoritative
+// per-session probes before any downgrade), so a periodic call is safe to race
+// against StartDesktop/StopDesktop.
+//
+// Interval is configurable via HELIX_SANDBOX_CONTAINER_RECONCILE_INTERVAL.
+func (apiServer *HelixAPIServer) startSandboxContainerReconciler(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = config.DefaultSandboxContainerReconcileInterval
+	}
+	if apiServer.externalAgentExecutor == nil {
+		log.Info().Msg("sandbox-container reconciler: no external agent executor configured, not starting")
+		return
+	}
+
+	log.Info().
+		Dur("interval", interval).
+		Msg("🔁 [SANDBOX_RECONCILE] Started periodic dev-container reconciliation")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			apiServer.reconcileSandboxContainers(ctx)
+		}
+	}
+}
+
+// reconcileSandboxContainers runs one sweep across every online sandbox.
+//
+// Offline sandboxes are skipped deliberately: their RevDial connection is gone,
+// so discovery would fail for every session on them and tell us nothing new.
+// Their sessions are handled by the reconnect path (DiscoverContainersFromSandbox
+// on RevDial connect), which runs the same downgrade logic the moment the
+// sandbox comes back.
+//
+// Errors are logged and never returned — a transient store or RevDial failure
+// must not kill the ticker.
+func (apiServer *HelixAPIServer) reconcileSandboxContainers(ctx context.Context) {
+	instances, err := apiServer.Store.ListSandboxInstances(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("sandbox-container reconciler: failed to list sandbox instances")
+		return
+	}
+
+	for _, instance := range instances {
+		// Bail on shutdown rather than working through a long instance list.
+		if ctx.Err() != nil {
+			return
+		}
+		if instance.Status != sandboxInstanceStatusOnline {
+			continue
+		}
+
+		sweepCtx, cancel := context.WithTimeout(ctx, perSandboxReconcileTimeout)
+		err := apiServer.externalAgentExecutor.DiscoverContainersFromSandbox(sweepCtx, instance.ID)
+		cancel()
+		if err != nil {
+			log.Debug().Err(err).
+				Str("sandbox_id", instance.ID).
+				Msg("sandbox-container reconciler: discovery failed for sandbox")
+		}
+	}
+}

--- a/api/pkg/server/sandbox_container_reconciler_test.go
+++ b/api/pkg/server/sandbox_container_reconciler_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// Only online sandboxes are swept. An offline sandbox has no RevDial connection,
+// so discovery would fail for every session on it and teach us nothing; its
+// sessions are reconciled by the existing on-reconnect discovery instead.
+func TestReconcileSandboxContainers_OnlySweepsOnlineSandboxes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+	server := &HelixAPIServer{Store: mockStore, externalAgentExecutor: mockExecutor}
+
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{
+			{ID: "sbox_online", Status: "online"},
+			{ID: "sbox_offline", Status: "offline"},
+			{ID: "local", Status: "online"},
+		}, nil)
+
+	swept := map[string]bool{}
+	mockExecutor.EXPECT().
+		DiscoverContainersFromSandbox(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, sandboxID string) error {
+			swept[sandboxID] = true
+			return nil
+		}).
+		Times(2)
+
+	server.reconcileSandboxContainers(context.Background())
+
+	assert.True(t, swept["sbox_online"], "online sandbox should be swept")
+	assert.True(t, swept["local"], "the single-node local sandbox should be swept too")
+	assert.False(t, swept["sbox_offline"], "offline sandbox should be skipped")
+}
+
+// One sandbox failing must not abort the sweep — a wedged RevDial connection on
+// sandbox A cannot be allowed to leave sandbox B's dead sessions unreconciled.
+func TestReconcileSandboxContainers_ContinuesAfterDiscoveryError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+	server := &HelixAPIServer{Store: mockStore, externalAgentExecutor: mockExecutor}
+
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{
+			{ID: "sbox_broken", Status: "online"},
+			{ID: "sbox_ok", Status: "online"},
+		}, nil)
+
+	mockExecutor.EXPECT().
+		DiscoverContainersFromSandbox(gomock.Any(), "sbox_broken").
+		Return(errors.New("revdial: connection closed"))
+	reachedSecond := false
+	mockExecutor.EXPECT().
+		DiscoverContainersFromSandbox(gomock.Any(), "sbox_ok").
+		DoAndReturn(func(_ context.Context, _ string) error {
+			reachedSecond = true
+			return nil
+		})
+
+	server.reconcileSandboxContainers(context.Background())
+
+	assert.True(t, reachedSecond, "sweep must continue past a failing sandbox")
+}
+
+// Each sandbox gets a bounded context so a hung RevDial call cannot stall the
+// whole sweep indefinitely.
+func TestReconcileSandboxContainers_BoundsEachSandbox(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+	server := &HelixAPIServer{Store: mockStore, externalAgentExecutor: mockExecutor}
+
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{{ID: "sbox_1", Status: "online"}}, nil)
+
+	mockExecutor.EXPECT().
+		DiscoverContainersFromSandbox(gomock.Any(), "sbox_1").
+		DoAndReturn(func(ctx context.Context, _ string) error {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok, "per-sandbox context must carry a deadline")
+			assert.LessOrEqual(t, time.Until(deadline), perSandboxReconcileTimeout)
+			return nil
+		})
+
+	server.reconcileSandboxContainers(context.Background())
+}
+
+// A store failure must be swallowed so the ticker survives a transient DB hiccup.
+func TestReconcileSandboxContainers_StoreErrorDoesNotPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+	server := &HelixAPIServer{Store: mockStore, externalAgentExecutor: mockExecutor}
+
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return(nil, errors.New("connection refused"))
+
+	server.reconcileSandboxContainers(context.Background())
+}
+
+// A cancelled context stops the sweep rather than working through the remaining
+// instances during shutdown.
+func TestReconcileSandboxContainers_StopsOnCancelledContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+	server := &HelixAPIServer{Store: mockStore, externalAgentExecutor: mockExecutor}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		DoAndReturn(func(_ context.Context) ([]*types.SandboxInstance, error) {
+			cancel()
+			return []*types.SandboxInstance{
+				{ID: "sbox_1", Status: "online"},
+				{ID: "sbox_2", Status: "online"},
+			}, nil
+		})
+
+	// No DiscoverContainersFromSandbox expectations: the cancelled context must
+	// short-circuit before the first sandbox.
+	server.reconcileSandboxContainers(ctx)
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -791,6 +791,13 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, _ *system.C
 		apiServer.Cfg.SandboxStaleThreshold,
 	)
 
+	// Reconcile dev-container state against every online sandbox on a timer.
+	// Discovery otherwise only runs on sandbox register / RevDial connect, so a
+	// container that dies while its sandbox stays connected leaves its session
+	// pinned at external_agent_status="running" forever. Interval configurable
+	// via HELIX_SANDBOX_CONTAINER_RECONCILE_INTERVAL.
+	go apiServer.startSandboxContainerReconciler(ctx, apiServer.Cfg.SandboxContainerReconcileInterval)
+
 	// Compute manager reconcile loop: brings sandbox hosts into
 	// existence via a cloud Provider (currently only YellowDog) and
 	// keeps the count at Floor. Nil when HELIX_COMPUTE_PROVIDER is

--- a/design/2026-08-15-dead-sandbox-reconciliation.md
+++ b/design/2026-08-15-dead-sandbox-reconciliation.md
@@ -1,0 +1,74 @@
+# Dead sandboxes reported as running
+
+## Symptom
+
+Task `spt_01m020k5y9z6xe800r9vz70yhr` (headless, keel project) showed, all at once:
+
+- a green "Sandbox running" dot in the chat header,
+- a ticking `Working for 1m 8s` spinner,
+- an enabled `PR: keel` action,
+- `Desktop not running` in the right-hand panel and `failed to create exec` in the terminal drawer,
+- an errored interaction: `Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)`.
+
+The container had been `Exited (1)` for over 20 minutes.
+
+## What actually happened
+
+Reconstructed from the API log, hydra, and the DB (all times UTC, 2026-08-15):
+
+| Time | Event |
+|---|---|
+| 08:12:54 | Implementation approved. `ensurePullRequest` takes the **keel repo mutex** (`spec_task_workflow_handlers.go`, `WithRepoLock(... PushBranchToRemote ...)`) and starts a native `git push` to `github.com/keel-hq/keel`. The same click queues the approval prompt and cold-starts the headless container. |
+| 08:12:56 | Container boots; `helix-workspace-setup.sh` runs `git pull origin helix-specs`. `handleUploadPack` blocks on `lock.Lock()` — the push holds it. (`Handling upload-pack request` is logged; `Syncing from upstream before serving pull` is not.) |
+| 08:15:27–08:20:27 | GitHub is unreachable in bursts (`fatal: unable to access …`, `context deadline exceeded`). The push burns 5 minutes and fails. Lock still held. |
+| 08:17:58 | Inside the container `wait_for_setup_complete` hits its hard 300 s cap (`desktop/shared/start-zed-core.sh`): `FATAL: Workspace setup did not complete after 300s` → PID 1 exits → **container exits 1**. Zed never launched, so no external-agent WebSocket. |
+| 08:18:20 | The auto-wake worker's 5-minute cold-start grace expired at 08:17:54, four seconds before the container gave up. It burns both retries in two ticks and marks the interaction `state=error`. |
+| 08:20:27 | Lock released; the API serves the upload-pack to a client that died 2.5 minutes earlier. |
+| 08:26:40 | API restarts. On RevDial reconnect, `DiscoverContainersFromSandbox` **resurrects the dead session**: hydra still lists the exited container, so the session is re-added to the in-memory map and force-written back to `external_agent_status = "running"`. |
+| 08:35:19 | A CI-passed webhook injects a new prompt into the dead session → `state=waiting` → the `Working for …` spinner. |
+
+Corroboration: `FETCH_HEAD` in `keel/.git/worktrees/helix-specs` is 0 bytes, stamped 08:12 — the fetch started and never returned. The container's setup log ends mid-line at `Pulling latest changes from remote...`.
+
+## Why the status stayed green
+
+Three independent "exists ⇒ alive" bugs, none of which any single reconnect could correct:
+
+1. **`HydraExecutor.GetSession` is an in-memory map lookup.** Both `getSession` (`session_handlers.go`) and `populateSessionState` (`spec_driven_task_handlers.go`) call it as a "live check against the executor". It never asks hydra or Docker anything. `StartDesktop` inserts the entry; only `StopDesktop`, the idle checker, and sandbox-disconnect remove it. A container whose entrypoint exits on its own removes nothing.
+
+2. **`hydra.ListDevContainers` returned a cached status.** `dc.Status` was only written when hydra itself stopped a container, or lazily by `GetDevContainer`. There is no container-exit monitor, so a self-exited container kept `Status: "running"` indefinitely. That list is the control plane's live-set.
+
+3. **`markMissingSessionsStopped`'s "authoritative probe" only checked `err == nil`.** `GetDevContainer` returns a container hydra still tracks even when Docker reports it exited, so the probe read a dead container as alive and skipped the downgrade — every time.
+
+And the reconciliation that would have caught it **only ran on sandbox lifecycle events** (`/sandboxes/register`, RevDial connect). A dev container dying while its sandbox stays happily connected fires neither.
+
+## The fix
+
+- `hydra.ListDevContainers(ctx)` refreshes each container's status from Docker. Status and IP handling is now shared with `GetDevContainer` via `inspectContainerState`, which reports **stopped** whenever Docker cannot confirm the container is running, and writes that back to the cache.
+- `DiscoverContainersFromSandbox` filters hydra's list to running containers (`filterRunningContainers`) before using it as the live-set, so a reconnect can no longer resurrect an exited container.
+- `markMissingSessionsStopped`'s probe requires `Status == running`. The parameter is narrowed to a `devContainerProber` interface so the "tracked but exited" case is unit-testable.
+- New `startSandboxContainerReconciler` sweeps every online sandbox on a timer (`HELIX_SANDBOX_CONTAINER_RECONCILE_INTERVAL`, default 30s), making reconciliation time-driven rather than connection-driven. It reuses `DiscoverContainersFromSandbox`, which is already idempotent and correctly locked.
+- Frontend: `deriveSandboxState` / `isSandboxOffline` extracted from `useSandboxState` as pure helpers. `InteractionLiveStream` takes `agentOffline` and renders `AgentOfflineNotice` instead of the ticking timer. `SpecTaskActionButtons` disables Open PR unless `sandbox_state === "running"`.
+
+## Deliberately not fixed here
+
+The **repo-lock-across-a-network-push** in `ensurePullRequest` is the trigger, and it will re-trigger. It is not fixed in this change because the agent pushes its branch from inside the sandbox: the sandbox owns the working copy and may not be on a filesystem the control plane can reach, so the push cannot simply be moved out of the sandbox's path. The UI now refuses to offer the action when the sandbox is gone rather than pretending it will work.
+
+Two smaller ones, also untouched:
+
+- `helix-workspace-setup.sh` has **no timeout on any git operation**, so a hung fetch consumes the whole 300 s setup budget. The `helix-specs` pull that hung is a nice-to-have (refresh the startup script); it should not be able to kill the session.
+- The container's 300 s setup timeout and the auto-wake 5-minute cold-start grace are the same duration, so auto-wake exhausts its retries the instant the container gives up — zero margin.
+- Headless's FATAL message points at `/tmp/helix-workspace-setup.log`, but headless `launch_terminal` writes to `/tmp/helix-Helix-Setup.log`. The advertised path does not exist.
+
+## Deploying
+
+The hydra changes run **inside** the sandbox container and are not picked up by Air:
+
+```bash
+./stack build-sandbox
+# or, for a dev hot-swap:
+cd api && CGO_ENABLED=0 GOOS=linux go build -o /tmp/hydra-linux ./cmd/hydra
+docker cp /tmp/hydra-linux helix-sandbox-nvidia-1:/usr/local/bin/hydra
+docker compose -f docker-compose.dev.yaml exec -T sandbox-nvidia pkill -TERM hydra
+```
+
+The API-side changes hot-reload. They are independently sufficient for the downgrade path: the per-session probe reaches Docker through `GetDevContainer`, which refreshed status even before this change.

--- a/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
+++ b/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
@@ -28,6 +28,7 @@ import { SESSION_TYPE_TEXT } from "../../types";
 import { Api } from "../../api/api";
 import { useQueryClient } from "@tanstack/react-query";
 import { GET_SESSION_QUERY_KEY, useGetSession } from "../../services/sessionService";
+import { deriveSandboxState } from "./sandboxState";
 
 // Hook to track sandbox container state for external agent sessions
 // Exported for use in SpecTaskDetailContent.tsx toolbar buttons
@@ -39,58 +40,15 @@ export const useSandboxState = (sessionId: string, enabled: boolean = true) => {
     refetchInterval: 3000, // Poll every 3 seconds
   });
 
-  const { sandboxState, statusMessage, hasDesktopLifecycleState } = useMemo(() => {
-    if (!sessionResponse?.data) {
-      return {
-        sandboxState: "loading",
-        statusMessage: "",
-        hasDesktopLifecycleState: false,
-      };
-    }
-
-    const session = sessionResponse.data;
-    const status = session.config?.external_agent_status || "";
-    const desiredState = (session.config as (typeof session.config & { desired_state?: string }))?.desired_state || "";
-    const hasContainer = !!session.config?.container_name;
-    const msg = session.config?.status_message || "";
-
-    // Map session metadata to sandbox state
-    // Check stopped status first - it takes priority from the backend check
-    let state: string;
-    if (status === "stopped") {
-      state = "absent";
-    } else if (
-      status === "running" ||
-      (hasContainer && desiredState === "running")
-    ) {
-      state = "running";
-    } else if (status === "starting") {
-      state = "starting";
-    } else if (desiredState === "stopped") {
-      state = "absent";
-    } else if (!hasContainer && desiredState === "running") {
-      state = "starting";
-    } else if (!hasContainer) {
-      state = "absent";
-    } else {
-      state = hasContainer ? "running" : "absent";
-    }
-
-    return {
-      sandboxState: state,
-      statusMessage: msg,
-      // A newly-created spec-task session exists before StartDesktop has written
-      // any lifecycle fields. Keep that state distinct from a desktop that was
-      // provisioned and subsequently stopped so callers can render the launch
-      // transition instead of a misleading "Desktop Paused" action.
-      hasDesktopLifecycleState: !!(status || desiredState || hasContainer),
-    };
-  }, [sessionResponse?.data]);
+  const { sandboxState, statusMessage, hasDesktopLifecycleState } = useMemo(
+    () => deriveSandboxState(sessionResponse?.data?.config),
+    [sessionResponse?.data],
+  );
 
   // Backend now returns 'starting' state for recently-created containers
   // Include 'loading' in isStarting to prevent DesktopStreamViewer from mounting
   // before we know the real state (avoids mount/unmount flicker)
-  const isRunning = sandboxState === "running" || sandboxState === "resumable";
+  const isRunning = sandboxState === "running";
   const isStarting = sandboxState === "starting" || sandboxState === "loading";
   // Show "paused" only if container was previously running but is now absent
   const isPaused = sandboxState === "absent";

--- a/frontend/src/components/external-agent/sandboxState.test.ts
+++ b/frontend/src/components/external-agent/sandboxState.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSandboxState, isSandboxOffline } from "./sandboxState";
+
+describe("deriveSandboxState", () => {
+  it("reports loading until the session has been fetched", () => {
+    expect(deriveSandboxState(undefined)).toEqual({
+      sandboxState: "loading",
+      statusMessage: "",
+      hasDesktopLifecycleState: false,
+    });
+  });
+
+  it("treats an explicit stopped status as absent even with a container name", () => {
+    // The backend clears container metadata when it downgrades a session, but a
+    // read that races the write can still carry both fields.
+    const state = deriveSandboxState({
+      external_agent_status: "stopped",
+      container_name: "headless-external-ses_1",
+    });
+
+    expect(state.sandboxState).toBe("absent");
+    expect(state.hasDesktopLifecycleState).toBe(true);
+  });
+
+  it("reports running for a running container", () => {
+    expect(
+      deriveSandboxState({
+        external_agent_status: "running",
+        container_name: "headless-external-ses_1",
+      }).sandboxState,
+    ).toBe("running");
+  });
+
+  it("reports starting during boot", () => {
+    expect(
+      deriveSandboxState({ external_agent_status: "starting" }).sandboxState,
+    ).toBe("starting");
+  });
+
+  it("surfaces the transient status message", () => {
+    expect(
+      deriveSandboxState({
+        external_agent_status: "starting",
+        status_message: "Unpacking build cache (2.1/7.0 GB)",
+      }).statusMessage,
+    ).toBe("Unpacking build cache (2.1/7.0 GB)");
+  });
+
+  it("reports absent with no lifecycle state for a plain chat session", () => {
+    const state = deriveSandboxState({ agent_type: "text" });
+
+    expect(state.sandboxState).toBe("absent");
+    expect(state.hasDesktopLifecycleState).toBe(false);
+  });
+});
+
+describe("isSandboxOffline", () => {
+  it("is true for a session whose container has stopped", () => {
+    expect(
+      isSandboxOffline({
+        external_agent_status: "stopped",
+        container_name: "headless-external-ses_1",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false while the sandbox is running", () => {
+    expect(
+      isSandboxOffline({
+        external_agent_status: "running",
+        container_name: "headless-external-ses_1",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false while the sandbox is still booting", () => {
+    expect(isSandboxOffline({ external_agent_status: "starting" })).toBe(false);
+  });
+
+  // Guards the regression this helper could easily introduce: an ordinary LLM
+  // chat has no container fields at all and derives to "absent", but its agent
+  // is not offline. Treating it as offline would suppress the streaming
+  // indicator for every normal chat in the product.
+  it("is false for a plain chat session with no sandbox", () => {
+    expect(isSandboxOffline({ agent_type: "text" })).toBe(false);
+    expect(isSandboxOffline({})).toBe(false);
+  });
+
+  it("is false before the session has loaded", () => {
+    expect(isSandboxOffline(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/components/external-agent/sandboxState.ts
+++ b/frontend/src/components/external-agent/sandboxState.ts
@@ -1,0 +1,82 @@
+import { TypesSessionMetadata } from "../../api/api";
+
+export type SandboxState = "loading" | "running" | "starting" | "absent";
+
+export interface DerivedSandboxState {
+  sandboxState: SandboxState;
+  statusMessage: string;
+  /**
+   * A newly-created spec-task session exists before StartDesktop has written
+   * any lifecycle fields. Keep that state distinct from a desktop that was
+   * provisioned and subsequently stopped so callers can render the launch
+   * transition instead of a misleading "Desktop Paused" action.
+   *
+   * It also distinguishes an external-agent session from a plain LLM chat,
+   * which has no sandbox at all and must never be treated as one that stopped.
+   */
+  hasDesktopLifecycleState: boolean;
+}
+
+type SessionConfigWithDesiredState = TypesSessionMetadata & {
+  desired_state?: string;
+};
+
+/**
+ * Maps a session's config metadata onto the sandbox lifecycle state the UI
+ * renders. Pure so it can be reused by any component that already holds a
+ * polled session, without opening a second query for the same row.
+ */
+export const deriveSandboxState = (
+  config?: TypesSessionMetadata,
+): DerivedSandboxState => {
+  if (!config) {
+    return {
+      sandboxState: "loading",
+      statusMessage: "",
+      hasDesktopLifecycleState: false,
+    };
+  }
+
+  const status = config.external_agent_status || "";
+  const desiredState =
+    (config as SessionConfigWithDesiredState)?.desired_state || "";
+  const hasContainer = !!config.container_name;
+  const statusMessage = config.status_message || "";
+
+  // Map session metadata to sandbox state.
+  // Check stopped status first - it takes priority from the backend check.
+  let sandboxState: SandboxState;
+  if (status === "stopped") {
+    sandboxState = "absent";
+  } else if (status === "running" || (hasContainer && desiredState === "running")) {
+    sandboxState = "running";
+  } else if (status === "starting") {
+    sandboxState = "starting";
+  } else if (desiredState === "stopped") {
+    sandboxState = "absent";
+  } else if (!hasContainer && desiredState === "running") {
+    sandboxState = "starting";
+  } else if (!hasContainer) {
+    sandboxState = "absent";
+  } else {
+    sandboxState = "running";
+  }
+
+  return {
+    sandboxState,
+    statusMessage,
+    hasDesktopLifecycleState: !!(status || desiredState || hasContainer),
+  };
+};
+
+/**
+ * True when this session is backed by a sandbox that is no longer running.
+ *
+ * Deliberately requires `hasDesktopLifecycleState`: a plain LLM chat session
+ * has no container fields at all and derives to "absent", but its agent is not
+ * offline — suppressing its streaming indicator would break ordinary chat.
+ */
+export const isSandboxOffline = (config?: TypesSessionMetadata): boolean => {
+  const { sandboxState, hasDesktopLifecycleState } = deriveSandboxState(config);
+  return hasDesktopLifecycleState && sandboxState === "absent";
+};

--- a/frontend/src/components/session/AgentOfflineNotice.tsx
+++ b/frontend/src/components/session/AgentOfflineNotice.tsx
@@ -1,0 +1,59 @@
+import type { FC } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
+import { PlugZap } from "lucide-react";
+
+import { APP_FONT_FAMILY } from "../../styles/typography";
+
+/**
+ * Replaces the streaming "Working for …" indicator once a session's sandbox has
+ * stopped while an interaction is still `state=waiting`.
+ *
+ * The interaction row alone cannot express this: it stays waiting until the
+ * agent answers or the auto-wake worker errors it out, which can be minutes
+ * after the container died. Rendering the ticking timer in that window told the
+ * user the agent was busy when nothing was running at all.
+ */
+const AgentOfflineNotice: FC = () => {
+  const theme = useTheme();
+  const dividerColor =
+    theme.palette.mode === "dark"
+      ? "rgba(255,255,255,0.045)"
+      : "rgba(0,0,0,0.055)";
+
+  return (
+    <Box
+      role="status"
+      aria-label="Sandbox stopped"
+      sx={{
+        mt: 0.5,
+        mb: 1,
+        pt: 0.5,
+        pb: 1,
+        borderBottom: `1px solid ${dividerColor}`,
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        color: "text.secondary",
+        px: "4px",
+        minHeight: 20,
+      }}
+    >
+      <PlugZap size={14} strokeWidth={1.8} />
+      <Typography
+        variant="body2"
+        sx={{
+          fontSize: "0.75rem",
+          lineHeight: "20px",
+          color: "inherit",
+          fontFamily: APP_FONT_FAMILY,
+        }}
+      >
+        Sandbox stopped — the agent is not running. Start it to continue.
+      </Typography>
+    </Box>
+  );
+};
+
+export default AgentOfflineNotice;

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -63,6 +63,7 @@ import {
   resolveChatTurnAssistantPreview,
 } from "./ChatTurnNavigator.logic";
 import { splitSystemPrefix } from "./CollapsibleSystemPrefix";
+import { isSandboxOffline } from "../external-agent/sandboxState";
 
 interface EmbeddedSessionViewProps {
   sessionId: string;
@@ -249,6 +250,14 @@ const EmbeddedSessionView = forwardRef<
   // below so a forbidden / missing session degrades gracefully instead of
   // spinning on "Loading session…" forever.
   const sessionErrorStatus = (sessionError as any)?.response?.status as number | undefined;
+
+  // Whether this session's sandbox has stopped. Derived from the session we
+  // already poll above rather than via useSandboxState, so we don't open a
+  // second query against the same row with different parameters.
+  const agentOffline = useMemo(
+    () => isSandboxOffline(session?.config),
+    [session?.config],
+  );
 
   // Fetch paginated interactions (newest first via order=desc)
   // Page 0 = newest interactions, higher pages = older interactions.
@@ -717,6 +726,7 @@ const EmbeddedSessionView = forwardRef<
                     session_id={sessionId}
                     interaction={interaction}
                     session={session}
+                    agentOffline={agentOffline}
                     serverConfig={account.serverConfig}
                     onMessageUpdate={scrollToBottom}
                   />

--- a/frontend/src/components/session/InteractionLiveStream.test.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.test.tsx
@@ -29,7 +29,7 @@ describe("InteractionLiveStream", () => {
     vi.useRealTimers();
   });
 
-  it("keeps counting from the persisted request time after mounting", () => {
+  const renderStream = (agentOffline?: boolean) =>
     render(
       <InteractionLiveStream
         session_id="session-1"
@@ -40,9 +40,37 @@ describe("InteractionLiveStream", () => {
         }}
         session={{ id: "session-1" }}
         serverConfig={{ filestore_prefix: "/api/v1/filestore" }}
+        agentOffline={agentOffline}
       />,
     );
 
+  it("keeps counting from the persisted request time after mounting", () => {
+    renderStream();
+
     expect(screen.getByText("Working for 2m 5s")).toBeInTheDocument();
+  });
+
+  // An interaction stays `state=waiting` long after the container backing it has
+  // exited — until the agent answers or the auto-wake worker errors it out. The
+  // row alone cannot express that, so without the sandbox state the chat renders
+  // a ticking timer against a dead sandbox.
+  it("does not show a running timer when the sandbox has stopped", () => {
+    renderStream(true);
+
+    expect(screen.queryByText(/Working for/)).not.toBeInTheDocument();
+  });
+
+  it("explains that the sandbox stopped instead of the timer", () => {
+    renderStream(true);
+
+    expect(screen.getByRole("status", { name: "Sandbox stopped" })).toBeInTheDocument();
+    expect(screen.getByText(/the agent is not running/i)).toBeInTheDocument();
+  });
+
+  it("still shows the timer when the sandbox is alive", () => {
+    renderStream(false);
+
+    expect(screen.getByText("Working for 2m 5s")).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: "Sandbox stopped" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/session/InteractionLiveStream.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../api/api";
 import ToolStepsWidget from "./ToolStepsWidget";
 import ActivitySummary from "./ActivitySummary";
+import AgentOfflineNotice from "./AgentOfflineNotice";
 import { getInteractionRequestTimeMs } from "./interactionDuration";
 
 export const InteractionLiveStream: FC<{
@@ -25,6 +26,14 @@ export const InteractionLiveStream: FC<{
   interaction: TypesInteraction;
   serverConfig?: TypesServerConfigForFrontend;
   session: TypesSession;
+  /**
+   * True when this session's sandbox is no longer running. An interaction can
+   * sit in `state=waiting` long after the container backing it has exited (the
+   * agent never connected, or died mid-turn), and nothing about the interaction
+   * row itself reveals that. Without this the chat renders a ticking
+   * "Working for 12m 4s" against a dead sandbox.
+   */
+  agentOffline?: boolean;
   onMessageChange?: {
     (message: string): void;
   };
@@ -35,6 +44,7 @@ export const InteractionLiveStream: FC<{
   serverConfig,
   session,
   interaction,
+  agentOffline = false,
   onMessageChange,
   onMessageUpdate,
   onFilterDocument,
@@ -135,22 +145,27 @@ export const InteractionLiveStream: FC<{
     return null;
   }
 
+  // A dead sandbox cannot be streaming, whatever the interaction row says.
+  const isStreaming = isActivelyStreaming && !agentOffline;
+
   return (
     <>
       {stepInfos.length > 0 && (
-        <ToolStepsWidget
-          steps={toolSteps}
-          isLiveStreaming={isActivelyStreaming}
-        />
+        <ToolStepsWidget steps={toolSteps} isLiveStreaming={isStreaming} />
       )}
 
-      {/* Show thinking indicator when waiting and no content yet */}
-      {interaction.state === "waiting" && !hasContent && (
+      {/* Show thinking indicator when waiting and no content yet. Suppressed
+          once the sandbox is gone: there is no agent left to be working. */}
+      {interaction.state === "waiting" && !hasContent && !agentOffline && (
         <ActivitySummary
           hasActivity={false}
           isStreaming
           startedAt={activityStartedAt}
         />
+      )}
+
+      {interaction.state === "waiting" && !hasContent && agentOffline && (
+        <AgentOfflineNotice />
       )}
 
       {hasContent && (
@@ -160,8 +175,8 @@ export const InteractionLiveStream: FC<{
             responseEntries={responseEntries}
             session={session}
             getFileURL={useClientURL}
-            showBlinker={true}
-            isStreaming={isActivelyStreaming}
+            showBlinker={!agentOffline}
+            isStreaming={isStreaming}
             durationMs={effectiveDurationMs}
             activityStartedAt={activityStartedAt}
             onFilterDocument={onFilterDocument}

--- a/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import SpecTaskActionButtons, {
+  SANDBOX_STOPPED_TOOLTIP,
+  type SpecTaskForActions,
+} from "./SpecTaskActionButtons";
+
+// The component's data hooks all resolve to "nothing pending, nothing to
+// connect" so the tests exercise the button-gating logic rather than mutation
+// or OAuth state.
+const idleMutation = { mutate: vi.fn(), isPending: false };
+
+vi.mock("../../services/specTaskWorkflowService", () => ({
+  useApproveImplementation: () => idleMutation,
+  useStopAgent: () => idleMutation,
+  useSkipSpec: () => idleMutation,
+  useReopenTask: () => idleMutation,
+}));
+
+vi.mock("../../services/specTaskService", () => ({
+  useUpdateSpecTask: () => idleMutation,
+}));
+
+vi.mock("../../services/oauthProvidersService", () => ({
+  useListOAuthProviders: () => ({ data: [] }),
+  useListOAuthConnections: () => ({ data: [] }),
+}));
+
+vi.mock("../../hooks/useOAuthFlow", () => ({
+  useOAuthFlow: () => ({ startOAuthFlow: vi.fn(), isLoading: false }),
+}));
+
+const implementationTask = (
+  overrides: Partial<SpecTaskForActions> = {},
+): SpecTaskForActions => ({
+  id: "spt_1",
+  status: "implementation",
+  branch_name: "feature/000345-can-we-look-into",
+  base_branch: "master",
+  last_push_at: "2026-08-15T07:30:00.000Z",
+  sandbox_state: "running",
+  ...overrides,
+});
+
+const openPRButton = () => screen.getByRole("button", { name: /Open PR/i });
+
+describe.each(["inline", "stacked"] as const)(
+  "SpecTaskActionButtons (%s) Open PR gating",
+  (variant) => {
+    const renderButtons = (task: SpecTaskForActions) =>
+      render(
+        <SpecTaskActionButtons task={task} variant={variant} hasExternalRepo />,
+      );
+
+    it("enables Open PR while the sandbox is running", () => {
+      renderButtons(implementationTask());
+
+      expect(openPRButton()).toBeEnabled();
+    });
+
+    // Approving an implementation tells the agent to push its branch from
+    // inside the sandbox. The sandbox owns the working copy and may not even be
+    // on a filesystem the control plane can reach, so with the sandbox stopped
+    // there is nothing to push from.
+    it("disables Open PR once the sandbox has stopped", () => {
+      renderButtons(implementationTask({ sandbox_state: "absent" }));
+
+      expect(openPRButton()).toBeDisabled();
+    });
+
+    // "starting" means the container exists but the agent has not connected
+    // yet, so it cannot receive the push instruction either.
+    it("disables Open PR while the sandbox is still starting", () => {
+      renderButtons(implementationTask({ sandbox_state: "starting" }));
+
+      expect(openPRButton()).toBeDisabled();
+    });
+
+    it("disables Open PR when the task never had a sandbox", () => {
+      renderButtons(implementationTask({ sandbox_state: undefined }));
+
+      expect(openPRButton()).toBeDisabled();
+    });
+
+    it("explains why Open PR is unavailable", async () => {
+      renderButtons(implementationTask({ sandbox_state: "absent" }));
+
+      // MUI renders the tooltip text into the trigger's aria description via
+      // the title attribute on the wrapping span until hover; assert on the
+      // accessible description the user gets either way.
+      expect(
+        await screen.findByLabelText(SANDBOX_STOPPED_TOOLTIP, { exact: false }),
+      ).toBeInTheDocument();
+    });
+
+    it("still blocks Open PR before the agent has pushed", () => {
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: "running" }),
+      );
+
+      expect(openPRButton()).toBeDisabled();
+    });
+  },
+);

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -153,6 +153,8 @@ export interface SpecTaskForActions {
   repo_pull_requests?: RepoPR[];
   last_push_at?: string;
   rebase_requested_at?: string;
+  /** "running" | "starting" | "absent" — derived server-side from the session's live container state. */
+  sandbox_state?: string;
 }
 
 interface SpecTaskActionButtonsProps {
@@ -188,6 +190,9 @@ interface SpecTaskActionButtonsProps {
   /** Tooltip text explaining why start action is blocked */
   blockedReason?: string;
 }
+
+export const SANDBOX_STOPPED_TOOLTIP =
+  "Sandbox is stopped. The agent pushes its branch from inside the sandbox — start it to open a PR.";
 
 const COMPACT_BUTTON_METRICS: Record<
   ToolbarDensity,
@@ -399,6 +404,19 @@ export default function SpecTaskActionButtons({
     !!task.rebase_requested_at &&
     (!task.last_push_at ||
       new Date(task.last_push_at).getTime() <= new Date(task.rebase_requested_at).getTime());
+
+  // Approving an implementation instructs the agent to push its branch from
+  // inside the sandbox before the PR is opened. The sandbox owns the working
+  // copy — it is not necessarily on a filesystem the control plane can reach —
+  // so with a stopped sandbox there is nothing to push from and the approval
+  // silently produces a PR against whatever was last pushed, or none at all.
+  // Gate the action until the sandbox is back.
+  //
+  // Only "running" enables it: "starting" means the container exists but the
+  // agent has not connected yet and cannot receive the push instruction.
+  // sandbox_state is absent on tasks that never had a session, which likewise
+  // cannot push.
+  const sandboxStopped = task.sandbox_state !== "running";
 
   // Button size based on variant
   const buttonSize = "small";
@@ -714,15 +732,17 @@ export default function SpecTaskActionButtons({
             tooltip={
               isArchived
                 ? "Task is archived"
-                : rebasePending
-                  ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
-                  : !hasPushed
-                    ? "Waiting for agent to push code..."
-                    : ""
+                : sandboxStopped
+                  ? SANDBOX_STOPPED_TOOLTIP
+                  : rebasePending
+                    ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
+                    : !hasPushed
+                      ? "Waiting for agent to push code..."
+                      : ""
             }
             variant="contained"
             color="success"
-            disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending}
+            disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending || sandboxStopped}
             icon={
               approveImplementationMutation.isPending || rebasePending ? (
                 <CircularProgress size={16} color="inherit" />
@@ -802,11 +822,13 @@ export default function SpecTaskActionButtons({
             title={
               isArchived
                 ? "Task is archived"
-                : rebasePending
-                  ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
-                  : !hasPushed
-                    ? "Waiting for agent to push code..."
-                    : ""
+                : sandboxStopped
+                  ? SANDBOX_STOPPED_TOOLTIP
+                  : rebasePending
+                    ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
+                    : !hasPushed
+                      ? "Waiting for agent to push code..."
+                      : ""
             }
             placement="top"
           >
@@ -823,7 +845,7 @@ export default function SpecTaskActionButtons({
                   )
                 }
                 onClick={handleOpenPR}
-                disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending}
+                disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending || sandboxStopped}
                 fullWidth
                 sx={buttonSx}
               >

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -9,6 +9,7 @@ import SendIcon from '@mui/icons-material/Send'
 
 import InteractionLiveStream from '../components/session/InteractionLiveStream'
 import Interaction from '../components/session/Interaction'
+import { isSandboxOffline } from '../components/external-agent/sandboxState'
 import Disclaimer from '../components/widgets/Disclaimer'
 import SessionToolbar from '../components/session/SessionToolbar'
 
@@ -139,6 +140,7 @@ const MemoizedInteraction = React.memo((props: MemoizedInteractionProps) => {
           session_id={props.session_id}
           interaction={props.interaction}
           session={props.session}
+          agentOffline={isSandboxOffline(props.session.config)}
           serverConfig={props.serverConfig}
           onMessageUpdate={props.isLastInteraction ? props.scrollToBottom : undefined}
           onFilterDocument={props.appID ? props.onHandleFilterDocument : undefined}


### PR DESCRIPTION
## Problem

A task whose headless container had been `Exited (1)` for 20+ minutes still showed a green **Sandbox running** dot, a ticking **Working for 1m 8s** timer, and an enabled **PR: keel** button — while the panel next to it said *Desktop not running* and the terminal said *failed to create exec*.

Reconstructed from the API log, hydra and the DB for `spt_01m020k5y9z6xe800r9vz70yhr`:

1. Approving the implementation took the **keel repo mutex** and started a `git push` to GitHub.
2. Two seconds later the container booted and its `git pull origin helix-specs` blocked on that same mutex.
3. GitHub was unreachable in bursts; the push burned 5 minutes and failed.
4. At T+300s the container's `wait_for_setup_complete` cap fired — `FATAL: Workspace setup did not complete after 300s` — PID 1 exited, container exit 1, Zed never connected.
5. Nothing ever told the control plane. On the next API restart, discovery **resurrected** the dead session as running.

Corroboration: `FETCH_HEAD` in the helix-specs worktree is 0 bytes stamped at the boot minute; the setup log ends mid-line at `Pulling latest changes from remote...`.

## Root causes

Three independent "exists ⇒ alive" bugs:

- **`hydra.ListDevContainers` returned a cached status.** `dc.Status` was only written when hydra itself stopped a container, or lazily by `GetDevContainer`. There is no container-exit monitor, so a self-exited container kept `Status: "running"` forever — and that list is the control plane's live-set.
- **`markMissingSessionsStopped`'s "authoritative probe" only checked `err == nil`.** `GetDevContainer` returns a container hydra still tracks even when Docker reports it exited, so the probe read dead containers as alive and skipped the downgrade every time.
- **Reconciliation only ran on sandbox lifecycle events** (`/sandboxes/register`, RevDial connect). A dev container dying while its sandbox stays connected fires neither.

Downstream, `HydraExecutor.GetSession` — what both `getSession` and `populateSessionState` call as their "live check against the executor" — is a plain in-memory map lookup that never asks Docker anything. It becomes accurate once the reconciler evicts stale entries.

## Changes

**Backend**
- `hydra.ListDevContainers(ctx)` refreshes each container's status from Docker. Status/IP handling is now shared with `GetDevContainer` via `inspectContainerState`, which reports **stopped** whenever Docker cannot confirm the container is running, and writes that back to the cache.
- `DiscoverContainersFromSandbox` filters hydra's list to running containers before using it as the live-set, so a reconnect can no longer resurrect an exited container.
- The reconcile probe requires `Status == running`; its parameter is narrowed to a `devContainerProber` interface so the tracked-but-exited case is unit-testable.
- New `startSandboxContainerReconciler` sweeps every online sandbox on a timer (`HELIX_SANDBOX_CONTAINER_RECONCILE_INTERVAL`, default 30s), making reconciliation time-driven rather than connection-driven. It reuses the existing, already-idempotent and correctly-locked `DiscoverContainersFromSandbox`.

**Frontend**
- `deriveSandboxState` / `isSandboxOffline` extracted from `useSandboxState` as pure helpers, so components that already poll the session don't open a second query for the same row.
- `InteractionLiveStream` takes `agentOffline` and renders a "Sandbox stopped — the agent is not running" notice instead of the ticking timer. Also stops the blinker and the tool-step streaming state.
- `SpecTaskActionButtons` disables **Open PR** unless `sandbox_state === "running"`, with a tooltip explaining why. `"starting"` also blocks it — the container exists but the agent hasn't connected and can't receive the push instruction.

## Deliberately out of scope

The repo-lock-held-across-a-network-push in `ensurePullRequest` is the trigger and will re-trigger. It is not fixed here because **the agent pushes its branch from inside the sandbox** — the sandbox owns the working copy and may not be on a filesystem the control plane can reach, so the push can't simply be moved off that path. The UI now refuses to offer the action when the sandbox is gone rather than pretending it will work.

Also noted but untouched (see the design doc): `helix-workspace-setup.sh` has no timeout on any git operation; the container's 300s setup cap and the auto-wake 5-minute grace are the same duration so auto-wake has zero margin; and headless's FATAL message points at a log path headless never writes.

## Testing

- `api/pkg/external-agent`: `filterRunningContainers` + the tracked-but-exited downgrade, a genuinely-running container missing from a stale snapshot (must survive), and a container hydra has forgotten.
- `api/pkg/server`: reconciler skips offline sandboxes, continues past a failing one, bounds each sandbox with a deadline, survives a store error, and stops on a cancelled context.
- `api/pkg/hydra`: a container whose status cannot be confirmed against Docker is never reported running, on both the list and single-container paths, and the stale cache entry is corrected.
- Frontend: 11 cases for `deriveSandboxState`/`isSandboxOffline` (including the regression where a plain LLM chat must **not** be treated as an offline sandbox), 4 for `InteractionLiveStream`, 12 for the Open PR gate across both variants.

Verified green: `go build ./...`, `go test ./pkg/external-agent/ ./pkg/hydra/ ./pkg/server/`, 701 frontend tests, `yarn build`. The only failing Go test in the touched packages is `TestDiskPressureSuite`, which fails identically on a clean `origin/main` (needs ZFS on the host).

Both fixes were mutation-checked: reverting the probe's status check fails `TestMarkMissingSessionsStopped_DowngradesTrackedButExitedContainer`, and hardcoding `sandboxStopped = false` fails 8 of the 12 Open PR tests.

**Not tested end-to-end in a live stack** — the hydra half runs inside the sandbox container and needs `./stack build-sandbox` (or a `docker cp` hot-swap) to deploy; deployment notes are in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)