### PR TITLE
fix(api): apply code-agent model overrides in proxy

### DIFF
--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/data"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/filestore"
 	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
@@ -41,9 +42,13 @@ type ChatCompletionOptions struct {
 	RAGSourceID     string
 	Provider        string
 	ReasoningEffort string
-	QueryParams     map[string]string
-	OAuthTokens     map[string]string // OAuth tokens mapped by provider name
-	Conversational  bool              // Whether to send thoughts about tools and decisions
+	// CodeAgentOverrides is set only for session-scoped coding-agent proxy
+	// requests. Applying it to the loaded Agent keeps the controller's
+	// authoritative model selection aligned with the session or SpecTask.
+	CodeAgentOverrides *types.CodeAgentOverrides
+	QueryParams        map[string]string
+	OAuthTokens        map[string]string // OAuth tokens mapped by provider name
+	Conversational     bool              // Whether to send thoughts about tools and decisions
 }
 
 // ChatCompletion is used by the OpenAI compatible API. Doesn't handle any historical sessions, etc.
@@ -988,6 +993,7 @@ func (c *Controller) loadAssistant(ctx context.Context, user *types.User, opts *
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate secrets: %w", err)
 	}
+	app = external_agent.ApplyCodeAgentOverrides(app, opts.CodeAgentOverrides)
 
 	assistant := data.GetAssistant(app, opts.AssistantID)
 

--- a/api/pkg/controller/inference_reasoning_effort_test.go
+++ b/api/pkg/controller/inference_reasoning_effort_test.go
@@ -25,3 +25,38 @@ func TestLoadAssistant_AppliesDirectChatReasoningEffort(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "high", assistant.ReasoningEffort)
 }
+
+func TestLoadAssistant_AppliesCodeAgentOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetAppWithTools(gomock.Any(), "app-1").Return(&types.App{
+		ID: "app-1",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			AgentType:        types.AgentTypeZedExternal,
+			CodeAgentRuntime: types.CodeAgentRuntimeOpenCode,
+			Provider:         "pe-deepseek",
+			Model:            "deepseek-v4-flash",
+			ReasoningEffort:  types.ReasoningEffortNone,
+		}}}},
+	}, nil)
+	mockStore.EXPECT().ListSecrets(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	c := &Controller{Options: Options{Store: mockStore}}
+	assistant, err := c.loadAssistant(
+		context.Background(),
+		&types.User{ID: "user-1"},
+		&ChatCompletionOptions{
+			AppID: "app-1",
+			CodeAgentOverrides: &types.CodeAgentOverrides{
+				ProviderRef:     "pe-qwen",
+				Model:           "qwen3.8-27b",
+				ReasoningEffort: "medium",
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "pe-qwen", assistant.Provider)
+	require.Equal(t, "qwen3.8-27b", assistant.Model)
+	require.Equal(t, "medium", assistant.ReasoningEffort)
+}

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -221,11 +221,12 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 	})
 
 	options := &controller.ChatCompletionOptions{
-		OrganizationID: user.OrganizationID,
-		AppID:          r.URL.Query().Get("app_id"),
-		AssistantID:    r.URL.Query().Get("assistant_id"),
-		RAGSourceID:    r.URL.Query().Get("rag_source_id"),
-		Provider:       validatedProvider,
+		OrganizationID:     user.OrganizationID,
+		AppID:              r.URL.Query().Get("app_id"),
+		AssistantID:        r.URL.Query().Get("assistant_id"),
+		RAGSourceID:        r.URL.Query().Get("rag_source_id"),
+		Provider:           validatedProvider,
+		CodeAgentOverrides: usageAttribution.CodeAgentOverrides,
 		QueryParams: func() map[string]string {
 			params := make(map[string]string)
 			for key, values := range r.URL.Query() {

--- a/api/pkg/server/proxy_usage_attribution.go
+++ b/api/pkg/server/proxy_usage_attribution.go
@@ -8,9 +8,10 @@ import (
 )
 
 type proxyUsageAttribution struct {
-	SessionID        string
-	AppID            string
-	CodeAgentRuntime types.CodeAgentRuntime
+	SessionID          string
+	AppID              string
+	CodeAgentRuntime   types.CodeAgentRuntime
+	CodeAgentOverrides *types.CodeAgentOverrides
 }
 
 func (s *HelixAPIServer) resolveProxyUsageAttribution(ctx context.Context, user *types.User, defaultSessionID string) (*proxyUsageAttribution, error) {
@@ -38,8 +39,22 @@ func (s *HelixAPIServer) resolveProxyUsageAttribution(ctx context.Context, user 
 
 	attribution.SessionID = session.ID
 	attribution.CodeAgentRuntime = session.Metadata.CodeAgentRuntime
+	attribution.CodeAgentOverrides = session.Metadata.CodeAgentOverrides
 	if session.ParentApp != "" {
 		attribution.AppID = session.ParentApp
+	}
+	if session.Metadata.SpecTaskID != "" {
+		task, err := s.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load API key spec task %q: %w", session.Metadata.SpecTaskID, err)
+		}
+		if task.PlanningSessionID != "" && task.PlanningSessionID != session.ID {
+			return nil, fmt.Errorf("API key session %q does not own spec task %q", session.ID, task.ID)
+		}
+		attribution.CodeAgentOverrides = task.CodeAgentOverrides
+		if task.HelixAppID != "" {
+			attribution.AppID = task.HelixAppID
+		}
 	}
 	return attribution, nil
 }

--- a/api/pkg/server/proxy_usage_attribution_test.go
+++ b/api/pkg/server/proxy_usage_attribution_test.go
@@ -24,8 +24,8 @@ func TestResolveProxyUsageAttributionUsesCurrentSessionApp(t *testing.T) {
 		OrganizationID: "org_123",
 		ParentApp:      "app_current",
 		Metadata: types.SessionMetadata{
-			SpecTaskID:       "spt_123",
-			CodeAgentRuntime: types.CodeAgentRuntimeOpenCode,
+			CodeAgentRuntime:   types.CodeAgentRuntimeOpenCode,
+			CodeAgentOverrides: &types.CodeAgentOverrides{Model: "qwen3.8-27b"},
 		},
 	}, nil)
 
@@ -34,6 +34,43 @@ func TestResolveProxyUsageAttributionUsesCurrentSessionApp(t *testing.T) {
 	require.Equal(t, "ses_123", attribution.SessionID)
 	require.Equal(t, "app_current", attribution.AppID)
 	require.Equal(t, types.CodeAgentRuntimeOpenCode, attribution.CodeAgentRuntime)
+	require.Equal(t, "qwen3.8-27b", attribution.CodeAgentOverrides.Model)
+}
+
+func TestResolveProxyUsageAttributionUsesAuthoritativeSpecTaskConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	mockStore.EXPECT().GetSession(gomock.Any(), "ses_123").Return(&types.Session{
+		ID:             "ses_123",
+		OrganizationID: "org_123",
+		ParentApp:      "app_stale",
+		Metadata: types.SessionMetadata{
+			SpecTaskID:       "spt_123",
+			CodeAgentRuntime: types.CodeAgentRuntimeOpenCode,
+		},
+	}, nil)
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_123").Return(&types.SpecTask{
+		ID:                "spt_123",
+		PlanningSessionID: "ses_123",
+		HelixAppID:        "app_current",
+		CodeAgentOverrides: &types.CodeAgentOverrides{
+			ProviderRef:     "pe_qwen",
+			Model:           "qwen3.8-27b",
+			ReasoningEffort: "medium",
+		},
+	}, nil)
+
+	attribution, err := server.resolveProxyUsageAttribution(context.Background(), &types.User{
+		SessionID:      "ses_123",
+		SpecTaskID:     "spt_123",
+		OrganizationID: "org_123",
+	}, "response_123")
+	require.NoError(t, err)
+	require.Equal(t, "app_current", attribution.AppID)
+	require.Equal(t, "pe_qwen", attribution.CodeAgentOverrides.ProviderRef)
+	require.Equal(t, "qwen3.8-27b", attribution.CodeAgentOverrides.Model)
+	require.Equal(t, "medium", attribution.CodeAgentOverrides.ReasoningEffort)
 }
 
 func TestResolveProxyUsageAttributionLeavesOrdinaryAPIRequestUnchanged(t *testing.T) {

--- a/design/2026-08-15-code-agent-proxy-model-overrides.md
+++ b/design/2026-08-15-code-agent-proxy-model-overrides.md
@@ -1,0 +1,57 @@
+# Code-agent proxy model override RCA
+
+## Incident
+
+SpecTask `spt_01m029jyfb6mktngv1mh577cfm` was configured to run OpenCode with
+provider `pe_01kzpnf69hf73basd52k942vs3` and model `qwen3.8-27b`. Its proxy
+calls were instead dispatched as `deepseek-v4-flash`, the reusable Agent's
+stored default, and failed because that model was not available upstream.
+
+## Evidence
+
+- The task row and both execution-config endpoints reported `qwen3.8-27b`.
+- The session's live `/zed-config` reported
+  `ds4-flash-node06/qwen3.8-27b`.
+- The running OpenCode process had
+  `model=helix/ds4-flash-node06/qwen3.8-27b` in
+  `OPENCODE_CONFIG_CONTENT`.
+- OpenCode's own log recorded every attempted stream with
+  `modelID=ds4-flash-node06/qwen3.8-27b`.
+- Helix LLM call `llmc_01m02aa01cfe9yxmndszknazrp` recorded
+  `deepseek-v4-flash` and the upstream 404.
+
+This rules out the picker, persistence, Zed config, settings sync, and
+OpenCode. The rewrite occurred inside the Helix OpenAI-compatible proxy.
+
+## Root cause
+
+The session-scoped API key correctly attributed the proxy call to the coding
+Agent by setting `ChatCompletionOptions.AppID`. The controller then loaded the
+reusable Agent and unconditionally replaced the incoming request's model and
+provider with that Agent's stored assistant defaults. It did not apply the
+session or SpecTask `CodeAgentOverrides`, even though those overrides had been
+used to generate the code-agent configuration.
+
+Normal chat worked because it did not enter this app-backed proxy path.
+
+## Fix
+
+Proxy attribution now carries the authoritative code-agent overrides:
+
+- session overrides for exploratory/project coding sessions;
+- SpecTask overrides and Agent ID for task sessions.
+
+The controller applies those overrides to a copy of the loaded Agent before
+performing its existing authoritative model selection. This preserves the
+security property that a sandbox cannot select an arbitrary model while making
+the controller agree with the model configuration Helix issued to the sandbox.
+
+## Verification
+
+- Controller and proxy-attribution unit tests pass.
+- The affected server packages build successfully.
+- After hot reload, sending `Reply with exactly: PROXY_OVERRIDE_OK` through the
+  original SpecTask completed successfully. LLM call
+  `llmc_01m02b7wxggf0sa606yknqyf1b` used provider
+  `pe_01kzpnf69hf73basd52k942vs3`, model `qwen3.8-27b`, produced 120 completion
+  tokens, and had no error.


### PR DESCRIPTION
## Root cause

Session-scoped code-agent calls were attributed to the backing Agent, then the inference controller reloaded that Agent and replaced the incoming request model with its stored default. SpecTask and session code-agent overrides were only applied while generating OpenCode/Zed configuration, so OpenCode sent qwen3.8-27b but Helix dispatched deepseek-v4-flash.

## Fix

- carry authoritative session/SpecTask code-agent overrides through proxy attribution
- apply the overrides to the loaded Agent copy before the controller selects the provider and model
- retain server-side enforcement so sandbox requests cannot choose arbitrary models
- add regression coverage and an RCA design note

## Verification

- CGO_ENABLED=1 go test ./pkg/controller ./pkg/server -count=1
- CGO_ENABLED=1 go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- live retry on SpecTask spt_01m029jyfb6mktngv1mh577cfm returned PROXY_OVERRIDE_OK
- LLM call llmc_01m02b7wxggf0sa606yknqyf1b used qwen3.8-27b, completed 120 tokens, and had no error