### PR TITLE
feat(api): curated reasoning-effort registry + stop defaulting assistant max_tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,77 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 41222 ubuntu@
   "cd ~/helix && docker compose -f docker-compose.dev.yaml restart api"
 ```
 
+## Reasoning Effort per Model
+
+**Source of truth: `api/pkg/model/reasoning_efforts.go`.** If an agent turn dies with a
+400 mentioning `reasoning effort`, start there.
+
+Reasoning-effort support is **not discoverable at runtime**. An OpenAI-compatible
+`/v1/models` response carries no capability data — vLLM returns only `id`, `owned_by`,
+`root`, `max_model_len`, `permission`. The accepted set lives in the model's chat
+template and is only learnable by sending a request and reading the 400. So Helix keeps
+a curated table, and **every entry records the source it came from** (`probed`,
+`catalogue`, `vendor`) plus a `verified_at` date.
+
+Passing an unsupported value is not a soft failure: the provider 400s, the coding agent
+retries the same 400 ~9 times over ~70s, then aborts the turn with no work done and a
+generic "agent turn aborted" in the UI.
+
+### Traps this table exists to record
+
+| Model | Accepts | **Rejects** | Default |
+|---|---|---|---|
+| `qwen3.8-27b` | `none`, `low`, `medium`, `xhigh` | **`high`**, `max`, `minimal` | `xhigh` |
+| `deepseek-v4-flash` / `-pro` | `high`, `xhigh` | — | `high` |
+| Claude Opus 5 / 4.8 / 4.7, Sonnet 5, Fable 5 | `low`…`max` incl. `xhigh` | — | `high` |
+| Claude Opus 4.6 / Sonnet 4.6 | `low`, `medium`, `high`, `max` | **`xhigh`** | `high` |
+| Claude Sonnet 4.5 / Haiku 4.5 | *(none — predates the parameter)* | any value | — |
+
+- **`qwen3.8-27b` rejects `high` but accepts `xhigh`** — the reverse of every other model,
+  and the exact bug that made a spec task fail. Its template also **silently coerces** any
+  unrecognized value (`foo`, `HIGH`, `ultra`) to the `xhigh` default, so probing only for
+  rejections does not reveal the supported set.
+- **Claude reads `output_config.effort`, never a top-level `reasoning_effort`.** A value
+  sent under the wrong key is ignored with no error — the symptom is "the setting does
+  nothing", not a 400.
+- **`xhigh` arrived with Opus 4.7.** Offering it on a 4.6-generation model errors.
+
+### How it flows
+
+`LookupReasoningEfforts(modelID)` matches on the **longest family prefix**, so dated and
+suffixed builds (`deepseek-v4-flash-0731`, `qwen3.8-27b-instruct`, `provider/model`)
+resolve without their own row. Adding a model is a data edit — append a profile, no code
+change. It reaches the frontend two ways:
+
+- `types.OpenAIModel.ReasoningEfforts` on `/v1/provider-endpoints?load_models=true` —
+  deliberately **separate from `ModelInfo`**, because a non-nil `ModelInfo` is what the
+  Anthropic proxy and usage handlers read as "this model is priceable". Self-hosted models
+  have effort profiles but no pricing entry, so the two must not be conflated.
+- `ModelInfo.SupportedReasoningEfforts` / `DefaultReasoningEffort` — the curated table only
+  **fills gaps** here; `model_info.json` wins where it has data.
+
+Frontend: `useModelReasoningEfforts(modelId)` →
+`getCodeAgentEffortOptions(runtime, supportedEfforts)`. The runtime only decides which
+tiers the *harness* can express; the model decides which the provider will accept. An
+unknown model returns `undefined` and the full runtime list stands — **never guess a
+narrower list**, and never offer an effort for a model with no profile.
+
+### Debugging a suspected effort problem
+
+```bash
+# What did Helix actually send vs what did the caller ask for?
+docker exec helix-postgres-1 psql -U postgres -d postgres -c \
+  "SELECT id, model, original_request->>'reasoning_effort' AS asked, \
+   request->>'reasoning_effort' AS sent, left(error,120) AS err \
+   FROM llm_calls WHERE session_id='ses_…' ORDER BY created DESC LIMIT 10;"
+
+# Probe a provider directly — prompt_tokens reveals the template branch taken;
+# equal counts across values mean they collapse to the same default.
+curl -s $BASE_URL/chat/completions -H "Authorization: Bearer $KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"…","max_tokens":1,"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"high"}'
+```
+
 ## Code Patterns
 
 ### Go

--- a/api/pkg/model/model_info.go
+++ b/api/pkg/model/model_info.go
@@ -125,6 +125,12 @@ func toModelInfo(m ModelInfoData) types.ModelInfo {
 			}
 			return m.ReasoningConfig.SupportedReasoningEfforts
 		}(),
+		DefaultReasoningEffort: func() string {
+			if m.ReasoningConfig == nil {
+				return ""
+			}
+			return m.ReasoningConfig.DefaultReasoningEffort
+		}(),
 		ContextLength:       m.ContextLength,
 		SupportedParameters: m.Endpoint.SupportedParameters,
 		MaxCompletionTokens: m.Endpoint.MaxCompletionTokens,
@@ -136,7 +142,22 @@ func isAnthropicDirectSlug(s string) bool {
 	return s == "anthropic"
 }
 
-func (p *BaseModelInfoProvider) GetModelInfo(_ context.Context, request *ModelInfoRequest) (*types.ModelInfo, error) {
+// GetModelInfo resolves a model against the bundled catalogue, then fills in
+// reasoning-effort fields from the curated table for catalogue entries that
+// don't carry them. It deliberately does NOT synthesize an entry for a model the
+// catalogue has never heard of: a non-nil ModelInfo is what the Anthropic proxy
+// and the usage handlers treat as "this model is priceable", so inventing one
+// would wave unpriced models through the billing gate.
+func (p *BaseModelInfoProvider) GetModelInfo(ctx context.Context, request *ModelInfoRequest) (*types.ModelInfo, error) {
+	info, err := p.getModelInfo(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	applyReasoningEffortProfile(info, request.Model)
+	return info, nil
+}
+
+func (p *BaseModelInfoProvider) getModelInfo(_ context.Context, request *ModelInfoRequest) (*types.ModelInfo, error) {
 	p.dataMu.RLock()
 	defer p.dataMu.RUnlock()
 

--- a/api/pkg/model/reasoning_efforts.go
+++ b/api/pkg/model/reasoning_efforts.go
@@ -1,0 +1,213 @@
+package model
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// This file is the curated record of which reasoning-effort values each model
+// family actually accepts.
+//
+// It exists because the value is not discoverable at runtime. vLLM's /v1/models
+// returns the plain OpenAI ModelCard (id, owned_by, max_model_len, permission)
+// and says nothing about sampling parameters, so a self-hosted model's accepted
+// effort set can only be learned by sending a request and reading the 400 — and
+// some templates accept an unrecognized value silently instead of rejecting it,
+// so probing for rejections alone does not give the supported set either.
+//
+// Passing an unsupported value is not a soft failure: the provider rejects the
+// whole request, the coding agent retries the same 400 several times, and the
+// turn aborts with no work done.
+//
+// Every profile carries the source it was established from and, where relevant,
+// the values that are known to be REJECTED, so a mismatch between this table and
+// a live provider can be triaged without re-deriving it. Adding a model is a
+// data edit — append a profile, no code change.
+
+// reasoningEffortProfiles is the curated table. Matching is longest-prefix over
+// the normalized model id, so a dated build (qwen3.8-27b-20260731) resolves to
+// its family entry without needing its own row.
+var reasoningEffortProfiles = []types.ReasoningEffortProfile{
+	// --- Anthropic -----------------------------------------------------------
+	// Claude reads effort from output_config.effort. A top-level
+	// reasoning_effort is not read, so a value sent there has no effect and
+	// produces no error — the symptom is "the setting does nothing".
+	// xhigh arrived with Opus 4.7; 4.6-generation models reject it.
+	{
+		Family: "claude-opus-5", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "Thinking is on by default. Disabling thinking is accepted only at effort high or below; pairing thinking:disabled with xhigh or max is a 400.",
+	},
+	{
+		Family: "claude-fable-5", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "Thinking is always on; an explicit thinking:disabled is a 400 at any effort.",
+	},
+	{
+		Family: "claude-mythos-5", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "Same API surface as claude-fable-5.",
+	},
+	{
+		Family: "claude-opus-4-8", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+	},
+	{
+		Family: "claude-opus-4-7", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "First Claude model with xhigh.",
+	},
+	{
+		Family: "claude-sonnet-5", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "First Sonnet-tier model with xhigh.",
+	},
+	{
+		Family: "claude-opus-4-6", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "max"},
+		Rejected:  []string{"xhigh"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "xhigh did not exist yet on the 4.6 generation.",
+	},
+	{
+		Family: "claude-sonnet-4-6", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high", "max"},
+		Rejected:  []string{"xhigh"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+	},
+	{
+		Family: "claude-opus-4-5", Parameter: types.EffortParamOutputConfigEffort,
+		Supported: []string{"low", "medium", "high"},
+		Rejected:  []string{"xhigh", "max"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+	},
+	{
+		Family: "claude-sonnet-4-5", Parameter: types.EffortParamOutputConfigEffort,
+		SupportsEffort: false,
+		Source:         types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "Predates the effort parameter; sending any effort value errors.",
+	},
+	{
+		Family: "claude-haiku-4-5", Parameter: types.EffortParamOutputConfigEffort,
+		SupportsEffort: false,
+		Source:         types.EffortSourceVendor, VerifiedAt: "2026-08-15",
+		Notes: "Predates the effort parameter; sending any effort value errors.",
+	},
+
+	// --- OpenAI --------------------------------------------------------------
+	{
+		Family: "gpt-5.5-pro", Parameter: types.EffortParamReasoningEffort,
+		Supported: []string{"medium", "high", "xhigh"},
+		Default:   "medium", SupportsEffort: true,
+		Source: types.EffortSourceCatalogue, VerifiedAt: "2026-08-15",
+		Notes: "Reasoning is mandatory on this model; there is no off setting.",
+	},
+
+	// --- DeepSeek ------------------------------------------------------------
+	{
+		Family: "deepseek-v4-flash", Parameter: types.EffortParamReasoningEffort,
+		Supported: []string{"high", "xhigh"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceCatalogue, VerifiedAt: "2026-08-15",
+		Notes: "Catalogue entry describes the 20260423 build. Later dated builds (e.g. -0731) match this family by prefix and have NOT been probed separately; if one rejects high or xhigh, add a dated row above this one.",
+	},
+	{
+		Family: "deepseek-v4-pro", Parameter: types.EffortParamReasoningEffort,
+		Supported: []string{"high", "xhigh"},
+		Default:   "high", SupportsEffort: true,
+		Source: types.EffortSourceCatalogue, VerifiedAt: "2026-08-15",
+	},
+
+	// --- Qwen ----------------------------------------------------------------
+	{
+		Family: "qwen3.8-27b", Parameter: types.EffortParamReasoningEffort,
+		Supported: []string{"none", "low", "medium", "xhigh"},
+		Rejected:  []string{"high", "max", "minimal"},
+		Default:   "xhigh", SupportsEffort: true,
+		Source: types.EffortSourceProbed, VerifiedAt: "2026-08-15",
+		Notes: "Probed against a vLLM 0.11.2 deployment. The chat template raises on the OpenAI ladder names high/max/minimal and SILENTLY COERCES any other unrecognized value to the xhigh default, so probing for rejections alone does not reveal the supported set. Note high is rejected while xhigh is accepted, which is the reverse of most models.",
+	},
+}
+
+// normalizeModelIDForEffort lowercases and strips a provider prefix so
+// "anthropic/claude-opus-5" and "claude-opus-5" resolve to the same profile.
+func normalizeModelIDForEffort(modelID string) string {
+	s := strings.ToLower(strings.TrimSpace(modelID))
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		s = s[idx+1:]
+	}
+	return s
+}
+
+// LookupReasoningEfforts returns the curated profile for a model id, matching on
+// the longest family prefix so dated and quantized builds resolve to their
+// family. It reports false when the model is not in the table — callers must not
+// invent an effort list for an unknown model, because offering a value the
+// provider rejects is what aborts a turn.
+func LookupReasoningEfforts(modelID string) (*types.ReasoningEffortProfile, bool) {
+	normalized := normalizeModelIDForEffort(modelID)
+	if normalized == "" {
+		return nil, false
+	}
+
+	best := -1
+	for idx := range reasoningEffortProfiles {
+		family := reasoningEffortProfiles[idx].Family
+		if !strings.HasPrefix(normalized, family) {
+			continue
+		}
+		if best == -1 || len(family) > len(reasoningEffortProfiles[best].Family) {
+			best = idx
+		}
+	}
+	if best == -1 {
+		return nil, false
+	}
+
+	profile := reasoningEffortProfiles[best]
+	return &profile, true
+}
+
+// ListReasoningEffortProfiles returns every curated profile, sorted by family,
+// for the admin/debug surface.
+func ListReasoningEffortProfiles() []types.ReasoningEffortProfile {
+	out := make([]types.ReasoningEffortProfile, len(reasoningEffortProfiles))
+	copy(out, reasoningEffortProfiles)
+	sort.Slice(out, func(i, j int) bool { return out[i].Family < out[j].Family })
+	return out
+}
+
+// applyReasoningEffortProfile fills in reasoning-effort fields the bundled
+// catalogue does not carry. It only ever fills gaps: when model_info.json
+// already lists efforts for a model, that entry wins, because it ships with the
+// pricing data the rest of the catalogue is keyed on and is regenerated as a
+// unit. The curated table is for models the catalogue does not describe.
+func applyReasoningEffortProfile(info *types.ModelInfo, modelID string) {
+	if info == nil || len(info.SupportedReasoningEfforts) > 0 {
+		return
+	}
+	profile, ok := LookupReasoningEfforts(modelID)
+	if !ok || !profile.SupportsEffort {
+		return
+	}
+	info.SupportsReasoningEffort = true
+	info.SupportedReasoningEfforts = profile.Supported
+	info.DefaultReasoningEffort = profile.Default
+}

--- a/api/pkg/model/reasoning_efforts_test.go
+++ b/api/pkg/model/reasoning_efforts_test.go
@@ -1,0 +1,195 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestQwen38RejectsHighAcceptsXHigh pins the finding that motivated this table.
+// The provider serving qwen3.8-27b rejects "high" — the value the UI used to
+// offer by default — while accepting "xhigh". Getting this backwards 400s every
+// request of the turn and aborts it with no work done.
+func TestQwen38RejectsHighAcceptsXHigh(t *testing.T) {
+	profile, ok := LookupReasoningEfforts("qwen3.8-27b")
+	require.True(t, ok, "qwen3.8-27b must be in the curated table")
+
+	assert.Contains(t, profile.Supported, "xhigh")
+	assert.Contains(t, profile.Supported, "medium")
+	assert.Contains(t, profile.Supported, "low")
+	assert.NotContains(t, profile.Supported, "high")
+	assert.Contains(t, profile.Rejected, "high")
+	assert.Equal(t, "xhigh", profile.Default)
+	assert.Equal(t, types.EffortSourceProbed, profile.Source)
+}
+
+// TestClaudeUsesOutputConfigEffort guards the parameter name. Claude reads
+// output_config.effort; a value sent as a top-level reasoning_effort is ignored
+// with no error, so the failure looks like "the setting does nothing".
+func TestClaudeUsesOutputConfigEffort(t *testing.T) {
+	for _, modelID := range []string{"claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"} {
+		t.Run(modelID, func(t *testing.T) {
+			profile, ok := LookupReasoningEfforts(modelID)
+			require.True(t, ok)
+			assert.Equal(t, types.EffortParamOutputConfigEffort, profile.Parameter)
+			assert.Contains(t, profile.Supported, "xhigh")
+			assert.Equal(t, "high", profile.Default)
+		})
+	}
+}
+
+// TestClaude46GenerationRejectsXHigh pins the generational split: xhigh arrived
+// with Opus 4.7, so offering it on a 4.6-generation model is an error.
+func TestClaude46GenerationRejectsXHigh(t *testing.T) {
+	for _, modelID := range []string{"claude-opus-4-6", "claude-sonnet-4-6"} {
+		t.Run(modelID, func(t *testing.T) {
+			profile, ok := LookupReasoningEfforts(modelID)
+			require.True(t, ok)
+			assert.NotContains(t, profile.Supported, "xhigh")
+			assert.Contains(t, profile.Rejected, "xhigh")
+			assert.Contains(t, profile.Supported, "max")
+		})
+	}
+}
+
+// TestModelsWithoutEffortSupport covers the models that take no effort value at
+// all — the UI must render no selector rather than a default one.
+func TestModelsWithoutEffortSupport(t *testing.T) {
+	for _, modelID := range []string{"claude-sonnet-4-5", "claude-haiku-4-5"} {
+		t.Run(modelID, func(t *testing.T) {
+			profile, ok := LookupReasoningEfforts(modelID)
+			require.True(t, ok)
+			assert.False(t, profile.SupportsEffort)
+			assert.Empty(t, profile.Supported)
+		})
+	}
+}
+
+// TestLookupMatchesLongestFamilyPrefix covers dated and suffixed builds
+// resolving to their family, which is how a deepseek-v4-flash-0731 deployment
+// gets an answer without its own row.
+func TestLookupMatchesLongestFamilyPrefix(t *testing.T) {
+	tests := []struct {
+		modelID    string
+		wantFamily string
+	}{
+		{"deepseek-v4-flash-0731", "deepseek-v4-flash"},
+		{"deepseek-v4-flash", "deepseek-v4-flash"},
+		{"qwen3.8-27b-instruct", "qwen3.8-27b"},
+		{"anthropic/claude-opus-5", "claude-opus-5"},
+		{"ds4-flash-node06/qwen3.8-27b", "qwen3.8-27b"},
+		{"claude-opus-4-8", "claude-opus-4-8"},
+		{"CLAUDE-OPUS-5", "claude-opus-5"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.modelID, func(t *testing.T) {
+			profile, ok := LookupReasoningEfforts(tc.modelID)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantFamily, profile.Family)
+		})
+	}
+}
+
+// TestLookupUnknownModelReportsUnknown is the important negative case: an
+// unknown model must yield no profile, so callers render no effort options
+// rather than a guessed list the provider would reject.
+func TestLookupUnknownModelReportsUnknown(t *testing.T) {
+	for _, modelID := range []string{"", "   ", "llama-4-70b", "some-unknown-model"} {
+		profile, ok := LookupReasoningEfforts(modelID)
+		assert.False(t, ok, "model %q must not resolve", modelID)
+		assert.Nil(t, profile)
+	}
+}
+
+// TestProfileTableIsWellFormed catches data-entry mistakes in the table itself:
+// a value cannot be both supported and rejected, and a default must be
+// supported.
+func TestProfileTableIsWellFormed(t *testing.T) {
+	for _, profile := range ListReasoningEffortProfiles() {
+		t.Run(profile.Family, func(t *testing.T) {
+			assert.NotEmpty(t, profile.Parameter, "parameter must be set")
+			assert.NotEmpty(t, profile.Source, "source must be set")
+			assert.NotEmpty(t, profile.VerifiedAt, "verified_at must be set")
+
+			for _, rejected := range profile.Rejected {
+				assert.NotContains(t, profile.Supported, rejected,
+					"%q cannot be both supported and rejected", rejected)
+			}
+			if profile.SupportsEffort {
+				assert.NotEmpty(t, profile.Supported)
+				if profile.Default != "" {
+					assert.Contains(t, profile.Supported, profile.Default,
+						"default %q must be a supported value", profile.Default)
+				}
+			} else {
+				assert.Empty(t, profile.Supported)
+			}
+		})
+	}
+}
+
+// TestOverlayFillsCatalogueGapsOnly verifies the precedence rule: the bundled
+// catalogue wins where it has data, and the curated table only fills gaps.
+func TestOverlayFillsCatalogueGapsOnly(t *testing.T) {
+	t.Run("fills a gap", func(t *testing.T) {
+		info := &types.ModelInfo{}
+		applyReasoningEffortProfile(info, "claude-opus-5")
+		assert.True(t, info.SupportsReasoningEffort)
+		assert.Equal(t, []string{"low", "medium", "high", "xhigh", "max"}, info.SupportedReasoningEfforts)
+		assert.Equal(t, "high", info.DefaultReasoningEffort)
+	})
+
+	t.Run("does not override the catalogue", func(t *testing.T) {
+		info := &types.ModelInfo{
+			SupportedReasoningEfforts: []string{"catalogue-value"},
+			DefaultReasoningEffort:    "catalogue-value",
+		}
+		applyReasoningEffortProfile(info, "claude-opus-5")
+		assert.Equal(t, []string{"catalogue-value"}, info.SupportedReasoningEfforts)
+		assert.Equal(t, "catalogue-value", info.DefaultReasoningEffort)
+	})
+
+	t.Run("leaves unknown models untouched", func(t *testing.T) {
+		info := &types.ModelInfo{}
+		applyReasoningEffortProfile(info, "some-unknown-model")
+		assert.False(t, info.SupportsReasoningEffort)
+		assert.Empty(t, info.SupportedReasoningEfforts)
+	})
+
+	t.Run("leaves effort-less models untouched", func(t *testing.T) {
+		info := &types.ModelInfo{}
+		applyReasoningEffortProfile(info, "claude-haiku-4-5")
+		assert.False(t, info.SupportsReasoningEffort)
+		assert.Empty(t, info.SupportedReasoningEfforts)
+	})
+}
+
+// TestGetModelInfoAppliesOverlay checks the wiring end-to-end through the real
+// provider, including that a model absent from the catalogue still errors (the
+// billing gate depends on that error).
+func TestGetModelInfoAppliesOverlay(t *testing.T) {
+	provider, err := NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	t.Run("unknown model still errors", func(t *testing.T) {
+		_, err := provider.GetModelInfo(context.Background(), &ModelInfoRequest{
+			Provider: "ds4-flash-node06",
+			Model:    "qwen3.8-27b",
+		})
+		require.Error(t, err, "a model with no catalogue entry must not become priceable")
+	})
+
+	t.Run("catalogue model keeps its own efforts", func(t *testing.T) {
+		info, err := provider.GetModelInfo(context.Background(), &ModelInfoRequest{
+			Provider: "deepseek",
+			Model:    "deepseek-v4-flash",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"high", "xhigh"}, info.SupportedReasoningEfforts)
+		assert.Equal(t, "high", info.DefaultReasoningEffort)
+	})
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -30602,6 +30602,19 @@ const docTemplate = `{
                 "EffectDeny"
             ]
         },
+        "types.EffortSource": {
+            "type": "string",
+            "enum": [
+                "probed",
+                "catalogue",
+                "vendor"
+            ],
+            "x-enum-varnames": [
+                "EffortSourceProbed",
+                "EffortSourceCatalogue",
+                "EffortSourceVendor"
+            ]
+        },
         "types.EvaluationAssertion": {
             "type": "object",
             "properties": {
@@ -32674,6 +32687,10 @@ const docTemplate = `{
                 "context_length": {
                     "type": "integer"
                 },
+                "default_reasoning_effort": {
+                    "description": "DefaultReasoningEffort is the value the model applies when none is sent.\nEmpty when unknown.",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -33074,6 +33091,14 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/types.OpenAIPermission"
                     }
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts is the curated set of reasoning-effort values this model\naccepts. It is a separate field from ModelInfo on purpose: ModelInfo being\nnon-nil is what the billing path reads as \"this model is priceable\", so\neffort capability — which is known for models that have no pricing entry,\ne.g. self-hosted vLLM deployments — must not be smuggled in through it.\nNil means Helix does not know; a UI must not offer a guessed effort list,\nbecause sending a value the provider rejects aborts the whole turn.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ReasoningEffortProfile"
+                        }
+                    ]
                 },
                 "root": {
                     "type": "string"
@@ -35060,6 +35085,57 @@ const docTemplate = `{
                 "threshold": {
                     "description": "this is the threshold for a \"good\" answer - will default to 0.2",
                     "type": "number"
+                }
+            }
+        },
+        "types.ReasoningEffortProfile": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "description": "Default is the value applied when none is sent. Empty when unknown.",
+                    "type": "string"
+                },
+                "family": {
+                    "description": "Family is the normalized model-id prefix this profile applies to.",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Notes carries anything a debugger needs that the fields above do not say.",
+                    "type": "string"
+                },
+                "parameter": {
+                    "description": "Parameter is the wire field that carries the value.",
+                    "type": "string"
+                },
+                "rejected": {
+                    "description": "Rejected lists values known to fail with an error. Deliberately separate\nfrom \"absent from Supported\": a value can be missing from Supported because\nit is silently coerced rather than because it errors, and only the erroring\nones abort a turn.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "description": "Source is how this entry was established.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EffortSource"
+                        }
+                    ]
+                },
+                "supported": {
+                    "description": "Supported lists the values the model accepts and acts on.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "supports_effort": {
+                    "description": "SupportsEffort is false for models that accept no effort value at all.",
+                    "type": "boolean"
+                },
+                "verified_at": {
+                    "description": "VerifiedAt is the date the entry was last checked (YYYY-MM-DD).",
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -520,6 +520,13 @@ func (s *HelixAPIServer) refreshProviderModels(ctx context.Context, providerEndp
 				models[idx].ModelInfo = modelInfo
 			}
 
+			// Effort capability is resolved independently of the pricing
+			// catalogue: self-hosted models (vLLM and friends) have no catalogue
+			// entry and never will, but we still know what efforts they accept.
+			if profile, ok := model.LookupReasoningEfforts(m.ID); ok {
+				models[idx].ReasoningEfforts = profile
+			}
+
 			// If billing is enabled and we don't have pricing, disable the model
 			if providerEndpoint.BillingEnabled {
 				if modelInfo == nil {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -30598,6 +30598,19 @@
                 "EffectDeny"
             ]
         },
+        "types.EffortSource": {
+            "type": "string",
+            "enum": [
+                "probed",
+                "catalogue",
+                "vendor"
+            ],
+            "x-enum-varnames": [
+                "EffortSourceProbed",
+                "EffortSourceCatalogue",
+                "EffortSourceVendor"
+            ]
+        },
         "types.EvaluationAssertion": {
             "type": "object",
             "properties": {
@@ -32670,6 +32683,10 @@
                 "context_length": {
                     "type": "integer"
                 },
+                "default_reasoning_effort": {
+                    "description": "DefaultReasoningEffort is the value the model applies when none is sent.\nEmpty when unknown.",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -33070,6 +33087,14 @@
                     "items": {
                         "$ref": "#/definitions/types.OpenAIPermission"
                     }
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts is the curated set of reasoning-effort values this model\naccepts. It is a separate field from ModelInfo on purpose: ModelInfo being\nnon-nil is what the billing path reads as \"this model is priceable\", so\neffort capability — which is known for models that have no pricing entry,\ne.g. self-hosted vLLM deployments — must not be smuggled in through it.\nNil means Helix does not know; a UI must not offer a guessed effort list,\nbecause sending a value the provider rejects aborts the whole turn.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ReasoningEffortProfile"
+                        }
+                    ]
                 },
                 "root": {
                     "type": "string"
@@ -35056,6 +35081,57 @@
                 "threshold": {
                     "description": "this is the threshold for a \"good\" answer - will default to 0.2",
                     "type": "number"
+                }
+            }
+        },
+        "types.ReasoningEffortProfile": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "description": "Default is the value applied when none is sent. Empty when unknown.",
+                    "type": "string"
+                },
+                "family": {
+                    "description": "Family is the normalized model-id prefix this profile applies to.",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Notes carries anything a debugger needs that the fields above do not say.",
+                    "type": "string"
+                },
+                "parameter": {
+                    "description": "Parameter is the wire field that carries the value.",
+                    "type": "string"
+                },
+                "rejected": {
+                    "description": "Rejected lists values known to fail with an error. Deliberately separate\nfrom \"absent from Supported\": a value can be missing from Supported because\nit is silently coerced rather than because it errors, and only the erroring\nones abort a turn.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "description": "Source is how this entry was established.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EffortSource"
+                        }
+                    ]
+                },
+                "supported": {
+                    "description": "Supported lists the values the model accepts and acts on.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "supports_effort": {
+                    "description": "SupportsEffort is false for models that accept no effort value at all.",
+                    "type": "boolean"
+                },
+                "verified_at": {
+                    "description": "VerifiedAt is the date the entry was last checked (YYYY-MM-DD).",
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5558,6 +5558,16 @@ definitions:
     x-enum-varnames:
     - EffectAllow
     - EffectDeny
+  types.EffortSource:
+    enum:
+    - probed
+    - catalogue
+    - vendor
+    type: string
+    x-enum-varnames:
+    - EffortSourceProbed
+    - EffortSourceCatalogue
+    - EffortSourceVendor
   types.EvaluationAssertion:
     properties:
       llm_judge_prompt:
@@ -7059,6 +7069,11 @@ definitions:
         type: string
       context_length:
         type: integer
+      default_reasoning_effort:
+        description: |-
+          DefaultReasoningEffort is the value the model applies when none is sent.
+          Empty when unknown.
+        type: string
       description:
         type: string
       input_modalities:
@@ -7340,6 +7355,17 @@ definitions:
         items:
           $ref: '#/definitions/types.OpenAIPermission'
         type: array
+      reasoning_efforts:
+        allOf:
+        - $ref: '#/definitions/types.ReasoningEffortProfile'
+        description: |-
+          ReasoningEfforts is the curated set of reasoning-effort values this model
+          accepts. It is a separate field from ModelInfo on purpose: ModelInfo being
+          non-nil is what the billing path reads as "this model is priceable", so
+          effort capability — which is known for models that have no pricing entry,
+          e.g. self-hosted vLLM deployments — must not be smuggled in through it.
+          Nil means Helix does not know; a UI must not offer a guessed effort list,
+          because sending a value the provider rejects aborts the whole turn.
       root:
         type: string
       type:
@@ -8754,6 +8780,48 @@ definitions:
       threshold:
         description: this is the threshold for a "good" answer - will default to 0.2
         type: number
+    type: object
+  types.ReasoningEffortProfile:
+    properties:
+      default:
+        description: Default is the value applied when none is sent. Empty when unknown.
+        type: string
+      family:
+        description: Family is the normalized model-id prefix this profile applies
+          to.
+        type: string
+      notes:
+        description: Notes carries anything a debugger needs that the fields above
+          do not say.
+        type: string
+      parameter:
+        description: Parameter is the wire field that carries the value.
+        type: string
+      rejected:
+        description: |-
+          Rejected lists values known to fail with an error. Deliberately separate
+          from "absent from Supported": a value can be missing from Supported because
+          it is silently coerced rather than because it errors, and only the erroring
+          ones abort a turn.
+        items:
+          type: string
+        type: array
+      source:
+        allOf:
+        - $ref: '#/definitions/types.EffortSource'
+        description: Source is how this entry was established.
+      supported:
+        description: Supported lists the values the model accepts and acts on.
+        items:
+          type: string
+        type: array
+      supports_effort:
+        description: SupportsEffort is false for models that accept no effort value
+          at all.
+        type: boolean
+      verified_at:
+        description: VerifiedAt is the date the entry was last checked (YYYY-MM-DD).
+        type: string
     type: object
   types.RegisterRequest:
     properties:

--- a/api/pkg/store/store_apps.go
+++ b/api/pkg/store/store_apps.go
@@ -451,9 +451,10 @@ func setAppDefaults(apps ...*types.App) {
 				assistant.FrequencyPenalty = 0
 			}
 
-			if assistant.MaxTokens == 0 {
-				assistant.MaxTokens = 2000
-			}
+			// No MaxTokens default: leaving it unset lets each caller size its
+			// own completion budget. Defaulting it truncated external coding
+			// agents mid-turn, which the proxy applies over the agent's own
+			// max_tokens (see api/pkg/controller/inference.go).
 
 			if assistant.PresencePenalty == 0 {
 				assistant.PresencePenalty = 0

--- a/api/pkg/types/models.go
+++ b/api/pkg/types/models.go
@@ -210,9 +210,60 @@ type ModelInfo struct { //nolint:revive
 	// SupportedReasoningEfforts lists the effort values the model accepts,
 	// e.g. ["high","low","medium","none","xhigh"]. Empty when unknown.
 	SupportedReasoningEfforts []string `json:"supported_reasoning_efforts"`
-	ContextLength             int      `json:"context_length"`
+	// DefaultReasoningEffort is the value the model applies when none is sent.
+	// Empty when unknown.
+	DefaultReasoningEffort string `json:"default_reasoning_effort,omitempty"`
+	ContextLength          int    `json:"context_length"`
 	MaxCompletionTokens       int      `json:"max_completion_tokens"`
 	Pricing                   Pricing  `json:"pricing"`
+}
+
+// EffortSource records how a ReasoningEffortProfile was established, so a
+// mismatch between the curated table and a live provider can be triaged without
+// re-deriving it: "probed" was observed against a real endpoint, "catalogue"
+// came from the bundled model_info.json, "vendor" from published API docs.
+type EffortSource string
+
+const (
+	EffortSourceProbed    EffortSource = "probed"
+	EffortSourceCatalogue EffortSource = "catalogue"
+	EffortSourceVendor    EffortSource = "vendor"
+)
+
+// Wire parameters that carry the reasoning-effort value. Models differ, and
+// sending the value under the wrong key is silently ignored rather than
+// rejected — Claude reads output_config.effort and never a top-level
+// reasoning_effort.
+const (
+	EffortParamReasoningEffort    = "reasoning_effort"
+	EffortParamOutputConfigEffort = "output_config.effort"
+)
+
+// ReasoningEffortProfile is the set of reasoning-effort values one model family
+// accepts. See api/pkg/model/reasoning_efforts.go for the curated table and why
+// it cannot be discovered at runtime.
+type ReasoningEffortProfile struct {
+	// Family is the normalized model-id prefix this profile applies to.
+	Family string `json:"family"`
+	// Parameter is the wire field that carries the value.
+	Parameter string `json:"parameter"`
+	// Supported lists the values the model accepts and acts on.
+	Supported []string `json:"supported,omitempty"`
+	// Default is the value applied when none is sent. Empty when unknown.
+	Default string `json:"default,omitempty"`
+	// Rejected lists values known to fail with an error. Deliberately separate
+	// from "absent from Supported": a value can be missing from Supported because
+	// it is silently coerced rather than because it errors, and only the erroring
+	// ones abort a turn.
+	Rejected []string `json:"rejected,omitempty"`
+	// SupportsEffort is false for models that accept no effort value at all.
+	SupportsEffort bool `json:"supports_effort"`
+	// Source is how this entry was established.
+	Source EffortSource `json:"source"`
+	// VerifiedAt is the date the entry was last checked (YYYY-MM-DD).
+	VerifiedAt string `json:"verified_at,omitempty"`
+	// Notes carries anything a debugger needs that the fields above do not say.
+	Notes string `json:"notes,omitempty"`
 }
 
 type Pricing struct {

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -120,6 +120,14 @@ type OpenAIModel struct {
 	ContextLength int                `json:"context_length,omitempty"`
 	Enabled       bool               `json:"enabled,omitempty"`
 	ModelInfo     *ModelInfo         `json:"model_info,omitempty"`
+	// ReasoningEfforts is the curated set of reasoning-effort values this model
+	// accepts. It is a separate field from ModelInfo on purpose: ModelInfo being
+	// non-nil is what the billing path reads as "this model is priceable", so
+	// effort capability — which is known for models that have no pricing entry,
+	// e.g. self-hosted vLLM deployments — must not be smuggled in through it.
+	// Nil means Helix does not know; a UI must not offer a guessed effort list,
+	// because sending a value the provider rejects aborts the whole turn.
+	ReasoningEfforts *ReasoningEffortProfile `json:"reasoning_efforts,omitempty"`
 }
 
 // UnmarshalJSON accepts the context-window fields commonly returned by

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3553,6 +3553,12 @@ export enum TypesEffect {
   EffectDeny = "deny",
 }
 
+export enum TypesEffortSource {
+  EffortSourceProbed = "probed",
+  EffortSourceCatalogue = "catalogue",
+  EffortSourceVendor = "vendor",
+}
+
 export interface TypesEvaluationAssertion {
   /** Custom prompt for LLM judge mode */
   llm_judge_prompt?: string;
@@ -4481,6 +4487,11 @@ export interface TypesModel {
 export interface TypesModelInfo {
   author?: string;
   context_length?: number;
+  /**
+   * DefaultReasoningEffort is the value the model applies when none is sent.
+   * Empty when unknown.
+   */
+  default_reasoning_effort?: string;
   description?: string;
   input_modalities?: TypesModality[];
   max_completion_tokens?: number;
@@ -4638,6 +4649,16 @@ export interface TypesOpenAIModel {
   owned_by?: string;
   parent?: string;
   permission?: TypesOpenAIPermission[];
+  /**
+   * ReasoningEfforts is the curated set of reasoning-effort values this model
+   * accepts. It is a separate field from ModelInfo on purpose: ModelInfo being
+   * non-nil is what the billing path reads as "this model is priceable", so
+   * effort capability — which is known for models that have no pricing entry,
+   * e.g. self-hosted vLLM deployments — must not be smuggled in through it.
+   * Nil means Helix does not know; a UI must not offer a guessed effort list,
+   * because sending a value the provider rejects aborts the whole turn.
+   */
+  reasoning_efforts?: TypesReasoningEffortProfile;
   root?: string;
   type?: string;
 }
@@ -5490,6 +5511,32 @@ export interface TypesRAGSettings {
   text_splitter?: TypesTextSplitterType;
   /** this is the threshold for a "good" answer - will default to 0.2 */
   threshold?: number;
+}
+
+export interface TypesReasoningEffortProfile {
+  /** Default is the value applied when none is sent. Empty when unknown. */
+  default?: string;
+  /** Family is the normalized model-id prefix this profile applies to. */
+  family?: string;
+  /** Notes carries anything a debugger needs that the fields above do not say. */
+  notes?: string;
+  /** Parameter is the wire field that carries the value. */
+  parameter?: string;
+  /**
+   * Rejected lists values known to fail with an error. Deliberately separate
+   * from "absent from Supported": a value can be missing from Supported because
+   * it is silently coerced rather than because it errors, and only the erroring
+   * ones abort a turn.
+   */
+  rejected?: string[];
+  /** Source is how this entry was established. */
+  source?: TypesEffortSource;
+  /** Supported lists the values the model accepts and acts on. */
+  supported?: string[];
+  /** SupportsEffort is false for models that accept no effort value at all. */
+  supports_effort?: boolean;
+  /** VerifiedAt is the date the entry was last checked (YYYY-MM-DD). */
+  verified_at?: string;
 }
 
 export interface TypesRegisterRequest {

--- a/frontend/src/components/agent/CodeAgentEffortSelect.test.ts
+++ b/frontend/src/components/agent/CodeAgentEffortSelect.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { getCodeAgentEffortOptions } from './CodeAgentEffortSelect'
+
+const values = (runtime: string, supported?: readonly string[]) =>
+  getCodeAgentEffortOptions(runtime, supported).map((option) => option.value)
+
+describe('getCodeAgentEffortOptions', () => {
+  it('keeps the full runtime list when the model has no known profile', () => {
+    // Undefined means Helix has no profile — an empty or guessed-narrow
+    // selector would be worse than an occasionally-wrong option.
+    expect(values('codex_cli')).toContain('high')
+    expect(values('claude_code')).toContain('xhigh')
+    expect(values('opencode', [])).toContain('high')
+  })
+
+  it('drops efforts the model rejects', () => {
+    // qwen3.8-27b: the provider 400s on "high" and accepts "xhigh". Offering
+    // "high" is what aborted a real spec-task turn.
+    const narrowed = values('opencode', ['none', 'low', 'medium', 'xhigh'])
+    expect(narrowed).not.toContain('high')
+    expect(narrowed).toContain('xhigh')
+    expect(narrowed).toContain('medium')
+    expect(narrowed).toContain('low')
+  })
+
+  it('always keeps "default", which means send nothing rather than a provider value', () => {
+    expect(values('opencode', ['xhigh'])).toContain('default')
+    expect(values('claude_code', ['low'])).toContain('default')
+  })
+
+  it('narrows the claude list to a 4.6-generation model that rejects xhigh', () => {
+    const narrowed = values('claude_code', ['low', 'medium', 'high', 'max'])
+    expect(narrowed).not.toContain('xhigh')
+    expect(narrowed).toContain('max')
+    expect(narrowed).toContain('high')
+  })
+
+  it('falls back to the runtime list when narrowing would leave only "default"', () => {
+    // A profile listing nothing the harness can express should not produce a
+    // selector with a single meaningless entry.
+    const narrowed = values('codex_cli', ['some-effort-the-harness-cannot-send'])
+    expect(narrowed.length).toBeGreaterThan(1)
+    expect(narrowed).toContain('high')
+  })
+
+  it('matches effort values case-insensitively', () => {
+    expect(values('opencode', ['XHigh', 'MEDIUM'])).toEqual(
+      expect.arrayContaining(['default', 'medium', 'xhigh']),
+    )
+  })
+})

--- a/frontend/src/components/agent/CodeAgentEffortSelect.tsx
+++ b/frontend/src/components/agent/CodeAgentEffortSelect.tsx
@@ -32,8 +32,36 @@ export const CODEX_EFFORT_OPTIONS: ReadonlyArray<CodeAgentEffortOption> = [
   { value: 'ultra', label: 'Ultra', description: 'Deepest reasoning for supported models' },
 ]
 
-export const getCodeAgentEffortOptions = (runtime: string): ReadonlyArray<CodeAgentEffortOption> =>
-  runtime === 'claude_code' ? CLAUDE_CODE_EFFORT_OPTIONS : CODEX_EFFORT_OPTIONS
+/**
+ * Effort options for a code agent.
+ *
+ * `runtime` only decides which tiers the *harness* can express. The model
+ * decides which of them the provider will actually accept, and the two differ:
+ * qwen3.8-27b rejects `high` (the value this list used to offer unconditionally)
+ * while accepting `xhigh`. Sending a value the provider rejects is a hard 400
+ * that the agent retries and then aborts the turn on, so when the backend tells
+ * us what a model supports — `model.reasoning_efforts.supported`, see
+ * api/pkg/model/reasoning_efforts.go — narrow to that set.
+ *
+ * `supportedEfforts` undefined means "Helix has no profile for this model": keep
+ * the full runtime list rather than guessing a narrower one, since an empty
+ * selector would be worse than an occasionally-wrong option.
+ */
+export const getCodeAgentEffortOptions = (
+  runtime: string,
+  supportedEfforts?: readonly string[],
+): ReadonlyArray<CodeAgentEffortOption> => {
+  const runtimeOptions = runtime === 'claude_code' ? CLAUDE_CODE_EFFORT_OPTIONS : CODEX_EFFORT_OPTIONS
+  if (!supportedEfforts || supportedEfforts.length === 0) return runtimeOptions
+
+  const supported = new Set(supportedEfforts.map((effort) => effort.toLowerCase()))
+  // 'default' is not a provider value — it means "send nothing" — so it always
+  // survives the filter.
+  const narrowed = runtimeOptions.filter(
+    (option) => option.value === 'default' || supported.has(option.value),
+  )
+  return narrowed.length > 1 ? narrowed : runtimeOptions
+}
 
 export const CodeAgentEffortSelect: FC<{
   options: ReadonlyArray<CodeAgentEffortOption>

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -135,7 +135,7 @@ const DEFAULT_VALUES = {
   frequency_penalty: 0,
   presence_penalty: 0,
   top_p: 1,
-  max_tokens: 2000,
+  max_tokens: 0,
   reasoning_effort: 'medium',
   max_iterations: 10,
 } as const

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { TypesCodeAgentRuntime, TypesSandboxRuntime } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
@@ -7,6 +9,17 @@ import SpecTaskExecutionControls from "./SpecTaskExecutionControls";
 vi.mock("../../hooks/useSnackbar", () => ({
   default: () => ({ success: vi.fn(), error: vi.fn() }),
 }));
+
+// The controls read the selected model's supported reasoning efforts through
+// React Query (useModelReasoningEfforts), so they need a client the same way
+// they do under App.tsx. Retries off so a query that has nothing to resolve
+// fails fast instead of holding the test open.
+const render = (ui: ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
 
 const codexAgent = {
   id: "app_codex",

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -25,6 +25,7 @@ import {
 } from "../agent/CodingAgentForm";
 import AgentHarness, { getAgentHarnessLabel } from "../agent/AgentHarness";
 import { getCodeAgentEffortOptions } from "../agent/CodeAgentEffortSelect";
+import { useModelReasoningEfforts } from "../../hooks/useModelReasoningEfforts";
 import SpecTaskModelPicker from "./SpecTaskModelPicker";
 
 type MaybePromise = void | Promise<unknown>;
@@ -136,7 +137,11 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
     || currentExecutionConfig?.reasoning_effort
     || "default";
   const effectiveTier = codeAgentOverrides.service_tier || currentExecutionConfig?.service_tier || "standard";
-  const effortOptions = getCodeAgentEffortOptions(runtime);
+  // Narrow the harness tier list to what the selected model actually accepts.
+  // Undefined means Helix has no profile for the model, in which case the full
+  // runtime list stands. See api/pkg/model/reasoning_efforts.go.
+  const supportedEfforts = useModelReasoningEfforts(effectiveModel);
+  const effortOptions = getCodeAgentEffortOptions(runtime, supportedEfforts);
   const effectiveSandboxResources = sandboxResourceOverrides?.vcpus
     ? sandboxResourceOverrides
     : DEFAULT_SANDBOX_PRESET;

--- a/frontend/src/hooks/useModelReasoningEfforts.ts
+++ b/frontend/src/hooks/useModelReasoningEfforts.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react'
+
+import useRouter from './useRouter'
+import { useGetOrgByName } from '../services/orgService'
+import { useListProviders } from '../services/providersService'
+
+/**
+ * Returns the reasoning-effort values a model actually accepts, or undefined
+ * when Helix has no profile for it.
+ *
+ * The backend resolves this from a curated table (api/pkg/model/reasoning_efforts.go)
+ * rather than from the provider, because an OpenAI-compatible /v1/models
+ * response carries no capability data at all — vLLM returns only id, owned_by
+ * and max_model_len. Offering an effort the provider rejects is a hard 400 that
+ * aborts the agent's turn, so callers should narrow their options to this set
+ * when it is present and leave them alone when it is not.
+ *
+ * Shares the providers query cache with SpecTaskModelPicker, so this adds no
+ * extra request.
+ */
+export function useModelReasoningEfforts(modelId?: string): string[] | undefined {
+  const router = useRouter()
+  const orgName = router.params.org_id
+  const { data: org, isLoading: loadingOrg } = useGetOrgByName(orgName, orgName !== undefined)
+  const { data: providers = [] } = useListProviders({
+    loadModels: true,
+    orgId: org?.id,
+    enabled: !loadingOrg,
+  })
+
+  const orgId = org?.id
+
+  return useMemo(() => {
+    if (!modelId) return undefined
+    for (const provider of providers) {
+      for (const model of provider.available_models || []) {
+        if (model.id !== modelId) continue
+        const supported = model.reasoning_efforts?.supported
+        if (supported && supported.length > 0) return supported
+      }
+    }
+    return undefined
+    // orgId is a primitive that changes the provider set; providers is the
+    // query result this reads from.
+  }, [modelId, providers, orgId])
+}
+
+export default useModelReasoningEfforts

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5558,6 +5558,16 @@ definitions:
     x-enum-varnames:
     - EffectAllow
     - EffectDeny
+  types.EffortSource:
+    enum:
+    - probed
+    - catalogue
+    - vendor
+    type: string
+    x-enum-varnames:
+    - EffortSourceProbed
+    - EffortSourceCatalogue
+    - EffortSourceVendor
   types.EvaluationAssertion:
     properties:
       llm_judge_prompt:
@@ -7059,6 +7069,11 @@ definitions:
         type: string
       context_length:
         type: integer
+      default_reasoning_effort:
+        description: |-
+          DefaultReasoningEffort is the value the model applies when none is sent.
+          Empty when unknown.
+        type: string
       description:
         type: string
       input_modalities:
@@ -7340,6 +7355,17 @@ definitions:
         items:
           $ref: '#/definitions/types.OpenAIPermission'
         type: array
+      reasoning_efforts:
+        allOf:
+        - $ref: '#/definitions/types.ReasoningEffortProfile'
+        description: |-
+          ReasoningEfforts is the curated set of reasoning-effort values this model
+          accepts. It is a separate field from ModelInfo on purpose: ModelInfo being
+          non-nil is what the billing path reads as "this model is priceable", so
+          effort capability — which is known for models that have no pricing entry,
+          e.g. self-hosted vLLM deployments — must not be smuggled in through it.
+          Nil means Helix does not know; a UI must not offer a guessed effort list,
+          because sending a value the provider rejects aborts the whole turn.
       root:
         type: string
       type:
@@ -8754,6 +8780,48 @@ definitions:
       threshold:
         description: this is the threshold for a "good" answer - will default to 0.2
         type: number
+    type: object
+  types.ReasoningEffortProfile:
+    properties:
+      default:
+        description: Default is the value applied when none is sent. Empty when unknown.
+        type: string
+      family:
+        description: Family is the normalized model-id prefix this profile applies
+          to.
+        type: string
+      notes:
+        description: Notes carries anything a debugger needs that the fields above
+          do not say.
+        type: string
+      parameter:
+        description: Parameter is the wire field that carries the value.
+        type: string
+      rejected:
+        description: |-
+          Rejected lists values known to fail with an error. Deliberately separate
+          from "absent from Supported": a value can be missing from Supported because
+          it is silently coerced rather than because it errors, and only the erroring
+          ones abort a turn.
+        items:
+          type: string
+        type: array
+      source:
+        allOf:
+        - $ref: '#/definitions/types.EffortSource'
+        description: Source is how this entry was established.
+      supported:
+        description: Supported lists the values the model accepts and acts on.
+        items:
+          type: string
+        type: array
+      supports_effort:
+        description: SupportsEffort is false for models that accept no effort value
+          at all.
+        type: boolean
+      verified_at:
+        description: VerifiedAt is the date the entry was last checked (YYYY-MM-DD).
+        type: string
     type: object
   types.RegisterRequest:
     properties:

--- a/openapi.json
+++ b/openapi.json
@@ -35172,6 +35172,19 @@
                     "EffectDeny"
                 ]
             },
+            "types.EffortSource": {
+                "type": "string",
+                "enum": [
+                    "probed",
+                    "catalogue",
+                    "vendor"
+                ],
+                "x-enum-varnames": [
+                    "EffortSourceProbed",
+                    "EffortSourceCatalogue",
+                    "EffortSourceVendor"
+                ]
+            },
             "types.EvaluationAssertion": {
                 "type": "object",
                 "properties": {
@@ -37244,6 +37257,10 @@
                     "context_length": {
                         "type": "integer"
                     },
+                    "default_reasoning_effort": {
+                        "description": "DefaultReasoningEffort is the value the model applies when none is sent.\nEmpty when unknown.",
+                        "type": "string"
+                    },
                     "description": {
                         "type": "string"
                     },
@@ -37644,6 +37661,14 @@
                         "items": {
                             "$ref": "#/components/schemas/types.OpenAIPermission"
                         }
+                    },
+                    "reasoning_efforts": {
+                        "description": "ReasoningEfforts is the curated set of reasoning-effort values this model\naccepts. It is a separate field from ModelInfo on purpose: ModelInfo being\nnon-nil is what the billing path reads as \"this model is priceable\", so\neffort capability — which is known for models that have no pricing entry,\ne.g. self-hosted vLLM deployments — must not be smuggled in through it.\nNil means Helix does not know; a UI must not offer a guessed effort list,\nbecause sending a value the provider rejects aborts the whole turn.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.ReasoningEffortProfile"
+                            }
+                        ]
                     },
                     "root": {
                         "type": "string"
@@ -39630,6 +39655,57 @@
                     "threshold": {
                         "description": "this is the threshold for a \"good\" answer - will default to 0.2",
                         "type": "number"
+                    }
+                }
+            },
+            "types.ReasoningEffortProfile": {
+                "type": "object",
+                "properties": {
+                    "default": {
+                        "description": "Default is the value applied when none is sent. Empty when unknown.",
+                        "type": "string"
+                    },
+                    "family": {
+                        "description": "Family is the normalized model-id prefix this profile applies to.",
+                        "type": "string"
+                    },
+                    "notes": {
+                        "description": "Notes carries anything a debugger needs that the fields above do not say.",
+                        "type": "string"
+                    },
+                    "parameter": {
+                        "description": "Parameter is the wire field that carries the value.",
+                        "type": "string"
+                    },
+                    "rejected": {
+                        "description": "Rejected lists values known to fail with an error. Deliberately separate\nfrom \"absent from Supported\": a value can be missing from Supported because\nit is silently coerced rather than because it errors, and only the erroring\nones abort a turn.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source": {
+                        "description": "Source is how this entry was established.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.EffortSource"
+                            }
+                        ]
+                    },
+                    "supported": {
+                        "description": "Supported lists the values the model accepts and acts on.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "supports_effort": {
+                        "description": "SupportsEffort is false for models that accept no effort value at all.",
+                        "type": "boolean"
+                    },
+                    "verified_at": {
+                        "description": "VerifiedAt is the date the entry was last checked (YYYY-MM-DD).",
+                        "type": "string"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -30598,6 +30598,19 @@
                 "EffectDeny"
             ]
         },
+        "types.EffortSource": {
+            "type": "string",
+            "enum": [
+                "probed",
+                "catalogue",
+                "vendor"
+            ],
+            "x-enum-varnames": [
+                "EffortSourceProbed",
+                "EffortSourceCatalogue",
+                "EffortSourceVendor"
+            ]
+        },
         "types.EvaluationAssertion": {
             "type": "object",
             "properties": {
@@ -32670,6 +32683,10 @@
                 "context_length": {
                     "type": "integer"
                 },
+                "default_reasoning_effort": {
+                    "description": "DefaultReasoningEffort is the value the model applies when none is sent.\nEmpty when unknown.",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -33070,6 +33087,14 @@
                     "items": {
                         "$ref": "#/definitions/types.OpenAIPermission"
                     }
+                },
+                "reasoning_efforts": {
+                    "description": "ReasoningEfforts is the curated set of reasoning-effort values this model\naccepts. It is a separate field from ModelInfo on purpose: ModelInfo being\nnon-nil is what the billing path reads as \"this model is priceable\", so\neffort capability — which is known for models that have no pricing entry,\ne.g. self-hosted vLLM deployments — must not be smuggled in through it.\nNil means Helix does not know; a UI must not offer a guessed effort list,\nbecause sending a value the provider rejects aborts the whole turn.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ReasoningEffortProfile"
+                        }
+                    ]
                 },
                 "root": {
                     "type": "string"
@@ -35056,6 +35081,57 @@
                 "threshold": {
                     "description": "this is the threshold for a \"good\" answer - will default to 0.2",
                     "type": "number"
+                }
+            }
+        },
+        "types.ReasoningEffortProfile": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "description": "Default is the value applied when none is sent. Empty when unknown.",
+                    "type": "string"
+                },
+                "family": {
+                    "description": "Family is the normalized model-id prefix this profile applies to.",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Notes carries anything a debugger needs that the fields above do not say.",
+                    "type": "string"
+                },
+                "parameter": {
+                    "description": "Parameter is the wire field that carries the value.",
+                    "type": "string"
+                },
+                "rejected": {
+                    "description": "Rejected lists values known to fail with an error. Deliberately separate\nfrom \"absent from Supported\": a value can be missing from Supported because\nit is silently coerced rather than because it errors, and only the erroring\nones abort a turn.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
+                    "description": "Source is how this entry was established.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EffortSource"
+                        }
+                    ]
+                },
+                "supported": {
+                    "description": "Supported lists the values the model accepts and acts on.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "supports_effort": {
+                    "description": "SupportsEffort is false for models that accept no effort value at all.",
+                    "type": "boolean"
+                },
+                "verified_at": {
+                    "description": "VerifiedAt is the date the entry was last checked (YYYY-MM-DD).",
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
Two fixes from investigating a spec task that showed "finished" in AgentChat while having done no work.

## 1. Stop defaulting assistant `max_tokens` to 2000

`setAppDefaults` stamped `MaxTokens = 2000` on **every** assistant, including `zed_external` coding agents. The proxy loads that assistant config and applies it over the value the agent sent (`inference.go:203`), so external coding agents were clamped from their own **32000 down to 2000**:

```
ORIG max_tokens: 32000   (what Zed/OpenCode sent)
REQ  max_tokens: 2000    (what Helix sent upstream)
completion_tokens: 2000  ← hit the cap exactly
```

The model was cut off mid-`<thinking>`, never emitted the tool call it was about to make, and the agent ended the turn. Helix marked the interaction complete; the UI showed a mid-turn note as if it were the final answer.

A completion cap is meaningful for a Helix agent answering a user and meaningless for an external agent that sizes its own budget per request. `AppSettings` `DEFAULT_VALUES` is updated to match, as both files' comments require (`0` is the existing "unset" convention there — `context_limit` already uses it).

**Note for deploy:** this only affects newly-created apps. 120 existing app rows had `2000` baked into their persisted config JSON; those were cleared separately on the dev instance.

## 2. Curated reasoning-effort registry

The follow-up task then failed differently — 9 identical 400s, then an aborted turn:

```
400 Bad Request: Unexpected reasoning effort high.
Supported types are xhigh (default), medium, and low.
```

The effort dropdown was keyed on the **runtime**, not the model, so it offered `High` for a model that rejects it. 21/21 calls with `high` on `qwen3.8-27b` failed; `medium` and unset worked.

This is not fixable by asking the provider. vLLM's `/v1/models` returns the plain OpenAI ModelCard — `id`, `owned_by`, `root`, `max_model_len`, `permission` — and nothing about sampling parameters. The accepted set lives in the model's Jinja chat template.

`api/pkg/model/reasoning_efforts.go` records model family → accepted efforts, default, and known-rejected values. Every entry carries the **source** it was established from (`probed` / `catalogue` / `vendor`) and a `verified_at` date, so a mismatch with a live provider can be triaged without re-deriving it. Lookup matches on the longest family prefix, so `deepseek-v4-flash-0731`, `qwen3.8-27b-instruct`, and `provider/model` resolve without their own rows — adding a model is a data edit.

Traps recorded:

| Model | Accepts | Rejects | Default |
|---|---|---|---|
| `qwen3.8-27b` | `none`, `low`, `medium`, `xhigh` | **`high`**, `max`, `minimal` | `xhigh` |
| `deepseek-v4-flash` / `-pro` | `high`, `xhigh` | — | `high` |
| Claude Opus 5 / 4.8 / 4.7, Sonnet 5, Fable 5 | `low`…`max` incl. `xhigh` | — | `high` |
| Claude Opus 4.6 / Sonnet 4.6 | `low`, `medium`, `high`, `max` | **`xhigh`** | `high` |
| Claude Sonnet 4.5 / Haiku 4.5 | *(none)* | any value | — |

- `qwen3.8-27b` rejects `high` but accepts `xhigh` — the reverse of most models. Its template also **silently coerces** unrecognized values (`foo`, `HIGH`, `ultra`) to the `xhigh` default, so probing only for rejections does not reveal the supported set.
- Claude reads `output_config.effort`, never a top-level `reasoning_effort` — a value under the wrong key is ignored with no error.
- `xhigh` arrived with Opus 4.7; 4.6-generation models reject it.

### Design note

`ReasoningEfforts` is a field on `types.OpenAIModel` **separate from `ModelInfo`** on purpose: a non-nil `ModelInfo` is what `anthropic_api_proxy_handler.go` and `usage_handlers.go` read as "this model is priceable". Self-hosted models have effort profiles but no pricing entry, so synthesizing a `ModelInfo` for them would wave unpriced models through the billing gate. `GetModelInfo` still errors for models the catalogue doesn't know; the curated table only fills reasoning gaps in entries it already resolves, and `model_info.json` wins where it has data.

Frontend narrows the dropdown via `useModelReasoningEfforts` (shares the existing providers query cache — no extra request). An unknown model keeps the full runtime list rather than a guessed narrower one.

`CLAUDE.md` (and `AGENTS.md`, a symlink to it) gets a "Reasoning Effort per Model" section with the trap table and the two debugging queries.

## Testing

- `go test ./pkg/model/ ./pkg/types/ ./pkg/config/` — pass; 8 new tests pin the qwen `high`/`xhigh` inversion, the Claude parameter name, the 4.6 `xhigh` split, prefix matching, the unknown-model negative case, table well-formedness, and the catalogue-wins overlay precedence.
- `go build ./api/...` and `yarn build` clean; `./stack update_openapi` regenerated.
- The `max_tokens` fix is verified live: after deploying, a new task's requests show `orig_max: 32000 → req_max: 32000`, no clamping.

**NOT tested:** the effort registry end-to-end through a live agent turn — that needs a task configured with a model whose effort set the registry narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
