### PR TITLE
fix: reconstruct streamed tool calls in LLM call logs + admin LLM calls detail drawer

### DIFF
--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -197,6 +197,9 @@ func appendChunk(resp *openai.ChatCompletionResponse, chunk *openai.ChatCompleti
 		}
 	}
 
+	// The accumulated response is a full completion, not a chunk.
+	resp.Object = "chat.completion"
+
 	if chunk.Model != "" {
 		resp.Model = chunk.Model
 	}
@@ -211,22 +214,65 @@ func appendChunk(resp *openai.ChatCompletionResponse, chunk *openai.ChatCompleti
 
 	// Append the chunk to the response
 	if len(chunk.Choices) > 0 {
+		delta := chunk.Choices[0].Delta
+		msg := &resp.Choices[0].Message
+
 		// Role
-		if chunk.Choices[0].Delta.Role != "" {
-			resp.Choices[0].Message.Role = chunk.Choices[0].Delta.Role
+		if delta.Role != "" {
+			msg.Role = delta.Role
 		}
 
 		// Content
-		resp.Choices[0].Message.Content += chunk.Choices[0].Delta.Content
+		msg.Content += delta.Content
+		msg.ReasoningContent += delta.ReasoningContent
 
-		// Function calls
-		if chunk.Choices[0].Delta.FunctionCall != nil {
-			resp.Choices[0].Message.FunctionCall = chunk.Choices[0].Delta.FunctionCall
+		// Legacy function calls stream the arguments in fragments; only the
+		// first fragment carries the name.
+		if delta.FunctionCall != nil {
+			if msg.FunctionCall == nil {
+				msg.FunctionCall = &openai.FunctionCall{}
+			}
+			if delta.FunctionCall.Name != "" {
+				msg.FunctionCall.Name = delta.FunctionCall.Name
+			}
+			msg.FunctionCall.Arguments += delta.FunctionCall.Arguments
 		}
 
-		// Tool calls
-		if len(chunk.Choices[0].Delta.ToolCalls) > 0 {
-			resp.Choices[0].Message.ToolCalls = append(resp.Choices[0].Message.ToolCalls, chunk.Choices[0].Delta.ToolCalls...)
+		// A single tool call arrives as many deltas sharing an index: the first
+		// carries id/type/name, the rest only argument fragments. Merge by
+		// index instead of appending each fragment as its own tool call.
+		for _, tc := range delta.ToolCalls {
+			var idx int
+			if tc.Index != nil {
+				idx = *tc.Index
+			} else if tc.ID != "" || len(msg.ToolCalls) == 0 {
+				// No index: a fragment carrying an ID starts a new tool call,
+				// an ID-less fragment continues the last one.
+				idx = len(msg.ToolCalls)
+			} else {
+				idx = len(msg.ToolCalls) - 1
+			}
+			if idx < 0 {
+				continue
+			}
+			for idx >= len(msg.ToolCalls) {
+				msg.ToolCalls = append(msg.ToolCalls, openai.ToolCall{})
+			}
+			merged := &msg.ToolCalls[idx]
+			if tc.ID != "" {
+				merged.ID = tc.ID
+			}
+			if tc.Type != "" {
+				merged.Type = tc.Type
+			}
+			if tc.Function.Name != "" {
+				merged.Function.Name = tc.Function.Name
+			}
+			merged.Function.Arguments += tc.Function.Arguments
+		}
+
+		if chunk.Choices[0].FinishReason != "" {
+			resp.Choices[0].FinishReason = chunk.Choices[0].FinishReason
 		}
 	}
 

--- a/api/pkg/openai/logger/openai_logger_test.go
+++ b/api/pkg/openai/logger/openai_logger_test.go
@@ -82,6 +82,121 @@ func TestAppendChunkAcceptsFinalOnlyUsage(t *testing.T) {
 	assert.Equal(t, 42, resp.Usage.TotalTokens)
 }
 
+func TestAppendChunkMergesToolCallDeltasByIndex(t *testing.T) {
+	resp := &openai.ChatCompletionResponse{}
+	idx0, idx1 := 0, 1
+
+	// First fragment carries id/type/name + start of arguments.
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				Role: "assistant",
+				ToolCalls: []openai.ToolCall{{
+					Index:    &idx0,
+					ID:       "call_1",
+					Type:     openai.ToolTypeFunction,
+					Function: openai.FunctionCall{Name: "get_weather", Arguments: `{"loc`},
+				}},
+			},
+		}},
+	})
+	// Subsequent fragments carry only argument pieces.
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				ToolCalls: []openai.ToolCall{{
+					Index:    &idx0,
+					Function: openai.FunctionCall{Arguments: `ation":"London"}`},
+				}},
+			},
+		}},
+	})
+	// A second tool call at index 1.
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				ToolCalls: []openai.ToolCall{{
+					Index:    &idx1,
+					ID:       "call_2",
+					Type:     openai.ToolTypeFunction,
+					Function: openai.FunctionCall{Name: "get_time", Arguments: `{}`},
+				}},
+			},
+		}},
+	})
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			FinishReason: openai.FinishReasonToolCalls,
+		}},
+	})
+
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 2)
+	tc0 := resp.Choices[0].Message.ToolCalls[0]
+	assert.Equal(t, "call_1", tc0.ID)
+	assert.Equal(t, openai.ToolTypeFunction, tc0.Type)
+	assert.Equal(t, "get_weather", tc0.Function.Name)
+	assert.Equal(t, `{"location":"London"}`, tc0.Function.Arguments)
+	tc1 := resp.Choices[0].Message.ToolCalls[1]
+	assert.Equal(t, "call_2", tc1.ID)
+	assert.Equal(t, "get_time", tc1.Function.Name)
+	assert.Equal(t, `{}`, tc1.Function.Arguments)
+	assert.Equal(t, openai.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+	assert.Equal(t, "chat.completion", resp.Object)
+}
+
+func TestAppendChunkMergesToolCallDeltasWithoutIndex(t *testing.T) {
+	resp := &openai.ChatCompletionResponse{}
+
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				ToolCalls: []openai.ToolCall{{
+					ID:       "call_1",
+					Type:     openai.ToolTypeFunction,
+					Function: openai.FunctionCall{Name: "run", Arguments: `{"a":`},
+				}},
+			},
+		}},
+	})
+	// Providers that omit index: fragments merge into the last tool call.
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				ToolCalls: []openai.ToolCall{{
+					Function: openai.FunctionCall{Arguments: `1}`},
+				}},
+			},
+		}},
+	})
+
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, "call_1", resp.Choices[0].Message.ToolCalls[0].ID)
+	assert.Equal(t, `{"a":1}`, resp.Choices[0].Message.ToolCalls[0].Function.Arguments)
+}
+
+func TestAppendChunkAccumulatesFunctionCallArguments(t *testing.T) {
+	resp := &openai.ChatCompletionResponse{}
+
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				FunctionCall: &openai.FunctionCall{Name: "run", Arguments: `{"a":`},
+			},
+		}},
+	})
+	appendChunk(resp, &openai.ChatCompletionStreamResponse{
+		Choices: []openai.ChatCompletionStreamChoice{{
+			Delta: openai.ChatCompletionStreamChoiceDelta{
+				FunctionCall: &openai.FunctionCall{Arguments: `1}`},
+			},
+		}},
+	})
+
+	require.NotNil(t, resp.Choices[0].Message.FunctionCall)
+	assert.Equal(t, "run", resp.Choices[0].Message.FunctionCall.Name)
+	assert.Equal(t, `{"a":1}`, resp.Choices[0].Message.FunctionCall.Arguments)
+}
+
 func TestCreateChatCompletionStreamLogsLatestUsageSnapshot(t *testing.T) {
 	chunks := []openai.ChatCompletionStreamResponse{
 		{

--- a/frontend/src/components/dashboard/LLMCallDrawer.test.tsx
+++ b/frontend/src/components/dashboard/LLMCallDrawer.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TypesLLMCall } from "../../api/api";
+import LLMCallDrawer, { formatTokenCount } from "./LLMCallDrawer";
+
+vi.mock("../../hooks/useSnackbar", () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+const openAICall: TypesLLMCall = {
+  id: "llmc_test1",
+  created: "2026-08-15T12:00:00Z",
+  model: "qwen3.8-27b",
+  provider: "vllm",
+  session_id: "ses_test1",
+  duration_ms: 4200,
+  time_to_first_token_ms: 800,
+  prompt_tokens: 188049,
+  completion_tokens: 828,
+  total_tokens: 188877,
+  stream: true,
+  request: {
+    messages: [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "What is the weather in London?" },
+    ],
+    tools: [{ type: "function", function: { name: "get_weather" } }],
+    max_tokens: 4096,
+    stream: true,
+  } as any,
+  response: {
+    choices: [{
+      finish_reason: "tool_calls",
+      message: {
+        role: "assistant",
+        tool_calls: [{
+          id: "call_1",
+          type: "function",
+          function: { name: "get_weather", arguments: '{"city":"London"}' },
+        }],
+      },
+    }],
+  } as any,
+};
+
+const anthropicCall: TypesLLMCall = {
+  id: "llmc_test2",
+  model: "claude-opus-4-8",
+  provider: "anthropic",
+  response: {
+    content: [
+      { type: "text", text: "Hello from Claude" },
+      { type: "tool_use", name: "read_file", input: { path: "/tmp/x" } },
+    ],
+    stop_reason: "tool_use",
+  } as any,
+};
+
+describe("LLMCallDrawer", () => {
+  it("renders metadata, token stats, and request summary for an OpenAI-shaped call", () => {
+    render(<LLMCallDrawer call={openAICall} open onClose={() => {}} />);
+
+    expect(screen.getByText("qwen3.8-27b")).toBeTruthy();
+    // token stats
+    expect(screen.getByText("188.0k")).toBeTruthy();
+    expect(screen.getByText("828")).toBeTruthy();
+    // duration formatting
+    expect(screen.getByText("4.2s")).toBeTruthy();
+    // request summary derived from the request JSON
+    expect(screen.getByText("Messages")).toBeTruthy();
+    expect(screen.getByText("Tools")).toBeTruthy();
+    // response summary
+    expect(screen.getByText("tool_calls")).toBeTruthy();
+    expect(screen.getByText("get_weather")).toBeTruthy();
+    // streaming indicator
+    expect(screen.getByText("stream")).toBeTruthy();
+  });
+
+  it("summarizes Anthropic-shaped responses (content blocks)", () => {
+    render(<LLMCallDrawer call={anthropicCall} open onClose={() => {}} />);
+
+    expect(screen.getByText("Hello from Claude")).toBeTruthy();
+    expect(screen.getByText("read_file")).toBeTruthy();
+    expect(screen.getByText("tool_use")).toBeTruthy();
+  });
+
+  it("shows the error prominently for failed calls", () => {
+    render(
+      <LLMCallDrawer
+        call={{ id: "llmc_err", model: "m", error: "status code: 400, reasoning effort" }}
+        open
+        onClose={() => {}}
+      />,
+    );
+    // Appears in both the error banner and the response JSON fallback.
+    expect(screen.getAllByText(/reasoning effort/).length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("formats counts into readable units", () => {
+    expect(formatTokenCount(undefined)).toBe("-");
+    expect(formatTokenCount(828)).toBe("828");
+    expect(formatTokenCount(188049)).toBe("188.0k");
+    expect(formatTokenCount(2500000)).toBe("2.50M");
+  });
+});

--- a/frontend/src/components/dashboard/LLMCallDrawer.tsx
+++ b/frontend/src/components/dashboard/LLMCallDrawer.tsx
@@ -1,0 +1,324 @@
+// Right-side detail drawer for a single LLM call in the admin panel.
+// Shows full metadata, token/cost breakdown, a request summary, and
+// tabbed JSON views of request / response / original request / error.
+
+import React, { FC, useMemo, useState, useEffect } from 'react'
+import {
+  Box,
+  Chip,
+  Divider,
+  Drawer,
+  IconButton,
+  Stack,
+  Tab,
+  Tabs,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { X, Copy } from 'lucide-react'
+import { TypesLLMCall } from '../../api/api'
+import JsonView from '../widgets/JsonView'
+import useSnackbar from '../../hooks/useSnackbar'
+
+export const formatTokenCount = (n?: number): string => {
+  if (n === undefined || n === null) return '-'
+  if (n >= 1000000) return `${(n / 1000000).toFixed(2)}M`
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`
+  return n.toLocaleString()
+}
+
+const formatCost = (n?: number): string | undefined => {
+  if (!n) return undefined
+  return `$${n.toFixed(n < 0.01 ? 6 : 4)}`
+}
+
+const formatDuration = (ms?: number): string => {
+  if (ms === undefined || ms === null) return '-'
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${ms}ms`
+}
+
+// Pull a plain-text preview of the assistant output out of either an
+// OpenAI-shaped (choices[0].message) or Anthropic-shaped (content blocks)
+// response object.
+const extractResponseSummary = (response: any): {
+  text?: string
+  toolCalls?: { name: string, arguments?: string }[]
+  finishReason?: string
+} => {
+  if (!response || typeof response !== 'object') return {}
+  const choice = response.choices?.[0]
+  if (choice) {
+    const toolCalls = (choice.message?.tool_calls || []).map((tc: any) => ({
+      name: tc.function?.name || tc.id || 'tool',
+      arguments: tc.function?.arguments,
+    }))
+    return {
+      text: choice.message?.content || undefined,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason: choice.finish_reason || undefined,
+    }
+  }
+  if (Array.isArray(response.content)) {
+    const text = response.content
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('\n') || undefined
+    const toolCalls = response.content
+      .filter((b: any) => b.type === 'tool_use')
+      .map((b: any) => ({ name: b.name, arguments: JSON.stringify(b.input) }))
+    return {
+      text,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason: response.stop_reason || undefined,
+    }
+  }
+  return {}
+}
+
+const summarizeRequest = (request: any): { label: string, value: string }[] => {
+  if (!request || typeof request !== 'object') return []
+  const out: { label: string, value: string }[] = []
+  const messages = request.messages
+  if (Array.isArray(messages)) {
+    out.push({ label: 'Messages', value: String(messages.length) })
+    const chars = messages.reduce((acc: number, m: any) => {
+      if (typeof m.content === 'string') return acc + m.content.length
+      if (Array.isArray(m.content)) {
+        return acc + m.content.reduce((a: number, p: any) => a + (typeof p.text === 'string' ? p.text.length : 0), 0)
+      }
+      return acc
+    }, 0)
+    out.push({ label: 'Context size', value: `${chars.toLocaleString()} chars` })
+  }
+  if (Array.isArray(request.tools) && request.tools.length > 0) {
+    out.push({ label: 'Tools', value: String(request.tools.length) })
+  }
+  if (request.max_tokens) out.push({ label: 'Max tokens', value: String(request.max_tokens) })
+  if (request.temperature !== undefined && request.temperature !== null) {
+    out.push({ label: 'Temperature', value: String(request.temperature) })
+  }
+  if (request.reasoning_effort) out.push({ label: 'Reasoning effort', value: String(request.reasoning_effort) })
+  if (request.stream !== undefined) out.push({ label: 'Stream', value: request.stream ? 'yes' : 'no' })
+  return out
+}
+
+const MetaRow: FC<{ label: string, value?: React.ReactNode, copyValue?: string }> = ({ label, value, copyValue }) => {
+  const snackbar = useSnackbar()
+  if (value === undefined || value === null || value === '') return null
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{ minHeight: 28 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ width: 130, flexShrink: 0 }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontSize: '0.8rem', wordBreak: 'break-all' }}>
+        {value}
+      </Typography>
+      {copyValue && (
+        <Tooltip title="Copy">
+          <IconButton
+            size="small"
+            aria-label={`Copy ${label}`}
+            sx={{ p: 0.25 }}
+            onClick={() => {
+              navigator.clipboard.writeText(copyValue)
+              snackbar.success('Copied to clipboard')
+            }}
+          >
+            <Copy size={13} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Stack>
+  )
+}
+
+const StatBox: FC<{ label: string, value: string, hint?: string }> = ({ label, value, hint }) => (
+  <Tooltip title={hint || ''}>
+    <Box
+      sx={{
+        background: 'linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: 2,
+        p: 1.5,
+        minWidth: 90,
+        flex: 1,
+      }}
+    >
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem', display: 'block' }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontSize: '0.85rem', fontFamily: 'var(--helix-font-mono)', fontWeight: 600 }}>
+        {value}
+      </Typography>
+    </Box>
+  </Tooltip>
+)
+
+interface LLMCallDrawerProps {
+  call: TypesLLMCall | null
+  open: boolean
+  onClose: () => void
+}
+
+const LLMCallDrawer: FC<LLMCallDrawerProps> = ({ call, open, onClose }) => {
+  const [tab, setTab] = useState<'response' | 'request' | 'original_request'>('response')
+
+  useEffect(() => {
+    if (open) setTab('response')
+  }, [open, call?.id])
+
+  const response = call?.response as any
+  const request = call?.request as any
+  const originalRequest = call?.original_request as any
+
+  const responseSummary = useMemo(() => extractResponseSummary(response), [response])
+  const requestSummary = useMemo(() => summarizeRequest(request), [request])
+
+  const totalCost = formatCost(call?.total_cost)
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { backgroundImage: 'none', width: 720, maxWidth: '100vw' } }}
+    >
+      {call && (
+        <Box sx={{ p: 2.5, height: '100%', display: 'flex', flexDirection: 'column', boxSizing: 'border-box' }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1, flexShrink: 0 }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+              <Typography variant="h6" noWrap>{call.model || 'LLM Call'}</Typography>
+              {call.error ? (
+                <Chip label="error" size="small" color="error" />
+              ) : (
+                <Chip label="ok" size="small" color="success" variant="outlined" />
+              )}
+              {call.stream && <Chip label="stream" size="small" variant="outlined" />}
+            </Stack>
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <X size={18} />
+            </IconButton>
+          </Stack>
+
+          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              {call.created ? new Date(call.created).toLocaleString() : ''}
+              {call.provider ? ` · ${call.provider}` : ''}
+              {call.step ? ` · ${call.step}` : ''}
+            </Typography>
+
+            <Stack direction="row" spacing={1} sx={{ mb: 1.5 }}>
+              <StatBox label="Duration" value={formatDuration(call.duration_ms)} />
+              <StatBox
+                label="First token"
+                value={formatDuration(call.time_to_first_token_ms)}
+                hint="Time to first streamed token"
+              />
+              <StatBox
+                label="Prompt tokens"
+                value={formatTokenCount(call.prompt_tokens)}
+                hint={`Context length: ${call.prompt_tokens?.toLocaleString() || '-'} tokens`}
+              />
+              <StatBox label="Completion" value={formatTokenCount(call.completion_tokens)} />
+              <StatBox label="Total" value={formatTokenCount(call.total_tokens)} />
+            </Stack>
+
+            {(call.cache_read_tokens || call.cache_write_tokens || totalCost) ? (
+              <Stack direction="row" spacing={1} sx={{ mb: 1.5 }}>
+                <StatBox label="Cache read" value={formatTokenCount(call.cache_read_tokens)} />
+                <StatBox label="Cache write" value={formatTokenCount(call.cache_write_tokens)} />
+                <StatBox label="Prompt cost" value={formatCost(call.prompt_cost) || '-'} />
+                <StatBox label="Completion cost" value={formatCost(call.completion_cost) || '-'} />
+                <StatBox label="Total cost" value={totalCost || '-'} />
+              </Stack>
+            ) : null}
+
+            <Divider sx={{ my: 1.5 }} />
+
+            <MetaRow label="Call ID" value={call.id} copyValue={call.id} />
+            <MetaRow label="Session" value={call.session_id} copyValue={call.session_id} />
+            <MetaRow label="Interaction" value={call.interaction_id} copyValue={call.interaction_id} />
+            <MetaRow label="App" value={call.app_id} copyValue={call.app_id} />
+            <MetaRow label="Project" value={call.project_id} copyValue={call.project_id} />
+            <MetaRow label="Spec task" value={call.spec_task_id} copyValue={call.spec_task_id} />
+            <MetaRow label="User" value={call.user_id} copyValue={call.user_id} />
+            <MetaRow label="Agent runtime" value={call.code_agent_runtime} />
+            {requestSummary.map(item => (
+              <MetaRow key={item.label} label={item.label} value={item.value} />
+            ))}
+            <MetaRow label="Finish reason" value={responseSummary.finishReason} />
+            {responseSummary.toolCalls && (
+              <MetaRow
+                label="Tool calls"
+                value={responseSummary.toolCalls.map(tc => tc.name).join(', ')}
+              />
+            )}
+
+            {call.error && (
+              <Box
+                sx={{
+                  mt: 1.5,
+                  p: 1.5,
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'error.main',
+                  backgroundColor: 'rgba(244, 67, 54, 0.08)',
+                }}
+              >
+                <Typography variant="caption" color="error" sx={{ fontWeight: 600, display: 'block', mb: 0.5 }}>
+                  Error
+                </Typography>
+                <Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                  {call.error}
+                </Typography>
+              </Box>
+            )}
+
+            {responseSummary.text && (
+              <Box sx={{ mt: 1.5 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+                  Response text
+                </Typography>
+                <Box
+                  sx={{
+                    mt: 0.5,
+                    p: 1.5,
+                    borderRadius: 1,
+                    backgroundColor: '#121212',
+                    maxHeight: 220,
+                    overflow: 'auto',
+                  }}
+                >
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: '0.8rem' }}>
+                    {responseSummary.text}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+
+            <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mt: 2, mb: 1, minHeight: 36 }}>
+              <Tab value="response" label="Response" sx={{ minHeight: 36, py: 0.5 }} />
+              <Tab value="request" label="Request" sx={{ minHeight: 36, py: 0.5 }} />
+              {originalRequest && (
+                <Tab value="original_request" label="Original request" sx={{ minHeight: 36, py: 0.5 }} />
+              )}
+            </Tabs>
+
+            {tab === 'response' && (
+              <JsonView data={call.error && !response ? { error: call.error } : response} withFancyRendering={false} withFancyRenderingControls={false} />
+            )}
+            {tab === 'request' && (
+              <JsonView data={request} withFancyRendering={false} withFancyRenderingControls={false} />
+            )}
+            {tab === 'original_request' && (
+              <JsonView data={originalRequest} withFancyRendering={false} withFancyRenderingControls={false} />
+            )}
+          </Box>
+        </Box>
+      )}
+    </Drawer>
+  )
+}
+
+export default LLMCallDrawer

--- a/frontend/src/components/dashboard/LLMCallsTable.tsx
+++ b/frontend/src/components/dashboard/LLMCallsTable.tsx
@@ -1,69 +1,134 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TablePagination,
-  Button,
   Box,
-  Typography,
+  Button,
+  Chip,
   IconButton,
+  TablePagination,
   Tooltip,
+  Typography,
 } from '@mui/material';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import useApi from '../../hooks/useApi';
-import { TypesPaginatedLLMCalls, TypesLLMCall } from '../../api/api';
+import { RefreshCw, Copy } from 'lucide-react';
+import { TypesLLMCall } from '../../api/api';
 import { useGetConfig } from '../../services/userService';
-import JsonView from '../widgets/JsonView';
 import { useListLLMCalls } from '../../services/llmCallsService';
-import DarkDialog from '../dialog/DarkDialog';
+import SimpleTable from '../widgets/SimpleTable';
+import LLMCallDrawer, { formatTokenCount } from './LLMCallDrawer';
+import useSnackbar from '../../hooks/useSnackbar';
 
 interface LLMCallsTableProps {
   sessionFilter: string;
 }
 
+const shortId = (id?: string): string => {
+  if (!id) return '';
+  return id.slice(-7);
+};
+
+const IdCell: FC<{ id?: string, label: string }> = ({ id, label }) => {
+  const snackbar = useSnackbar();
+  if (!id) return null;
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+      <Tooltip title={id}>
+        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'var(--helix-font-mono)', fontSize: '0.75rem' }}>
+          {shortId(id)}
+        </Typography>
+      </Tooltip>
+      <Tooltip title={`Copy ${label}`}>
+        <IconButton
+          size="small"
+          aria-label={`Copy ${label}`}
+          sx={{ p: 0.25 }}
+          onClick={(e) => {
+            e.stopPropagation();
+            navigator.clipboard.writeText(id);
+            snackbar.success('Copied to clipboard');
+          }}
+        >
+          <Copy size={12} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
+
 const LLMCallsTable: FC<LLMCallsTableProps> = ({ sessionFilter }) => {
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
-  const [modalContent, setModalContent] = useState<any>(null);
-  const [modalOpen, setModalOpen] = useState(false);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
+  const [currentCall, setCurrentCall] = useState<TypesLLMCall | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const { data: llmCalls, isLoading, error, refetch } = useListLLMCalls(sessionFilter, "", page, rowsPerPage, true);
+  const { data: llmCalls, isLoading, refetch } = useListLLMCalls(sessionFilter, "", page, rowsPerPage, true);
   const { data: serverConfig } = useGetConfig();
 
-  const handleChangePage = (event: unknown, newPage: number) => {
-    setPage(newPage);
+  const handleOpenCall = (call: TypesLLMCall) => {
+    setCurrentCall(call);
+    setDrawerOpen(true);
   };
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  };
-
-  const handleRefresh = () => {
-    refetch();
-  };
-
-  const handleOpenModal = (content: any) => {
-    setModalContent(content);
-    setModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-  };
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text).then(() => {
-      // Could add a toast notification here if desired
-    }).catch(err => {
-      console.error('Failed to copy text: ', err);
-    });
-  };
+  const tableData = useMemo(() => {
+    return (llmCalls?.calls || []).map((call: TypesLLMCall) => ({
+      id: call.id,
+      _data: call,
+      created: (
+        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+          {call.created ? new Date(call.created).toLocaleString() : ''}
+        </Typography>
+      ),
+      model: (
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleOpenCall(call);
+          }}
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600, whiteSpace: 'nowrap' }}>
+            {call.model || call.provider || call.id}
+          </Typography>
+        </a>
+      ),
+      provider: (
+        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+          {call.provider}
+        </Typography>
+      ),
+      step: (
+        <Typography variant="body2" color="text.secondary">
+          {call.step}
+        </Typography>
+      ),
+      session: <IdCell id={call.session_id} label="session ID" />,
+      duration: (
+        <Tooltip title={call.time_to_first_token_ms ? `First token: ${call.time_to_first_token_ms}ms` : ''}>
+          <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+            {call.duration_ms !== undefined && call.duration_ms >= 1000
+              ? `${(call.duration_ms / 1000).toFixed(1)}s`
+              : `${call.duration_ms ?? '-'}ms`}
+          </Typography>
+        </Tooltip>
+      ),
+      tokens: (
+        <Tooltip
+          title={`Prompt (context): ${call.prompt_tokens?.toLocaleString() ?? '-'} · Completion: ${call.completion_tokens?.toLocaleString() ?? '-'}${call.cache_read_tokens ? ` · Cache read: ${call.cache_read_tokens.toLocaleString()}` : ''}`}
+        >
+          <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'var(--helix-font-mono)', fontSize: '0.75rem', whiteSpace: 'nowrap' }}>
+            {formatTokenCount(call.prompt_tokens)} → {formatTokenCount(call.completion_tokens)}
+          </Typography>
+        </Tooltip>
+      ),
+      status: call.error ? (
+        <Tooltip title={call.error}>
+          <Chip label="error" size="small" color="error" variant="outlined" />
+        </Tooltip>
+      ) : (
+        <Chip label={call.stream ? 'ok · stream' : 'ok'} size="small" color="success" variant="outlined" />
+      ),
+    }));
+  }, [llmCalls?.calls]);
 
   if (!llmCalls) return null;
 
@@ -71,150 +136,52 @@ const LLMCallsTable: FC<LLMCallsTableProps> = ({ sessionFilter }) => {
     <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Typography variant="h6">LLM Calls</Typography>
-        <Button startIcon={<RefreshIcon />} onClick={handleRefresh}>
+        <Button startIcon={<RefreshCw size={16} />} onClick={() => refetch()}>
           Refresh
         </Button>
       </Box>
-      <Box sx={{ width: 0, minWidth: '100%', overflow: 'auto' }}>
-        <TableContainer sx={{ minWidth: 0 }}>
-          <Table stickyHeader aria-label="LLM calls table" sx={{ minWidth: 0 }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>ID</TableCell>
-                <TableCell>Created</TableCell>
-                <TableCell>Session ID</TableCell>
-                <TableCell>Interaction ID</TableCell>
-                <TableCell>Model</TableCell>
-                <TableCell>Provider</TableCell>
-                <TableCell>Step</TableCell>
-                <TableCell>Duration (ms)</TableCell>
-                <TableCell>Original Request</TableCell>
-                <TableCell>Request</TableCell>
-                <TableCell>Response</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              { serverConfig?.disable_llm_call_logging ? (
-                <TableRow>
-                  <TableCell colSpan={6}>LLM call logging is disabled by the administrator.</TableCell>
-                </TableRow>
-              ) : (
-                llmCalls.calls?.map((call: TypesLLMCall) => (
-                                  <TableRow key={call.id}>
-                  <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <Tooltip title={call.id}>
-                        <Typography variant="body2">
-                          {call.id?.startsWith('llmc_') ? 
-                            call.id.slice(-7) : 
-                            call.id?.slice(-7) || ''
-                          }
-                        </Typography>
-                      </Tooltip>
-                      <Tooltip title="Copy full ID">
-                        <IconButton 
-                          size="small" 
-                          onClick={() => copyToClipboard(call.id || '')}
-                          sx={{ p: 0.25 }}
-                        >
-                          <ContentCopyIcon sx={{ fontSize: 12 }} />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                  </TableCell>
-                <TableCell>{call.created ? new Date(call.created).toLocaleString() : ''}</TableCell>
-                <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <Tooltip title={call.session_id}>
-                        <Typography variant="body2">
-                          {call.session_id?.startsWith('ses_') ? 
-                            call.session_id.slice(-7) : 
-                            call.session_id?.slice(-7) || ''
-                          }
-                        </Typography>
-                      </Tooltip>
-                      <Tooltip title="Copy full Session ID">
-                        <IconButton 
-                          size="small" 
-                          onClick={() => copyToClipboard(call.session_id || '')}
-                          sx={{ p: 0.25 }}
-                        >
-                          <ContentCopyIcon sx={{ fontSize: 12 }} />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                  </TableCell>
-                <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <Tooltip title={call.interaction_id}>
-                        <Typography variant="body2">
-                          {call.interaction_id?.slice(-7) || ''}
-                        </Typography>
-                      </Tooltip>
-                      <Tooltip title="Copy full Interaction ID">
-                        <IconButton 
-                          size="small" 
-                          onClick={() => copyToClipboard(call.interaction_id || '')}
-                          sx={{ p: 0.25 }}
-                        >
-                          <ContentCopyIcon sx={{ fontSize: 12 }} />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                  </TableCell>
-                  <TableCell>{call.model}</TableCell>
-                  <TableCell>{call.provider}</TableCell>
-                  <TableCell>{call.step}</TableCell>
-                  <TableCell>{call.duration_ms}</TableCell>
-                  <TableCell>
-                    {call.original_request && (
-                      <Button onClick={() => handleOpenModal(call.original_request)}>View</Button>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <Button onClick={() => handleOpenModal(call.request)}>View</Button>
-                  </TableCell>
-                  <TableCell>
-                    {call.error ? (
-                      <Button onClick={() => handleOpenModal({ error: call.error })}>View Error</Button>
-                    ) : (
-                      <Button onClick={() => handleOpenModal(call.response)}>View</Button>
-                    )}
-                  </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-        <TablePagination
-          rowsPerPageOptions={[10, 25, 100]}
-          component="div"
-          count={llmCalls.totalCount || 0}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={handleChangePage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      </Box>
-      <DarkDialog
-        open={modalOpen}
-        onClose={handleCloseModal}
-        maxWidth="md"
-        fullWidth
-        PaperProps={{
-          sx: {
-            maxHeight: '80vh',
-          },
-        }}
-      >
-        <Box sx={{ p: 3, overflow: 'auto' }}>
-          <Typography variant="h6" component="h2" gutterBottom>
-            JSON Content
-          </Typography>
-          <JsonView data={modalContent} />
-        </Box>
-      </DarkDialog>
+      {serverConfig?.disable_llm_call_logging ? (
+        <Typography variant="body2" color="text.secondary">
+          LLM call logging is disabled by the administrator.
+        </Typography>
+      ) : (
+        <>
+          <SimpleTable
+            authenticated
+            compact
+            loading={isLoading}
+            fields={[
+              { name: 'created', title: 'Time' },
+              { name: 'model', title: 'Model' },
+              { name: 'provider', title: 'Provider' },
+              { name: 'step', title: 'Step' },
+              { name: 'session', title: 'Session' },
+              { name: 'duration', title: 'Duration' },
+              { name: 'tokens', title: 'Tokens' },
+              { name: 'status', title: 'Status' },
+            ]}
+            data={tableData}
+            onRowClick={(row) => handleOpenCall(row._data)}
+          />
+          <TablePagination
+            rowsPerPageOptions={[10, 25, 100]}
+            component="div"
+            count={llmCalls.totalCount || 0}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            onRowsPerPageChange={(event) => {
+              setRowsPerPage(parseInt(event.target.value, 10));
+              setPage(0);
+            }}
+          />
+        </>
+      )}
+      <LLMCallDrawer
+        call={currentCall}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      />
     </>
   );
 };

--- a/frontend/src/services/llmCallsService.ts
+++ b/frontend/src/services/llmCallsService.ts
@@ -1,17 +1,23 @@
 import { useQuery } from '@tanstack/react-query'
 import useApi from '../hooks/useApi';
 
-export const llmCallsQueryKey = (session: string, interaction: string) => [
+// Page/pageSize must be part of the key — the query fn closes over them, so
+// with a page-less key a page change would keep serving the cached first page.
+export const llmCallsQueryKey = (session: string, interaction: string, page: number, pageSize: number) => [
   "llm_calls",
   session,
-  interaction
+  interaction,
+  page,
+  pageSize
 ];
 
-export const appLLMCallsQueryKey = (appId: string, session: string, interaction: string) => [
+export const appLLMCallsQueryKey = (appId: string, session: string, interaction: string, page: number, pageSize: number) => [
   "app_llm_calls",
   appId,
   session,
-  interaction
+  interaction,
+  page,
+  pageSize
 ];
 
 export function useListLLMCalls(session: string, interaction: string, page: number, pageSize: number, enabled?: boolean) {
@@ -19,7 +25,7 @@ export function useListLLMCalls(session: string, interaction: string, page: numb
   const apiClient = api.getApiClient()  
 
   return useQuery({
-    queryKey: llmCallsQueryKey(session, interaction),
+    queryKey: llmCallsQueryKey(session, interaction, page, pageSize),
     queryFn: async () => {
       const response = await apiClient.v1LlmCallsList({
         session,
@@ -38,7 +44,7 @@ export function useListAppLLMCalls(appId: string, session: string, interaction: 
   const apiClient = api.getApiClient()  
 
   return useQuery({
-    queryKey: appLLMCallsQueryKey(appId, session, interaction),
+    queryKey: appLLMCallsQueryKey(appId, session, interaction, page, pageSize),
     queryFn: async () => {
       const response = await apiClient.v1AgentsLlmCallsDetail(appId, {
         session,


### PR DESCRIPTION
## What

Two changes to the admin panel's LLM calls surface (`?dialog=admin`):

### 1. fix(api): streamed tool-call responses were stored malformed

A single streamed tool call arrives as many SSE deltas sharing an `index`: the first carries `id`/`type`/`name`, the rest only argument fragments. `appendChunk` in the LLM call logger appended **every fragment as its own tool call**, so a streaming response with one tool call was stored (and displayed) as dozens of broken entries — a real production row had **93 fragment entries** for a single `edit` call:

```json
[
  {"id": "chatcmpl-tool-9cbb…", "index": 0, "function": {"name": "edit"}},
  {"type": "", "index": 0, "function": {"arguments": "{\"filePath\": \"/home"}},
  {"type": "", "index": 0, "function": {"arguments": "/retro"}},
  …90 more…
]
```

Now fragments merge by index into a single tool call. Also fixed while there: legacy `function_call` arguments were overwritten per-fragment (only the last survived), `reasoning_content` was dropped, `finish_reason` was never copied, and `object` was stored empty — all now accumulated/set. Unit tests added; the Anthropic proxy path already used the SDK accumulator and was fine.

Verified end-to-end against the dev stack: a live streamed 2-tool-call request through `/v1/chat/completions` now stores two clean tool calls with complete arguments, `finish_reason: "tool_calls"`, and `object: "chat.completion"`.

### 2. feat(frontend): admin LLM calls table redesign + detail drawer

Before: raw MUI table where request/response were bare "View" buttons opening an untitled JSON modal.

Now:
- `SimpleTable`-based list: time, model, provider, step, session (copyable), duration (TTFT in tooltip), `prompt → completion` token counts, ok/error status chip (error text in tooltip), stream indicator.
- Clicking a row opens a right-side **detail drawer** with: duration / time-to-first-token / token + cache stats / costs, all related IDs (session, interaction, app, project, spec task, user) with copy buttons, a request summary (message count, context size, tools, max_tokens, temperature, reasoning effort), finish reason + tool call names, extracted response text (handles both OpenAI `choices` and Anthropic content-block shapes), a prominent error banner, and tabbed JSON views of response / request / original request.

Render tests added for the drawer. `yarn build` + `yarn tsc` clean.

**NOT tested in a live browser** — the session's preview browser could not tunnel to the dev stack; please eyeball the admin dialog once. The data path (`useListLLMCalls` → `GET /api/v1/llm_calls`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 3. fix(frontend): LLM calls pagination never refetched

`useListLLMCalls` / `useListAppLLMCalls` closed over `page`/`pageSize` in the query fn but omitted them from the query key, so changing pages kept serving the cached first page. Keys now include both.
