### PR TITLE
fix(api): return 404 for missing organizations

### DIFF
--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -199,6 +199,10 @@ func (apiServer *HelixAPIServer) getOrganization(rw http.ResponseWriter, r *http
 	organization, err := apiServer.lookupOrg(r.Context(), reference)
 	if err != nil {
 		log.Err(err).Msg("error getting organization")
+		if errors.Is(err, store.ErrNotFound) {
+			http.Error(rw, "Organization not found", http.StatusNotFound)
+			return
+		}
 		http.Error(rw, "Could not get organization: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/api/pkg/server/organization_handlers_test.go
+++ b/api/pkg/server/organization_handlers_test.go
@@ -197,6 +197,29 @@ func TestDeleteOrganization_OrganizationNotFound(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "Organization not found")
 }
 
+func TestGetOrganization_OrganizationNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	orgID := "org_missing"
+
+	mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{
+		ID: orgID,
+	}).Return(nil, store.ErrNotFound)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/"+orgID, nil)
+	req = mux.SetURLVars(req, map[string]string{"id": orgID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user_1"}))
+
+	rr := httptest.NewRecorder()
+	server.getOrganization(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Equal(t, "Organization not found\n", rr.Body.String())
+}
+
 func TestDeleteOrganization_OnlyOwnerCanDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary\n\nReturn HTTP 404 when GET /api/v1/organizations/{id} targets a missing organization, instead of mapping store.ErrNotFound to 500.\n\n## Changes\n\n- Handle wrapped store.ErrNotFound in getOrganization.\n- Add a regression test for the missing-organization response.\n\n## Validation\n\n- docker run ... gofmt\n- docker run ... go test ./pkg/server -run 'TestGetOrganization_OrganizationNotFound|TestDeleteOrganization_OrganizationNotFound' -count=1\n- Result: passed\n\nCloses #3004