### PR TITLE
fix: restructure the provider endpoint dialog (and make header edits actually save)

### DIFF
--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -853,6 +853,12 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	}
 	existingEndpoint.Models = updatedEndpoint.Models
 	existingEndpoint.BaseURL = strings.TrimSpace(updatedEndpoint.BaseURL)
+	// A nil map means the caller left headers out of the request; an empty map
+	// means "remove every header". Both are legitimate, so only the nil case
+	// keeps the stored headers.
+	if updatedEndpoint.Headers != nil {
+		existingEndpoint.Headers = updatedEndpoint.Headers
+	}
 	if updatedEndpoint.APIKey != nil {
 		existingEndpoint.APIKey = strings.TrimSpace(*updatedEndpoint.APIKey)
 	}

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -1103,3 +1103,73 @@ func (s *ProviderHandlersSuite) TestFindProviderWithModel_ResolvesFromWrappedCac
 	s.Equal("dynprov", provider, "must resolve provider from wrapped cache payload")
 	s.Equal("some-dynamic-model", bareModel)
 }
+
+// The update handler used to drop `headers` entirely, so the "Custom headers"
+// section of the edit dialog silently did nothing. Headers are three-state:
+// omitted keeps what is stored, a populated map replaces it, and an empty map
+// removes every header.
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_Headers() {
+	endpointID := "ep_123"
+
+	newEndpoint := func() *types.ProviderEndpoint {
+		return &types.ProviderEndpoint{
+			ID:           endpointID,
+			Name:         "my-endpoint",
+			BaseURL:      "http://localhost:11434",
+			Owner:        "user_id",
+			OwnerType:    types.OwnerTypeUser,
+			EndpointType: types.ProviderEndpointTypeUser,
+			Headers:      map[string]string{"X-Existing": "old"},
+		}
+	}
+
+	testCases := []struct {
+		name    string
+		payload string
+		want    map[string]string
+	}{
+		{
+			name:    "replaces headers when provided",
+			payload: `{"name":"my-endpoint","base_url":"http://localhost:11434","headers":{"X-Existing":"new","X-Added":"yes"}}`,
+			want:    map[string]string{"X-Existing": "new", "X-Added": "yes"},
+		},
+		{
+			name:    "removes every header when the map is empty",
+			payload: `{"name":"my-endpoint","base_url":"http://localhost:11434","headers":{}}`,
+			want:    map[string]string{},
+		},
+		{
+			name:    "keeps stored headers when omitted",
+			payload: `{"name":"my-endpoint","base_url":"http://localhost:11434"}`,
+			want:    map[string]string{"X-Existing": "old"},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.server.Cfg.Providers.EnableCustomUserProviders = true
+
+			s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+				ProvidersManagementEnabled: true,
+			}, nil)
+			s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+				ID: endpointID,
+			}).Return(newEndpoint(), nil)
+			s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+					s.Equal(tc.want, ep.Headers)
+					return ep, nil
+				})
+
+			req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader([]byte(tc.payload)))
+			req = req.WithContext(s.authCtx)
+			req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+			rr := httptest.NewRecorder()
+			s.server.updateProviderEndpoint(rr, req)
+
+			s.Equal(http.StatusOK, rr.Code, rr.Body.String())
+		})
+	}
+}

--- a/frontend/src/components/dashboard/CreateProviderEndpointDialog.tsx
+++ b/frontend/src/components/dashboard/CreateProviderEndpointDialog.tsx
@@ -18,19 +18,18 @@ import {
   FormLabel,
   Checkbox,
   Typography,
-  IconButton,
   Box,
   Divider,
   Link,
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import { IProviderEndpoint } from '../../types';
 import { TypesProviderEndpointType } from '../../api/api'
 import { useCreateProviderEndpoint } from '../../services/providersService';
 import { PROVIDERS, Provider } from '../providers/types';
+import { getFormSelectSx } from '../../contexts/theme';
+import { CustomHeadersEditor, ProviderEndpointHeader } from './ProviderEndpointFormFields';
 
 const CUSTOM_PROVIDER_ID = 'user/custom';
 
@@ -79,7 +78,7 @@ const CreateProviderEndpointDialog: React.FC<CreateProviderEndpointDialogProps> 
     description: '',
     auth_type: 'none' as AuthType,
     billing_enabled: false,
-    headers: [] as Array<{ key: string; value: string }>,
+    headers: [] as ProviderEndpointHeader[],
   });
 
   const selectedProvider = PROVIDERS.find((p) => p.id === selectedProviderId);
@@ -133,28 +132,9 @@ const CreateProviderEndpointDialog: React.FC<CreateProviderEndpointDialogProps> 
     setError('');
   };
 
-  const handleHeaderChange = (index: number, field: 'key' | 'value', value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: prev.headers.map((header, i) =>
-        i === index ? { ...header, [field]: value } : header
-      ),
-    }));
+  const handleHeadersChange = (headers: ProviderEndpointHeader[]) => {
+    setFormData((prev) => ({ ...prev, headers }));
     setError('');
-  };
-
-  const addHeader = () => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: [...prev.headers, { key: '', value: '' }],
-    }));
-  };
-
-  const removeHeader = (index: number) => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: prev.headers.filter((_, i) => i !== index),
-    }));
   };
 
   const validateForm = useCallback(() => {
@@ -242,7 +222,7 @@ const CreateProviderEndpointDialog: React.FC<CreateProviderEndpointDialogProps> 
         <Stack spacing={2} sx={{ mt: 2 }}>
           {error && <Alert severity="error">{error}</Alert>}
 
-          <FormControl fullWidth>
+          <FormControl fullWidth sx={theme => getFormSelectSx(theme.palette.mode === 'light')}>
             <InputLabel id="provider-preset-label">Provider</InputLabel>
             <Select
               labelId="provider-preset-label"
@@ -347,13 +327,14 @@ const CreateProviderEndpointDialog: React.FC<CreateProviderEndpointDialogProps> 
             />
           )}
 
-          <FormControl fullWidth>
-            <InputLabel>Type</InputLabel>
+          <FormControl fullWidth sx={theme => getFormSelectSx(theme.palette.mode === 'light')}>
+            <InputLabel id="create-endpoint-type-label">Visibility</InputLabel>
             <Select
+              labelId="create-endpoint-type-label"
               name="endpoint_type"
               value={formData.endpoint_type}
               onChange={(e) => handleInputChange(e as React.ChangeEvent<HTMLInputElement | { name?: string; value: unknown }>)}
-              label="Type"
+              label="Visibility"
             >
               {/* Only show User option when providers management is enabled -
                   when disabled, only admins can create endpoints and "user" type
@@ -383,54 +364,7 @@ const CreateProviderEndpointDialog: React.FC<CreateProviderEndpointDialogProps> 
 
           <Divider sx={{ my: 2 }} />
 
-          <Box>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Typography variant="h6">Custom Headers</Typography>
-              <Button
-                startIcon={<AddIcon />}
-                onClick={addHeader}
-                variant="outlined"
-                size="small"
-              >
-                Add Header
-              </Button>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Add custom headers that will be sent with requests to this endpoint
-            </Typography>
-            
-            {formData.headers.map((header, index) => (
-              <Box key={index} sx={{ display: 'flex', gap: 1, mb: 2, alignItems: 'center' }}>
-                <TextField
-                  label="Header Name"
-                  value={header.key}
-                  onChange={(e) => handleHeaderChange(index, 'key', e.target.value)}
-                  placeholder="e.g., X-API-Key"
-                  sx={{ flex: 1 }}
-                />
-                <TextField
-                  label="Header Value"
-                  value={header.value}
-                  onChange={(e) => handleHeaderChange(index, 'value', e.target.value)}
-                  placeholder="e.g., your-api-key"
-                  sx={{ flex: 1 }}
-                />
-                <IconButton
-                  onClick={() => removeHeader(index)}
-                  color="error"
-                  size="small"
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </Box>
-            ))}
-            
-            {formData.headers.length === 0 && (
-              <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
-                No custom headers added. Click "Add Header" to add custom headers.
-              </Typography>
-            )}
-          </Box>
+          <CustomHeadersEditor headers={formData.headers} onChange={handleHeadersChange} />
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/frontend/src/components/dashboard/EditProviderEndpointDialog.tsx
+++ b/frontend/src/components/dashboard/EditProviderEndpointDialog.tsx
@@ -7,29 +7,34 @@ import {
   Button,
   TextField,
   FormControl,
-  InputLabel,
-  Select,
   MenuItem,
   Alert,
   Stack,
-  SelectChangeEvent,
   RadioGroup,
   FormControlLabel,
   Radio,
   FormLabel,
   IconButton,
+  Tooltip,
   Box,
   Divider,
   Typography,
   Switch,
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { Check, Copy, Server } from 'lucide-react';
 import { TypesProviderEndpointType } from '../../api/api'
 import { useUpdateProviderEndpoint } from '../../services/providersService';
 import useAccount from '../../hooks/useAccount';
+import { getFormSelectSx } from '../../contexts/theme';
+import { copyTextToClipboard } from '../../utils/clipboard';
+import { APP_MONO_FONT_FAMILY } from '../../styles/typography';
 import ProviderEndpointIcon, { PROVIDER_ICON_OPTIONS, ProviderMark } from '../providers/ProviderEndpointIcon';
-import { Server } from 'lucide-react';
+import {
+  CustomHeadersEditor,
+  FormRow,
+  FormSection,
+  ProviderEndpointHeader,
+} from './ProviderEndpointFormFields';
 
 // Helper function to determine auth type from endpoint
 interface EditableProviderEndpoint {
@@ -75,6 +80,38 @@ interface EditProviderEndpointDialogProps {
 
 type AuthType = 'api_key' | 'api_key_file' | 'none';
 
+const EndpointIdChip: React.FC<{ id: string }> = ({ id }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await copyTextToClipboard(id);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={0.25} sx={{ minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        noWrap
+        sx={{ fontFamily: APP_MONO_FONT_FAMILY }}
+      >
+        {id}
+      </Typography>
+      <Tooltip title={copied ? 'Copied' : 'Copy endpoint ID'}>
+        <IconButton
+          onClick={handleCopy}
+          aria-label="Copy endpoint ID"
+          sx={{ width: 24, height: 24, color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+};
+
 const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
   open,
   endpoint,
@@ -94,7 +131,7 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
     api_key_file: endpoint?.api_key_file || '',
     endpoint_type: endpoint?.endpoint_type || 'user',
     auth_type: getEndpointAuthType(endpoint),
-    headers: [] as Array<{ key: string; value: string }>,
+    headers: [] as ProviderEndpointHeader[],
   });
 
   const { mutateAsync: updateProviderEndpoint } = useUpdateProviderEndpoint();
@@ -123,16 +160,7 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
     }
   }, [endpoint]);
 
-  const handleTextFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-    setError('');
-  };
-
-  const handleSelectChange = (e: SelectChangeEvent) => {
+  const handleTextFieldChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
@@ -153,28 +181,9 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
     setError('');
   };
 
-  const handleHeaderChange = (index: number, field: 'key' | 'value', value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: prev.headers.map((header, i) =>
-        i === index ? { ...header, [field]: value } : header
-      ),
-    }));
+  const handleHeadersChange = (headers: ProviderEndpointHeader[]) => {
+    setFormData((prev) => ({ ...prev, headers }));
     setError('');
-  };
-
-  const addHeader = () => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: [...prev.headers, { key: '', value: '' }],
-    }));
-  };
-
-  const removeHeader = (index: number) => {
-    setFormData((prev) => ({
-      ...prev,
-      headers: prev.headers.filter((_, i) => i !== index),
-    }));
   };
 
   const validateForm = useCallback(() => {
@@ -238,7 +247,10 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
             ? formData.api_key_file
             : undefined,
         endpoint_type: (formData.endpoint_type as TypesProviderEndpointType),
-        headers: Object.keys(headersObj).length > 0 ? headersObj : undefined,
+        // Always send the map, including when it is empty: the server treats a
+        // missing `headers` as "leave them alone", so omitting it would make
+        // removing the last header impossible.
+        headers: headersObj,
       }
       await updateProviderEndpoint({ id: endpoint.id, body });
       refreshData();
@@ -270,222 +282,215 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
   // Don't render anything if we don't have an endpoint
   if (!endpoint?.id) return null;
 
+  const previewEndpoint = {
+    icon: formData.icon,
+    name: formData.name,
+    base_url: formData.base_url,
+  };
+
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Edit Provider Endpoint: {endpoint.name}</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} sx={{ mt: 2 }}>
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1.5, pb: 1.5 }}>
+        <ProviderEndpointIcon endpoint={previewEndpoint} size={28} />
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="h6" noWrap>{endpoint.name}</Typography>
+          <EndpointIdChip id={endpoint.id} />
+        </Box>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Stack spacing={3} sx={{ mt: 1 }}>
           {error && <Alert severity="error">{error}</Alert>}
 
-          <TextField
-            name="id"
-            label="Endpoint ID"
-            value={endpoint.id}
-            fullWidth
-            autoComplete="off"
-            disabled
-          />
+          <FormSection title="Details">
+            <Stack spacing={2}>
+              <FormRow>
+                <TextField
+                  name="name"
+                  label="Name"
+                  value={formData.name}
+                  onChange={handleTextFieldChange}
+                  required
+                  autoComplete="off"
+                  placeholder="my-provider"
+                  helperText="A unique name to identify this provider endpoint"
+                  sx={{ gridColumn: { sm: account.admin ? 'auto' : '1 / -1' } }}
+                />
 
-          <TextField
-            name="name"
-            label="Name"
-            value={formData.name}
-            onChange={handleTextFieldChange}
-            fullWidth
-            required
-            autoComplete="off"
-            placeholder="my-provider"
-            helperText="A unique name to identify this provider endpoint"
-          />
-
-          <TextField
-            name="description"
-            label="Description"
-            value={formData.description}
-            onChange={handleTextFieldChange}
-            fullWidth
-            multiline
-            minRows={3}
-            helperText="Explain what this endpoint serves and where it runs"
-          />
-
-          {account.admin && (
-            <>
-              <FormControl fullWidth>
-                <InputLabel>Provider icon</InputLabel>
-                <Select
-                  name="icon"
-                  value={formData.icon}
-                  onChange={handleSelectChange}
-                  label="Provider icon"
-                  renderValue={(value) => {
-                    const option = PROVIDER_ICON_OPTIONS.find(item => item.key === value)
-                    return (
+                {account.admin && (
+                  <TextField
+                    select
+                    name="icon"
+                    label="Provider icon"
+                    value={formData.icon}
+                    onChange={handleTextFieldChange}
+                    helperText="Defaults to a mark inferred from the name and base URL"
+                    // The empty value means "Automatic", so the label has to stay
+                    // shrunk or it would sit on top of the rendered value.
+                    InputLabelProps={{ shrink: true }}
+                    sx={theme => getFormSelectSx(theme.palette.mode === 'light')}
+                    SelectProps={{
+                      displayEmpty: true,
+                      renderValue: (value: unknown) => {
+                        const option = PROVIDER_ICON_OPTIONS.find(item => item.key === value)
+                        return (
+                          <Stack direction="row" spacing={1} alignItems="center">
+                            {option
+                              ? <ProviderMark provider={option.provider} size={22} />
+                              : <ProviderEndpointIcon endpoint={previewEndpoint} size={22} />}
+                            <span>{option?.label || 'Automatic'}</span>
+                          </Stack>
+                        )
+                      },
+                    }}
+                  >
+                    <MenuItem value="">
                       <Stack direction="row" spacing={1} alignItems="center">
-                        {option
-                          ? <ProviderMark provider={option.provider} size={22} />
-                          : <ProviderEndpointIcon endpoint={endpoint} size={22} />}
-                        <span>{option?.label || 'Automatic'}</span>
-                      </Stack>
-                    )
-                  }}
-                >
-                  <MenuItem value="">
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Server size={22} />
-                      <span>Automatic</span>
-                    </Stack>
-                  </MenuItem>
-                  {PROVIDER_ICON_OPTIONS.map(option => (
-                    <MenuItem key={option.key} value={option.key}>
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <ProviderMark provider={option.provider} size={22} />
-                        <span>{option.label}</span>
+                        <Server size={22} />
+                        <span>Automatic</span>
                       </Stack>
                     </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+                    {PROVIDER_ICON_OPTIONS.map(option => (
+                      <MenuItem key={option.key} value={option.key}>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <ProviderMark provider={option.provider} size={22} />
+                          <span>{option.label}</span>
+                        </Stack>
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              </FormRow>
 
-              <FormControlLabel
-                control={(
-                  <Switch
-                    name="billing_enabled"
-                    checked={formData.billing_enabled}
-                    onChange={event => setFormData(previous => ({
-                      ...previous,
-                      billing_enabled: event.target.checked,
-                    }))}
+              <TextField
+                name="description"
+                label="Description"
+                value={formData.description}
+                onChange={handleTextFieldChange}
+                fullWidth
+                multiline
+                minRows={2}
+                helperText="Explain what this endpoint serves and where it runs"
+              />
+            </Stack>
+          </FormSection>
+
+          <Divider />
+
+          <FormSection title="Connection">
+            <Stack spacing={2}>
+              <TextField
+                name="base_url"
+                label="Base URL"
+                value={formData.base_url}
+                onChange={handleTextFieldChange}
+                fullWidth
+                required
+                autoComplete="off"
+                placeholder="https://api.openai.com/v1"
+                helperText="OpenAI-compatible (https://api.openai.com/v1), Anthropic (https://api.anthropic.com/v1), or Google (https://generativelanguage.googleapis.com/v1beta/openai)"
+              />
+
+              <FormRow>
+                <FormControl component="fieldset">
+                  <FormLabel component="legend" sx={{ typography: 'body2', mb: 0.5 }}>
+                    Authentication
+                  </FormLabel>
+                  <RadioGroup
+                    row
+                    name="auth_type"
+                    value={formData.auth_type}
+                    onChange={handleAuthTypeChange}
+                  >
+                    <FormControlLabel value="api_key" control={<Radio size="small" />} label="API key" />
+                    <FormControlLabel value="api_key_file" control={<Radio size="small" />} label="Key file" />
+                    <FormControlLabel value="none" control={<Radio size="small" />} label="None" />
+                  </RadioGroup>
+                </FormControl>
+
+                {formData.auth_type === 'api_key' && (
+                  <TextField
+                    name="api_key"
+                    label="API key"
+                    value={formData.api_key}
+                    onChange={handleTextFieldChange}
+                    type="password"
+                    autoComplete="off"
+                    placeholder="••••••••"
+                    helperText="Leave blank to keep the existing API key"
                   />
                 )}
-                label="Charge users for inference through this provider"
-              />
-            </>
-          )}
 
-          <TextField
-            name="base_url"
-            label="Base URL"
-            value={formData.base_url}
-            onChange={handleTextFieldChange}
-            fullWidth
-            required
-            autoComplete="off"
-            placeholder="https://api.openai.com/v1"
-            helperText="OpenAI-compatible (https://api.openai.com/v1), Anthropic (https://api.anthropic.com/v1), or Google (https://generativelanguage.googleapis.com/v1beta/openai)"
-          />
+                {formData.auth_type === 'api_key_file' && (
+                  <TextField
+                    name="api_key_file"
+                    label="API key file path"
+                    value={formData.api_key_file}
+                    onChange={handleTextFieldChange}
+                    autoComplete="off"
+                    placeholder="/etc/helix/provider.key"
+                    helperText="Path to a file on the Helix server containing the API key"
+                  />
+                )}
+              </FormRow>
+            </Stack>
+          </FormSection>
 
-          <FormControl component="fieldset">
-            <FormLabel component="legend">Authentication Method</FormLabel>
-            <RadioGroup
-              name="auth_type"
-              value={formData.auth_type}
-              onChange={handleAuthTypeChange}
-            >
-              <FormControlLabel value="api_key" control={<Radio />} label="API Key" />
-              <FormControlLabel value="api_key_file" control={<Radio />} label="API Key File" />
-              <FormControlLabel value="none" control={<Radio />} label="None" />
-            </RadioGroup>
-          </FormControl>
+          <Divider />
 
-          {formData.auth_type === 'api_key' && (
-            <TextField
-              name="api_key"
-              label="API Key"
-              value={formData.api_key}
-              onChange={handleTextFieldChange}
-              fullWidth
-              type="password"
-              autoComplete="off"
-              helperText="Leave blank to keep the existing API key"
-            />
-          )}
-
-          {formData.auth_type === 'api_key_file' && (
-            <TextField
-              name="api_key_file"
-              label="API Key File Path"
-              value={formData.api_key_file}
-              onChange={handleTextFieldChange}
-              fullWidth
-              helperText="Specify a file path containing the API key"
-            />
-          )}
-
-          <FormControl fullWidth>
-            <InputLabel>Type</InputLabel>
-            <Select
-              name="endpoint_type"
-              value={formData.endpoint_type}
-              onChange={handleSelectChange}
-              label="Type"
-            >
-              <MenuItem value="user">User (available to you only)</MenuItem>
-              <MenuItem value="global">Global (available to all users in Helix installation)</MenuItem>
-            </Select>
-          </FormControl>
-
-          <Divider sx={{ my: 2 }} />
-
-          <Box>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Typography variant="h6">Custom Headers</Typography>
-              <Button
-                startIcon={<AddIcon />}
-                onClick={addHeader}
-                variant="outlined"
-                size="small"
+          <FormSection title="Availability">
+            <FormRow>
+              <TextField
+                select
+                name="endpoint_type"
+                label="Visibility"
+                value={formData.endpoint_type}
+                onChange={handleTextFieldChange}
+                helperText="Who can select this endpoint"
+                sx={theme => getFormSelectSx(theme.palette.mode === 'light')}
               >
-                Add Header
-              </Button>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Add custom headers that will be sent with requests to this endpoint
-            </Typography>
-            
-            {formData.headers.map((header, index) => (
-              <Box key={index} sx={{ display: 'flex', gap: 1, mb: 2, alignItems: 'center' }}>
-                <TextField
-                  label="Header Name"
-                  value={header.key}
-                  onChange={(e) => handleHeaderChange(index, 'key', e.target.value)}
-                  placeholder="e.g., X-API-Key"
-                  sx={{ flex: 1 }}
-                />
-                <TextField
-                  label="Header Value"
-                  value={header.value}
-                  onChange={(e) => handleHeaderChange(index, 'value', e.target.value)}
-                  placeholder="e.g., your-api-key"
-                  sx={{ flex: 1 }}
-                />
-                <IconButton
-                  onClick={() => removeHeader(index)}
-                  color="error"
-                  size="small"
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </Box>
-            ))}
-            
-            {formData.headers.length === 0 && (
-              <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
-                No custom headers added. Click "Add Header" to add custom headers.
-              </Typography>
-            )}
-          </Box>
+                <MenuItem value="user">User (available to you only)</MenuItem>
+                <MenuItem value="global">Global (available to all users in Helix installation)</MenuItem>
+              </TextField>
+
+              {account.admin && (
+                <Box>
+                  <FormControlLabel
+                    control={(
+                      <Switch
+                        name="billing_enabled"
+                        checked={formData.billing_enabled}
+                        onChange={event => setFormData(previous => ({
+                          ...previous,
+                          billing_enabled: event.target.checked,
+                        }))}
+                      />
+                    )}
+                    label="Charge users for inference"
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    Usage through this provider is billed to the user's wallet balance.
+                  </Typography>
+                </Box>
+              )}
+            </FormRow>
+          </FormSection>
+
+          <Divider />
+
+          <CustomHeadersEditor headers={formData.headers} onChange={handleHeadersChange} />
         </Stack>
       </DialogContent>
-      <DialogActions>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button 
-          onClick={handleSubmit} 
+        <Button
+          onClick={handleSubmit}
           variant="outlined"
           color="secondary"
           disabled={loading}
         >
-          Save Changes
+          Save changes
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/dashboard/ProviderEndpointFormFields.tsx
+++ b/frontend/src/components/dashboard/ProviderEndpointFormFields.tsx
@@ -1,0 +1,123 @@
+import React, { FC, ReactNode } from 'react'
+import {
+  Box,
+  Button,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Plus, Trash2 } from 'lucide-react'
+
+export interface ProviderEndpointHeader {
+  key: string
+  value: string
+}
+
+interface FormSectionProps {
+  title: string
+  description?: string
+  action?: ReactNode
+  children: ReactNode
+}
+
+/**
+ * A titled block of form controls. Used by the create and edit provider
+ * endpoint dialogs so both keep the same heading rhythm.
+ */
+export const FormSection: FC<FormSectionProps> = ({ title, description, action, children }) => (
+  <Box>
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+      sx={{ minHeight: 32, mb: description ? 0.5 : 1.5 }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{title}</Typography>
+      {action}
+    </Stack>
+    {description && (
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        {description}
+      </Typography>
+    )}
+    {children}
+  </Box>
+)
+
+/** Responsive two column form row that collapses to one column on narrow screens. */
+export const FormRow: FC<{ children: ReactNode }> = ({ children }) => (
+  <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' } }}>
+    {children}
+  </Box>
+)
+
+interface CustomHeadersEditorProps {
+  headers: ProviderEndpointHeader[]
+  onChange: (headers: ProviderEndpointHeader[]) => void
+}
+
+export const CustomHeadersEditor: FC<CustomHeadersEditorProps> = ({ headers, onChange }) => {
+  const updateHeader = (index: number, field: 'key' | 'value', value: string) => {
+    onChange(headers.map((header, i) => (i === index ? { ...header, [field]: value } : header)))
+  }
+
+  return (
+    <FormSection
+      title="Custom headers"
+      description="Sent with every request to this endpoint, in addition to the authentication header."
+      action={(
+        <Button
+          startIcon={<Plus size={16} />}
+          onClick={() => onChange([...headers, { key: '', value: '' }])}
+          variant="outlined"
+          size="small"
+        >
+          Add header
+        </Button>
+      )}
+    >
+      {headers.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+          No custom headers.
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {headers.map((header, index) => (
+            <Box
+              key={index}
+              sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr auto', gap: 1, alignItems: 'center' }}
+            >
+              <TextField
+                label="Header name"
+                value={header.key}
+                onChange={(e) => updateHeader(index, 'key', e.target.value)}
+                placeholder="X-Api-Key"
+                autoComplete="off"
+                size="small"
+              />
+              <TextField
+                label="Header value"
+                value={header.value}
+                onChange={(e) => updateHeader(index, 'value', e.target.value)}
+                placeholder="your-api-key"
+                autoComplete="off"
+                size="small"
+              />
+              <Tooltip title="Remove header">
+                <IconButton
+                  onClick={() => onChange(headers.filter((_, i) => i !== index))}
+                  aria-label={`Remove header ${header.key || index + 1}`}
+                  sx={{ width: 30, height: 30, color: 'text.secondary', '&:hover': { color: 'error.main' } }}
+                >
+                  <Trash2 size={18} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </FormSection>
+  )
+}

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -114,6 +114,40 @@ export const getFlatSelectOverrides = (isLight: boolean) => ({
   },
 })
 
+/**
+ * Opt back out of `getFlatSelectOverrides`.
+ *
+ * The flat look is right for selects that sit inline in toolbars and headers,
+ * but in a form a borderless select next to an outlined TextField reads as a
+ * broken field. Spread this into the `sx` of a form select to give it the same
+ * outline, height and focus ring as the TextFields around it. It has to repeat
+ * `!important` because the global rule uses it.
+ */
+export const getFormSelectSx = (isLight: boolean) => ({
+  '& .MuiOutlinedInput-root:has(> .MuiSelect-select)': {
+    borderRadius: '4px',
+    backgroundColor: 'transparent',
+    '&:hover, &.Mui-focused': {
+      backgroundColor: 'transparent',
+    },
+    '& > .MuiSelect-select': {
+      padding: '16.5px 32px 16.5px 14px',
+    },
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderWidth: '1px !important',
+      borderStyle: 'solid !important',
+      borderColor: isLight ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)',
+    },
+    '&:hover .MuiOutlinedInput-notchedOutline': {
+      borderColor: isLight ? 'rgba(0, 0, 0, 0.87)' : '#fff',
+    },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderWidth: '2px !important',
+      borderColor: 'primary.main',
+    },
+  },
+})
+
 export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const themeConfig = useThemeConfig()
   const api = useApi()


### PR DESCRIPTION
The edit dialog was a flat stack of 12 controls in a `maxWidth="sm"` box: no grouping, a disabled "Endpoint ID" field eating a full row, a stacked three-option radio group, and a "Provider icon" select whose label rendered on top of its own value.

## Layout

- `maxWidth="md"`, and the body is split into **Details / Connection / Availability / Custom headers**. `DialogContent dividers` keeps the title and actions pinned while the form scrolls.
- Endpoint ID moves into the title as monospace text with a copy button, beside the live provider mark (it updates as you change the icon). The disabled text field is gone.
- Fields pair two-up on wide screens; the authentication method is a row instead of a column.
- The custom-headers editor was duplicated verbatim between the create and edit dialogs — it is now `ProviderEndpointFormFields.tsx`, shared by both.

## Two rendering bugs found while testing

- **Provider icon label overlapped its value.** The empty value means "Automatic", so the label never shrank.
- **Selects in forms rendered borderless** next to outlined text fields. The theme applies `getFlatSelectOverrides` to *all* of `MuiOutlinedInput`/`MuiInput`/`MuiFilledInput`, which is right for the inline selects in toolbars and headers but reads as a broken field in a form. Added `getFormSelectSx` alongside it as the documented opt-out and used it for the form selects in both dialogs. No other select in the app changes.

## One real backend bug

`updateProviderEndpoint` decoded `types.UpdateProviderEndpoint` but never copied `Headers` onto the stored row. Custom headers could be set at create time and then **never edited or removed** — saving returned 200 and silently kept the old map. Fixed, with the three states made explicit: omitted keeps what is stored, a populated map replaces it, an empty map clears it. The edit dialog now always sends the map so clearing the last header is expressible.

## Testing

Driven against a live stack in a real browser (not a DOM harness):

- Opened the dialog in **light and dark**, on a real endpoint, as an admin.
- Exercised the API key / key file / none branches and the header rows.
- Created an endpoint with a custom header through the create dialog → persisted.
- Edited that header through the edit dialog → persisted (fails on `main`).
- Removed the last header → cleared to `{}` (fails on `main`).
- Deleted the throwaway endpoint; confirmed the pre-existing endpoint was untouched.

`TestUpdateProviderEndpoint_Headers` covers all three header states and fails without the handler fix. `yarn build` and `tsc --noEmit` are clean; the dashboard vitest suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
