### PR TITLE
Allow project MCPs for app-less sessions

### DIFF
--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -277,16 +277,6 @@ func (b *ExternalMCPBackend) getOrCreateServerOnce(ctx context.Context, user *ty
 		return nil, fmt.Errorf("forbidden: user does not own session")
 	}
 
-	// Get the app (agent) to find configured MCPs
-	if session.ParentApp == "" {
-		return nil, fmt.Errorf("session has no associated agent")
-	}
-
-	app, err := b.store.GetApp(ctx, session.ParentApp)
-	if err != nil {
-		return nil, fmt.Errorf("agent not found: %w", err)
-	}
-
 	var projectSkills *types.AssistantSkills
 	if session.ProjectID != "" {
 		project, err := b.store.GetProject(ctx, session.ProjectID)
@@ -296,8 +286,14 @@ func (b *ExternalMCPBackend) getOrCreateServerOnce(ctx context.Context, user *ty
 		projectSkills = project.Skills
 	}
 
-	// Find the MCP configuration by name
-	mcpConfig := b.findMCPConfig(app, projectSkills, mcpName)
+	mcpConfig := b.findMCPConfig(nil, projectSkills, mcpName)
+	if mcpConfig == nil && session.ParentApp != "" {
+		app, err := b.store.GetApp(ctx, session.ParentApp)
+		if err != nil {
+			return nil, fmt.Errorf("agent not found: %w", err)
+		}
+		mcpConfig = b.findMCPConfig(app, nil, mcpName)
+	}
 	if mcpConfig == nil {
 		return nil, fmt.Errorf("MCP server '%s' not configured for this agent", mcpName)
 	}
@@ -411,7 +407,7 @@ func (b *ExternalMCPBackend) findMCPConfig(app *types.App, projectSkills *types.
 		}
 	}
 
-	if app.Config.Helix.Assistants == nil {
+	if app == nil || app.Config.Helix.Assistants == nil {
 		return nil
 	}
 

--- a/api/pkg/server/mcp_backend_external_test.go
+++ b/api/pkg/server/mcp_backend_external_test.go
@@ -13,35 +13,27 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-func TestExternalMCPBackendUsesProjectMCPOverride(t *testing.T) {
+func TestExternalMCPBackendUsesProjectMCPBeforeStaleParentApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
 	mockGetter := mcpclient.NewMockClientGetter(ctrl)
 	mockClient := mcpclient.NewMockClient(ctrl)
 
 	const (
-		sessionID = "ses_project_mcp"
-		userID    = "usr_project_mcp"
-		appID     = "app_project_mcp"
-		projectID = "prj_project_mcp"
+		sessionID  = "ses_project_mcp"
+		userID     = "usr_project_mcp"
+		staleAppID = "app_missing"
+		projectID  = "prj_project_mcp"
 	)
-	appMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://app.example/mcp"}
 	projectMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://project.example/mcp"}
-	app := &types.App{
-		ID: appID,
-		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
-			MCPs: []types.AssistantMCP{appMCP},
-		}}}},
-	}
 	project := &types.Project{
 		ID:     projectID,
 		Skills: &types.AssistantSkills{MCPs: []types.AssistantMCP{projectMCP}},
 	}
 
 	mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(&types.Session{
-		ID: sessionID, Owner: userID, ParentApp: appID, ProjectID: projectID,
+		ID: sessionID, Owner: userID, ParentApp: staleAppID, ProjectID: projectID,
 	}, nil)
-	mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(app, nil)
 	mockStore.EXPECT().GetProject(gomock.Any(), projectID).Return(project, nil)
 	mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&projectMCP)).Return(mockClient, nil)
 	mockClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil)
@@ -52,6 +44,75 @@ func TestExternalMCPBackendUsesProjectMCPOverride(t *testing.T) {
 
 	if _, err := backend.getOrCreateServer(context.Background(), &types.User{ID: userID}, sessionID, "helixos"); err != nil {
 		t.Fatalf("get project MCP proxy: %v", err)
+	}
+}
+
+func TestExternalMCPBackendFallsBackToAppWhenProjectHasNoMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockGetter := mcpclient.NewMockClientGetter(ctrl)
+	mockClient := mcpclient.NewMockClient(ctrl)
+
+	const (
+		sessionID = "ses_app_fallback_mcp"
+		userID    = "usr_app_fallback_mcp"
+		appID     = "app_fallback_mcp"
+		projectID = "prj_app_fallback_mcp"
+	)
+	projectMCP := types.AssistantMCP{Name: "Other", URL: "https://project.example/other"}
+	appMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://app.example/mcp"}
+	app := &types.App{
+		ID: appID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			MCPs: []types.AssistantMCP{appMCP},
+		}}}},
+	}
+	mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(&types.Session{
+		ID: sessionID, Owner: userID, ParentApp: appID, ProjectID: projectID,
+	}, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), projectID).Return(&types.Project{
+		ID: projectID, Skills: &types.AssistantSkills{MCPs: []types.AssistantMCP{projectMCP}},
+	}, nil)
+	mockStore.EXPECT().GetApp(gomock.Any(), appID).Return(app, nil)
+	mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&appMCP)).Return(mockClient, nil)
+	mockClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil)
+
+	backend := NewExternalMCPBackend(mockStore)
+	backend.clientGetter = mockGetter
+	defer backend.Stop()
+
+	if _, err := backend.getOrCreateServer(context.Background(), &types.User{ID: userID}, sessionID, "helixos"); err != nil {
+		t.Fatalf("get App MCP fallback: %v", err)
+	}
+}
+
+func TestExternalMCPBackendUsesProjectMCPWithoutParentApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockGetter := mcpclient.NewMockClientGetter(ctrl)
+	mockClient := mcpclient.NewMockClient(ctrl)
+
+	const (
+		sessionID = "ses_project_only_mcp"
+		userID    = "usr_project_only_mcp"
+		projectID = "prj_project_only_mcp"
+	)
+	projectMCP := types.AssistantMCP{Name: "HelixOS", URL: "https://project.example/mcp"}
+	mockStore.EXPECT().GetSession(gomock.Any(), sessionID).Return(&types.Session{
+		ID: sessionID, Owner: userID, ParentApp: "", ProjectID: projectID,
+	}, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), projectID).Return(&types.Project{
+		ID: projectID, Skills: &types.AssistantSkills{MCPs: []types.AssistantMCP{projectMCP}},
+	}, nil)
+	mockGetter.EXPECT().NewClient(gomock.Any(), gomock.Any(), nil, gomock.Eq(&projectMCP)).Return(mockClient, nil)
+	mockClient.EXPECT().ListTools(gomock.Any(), gomock.Any()).Return(&mcp.ListToolsResult{}, nil)
+
+	backend := NewExternalMCPBackend(mockStore)
+	backend.clientGetter = mockGetter
+	defer backend.Stop()
+
+	if _, err := backend.getOrCreateServer(context.Background(), &types.User{ID: userID}, sessionID, "helixos"); err != nil {
+		t.Fatalf("get project MCP proxy without parent App: %v", err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- resolve project MCPs without requiring a ParentApp
- preserve project-over-App precedence and App fallback behavior
- prevent stale Apps from breaking project-owned MCPs

Customer impact:
- restores the HelixOS MCP and its outreach, persistence, escalation, and Slack tools for SpecTask harness sessions

Tests:
- go test ./pkg/server -count=1
- git diff --check