### PR TITLE
fix(tasks): allow Open PR when the sandbox is gone but commits landed

### DIFF
--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -110,13 +110,17 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Reject approval if the agent has not pushed any commits to the feature
-	// branch. Without this guard, approve-implementation would open an empty PR
-	// (external repos) or merge a zero-commit diff (internal repos). The UI
-	// disables the button in this state; this check is the defense-in-depth
-	// for direct API callers.
-	if specTask.LastPushAt == nil {
-		http.Error(w, "Agent has not pushed any commits yet", http.StatusConflict)
+	// Approval publishes the branch from two independent sources: the control
+	// plane pushes whatever already reached its copy of the repo, and — when the
+	// sandbox is live — the agent is instructed to commit and push anything still
+	// local to its working copy. Either one is enough to produce a non-empty PR,
+	// so only refuse when neither exists: nothing pushed and no sandbox to push
+	// from. Without this, approve-implementation would open an empty PR (external
+	// repos) or merge a zero-commit diff (internal repos).
+	s.populateSessionState(ctx, []*types.SpecTask{specTask})
+	sandboxLive := specTask.SandboxState == "running"
+	if specTask.LastPushAt == nil && !sandboxLive {
+		http.Error(w, "Agent has not pushed any commits and its sandbox is not running", http.StatusConflict)
 		return
 	}
 
@@ -186,64 +190,8 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 			}
 		}()
 
-		// Gather non-primary repo names so the push instruction tells the agent
-		// to push all repos, not just the primary one
-		var nonPrimaryRepoNames []string
-		projectRepos, repoErr := s.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
-			ProjectID: specTask.ProjectID,
-		})
-		if repoErr == nil {
-			for _, r := range projectRepos {
-				// Internal repos belong here too. Filtering on ExternalURL used to
-				// drop them, which directly contradicted the merge path:
-				// ensurePullRequestsForAllRepos fast-forwards exactly these
-				// non-primary internal repos, so it waits for a branch the agent
-				// was never told to push. In a project whose only internal repo is
-				// the shared playbook repo, that made contributing to it
-				// impossible — the agent never heard the repo named.
-				if r.Name != repo.Name {
-					nonPrimaryRepoNames = append(nonPrimaryRepoNames, r.Name)
-				}
-			}
-		}
-
 		// Send message to agent to commit and push any remaining uncommitted changes
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
-
-			message, err := prompts.ImplementationApprovedPushInstruction(
-				specTask.BranchName,
-				repo.Name,
-				repo.DefaultBranch,
-				services.GetTaskDirName(specTask),
-				nonPrimaryRepoNames,
-			)
-			if err != nil {
-				log.Error().
-					Err(err).
-					Str("task_id", specTask.ID).
-					Str("planning_session_id", specTask.PlanningSessionID).
-					Msg("Failed to generate push instruction for agent")
-				return
-			}
-
-			// interrupt=false: post-merge push instruction is a system-driven follow-up, not
-			// reactive feedback — enqueue it to defer behind any in-flight agent turn.
-			err = s.enqueueSpecTaskAgentMessage(context.Background(), specTask, message, false, "")
-			if err != nil {
-				log.Error().
-					Err(err).
-					Str("task_id", specTask.ID).
-					Str("planning_session_id", specTask.PlanningSessionID).
-					Msg("Failed to send push instruction to agent via WebSocket")
-			} else {
-				log.Info().
-					Str("task_id", specTask.ID).
-					Str("branch_name", specTask.BranchName).
-					Msg("Implementation approved - sent push instruction to agent via WebSocket")
-			}
-		}()
+		s.sendImplementationPushInstruction(ctx, specTask, repo)
 
 		// Re-fetch to get the latest RepoPullRequests (may have been set by concurrent push)
 		updatedTask, err := s.Store.GetSpecTask(ctx, specTaskID)
@@ -258,6 +206,29 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 
 	// Internal repo or external repo with no PRs automation implemented
 	// Server-side merge: agent can't push to main due to branch restrictions
+
+	// Nothing has reached the server yet, and the gate above guarantees a live
+	// sandbox in this state — the work is still sitting in the agent's working
+	// copy, committed or not. There is no branch to fast-forward, so instruct the
+	// agent to commit and push and let the push hook complete the merge.
+	// RebaseRequestedAt is the existing "this approval is waiting on the agent's
+	// next push" marker that tryAutoMergeAfterRebase keys off, so the merge
+	// happens automatically when the push lands — no second click.
+	if specTask.LastPushAt == nil {
+		specTask.Status = types.TaskStatusImplementationReview
+		specTask.StatusUpdatedAt = &now
+		specTask.RebaseRequestedAt = &now
+		specTask.ImplementationApprovedBy = user.ID
+		if err := s.Store.UpdateSpecTask(ctx, specTask); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to update spec task: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		s.sendImplementationPushInstruction(ctx, specTask, repo)
+
+		writeResponse(w, specTask, http.StatusOK)
+		return
+	}
 
 	// For external repos, acquire lock and sync before merge.
 	// The lock serializes git operations to prevent race conditions.
@@ -415,6 +386,70 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 
 	// Return updated task
 	writeResponse(w, specTask, http.StatusOK)
+}
+
+// sendImplementationPushInstruction asks the agent, in the background, to write
+// the PR metadata and commit + push every repo it touched. Both approval paths
+// use it: the PR path sends it so late uncommitted work still reaches the PR,
+// and the server-side-merge path sends it when the agent has pushed nothing yet.
+func (s *HelixAPIServer) sendImplementationPushInstruction(ctx context.Context, specTask *types.SpecTask, repo *types.GitRepository) {
+	// Gather non-primary repo names so the push instruction tells the agent
+	// to push all repos, not just the primary one
+	var nonPrimaryRepoNames []string
+	projectRepos, repoErr := s.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
+		ProjectID: specTask.ProjectID,
+	})
+	if repoErr == nil {
+		for _, r := range projectRepos {
+			// Internal repos belong here too. Filtering on ExternalURL used to
+			// drop them, which directly contradicted the merge path:
+			// ensurePullRequestsForAllRepos fast-forwards exactly these
+			// non-primary internal repos, so it waits for a branch the agent
+			// was never told to push. In a project whose only internal repo is
+			// the shared playbook repo, that made contributing to it
+			// impossible — the agent never heard the repo named.
+			if r.Name != repo.Name {
+				nonPrimaryRepoNames = append(nonPrimaryRepoNames, r.Name)
+			}
+		}
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		message, err := prompts.ImplementationApprovedPushInstruction(
+			specTask.BranchName,
+			repo.Name,
+			repo.DefaultBranch,
+			services.GetTaskDirName(specTask),
+			nonPrimaryRepoNames,
+		)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("task_id", specTask.ID).
+				Str("planning_session_id", specTask.PlanningSessionID).
+				Msg("Failed to generate push instruction for agent")
+			return
+		}
+
+		// interrupt=false: the push instruction is a system-driven follow-up, not
+		// reactive feedback — enqueue it to defer behind any in-flight agent turn.
+		err = s.enqueueSpecTaskAgentMessage(context.Background(), specTask, message, false, "")
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("task_id", specTask.ID).
+				Str("planning_session_id", specTask.PlanningSessionID).
+				Msg("Failed to send push instruction to agent via WebSocket")
+		} else {
+			log.Info().
+				Str("task_id", specTask.ID).
+				Str("branch_name", specTask.BranchName).
+				Msg("Implementation approved - sent push instruction to agent via WebSocket")
+		}
+	}()
 }
 
 // isRebasePending reports whether the agent has already been asked to rebase

--- a/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
@@ -59,32 +59,56 @@ describe.each(["inline", "stacked"] as const)(
       expect(openPRButton()).toBeEnabled();
     });
 
-    // Approving an implementation tells the agent to push its branch from
-    // inside the sandbox. The sandbox owns the working copy and may not even be
-    // on a filesystem the control plane can reach, so with the sandbox stopped
-    // there is nothing to push from.
-    it("disables Open PR once the sandbox has stopped", () => {
+    // The commits already reached the control plane's copy of the repo, so it
+    // can push them to the remote and open the PR without the sandbox. This is
+    // the common "agent finished, container was reaped" case.
+    it("enables Open PR once the sandbox has stopped, if the agent pushed", () => {
       renderButtons(implementationTask({ sandbox_state: "absent" }));
+
+      expect(openPRButton()).toBeEnabled();
+    });
+
+    // Nothing has reached the server, but a live agent can still be told to
+    // commit and push before the PR opens.
+    it("enables Open PR before the first push while the sandbox is live", () => {
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: "running" }),
+      );
+
+      expect(openPRButton()).toBeEnabled();
+    });
+
+    // Neither source of commits exists: nothing pushed, and no agent to push.
+    it("disables Open PR when nothing was pushed and the sandbox is gone", () => {
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: "absent" }),
+      );
 
       expect(openPRButton()).toBeDisabled();
     });
 
     // "starting" means the container exists but the agent has not connected
-    // yet, so it cannot receive the push instruction either.
-    it("disables Open PR while the sandbox is still starting", () => {
-      renderButtons(implementationTask({ sandbox_state: "starting" }));
+    // yet, so it cannot receive the commit-and-push instruction.
+    it("disables Open PR before the first push while the sandbox is starting", () => {
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: "starting" }),
+      );
 
       expect(openPRButton()).toBeDisabled();
     });
 
-    it("disables Open PR when the task never had a sandbox", () => {
-      renderButtons(implementationTask({ sandbox_state: undefined }));
+    it("disables Open PR when the task never had a sandbox or a push", () => {
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: undefined }),
+      );
 
       expect(openPRButton()).toBeDisabled();
     });
 
     it("explains why Open PR is unavailable", async () => {
-      renderButtons(implementationTask({ sandbox_state: "absent" }));
+      renderButtons(
+        implementationTask({ last_push_at: undefined, sandbox_state: "absent" }),
+      );
 
       // MUI renders the tooltip text into the trigger's aria description via
       // the title attribute on the wrapping span until hover; assert on the
@@ -92,14 +116,6 @@ describe.each(["inline", "stacked"] as const)(
       expect(
         await screen.findByLabelText(SANDBOX_STOPPED_TOOLTIP, { exact: false }),
       ).toBeInTheDocument();
-    });
-
-    it("still blocks Open PR before the agent has pushed", () => {
-      renderButtons(
-        implementationTask({ last_push_at: undefined, sandbox_state: "running" }),
-      );
-
-      expect(openPRButton()).toBeDisabled();
     });
   },
 );

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -192,7 +192,7 @@ interface SpecTaskActionButtonsProps {
 }
 
 export const SANDBOX_STOPPED_TOOLTIP =
-  "Sandbox is stopped. The agent pushes its branch from inside the sandbox — start it to open a PR.";
+  "Nothing has been pushed yet and the sandbox is stopped, so there is nothing to open a PR from. Start the sandbox so the agent can commit and push.";
 
 const COMPACT_BUTTON_METRICS: Record<
   ToolbarDensity,
@@ -405,18 +405,41 @@ export default function SpecTaskActionButtons({
     (!task.last_push_at ||
       new Date(task.last_push_at).getTime() <= new Date(task.rebase_requested_at).getTime());
 
-  // Approving an implementation instructs the agent to push its branch from
-  // inside the sandbox before the PR is opened. The sandbox owns the working
-  // copy — it is not necessarily on a filesystem the control plane can reach —
-  // so with a stopped sandbox there is nothing to push from and the approval
-  // silently produces a PR against whatever was last pushed, or none at all.
-  // Gate the action until the sandbox is back.
-  //
-  // Only "running" enables it: "starting" means the container exists but the
-  // agent has not connected yet and cannot receive the push instruction.
-  // sandbox_state is absent on tasks that never had a session, which likewise
-  // cannot push.
+  // Only "running" counts as a live sandbox: "starting" means the container
+  // exists but the agent has not connected yet and cannot receive the
+  // commit-and-push instruction. sandbox_state is absent on tasks that never
+  // had a session, which likewise cannot push.
   const sandboxStopped = task.sandbox_state !== "running";
+
+  // Approving publishes the branch from two independent sources: the control
+  // plane pushes whatever already reached its copy of the repo, and (when the
+  // sandbox is live) the agent is told to commit and push anything still local
+  // to the working copy. Either one is enough, so block only when the agent has
+  // pushed nothing AND its sandbox is gone — that is the one state where there
+  // is no work to publish from anywhere.
+  const nothingToPublish = !hasPushed && sandboxStopped;
+
+  const openPRTooltip = isArchived
+    ? "Task is archived"
+    : nothingToPublish
+      ? SANDBOX_STOPPED_TOOLTIP
+      : rebasePending
+        ? hasPushed
+          ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
+          : "Agent is committing and pushing — this will complete automatically."
+        : !hasPushed
+          ? "The agent will commit and push its changes before the PR is opened."
+          : "";
+
+  const openPRDisabled =
+    isArchived ||
+    approveImplementationMutation.isPending ||
+    rebasePending ||
+    nothingToPublish;
+
+  // While the approval is waiting on the agent's next push, say which of the two
+  // things it was asked for: a rebase (branch diverged) or the first push.
+  const pendingPushLabel = hasPushed ? "Rebasing..." : "Pushing...";
 
   // Button size based on variant
   const buttonSize = "small";
@@ -729,20 +752,10 @@ export default function SpecTaskActionButtons({
           />
           <CompactActionButton
             density={density}
-            tooltip={
-              isArchived
-                ? "Task is archived"
-                : sandboxStopped
-                  ? SANDBOX_STOPPED_TOOLTIP
-                  : rebasePending
-                    ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
-                    : !hasPushed
-                      ? "Waiting for agent to push code..."
-                      : ""
-            }
+            tooltip={openPRTooltip}
             variant="contained"
             color="success"
-            disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending || sandboxStopped}
+            disabled={openPRDisabled}
             icon={
               approveImplementationMutation.isPending || rebasePending ? (
                 <CircularProgress size={16} color="inherit" />
@@ -756,7 +769,7 @@ export default function SpecTaskActionButtons({
                   ? "Merging..."
                   : "Opening PR..."
                 : rebasePending
-                  ? "Rebasing..."
+                  ? pendingPushLabel
                   : isDirectPush
                     ? "Accept"
                     : "Open PR"
@@ -818,20 +831,7 @@ export default function SpecTaskActionButtons({
             </span>
           </Tooltip>
 
-          <Tooltip
-            title={
-              isArchived
-                ? "Task is archived"
-                : sandboxStopped
-                  ? SANDBOX_STOPPED_TOOLTIP
-                  : rebasePending
-                    ? "Branch has diverged. Agent is rebasing — merge will complete automatically."
-                    : !hasPushed
-                      ? "Waiting for agent to push code..."
-                      : ""
-            }
-            placement="top"
-          >
+          <Tooltip title={openPRTooltip} placement="top">
             <span style={{ flex: 1 }}>
               <Button
                 size={buttonSize}
@@ -845,7 +845,7 @@ export default function SpecTaskActionButtons({
                   )
                 }
                 onClick={handleOpenPR}
-                disabled={isArchived || approveImplementationMutation.isPending || !hasPushed || rebasePending || sandboxStopped}
+                disabled={openPRDisabled}
                 fullWidth
                 sx={buttonSx}
               >
@@ -854,7 +854,7 @@ export default function SpecTaskActionButtons({
                     ? "Merging..."
                     : "Opening PR..."
                   : rebasePending
-                    ? "Rebasing..."
+                    ? pendingPushLabel
                     : isDirectPush
                       ? "Accept"
                       : "Open PR"}


### PR DESCRIPTION
## Problem

A spec task started from chat finished its work and pushed the branch to Helix's copy of the repo, but nothing reached GitHub. The changes view rendered the full diff (8 files, +624/-48) while **Open PR was permanently disabled** — there was no way to publish the work.

The button was gated on `sandbox_state === "running"`, on the assumption that only the agent, from inside its sandbox, can publish the branch. That is not how it works: `ensurePullRequestForRepo` pushes to the external remote **from the control plane's own copy of the repo**, using the acting user's OAuth token. So once the container was reaped, a task whose commits had already landed server-side was stuck with a visible diff and a dead button.

## Fix

Gate on the actual precondition — block only when the agent has pushed nothing **and** no sandbox is live, i.e. there is no work to publish from anywhere:

| pushed | sandbox | before | after |
|---|---|---|---|
| yes | running | enabled | enabled |
| yes | gone | **disabled** | **enabled** — control plane pushes to the remote and opens the PR |
| no | running | **disabled** | **enabled** — agent is told to commit and push first |
| no | gone | disabled | disabled (tooltip explains why) |

### Backend (`spec_task_workflow_handlers.go`)

- The mirroring `409 "Agent has not pushed any commits yet"` guard is relaxed the same way, deriving sandbox liveness via `populateSessionState`.
- PR path: unchanged. Eager PR creation plus the existing commit-and-push instruction. With nothing pushed yet, eager creation is a no-op (`ensurePullRequestForRepo` already returns early on a missing / zero-commit branch) and the push hook opens the PR when the agent's push lands.
- Server-side-merge path: an approval with nothing pushed has no branch to fast-forward. It now sends the commit-and-push instruction — previously it fell through to the merge, failed, and told the agent to **rebase**, which is the wrong instruction — and stamps `RebaseRequestedAt`, the existing "waiting on the agent's next push" marker that `tryAutoMergeAfterRebase` keys off, so the merge completes automatically with no second click.
- The duplicated push-instruction block is extracted to `sendImplementationPushInstruction`, shared by both paths.

### Frontend (`SpecTaskActionButtons.tsx`)

- `nothingToPublish = !hasPushed && sandboxStopped` replaces the `!hasPushed || sandboxStopped` disable condition; tooltip and label logic hoisted so the inline and stacked variants cannot drift.
- While an approval waits on the agent's next push the label distinguishes the two cases: "Rebasing…" (branch diverged) vs "Pushing…" (nothing pushed yet).

## Testing

- `go build ./pkg/server/` clean; Air hot-reloaded it in the dev stack.
- `yarn build` clean.
- `SpecTaskActionButtons.test.tsx` gating tests rewritten for the new truth table (14 pass); 81 tests across `components/tasks` green.
- **Not tested end-to-end:** the approve click itself was not fired — doing so would open a real PR on a third-party repo from the live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
