### PR TITLE
fix(external-agent): evict phantom session entries so resume can restart a stopped sandbox

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -185,21 +185,37 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		return nil, err
 	}
 
-	// Check if session already exists and is running
-	h.mutex.RLock()
-	existingSession, exists := h.sessions[agent.SessionID]
-	h.mutex.RUnlock()
+	// Check if session already exists and is genuinely running.
+	//
+	// The in-memory map is NOT trustworthy on its own here. A phantom entry —
+	// one whose container is long gone — turns this early return into a silent
+	// no-op: resume answers 200 with an empty DevContainerID, the UI reports
+	// "Desktop started", and no container is ever created. HasRunningContainer
+	// probes hydra for the authoritative status and evicts the entry when the
+	// container is gone, so a phantom degrades into a real (re)create rather
+	// than a lie. It falls back to the map's own status when there is no
+	// connection manager, preserving the previous behaviour offline.
+	if h.HasRunningContainer(ctx, agent.SessionID) {
+		h.mutex.RLock()
+		existingSession := h.sessions[agent.SessionID]
+		h.mutex.RUnlock()
 
-	if exists && existingSession.Status == "running" {
 		log.Info().
 			Str("session_id", agent.SessionID).
 			Msg("Dev container already running, returning existing session")
-		return &types.DesktopAgentResponse{
+		resp := &types.DesktopAgentResponse{
 			SessionID:     agent.SessionID,
 			ScreenshotURL: fmt.Sprintf("/api/v1/sessions/%s/screenshot", agent.SessionID),
 			StreamURL:     fmt.Sprintf("/api/v1/sessions/%s/stream", agent.SessionID),
 			Status:        "running",
-		}, nil
+		}
+		// Report the container we are reusing. Callers persist this onto the
+		// session and log it; leaving it empty made a reused container
+		// indistinguishable from the phantom no-op in the logs.
+		if existingSession != nil {
+			resp.DevContainerID = existingSession.ContainerID
+		}
+		return resp, nil
 	}
 
 	// Inject project secrets onto agent.Env so every fresh container picks up
@@ -1956,16 +1972,28 @@ type devContainerProber interface {
 	GetDevContainer(ctx context.Context, sessionID string) (*hydra.DevContainerResponse, error)
 }
 
-// markMissingSessionsStopped downgrades sessions on the given sandbox that this
-// control-plane still marks "running" but that are absent from hydra's live set
-// (liveSessionIDs — containers Docker currently reports as running). For each
+// markMissingSessionsStopped reconciles sessions on the given sandbox that this
+// control-plane still believes are running but that are absent from hydra's live
+// set (liveSessionIDs — containers Docker currently reports as running). For each
 // candidate it authoritatively confirms the container is not running with a
 // per-session GetDevContainer probe — taken under the session's creation lock so
 // a concurrent StartDesktop that (re)created the container after hydra's snapshot
-// can't be wrongly torn down. Confirmed-dead sessions have their container
-// metadata cleared, status set to "stopped", and their stale in-memory entry
-// evicted, so the derived SandboxState becomes "absent" instead of showing a dead
-// container as running.
+// can't be wrongly torn down. Confirmed-dead sessions have their stale in-memory
+// entry evicted and, when the DB row still claims to be running, their container
+// metadata cleared and status set to "stopped", so the derived SandboxState
+// becomes "absent" instead of showing a dead container as running.
+//
+// "Believes it is running" deliberately spans BOTH sources of truth, because
+// they can disagree. StopDesktop evicts the in-memory entry and the caller writes
+// a terminal DB status, but a discovery sweep racing that stop re-adds the entry
+// (the container is still in hydra's snapshot for the few seconds Docker takes to
+// stop it) while the terminal DB write lands last. The session is then "stopped"
+// or "terminated_idle" in the DB and "running" in the map — and each half hides
+// the other: a DB-only candidate scan skips the session every sweep, so the
+// phantom entry is never evicted, while StartDesktop keeps short-circuiting on
+// that entry and refuses to create a container. Resume answers 200 and does
+// nothing, permanently, until the process restarts. Walking the in-memory map as
+// well as the DB is what makes that state reachable and self-healing.
 func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxID string, liveSessionIDs map[string]bool, prober devContainerProber) {
 	// Unlike the active_sandboxes counter (a multi-tenant autoscaler concern that
 	// skips "local"), session-status reconciliation applies to every sandbox
@@ -1981,55 +2009,67 @@ func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxI
 		return
 	}
 
-	for _, session := range sessions {
-		if liveSessionIDs[session.ID] {
-			continue // hydra confirms this container is alive
-		}
-		// Only downgrade sessions we believe are actively running with a
-		// container. Skip "starting" (StartDesktop may be mid-flight and not yet
-		// visible to hydra) and already-terminal states.
-		if session.Metadata.ExternalAgentStatus != "running" || session.Metadata.ContainerName == "" {
-			continue
-		}
+	candidates := h.staleReconcileCandidates(sessions, sandboxID, liveSessionIDs)
 
+	for _, sessionID := range candidates {
 		// Serialize against StartDesktop for this session before making a
-		// decision, so the probe + downgrade is atomic wrt a concurrent start.
+		// decision, so the probe + remediation is atomic wrt a concurrent start.
 		h.creationLocksMutex.Lock()
-		sessionLock, exists := h.creationLocks[session.ID]
+		sessionLock, exists := h.creationLocks[sessionID]
 		if !exists {
 			sessionLock = &sync.Mutex{}
-			h.creationLocks[session.ID] = sessionLock
+			h.creationLocks[sessionID] = sessionLock
 		}
 		h.creationLocksMutex.Unlock()
 
 		sessionLock.Lock()
 
 		// Re-read under the lock: StartDesktop may have just (re)created it.
-		current, err := h.store.GetSession(ctx, session.ID)
+		current, err := h.store.GetSession(ctx, sessionID)
 		if err != nil {
 			sessionLock.Unlock()
 			continue
 		}
-		if current.Metadata.ExternalAgentStatus != "running" || current.Metadata.ContainerName == "" {
-			sessionLock.Unlock()
-			continue
-		}
 
-		// Authoritatively confirm the container is not running before
-		// downgrading. hydra's list snapshot may pre-date a just-started
-		// container, so a direct live probe is the source of truth for the
-		// decision.
+		// Authoritatively confirm the container is not running before acting.
+		// hydra's list snapshot may pre-date a just-started container, so a
+		// direct live probe is the source of truth for the decision.
 		//
 		// The probe must check the reported status, not merely that the call
 		// succeeded: GetDevContainer returns a container hydra still tracks even
 		// when Docker reports it exited, so an `err == nil` check here treated a
 		// dead container as alive and skipped the downgrade forever.
 		if prober != nil {
-			if container, err := prober.GetDevContainer(ctx, session.ID); err == nil &&
+			if container, err := prober.GetDevContainer(ctx, sessionID); err == nil &&
 				container != nil && container.Status == hydra.DevContainerStatusRunning {
 				sessionLock.Unlock()
 				continue // container really is running; snapshot was just stale
 			}
+		}
+
+		// Evict the stale in-memory entry so GetSession/HasRunningContainer and
+		// StartDesktop agree with the probe. Unconditional: a phantom entry has
+		// to go even when the DB row is already terminal and needs no downgrade,
+		// because the entry on its own is enough to make StartDesktop refuse to
+		// create a container.
+		h.mutex.Lock()
+		_, wasTracked := h.sessions[sessionID]
+		delete(h.sessions, sessionID)
+		h.mutex.Unlock()
+
+		// The DB downgrade applies only to rows that still claim to be running.
+		// A terminal row is already correct, and rewriting "terminated_idle" to
+		// "stopped" would lose why the desktop went away.
+		if current.Metadata.ExternalAgentStatus != "running" || current.Metadata.ContainerName == "" {
+			if wasTracked {
+				log.Info().
+					Str("session_id", sessionID).
+					Str("sandbox_id", sandboxID).
+					Str("db_status", current.Metadata.ExternalAgentStatus).
+					Msg("Evicted phantom in-memory session whose container is not running")
+			}
+			sessionLock.Unlock()
+			continue
 		}
 
 		current.Metadata.ContainerName = ""
@@ -2040,35 +2080,80 @@ func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxI
 
 		if _, err := h.store.UpdateSession(ctx, *current); err != nil {
 			log.Warn().Err(err).
-				Str("session_id", session.ID).
+				Str("session_id", sessionID).
 				Str("sandbox_id", sandboxID).
 				Msg("Failed to mark stale dev container session stopped during discovery")
 			sessionLock.Unlock()
 			continue
 		}
 
-		// Evict the stale in-memory entry so GetSession/HasRunningContainer agree.
-		h.mutex.Lock()
-		delete(h.sessions, session.ID)
-		h.mutex.Unlock()
-
 		// Close the billing row too. Without this, a container destroyed
 		// outside StopDesktop (host redeploy, OOM kill, manual docker rm)
 		// leaves a row in `running` and the reaper keeps charging the org
 		// every minute for a container that no longer exists.
 		if h.sandboxMeter != nil {
-			if err := h.sandboxMeter.MarkSessionStopped(ctx, session.ID); err != nil {
-				log.Warn().Err(err).Str("session_id", session.ID).Msg("Failed to close sandbox billing row for stale container")
+			if err := h.sandboxMeter.MarkSessionStopped(ctx, sessionID); err != nil {
+				log.Warn().Err(err).Str("session_id", sessionID).Msg("Failed to close sandbox billing row for stale container")
 			}
 		}
 
 		log.Info().
-			Str("session_id", session.ID).
+			Str("session_id", sessionID).
 			Str("sandbox_id", sandboxID).
 			Msg("Marked stale dev container session stopped (not reported by hydra after reconnect)")
 
 		sessionLock.Unlock()
 	}
+}
+
+// staleReconcileCandidates returns the session ids on sandboxID that hydra does
+// not report as running but that one of the two state stores still believes is
+// running, deduplicated.
+//
+// The DB contributes only rows that claim to be running with a container:
+// "starting" is skipped because StartDesktop may be mid-flight and not yet
+// visible to hydra, terminal rows need no downgrade, and scanning every historic
+// session on the sandbox would mean a hydra probe per row.
+//
+// The in-memory map contributes every entry pinned to this sandbox. Those are
+// bounded by the number of live containers plus phantoms, so probing them is
+// cheap — and they are the only way to reach a session whose DB row already went
+// terminal while its map entry stayed "running".
+func (h *HydraExecutor) staleReconcileCandidates(sessions []*types.Session, sandboxID string, liveSessionIDs map[string]bool) []string {
+	candidates := make([]string, 0, len(sessions))
+	seen := make(map[string]bool, len(sessions))
+
+	add := func(sessionID string) {
+		if sessionID == "" || liveSessionIDs[sessionID] || seen[sessionID] {
+			return
+		}
+		seen[sessionID] = true
+		candidates = append(candidates, sessionID)
+	}
+
+	for _, session := range sessions {
+		if session.Metadata.ExternalAgentStatus != "running" || session.Metadata.ContainerName == "" {
+			continue
+		}
+		add(session.ID)
+	}
+
+	h.mutex.RLock()
+	for sessionID, tracked := range h.sessions {
+		// An unset SandboxID means the single-node "local" sandbox, matching the
+		// fallback StopDesktop and HasRunningContainer use when routing RevDial.
+		trackedSandboxID := tracked.SandboxID
+		if trackedSandboxID == "" {
+			trackedSandboxID = "local"
+		}
+		if trackedSandboxID != sandboxID {
+			continue
+		}
+		add(sessionID)
+	}
+	h.mutex.RUnlock()
+
+	return candidates
 }
 
 // ReconcileSandboxResources posts the DB-derived live-set to a connected

--- a/api/pkg/external-agent/reconcile_phantom_sessions_test.go
+++ b/api/pkg/external-agent/reconcile_phantom_sessions_test.go
@@ -1,0 +1,217 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/hydra"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// idleSession is a session the idle checker has already shut down: the DB row is
+// terminal, but (as in production) the container metadata was never cleared.
+func idleSession(id string) *types.Session {
+	session := runningSession(id)
+	session.Metadata.ExternalAgentStatus = "terminated_idle"
+	return session
+}
+
+// The production bug. StopDesktop evicts the in-memory entry and the idle
+// checker writes "terminated_idle", but a discovery sweep racing that stop
+// re-adds the entry as "running" and the terminal DB write lands last. The two
+// stores then permanently disagree, and each half used to hide the other: the
+// candidate scan read only the DB, saw a terminal row, and skipped the session
+// every sweep — so the phantom entry was never evicted — while StartDesktop
+// short-circuited on that same entry and refused to create a container. Resume
+// answered 200 with an empty DevContainerID and started nothing, forever.
+//
+// The phantom must be evicted even though the DB row needs no downgrade.
+func TestMarkMissingSessionsStopped_EvictsPhantomWithTerminalDBRow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	h.sessions["ses_phantom"] = &ZedSession{
+		SessionID:   "ses_phantom",
+		Status:      "running",
+		ContainerID: "cid-ses_phantom",
+		SandboxID:   "local",
+	}
+
+	// The DB row is terminal, so the DB contributes no candidate at all — the
+	// in-memory entry is the only reason this session gets looked at.
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "local").
+		Return([]*types.Session{idleSession("ses_phantom")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_phantom").
+		Return(idleSession("ses_phantom"), nil)
+
+	// Crucially NO UpdateSession: "terminated_idle" is already correct, and
+	// rewriting it to "stopped" would lose why the desktop went away.
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{}}
+
+	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, prober)
+
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_phantom"]
+	h.mutex.RUnlock()
+	assert.False(t, stillTracked, "phantom entry must be evicted so StartDesktop can recreate the container")
+	assert.Equal(t, []string{"ses_phantom"}, prober.calls, "the phantom must be probed before eviction")
+}
+
+// The safety counterpart: an in-memory entry that hydra's snapshot missed but
+// whose container the authoritative probe reports running must be left alone.
+// Evicting it would let a second container be created for a live session.
+func TestMarkMissingSessionsStopped_KeepsPhantomWhoseContainerIsAlive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	h.sessions["ses_alive"] = &ZedSession{
+		SessionID:   "ses_alive",
+		Status:      "running",
+		ContainerID: "cid-ses_alive",
+		SandboxID:   "local",
+	}
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "local").
+		Return([]*types.Session{idleSession("ses_alive")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_alive").
+		Return(idleSession("ses_alive"), nil)
+
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{
+		"ses_alive": {SessionID: "ses_alive", Status: hydra.DevContainerStatusRunning},
+	}}
+
+	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, prober)
+
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_alive"]
+	h.mutex.RUnlock()
+	assert.True(t, stillTracked, "a session whose container the probe reports running must survive")
+}
+
+// A sweep of one sandbox must not evict entries pinned to another. Each sandbox
+// reports only its own containers, so treating another sandbox's absence from
+// this snapshot as death would tear down healthy sessions.
+func TestMarkMissingSessionsStopped_IgnoresPhantomsOnOtherSandboxes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	h.sessions["ses_elsewhere"] = &ZedSession{
+		SessionID:   "ses_elsewhere",
+		Status:      "running",
+		ContainerID: "cid-ses_elsewhere",
+		SandboxID:   "sbox_2",
+	}
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{}, nil)
+
+	// No GetSession and no probe: the other sandbox's session is never a
+	// candidate for this sweep.
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{}}
+
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", map[string]bool{}, prober)
+
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_elsewhere"]
+	h.mutex.RUnlock()
+	assert.True(t, stillTracked, "sessions on other sandboxes must be untouched")
+	assert.Empty(t, prober.calls)
+}
+
+// A phantom whose DB row still claims to be running gets both remediations: the
+// map entry evicted AND the row downgraded. This is the pre-existing behaviour,
+// pinned so the candidate-set rework can't silently drop the DB downgrade.
+func TestMarkMissingSessionsStopped_PhantomWithRunningDBRowIsAlsoDowngraded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	h.sessions["ses_both"] = &ZedSession{
+		SessionID:   "ses_both",
+		Status:      "running",
+		ContainerID: "cid-ses_both",
+		SandboxID:   "local",
+	}
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "local").
+		Return([]*types.Session{runningSession("ses_both")}, nil)
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_both").
+		Return(runningSession("ses_both"), nil)
+
+	var downgraded *types.Session
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			downgraded = &s
+			return &s, nil
+		})
+
+	prober := &stubProber{containers: map[string]*hydra.DevContainerResponse{}}
+
+	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, prober)
+
+	require.NotNil(t, downgraded, "a DB row still claiming to run must be downgraded")
+	assert.Equal(t, "stopped", downgraded.Metadata.ExternalAgentStatus)
+	assert.Empty(t, downgraded.Metadata.ContainerName)
+
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_both"]
+	h.mutex.RUnlock()
+	assert.False(t, stillTracked)
+
+	// Probed exactly once — the session appears in both the DB scan and the
+	// in-memory scan and must not be reconciled twice.
+	assert.Equal(t, []string{"ses_both"}, prober.calls)
+}
+
+func TestStaleReconcileCandidates(t *testing.T) {
+	h := newTestExecutor(nil)
+	h.sessions["ses_phantom"] = &ZedSession{SessionID: "ses_phantom", SandboxID: "local"}
+	h.sessions["ses_dupe"] = &ZedSession{SessionID: "ses_dupe", SandboxID: "local"}
+	h.sessions["ses_live"] = &ZedSession{SessionID: "ses_live", SandboxID: "local"}
+	h.sessions["ses_other_sandbox"] = &ZedSession{SessionID: "ses_other_sandbox", SandboxID: "sbox_9"}
+	// An unset SandboxID means the single-node "local" sandbox.
+	h.sessions["ses_unset_sandbox"] = &ZedSession{SessionID: "ses_unset_sandbox"}
+
+	starting := runningSession("ses_starting")
+	starting.Metadata.ExternalAgentStatus = "starting"
+	noContainer := runningSession("ses_no_container")
+	noContainer.Metadata.ContainerName = ""
+
+	sessions := []*types.Session{
+		runningSession("ses_dupe"),    // in both sources — must appear once
+		runningSession("ses_db_only"), // DB-running, not tracked in memory
+		runningSession("ses_live"),    // hydra says alive — excluded
+		idleSession("ses_phantom"),    // terminal row; reachable only via the map
+		starting,                      // mid-flight start — never a candidate
+		noContainer,                   // running but no container name
+		idleSession("ses_long_gone"),  // terminal and untracked — nothing to do
+	}
+
+	candidates := h.staleReconcileCandidates(sessions, "local", map[string]bool{"ses_live": true})
+
+	assert.ElementsMatch(t, []string{
+		"ses_dupe",
+		"ses_db_only",
+		"ses_phantom",
+		"ses_unset_sandbox",
+	}, candidates)
+}

--- a/design/2026-08-18-phantom-session-map-entries.md
+++ b/design/2026-08-18-phantom-session-map-entries.md
@@ -1,0 +1,102 @@
+# Phantom in-memory session entries make "Start desktop" a silent no-op
+
+## Symptom
+
+A spec task whose sandbox had been idle-stopped could not be restarted. Clicking
+**Start** produced a success toast and nothing else — no container, no desktop,
+and the stream WebSocket retrying `no connection` forever.
+
+`POST /api/v1/sessions/{id}/resume` returned **HTTP 200**:
+
+```
+session_handlers.go:2327  Resuming external agent session
+hydra_executor.go:180     Starting dev container via Hydra
+hydra_executor.go:196     Dev container already running, returning existing session   <- false
+session_handlers.go:2364  External agent session resumed successfully  dev_container_id=
+```
+
+…while the sandbox had no such container at all:
+
+```
+$ docker exec helix-sandbox-nvidia-1 docker ps -a | grep ubuntu-external-<sid>
+(nothing)
+```
+
+The empty `dev_container_id` in the success line is the tell: that field is only
+unset on the early-return branch, which never touches a container.
+
+## How the state arises
+
+`HydraExecutor` keeps two records of whether a session is running: the
+`sessions` map in memory and `external_agent_status` on the session row. An
+idle shutdown racing a discovery sweep desynchronises them:
+
+| time | actor | effect |
+|---|---|---|
+| 22:06:56 | `idle_checker` → `StopDesktop` | takes the session lock, deletes the map entry, begins stopping the container (~5s) |
+| 22:07:01 | discovery sweep | container is still in hydra's snapshot; entry is untracked, so it is **re-added** to the map as `running` (`hydra_executor.go` "Recovered container from sandbox discovery") and the DB row is written back to `running` |
+| 22:07:01 | `idle_checker` (post-stop, outside the lock) | re-reads the session and writes `external_agent_status = "terminated_idle"` — landing **after** discovery's write |
+
+Final state: DB says `terminated_idle`, the map says `running`. The container is
+gone.
+
+## Why it never self-healed
+
+The two halves each prevented the other from being repaired:
+
+- **`StartDevContainer`** trusted `h.sessions[id].Status == "running"` with no
+  liveness check, so every resume short-circuited.
+- **`markMissingSessionsStopped`** — which owns the `delete(h.sessions, id)`
+  eviction — built its candidate list purely from the DB and skipped anything
+  not marked `running`:
+
+  ```go
+  if session.Metadata.ExternalAgentStatus != "running" || session.Metadata.ContainerName == "" {
+      continue
+  }
+  ```
+
+  The row said `terminated_idle`, so the session was skipped on every sweep and
+  the eviction line was unreachable.
+
+The session was therefore stuck until the API process restarted. `sandbox_state`
+correctly derived `absent`, so the UI kept offering a Start button that could
+never work.
+
+## Fix
+
+1. **`markMissingSessionsStopped` reconciles both stores.** The candidate set
+   (`staleReconcileCandidates`) is now the union of DB rows that claim to be
+   running and in-memory entries pinned to the sandbox. The DB side keeps its
+   `running` filter — scanning every historic row would mean a hydra probe per
+   row — while the map side is naturally bounded by live containers plus
+   phantoms.
+
+   The two remediations are decoupled. Map eviction is unconditional once the
+   probe confirms the container is dead, because the entry alone is enough to
+   block `StartDesktop`. The DB downgrade still only applies to rows that claim
+   to be running, so `terminated_idle` is not overwritten with `stopped` and the
+   reason the desktop went away is preserved.
+
+2. **`StartDevContainer` verifies before short-circuiting.** It now calls the
+   existing `HasRunningContainer`, which probes hydra and evicts a stale entry on
+   the spot, so a phantom degrades into a real create instead of a false success.
+   This makes resume correct immediately rather than only after the next
+   reconcile sweep. The early return also reports the reused `DevContainerID`,
+   so a genuine reuse is distinguishable from the no-op in the logs.
+
+The authoritative per-session `GetDevContainer` probe, taken under the session's
+creation lock, remains the guard against tearing down a container a concurrent
+`StartDesktop` just created.
+
+## Tests
+
+`api/pkg/external-agent/reconcile_phantom_sessions_test.go`:
+
+- phantom entry + terminal DB row → evicted, and `UpdateSession` is **not**
+  called (verified to fail before the fix)
+- phantom whose probe reports the container running → kept
+- phantom pinned to another sandbox → untouched by this sandbox's sweep
+- phantom + still-`running` DB row → both evicted and downgraded, probed once
+- `staleReconcileCandidates` dedup, `starting`/terminal filtering, and the
+  unset-`SandboxID`-means-`local` convention


### PR DESCRIPTION
## Symptom

A spec task whose sandbox had been idle-stopped could not be restarted. **Start** showed a success toast and did nothing — no container, and the stream WebSocket retrying `no connection` forever.

Reproduced live on a stuck task: `POST /api/v1/sessions/{id}/resume` returns **HTTP 200**…

```
session_handlers.go:2327  Resuming external agent session
hydra_executor.go:180     Starting dev container via Hydra
hydra_executor.go:196     Dev container already running, returning existing session   <- false
session_handlers.go:2364  External agent session resumed successfully  dev_container_id=
```

…while the sandbox has no such container:

```
$ docker exec helix-sandbox-nvidia-1 docker ps -a | grep ubuntu-external-<sid>
(nothing)
```

The empty `dev_container_id` is the tell — that field is only unset on the early-return branch, which never touches a container.

## Root cause

`HydraExecutor` keeps two records of liveness: the in-memory `sessions` map and `external_agent_status` on the session row. An idle shutdown racing a discovery sweep desynchronises them:

| time | actor | effect |
|---|---|---|
| 22:06:56 | `idle_checker` → `StopDesktop` | takes the session lock, deletes the map entry, begins stopping the container (~5s) |
| 22:07:01 | discovery sweep | container still in hydra's snapshot; entry is untracked, so it is **re-added** as `running` ("Recovered container from sandbox discovery") |
| 22:07:01 | `idle_checker`, post-stop and outside the lock | writes `external_agent_status = "terminated_idle"` — landing **after** discovery's write |

DB says `terminated_idle`, the map says `running`, the container is gone.

Each half then hid the other:

- **`StartDevContainer`** trusted `h.sessions[id].Status == "running"` with no liveness check → every resume short-circuited.
- **`markMissingSessionsStopped`**, which owns the `delete(h.sessions, id)` eviction, built its candidates from the DB alone and skipped anything not marked `running`:
  ```go
  if session.Metadata.ExternalAgentStatus != "running" || session.Metadata.ContainerName == "" {
      continue
  }
  ```
  The row said `terminated_idle`, so the session was skipped every sweep and the eviction line was unreachable.

Stuck until the API process restarted. `sandbox_state` correctly derived `absent`, so the UI kept offering a Start button that could never work.

## Fix

**`markMissingSessionsStopped` reconciles both stores.** The candidate set (new `staleReconcileCandidates`) is the union of DB rows claiming to run and in-memory entries pinned to the sandbox. The DB side keeps its `running` filter — scanning every historic row would mean a hydra probe per row — while the map side is bounded by live containers plus phantoms.

The two remediations are decoupled:
- **Map eviction is unconditional** once the probe confirms the container is dead — the entry alone is enough to block `StartDesktop`.
- **The DB downgrade still only applies to rows claiming to run**, so `terminated_idle` isn't overwritten with `stopped` and the reason the desktop went away is preserved.

**`StartDevContainer` verifies before short-circuiting**, via the existing `HasRunningContainer` (probes hydra, evicts a stale entry on the spot). A phantom now degrades into a real create instead of a false success, so resume is correct immediately rather than only after the next sweep. The early return also reports the reused `DevContainerID`, so genuine reuse is distinguishable from the no-op in logs.

The authoritative per-session `GetDevContainer` probe under the creation lock remains the guard against tearing down a container a concurrent `StartDesktop` just created. `DecrementSandboxContainerCount` is clamped with `GREATEST(…, 0)` and discovery re-`SET`s the count from ground truth each sweep, so the new `HasRunningContainer` call site can't drift the autoscaler counter.

## Tests

`api/pkg/external-agent/reconcile_phantom_sessions_test.go`:

- phantom + terminal DB row → evicted, `UpdateSession` **not** called — **verified to fail against the unfixed code** (`Should be false: phantom entry must be evicted…`)
- phantom whose probe reports the container running → kept
- phantom pinned to another sandbox → untouched by this sandbox's sweep
- phantom + still-`running` DB row → both evicted and downgraded, probed exactly once
- `staleReconcileCandidates`: dedup, `starting`/terminal filtering, unset-`SandboxID`-means-`local`

`go test ./pkg/external-agent/` and the `pkg/server` reconciler tests pass; `go vet` clean.

Design note: `design/2026-08-18-phantom-session-map-entries.md`.

## Not yet tested

The fix is **not** yet exercised end-to-end against a live stack — the race needs a real idle-stop/discovery overlap to reproduce naturally. There is a genuine phantom sitting in the running dev API's memory right now, so deploying this branch there and confirming the reconciler evicts it (and that resume then builds a container) is the end-to-end check worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)