### PR TITLE
fix(tasks): recover the changes view when a sandbox is still starting

### DIFF
--- a/frontend/src/components/external-agent/sandboxState.test.ts
+++ b/frontend/src/components/external-agent/sandboxState.test.ts
@@ -23,6 +23,25 @@ describe("deriveSandboxState", () => {
     expect(state.hasDesktopLifecycleState).toBe(true);
   });
 
+  it("treats an idle-terminated sandbox as absent", () => {
+    // The idle checker writes this status and leaves container_name in place.
+    // Reading it as running showed stop/restart actions for a sandbox that was
+    // gone, and left the changes view waiting on requests that only ever 503.
+    const state = deriveSandboxState({
+      external_agent_status: "terminated_idle",
+      container_name: "headless-external-ses_1",
+    });
+
+    expect(state.sandboxState).toBe("absent");
+    expect(state.hasDesktopLifecycleState).toBe(true);
+    expect(
+      isSandboxOffline({
+        external_agent_status: "terminated_idle",
+        container_name: "headless-external-ses_1",
+      }),
+    ).toBe(true);
+  });
+
   it("reports running for a running container", () => {
     expect(
       deriveSandboxState({

--- a/frontend/src/components/external-agent/sandboxState.ts
+++ b/frontend/src/components/external-agent/sandboxState.ts
@@ -45,8 +45,11 @@ export const deriveSandboxState = (
 
   // Map session metadata to sandbox state.
   // Check stopped status first - it takes priority from the backend check.
+  // "terminated_idle" is what the idle checker writes when it reaps a sandbox
+  // that nobody used; the container name stays on the row, so without this the
+  // session reads as running and every workspace request 503s forever.
   let sandboxState: SandboxState;
-  if (status === "stopped") {
+  if (status === "stopped" || status === "terminated_idle") {
     sandboxState = "absent";
   } else if (status === "running" || (hasContainer && desiredState === "running")) {
     sandboxState = "running";

--- a/frontend/src/components/tasks/TaskSessionPlaceholder.tsx
+++ b/frontend/src/components/tasks/TaskSessionPlaceholder.tsx
@@ -2,7 +2,11 @@ import React, { FC, ReactNode } from "react";
 import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { CircleCheck, CircleSlash, LogIn, MonitorPlay, Play } from "lucide-react";
 
-export type TaskSessionPlaceholderTone = "finished" | "archived" | "paused";
+export type TaskSessionPlaceholderTone =
+  | "finished"
+  | "archived"
+  | "paused"
+  | "connecting";
 
 interface TaskSessionPlaceholderProps {
   tone: TaskSessionPlaceholderTone;
@@ -35,6 +39,9 @@ const TONE_ICONS: Record<TaskSessionPlaceholderTone, ReactNode> = {
   finished: <CircleCheck size={22} />,
   archived: <CircleSlash size={22} />,
   paused: <MonitorPlay size={22} />,
+  // A sandbox that is still registering its bridge is on its way to working,
+  // so it gets progress rather than a stopped-looking icon.
+  connecting: <CircularProgress size={20} color="inherit" />,
 };
 
 /**

--- a/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.test.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkspaceDiffSurface from "./WorkspaceDiffSurface";
+import { DESKTOP_RECONNECT_GRACE_MS } from "./workspaceReviewService";
 
 const mocks = vi.hoisted(() => ({
   live: vi.fn(),
@@ -61,7 +62,7 @@ const renderSurface = (props = {}) =>
     />,
   );
 
-const idleQuery = { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: mocks.refetch };
+const idleQuery = { data: undefined, isLoading: false, isError: false, isFetching: false, failureCount: 0, refetch: mocks.refetch };
 
 describe("WorkspaceDiffSurface", () => {
   beforeEach(() => {
@@ -136,7 +137,10 @@ describe("WorkspaceDiffSurface", () => {
     expect(screen.getByTestId("code-view")).toBeInTheDocument();
   });
 
-  it("offers to start the desktop when the sandbox answers 503 mid-poll", () => {
+  it("reads a fresh 503 as a sandbox that is still coming up", () => {
+    // A task launched seconds ago answers 503 until its container registers
+    // the bridge. Telling the reviewer it is stopped — and offering to start
+    // it — is wrong for a task that is already working.
     mocks.live.mockReturnValue({
       ...idleQuery,
       isError: true,
@@ -145,8 +149,29 @@ describe("WorkspaceDiffSurface", () => {
 
     renderSurface({ onStartDesktop: vi.fn() });
 
-    expect(screen.getByText("Desktop not running")).toBeInTheDocument();
-    expect(screen.queryByText("Could not load workspace changes.")).not.toBeInTheDocument();
+    expect(screen.getByText("Connecting to the sandbox")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start desktop" })).not.toBeInTheDocument();
+  });
+
+  it("offers to start the desktop once the 503s have persisted", () => {
+    mocks.live.mockReturnValue({
+      ...idleQuery,
+      isError: true,
+      error: { response: { status: 503 } },
+    });
+
+    vi.useFakeTimers();
+    try {
+      renderSurface({ onStartDesktop: vi.fn() });
+      act(() => {
+        vi.advanceTimersByTime(DESKTOP_RECONNECT_GRACE_MS + 1);
+      });
+
+      expect(screen.getByText("Desktop not running")).toBeInTheDocument();
+      expect(screen.queryByText("Could not load workspace changes.")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("still reports a genuine failure as an error", () => {

--- a/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
@@ -22,6 +22,7 @@ import { copyTextToClipboard, workspaceFilePath } from "./clipboard";
 import TaskSessionPlaceholder from "../tasks/TaskSessionPlaceholder";
 import {
   isDesktopUnavailableError,
+  useDesktopReachability,
   useTurnWorkspaceReview,
   useWorkspaceReview,
 } from "./workspaceReviewService";
@@ -117,10 +118,15 @@ const WorkspaceDiffSurface: FC<WorkspaceDiffSurfaceProps> = ({
     ? scope
     : "";
   const query = interactionId ? turnReview : liveReview;
-  // A stopped sandbox answers 503. That is the ordinary state of a finished or
-  // paused task, not a failure, so it gets the shared start-desktop
-  // placeholder rather than an error — and no further polling.
-  const desktopUnavailable = isDesktopUnavailableError(query.error) && !source;
+  // A sandbox that is not answering returns 503. That is the ordinary state of
+  // a finished or paused task, not a failure, so it gets the shared
+  // start-desktop placeholder rather than an error. While the 503 is still
+  // fresh it is more likely the sandbox coming up than one that is gone —
+  // the review keeps polling either way, so the state resolves itself.
+  const reachability = useDesktopReachability({
+    unavailable: isDesktopUnavailableError(query.error) && !source,
+    settled: !!source,
+  });
   const fileCount = source?.files?.length || 0;
   const renderable = useMemo(
     () => parseRenderablePatch(source?.patch),
@@ -301,7 +307,13 @@ const WorkspaceDiffSurface: FC<WorkspaceDiffSurfaceProps> = ({
       )}
       {query.isLoading ? (
         <Box sx={{ flex: 1, display: "grid", placeItems: "center" }}><CircularProgress size={22} /></Box>
-      ) : desktopUnavailable ? (
+      ) : reachability === "connecting" ? (
+        <TaskSessionPlaceholder
+          tone="connecting"
+          title="Connecting to the sandbox"
+          description="This task's sandbox is still starting. Its workspace changes will appear as soon as it connects."
+        />
+      ) : reachability === "unreachable" ? (
         <TaskSessionPlaceholder
           tone="paused"
           title={desktopUnavailableTitle}

--- a/frontend/src/components/workspace-inspector/WorkspaceInspector.test.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceInspector.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkspaceInspector from "./WorkspaceInspector";
+import { DESKTOP_RECONNECT_GRACE_MS } from "./workspaceReviewService";
 
 const mocks = vi.hoisted(() => ({
   mergeParams: vi.fn(),
@@ -106,6 +107,7 @@ describe("WorkspaceInspector when the sandbox is stopped", () => {
       <WorkspaceInspector
         sessionId="session-id"
         primarySurface="changes"
+        desktopRunning={false}
         onStartDesktop={onStartDesktop}
       />,
     );
@@ -124,6 +126,7 @@ describe("WorkspaceInspector when the sandbox is stopped", () => {
       <WorkspaceInspector
         sessionId="session-id"
         primarySurface="changes"
+        desktopRunning={false}
         desktopUnavailableTitle="Task finished"
         desktopUnavailableDescription="This task has been merged to the default branch. Start the desktop to review its workspace."
         onStartDesktop={vi.fn()}
@@ -139,6 +142,7 @@ describe("WorkspaceInspector when the sandbox is stopped", () => {
       <WorkspaceInspector
         sessionId="session-id"
         primarySurface="files"
+        desktopRunning={false}
         onStartDesktop={vi.fn()}
         isDesktopStarting
       />,
@@ -165,6 +169,50 @@ describe("WorkspaceInspector when the sandbox is stopped", () => {
     expect(screen.getByText("Desktop not running")).toBeInTheDocument();
     // useWorkspaces is called (hooks must be unconditional) but disabled.
     expect(mocks.workspacesArgs).toEqual(["session-id", false]);
+  });
+
+  it("says the sandbox is still connecting while the 503 is fresh", () => {
+    // The bug this covers: a headless task that had just started showed
+    // "This task's sandbox is stopped" — for a sandbox whose bridge came up a
+    // second later — and stayed there until the page was reloaded.
+    render(
+      <WorkspaceInspector
+        sessionId="session-id"
+        primarySurface="changes"
+        onStartDesktop={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Connecting to the sandbox")).toBeInTheDocument();
+    expect(screen.queryByText(/sandbox is stopped/i)).not.toBeInTheDocument();
+    // Restarting a task that is already running must not be offered here.
+    expect(screen.queryByRole("button", { name: "Start desktop" })).not.toBeInTheDocument();
+  });
+
+  it("still reports a stopped sandbox once the 503s have persisted", () => {
+    // A session row can claim to be running while its container is really
+    // gone. The optimistic state is bounded so the start action comes back.
+    vi.useFakeTimers();
+    try {
+      render(
+        <WorkspaceInspector
+          sessionId="session-id"
+          primarySurface="changes"
+          onStartDesktop={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Connecting to the sandbox")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(DESKTOP_RECONNECT_GRACE_MS + 1);
+      });
+
+      expect(screen.getByText("Desktop not running")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Start desktop" })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("offers the subscription login when that is what is blocking the desktop", () => {

--- a/frontend/src/components/workspace-inspector/WorkspaceInspector.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceInspector.tsx
@@ -9,7 +9,11 @@ import WorkspaceDiffSurface from "./WorkspaceDiffSurface";
 import WorkspaceFileSurface from "./WorkspaceFileSurface";
 import { closeWorkspaceTabs, type WorkspaceTabCloseAction } from "./workspaceTabs";
 import TaskSessionPlaceholder from "../tasks/TaskSessionPlaceholder";
-import { isDesktopUnavailableError, useWorkspaces } from "./workspaceReviewService";
+import {
+  isDesktopUnavailableError,
+  useDesktopReachability,
+  useWorkspaces,
+} from "./workspaceReviewService";
 import type { WorkspaceReviewComment } from "./workspaceReviewComments";
 
 const NO_COMMENTS: readonly WorkspaceReviewComment[] = [];
@@ -71,6 +75,10 @@ const WorkspaceInspector: FC<WorkspaceInspectorProps> = ({
   const onPrimarySurfaceChangeRef = useRef(onPrimarySurfaceChange);
   onPrimarySurfaceChangeRef.current = onPrimarySurfaceChange;
   const workspacesQuery = useWorkspaces(sessionId, desktopRunning);
+  const reachability = useDesktopReachability({
+    unavailable: desktopRunning && isDesktopUnavailableError(workspacesQuery.error),
+    settled: !desktopRunning || workspacesQuery.isSuccess,
+  });
   const [workspace, setWorkspace] = useState<string>();
   const [openFiles, setOpenFiles] = useState<string[]>(() =>
     router.params.preview ? [router.params.preview] : [],
@@ -151,11 +159,31 @@ const WorkspaceInspector: FC<WorkspaceInspectorProps> = ({
     );
   }
 
+  // A task whose session is running still answers 503 for the first seconds
+  // after launch, while its container registers the bridge these endpoints
+  // are dialled through. Saying "sandbox is stopped" there is simply wrong —
+  // and offering a start button invites the user to restart a healthy task.
+  if (reachability === "connecting") {
+    return (
+      <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        <TaskSessionPlaceholder
+          tone="connecting"
+          title="Connecting to the sandbox"
+          description={
+            primarySurface === "files"
+              ? "This task's sandbox is still starting. Its workspace files will appear as soon as it connects."
+              : "This task's sandbox is still starting. Its workspace changes will appear as soon as it connects."
+          }
+        />
+      </Box>
+    );
+  }
+
   // Every workspace endpoint answers 503 while the sandbox is stopped, which
   // is the normal resting state of a finished or paused task. Show the same
   // start-desktop placeholder the Desktop tab uses rather than reporting a
   // failure to load changes.
-  if (!desktopRunning || isDesktopUnavailableError(workspacesQuery.error)) {
+  if (!desktopRunning || reachability === "unreachable") {
     return (
       <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
         <TaskSessionPlaceholder

--- a/frontend/src/components/workspace-inspector/workspaceReviewService.test.ts
+++ b/frontend/src/components/workspace-inspector/workspaceReviewService.test.ts
@@ -3,8 +3,11 @@ import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import {
+  DESKTOP_RECONNECT_GRACE_MS,
+  DESKTOP_RECOVERY_POLL_INTERVAL,
   desktopPollInterval,
   desktopQueryRetry,
+  useDesktopReachability,
   getWorkspaceFileSaveError,
   isDesktopUnavailableError,
   useUpdateWorkspaceFile,
@@ -44,11 +47,67 @@ describe("workspace query behaviour against a stopped sandbox", () => {
     expect(desktopQueryRetry(2, broken)).toBe(false);
   });
 
-  it("stops the poll once the sandbox has answered 503", () => {
+  it("backs the poll off after a 503 instead of stopping it", () => {
+    // Stopping outright stranded the changes view: a task whose sandbox 503'd
+    // for one second during startup stayed on the placeholder until the user
+    // reloaded the page.
     const interval = desktopPollInterval(3000);
     expect(interval({ state: { error: undefined } })).toBe(3000);
     expect(interval({ state: { error: broken } })).toBe(3000);
-    expect(interval({ state: { error: stopped } })).toBe(false);
+    expect(interval({ state: { error: stopped } })).toBe(
+      DESKTOP_RECOVERY_POLL_INTERVAL,
+    );
+  });
+
+  it("polls a normally-static query only while the sandbox is unreachable", () => {
+    const interval = desktopPollInterval(false);
+    expect(interval({ state: { error: undefined } })).toBe(false);
+    expect(interval({ state: { error: stopped } })).toBe(
+      DESKTOP_RECOVERY_POLL_INTERVAL,
+    );
+  });
+
+  it("classifies an unreachable sandbox as connecting, then gone", () => {
+    // The bound has to be elapsed time: React Query resets failureCount on
+    // every new fetch, so counting failed attempts never gets past one.
+    vi.useFakeTimers();
+    try {
+      const { result, rerender } = renderHook(
+        (props: { unavailable: boolean; settled: boolean }) =>
+          useDesktopReachability(props),
+        { initialProps: { unavailable: false, settled: false } },
+      );
+
+      expect(result.current).toBe("reachable");
+
+      // Reads as connecting from the very first unreachable render, so the
+      // stopped placeholder never flashes on a sandbox that is coming up.
+      rerender({ unavailable: true, settled: false });
+      expect(result.current).toBe("connecting");
+
+      // React Query blanks the error while it refetches an errored query that
+      // holds no data. That must neither restart the grace period nor drop
+      // the placeholder for the duration of the request.
+      act(() => {
+        vi.advanceTimersByTime(DESKTOP_RECONNECT_GRACE_MS - 1000);
+      });
+      rerender({ unavailable: false, settled: false });
+      expect(result.current).toBe("connecting");
+
+      act(() => {
+        vi.advanceTimersByTime(1001);
+      });
+      rerender({ unavailable: true, settled: false });
+      expect(result.current).toBe("unreachable");
+
+      // Answering ends the streak, so a later outage gets its own grace.
+      rerender({ unavailable: false, settled: true });
+      expect(result.current).toBe("reachable");
+      rerender({ unavailable: true, settled: false });
+      expect(result.current).toBe("connecting");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/src/components/workspace-inspector/workspaceReviewService.ts
+++ b/frontend/src/components/workspace-inspector/workspaceReviewService.ts
@@ -1,11 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import useApi from "../../hooks/useApi";
 
 /**
  * The workspace endpoints answer 503 when the session's desktop bridge cannot
- * be dialled, which is the ordinary state of a finished or paused task rather
- * than a failure. Callers render the start-desktop placeholder for this
- * instead of an error, so a stopped sandbox never reads as a broken feature.
+ * be dialled, which is the ordinary state of a finished or paused task — and
+ * of one whose container is still coming up — rather than a failure. Callers
+ * render a placeholder for this instead of an error, so neither a stopped nor
+ * a starting sandbox reads as a broken feature.
  */
 export function isDesktopUnavailableError(error: unknown): boolean {
   return (error as { response?: { status?: number } } | null)?.response?.status === 503;
@@ -24,19 +26,109 @@ export function getWorkspaceFileSaveError(error: unknown, path: string): string 
 }
 
 /**
- * A stopped sandbox is a settled state, not a flaky one. Retrying its 503 —
- * or polling straight through it — produces an endless stream of requests
- * against a container we already know is gone, each of which dials RevDial
- * and logs "container not ready" server-side. Only that status is treated as
- * terminal; anything else keeps normal retry behaviour.
+ * A stopped sandbox is a settled state, not a flaky one. Retrying its 503
+ * immediately produces a burst of requests against a container we already
+ * know is not answering, each of which dials RevDial and logs "container not
+ * ready" server-side. Only that status skips the retries; anything else keeps
+ * normal retry behaviour. Recovery comes from the slow poll below, not from
+ * hammering a single fetch.
  */
 export const desktopQueryRetry = (failureCount: number, error: unknown) =>
   !isDesktopUnavailableError(error) && failureCount < 2;
 
+/**
+ * How often to re-check a sandbox that answered 503.
+ *
+ * The status covers two situations that are indistinguishable over HTTP: a
+ * sandbox that is stopped, and one that is still registering RevDial in the
+ * seconds after the task started. Treating it as terminal left the changes
+ * view frozen on "Desktop not running" for a task that was already working —
+ * the bridge came up one second after the 503, and nothing asked again until
+ * the page was reloaded. These queries are already gated on the session's own
+ * desktop state, so a query that runs at all belongs to a sandbox that is
+ * meant to be up; keep checking it, just slowly.
+ */
+export const DESKTOP_RECOVERY_POLL_INTERVAL = 5_000;
+
+/**
+ * How long a 503 reads as "still connecting" before it reads as stopped.
+ *
+ * Bounds the optimistic state: a session row that claims to be running while
+ * its container is really gone — a host that restarted, a sandbox reaped
+ * without the row catching up — still reaches the placeholder that offers to
+ * start the desktop, instead of spinning forever.
+ *
+ * Measured in elapsed time rather than failed attempts on purpose. React
+ * Query resets a query's failureCount on every new fetch, so it counts
+ * retries within one fetch and never accumulates across polls.
+ */
+export const DESKTOP_RECONNECT_GRACE_MS = 30_000;
+
 export const desktopPollInterval =
-  (interval: number) =>
-  (query: { state: { error: unknown } }) =>
-    isDesktopUnavailableError(query.state.error) ? false : interval;
+  (interval: number | false) =>
+  (query: { state: { error: unknown } }): number | false =>
+    isDesktopUnavailableError(query.state.error)
+      ? DESKTOP_RECOVERY_POLL_INTERVAL
+      : interval;
+
+/**
+ * How a sandbox is currently answering the workspace endpoints.
+ *
+ * "reachable" covers both a sandbox that is answering and one nothing has
+ * asked about yet; the two placeholders only care about the failure states.
+ */
+export type DesktopReachability = "reachable" | "connecting" | "unreachable";
+
+/**
+ * Classifies an unreachable sandbox as still coming up or as gone, by how
+ * long it has been failing.
+ *
+ * `settled` — not the mere absence of a 503 — is what ends the streak. React
+ * Query clears a query's error at the start of every refetch when it holds no
+ * cached data, so a poll against an unreachable sandbox flickers through
+ * "no error" every few seconds. Keying off that restarted the grace period on
+ * every poll (so a dead sandbox never stopped saying "connecting") and blanked
+ * the placeholder for the duration of each request.
+ *
+ * The streak start is recorded during render rather than in an effect so the
+ * first unreachable render already reads as connecting — an effect would let
+ * the "sandbox is stopped" placeholder paint for a frame first.
+ */
+export function useDesktopReachability({
+  unavailable,
+  settled,
+}: {
+  /** The sandbox answered 503 just now. */
+  unavailable: boolean;
+  /** The sandbox answered, or is no longer expected to. */
+  settled: boolean;
+}): DesktopReachability {
+  const unavailableSince = useRef<number | null>(null);
+  const [, rerender] = useState(0);
+
+  if (settled) {
+    unavailableSince.current = null;
+  } else if (unavailable && unavailableSince.current === null) {
+    unavailableSince.current = Date.now();
+  }
+
+  const since = unavailableSince.current;
+
+  // Polling re-renders this anyway, but only a timer guarantees the hand-off
+  // to the stopped placeholder happens on time.
+  useEffect(() => {
+    if (since === null) return;
+    const remaining = DESKTOP_RECONNECT_GRACE_MS - (Date.now() - since);
+    if (remaining <= 0) return;
+    const timer = setTimeout(() => rerender((tick) => tick + 1), remaining);
+    return () => clearTimeout(timer);
+  }, [since]);
+
+  if (since === null) return "reachable";
+  return Date.now() - since < DESKTOP_RECONNECT_GRACE_MS
+    ? "connecting"
+    : "unreachable";
+}
 
 export const workspaceReviewKeys = {
   all: (sessionId: string) => ["workspace-review", sessionId] as const,
@@ -85,6 +177,10 @@ export function useWorkspaces(sessionId: string | undefined, enabled = true) {
     enabled: !!sessionId && enabled,
     staleTime: 30_000,
     refetchOnWindowFocus: false,
+    // The workspace list is static once loaded, so it polls only while the
+    // sandbox is unreachable — otherwise the surface stays on the
+    // start-desktop placeholder for the whole life of a running task.
+    refetchInterval: desktopPollInterval(false),
     retry: desktopQueryRetry,
   });
 }
@@ -139,6 +235,7 @@ export function useWorkspaceFiles(
     enabled: !!sessionId && enabled,
     staleTime: 10_000,
     refetchOnWindowFocus: false,
+    refetchInterval: desktopPollInterval(false),
     retry: desktopQueryRetry,
   });
 }


### PR DESCRIPTION
## Problem

Opening a headless task's **Changes** view seconds after launch showed:

> **Desktop not running** — This task's sandbox is stopped. Start the desktop to load its workspace changes.

…for a task whose agent was already working, and it stayed there until the page was reloaded.

The workspace endpoints answer `503` while the container registers RevDial. The frontend treated that as terminal — `useWorkspaces` had no refetch interval and `desktopPollInterval` returned `false` once a 503 landed. From a real task:

```
08:13:44  503 — Failed to connect to sandbox via RevDial ("no connection")
08:13:45  Desktop-bridge is ready              ← one second later
08:30:13  Successfully retrieved workspaces    ← the user's manual refresh, 16 min later
```

## Fix

A 503 cannot distinguish a stopped sandbox from a booting one, so it is no longer treated as settled:

- **Recovery polling.** `desktopPollInterval` backs off to a 5s recheck instead of stopping; `useWorkspaces`/`useWorkspaceFiles` poll only while unreachable. The `desktopRunning` gate still means a sandbox known to be stopped issues no requests at all, which was the original "don't hammer RevDial" intent.
- **Honest copy.** While the session claims to be running, the surface says *"Connecting to the sandbox"* with no start action — a healthy task is never described as stopped, nor offered a restart that would do nothing. After 30s unreachable it falls back to the start-desktop placeholder, so a session row that outlived its container still has an escape hatch.
- **Bound by elapsed time, not failed attempts.** React Query resets `failureCount` on every new fetch, and blanks `error` while refetching a query that holds no data. Keying off either left a dead sandbox saying "connecting" forever and flashed the placeholder on every poll — both caught by testing against a live sandbox.
- **`terminated_idle`.** `deriveSandboxState` ignored the status the idle checker writes when it reaps an unused sandbox. It leaves `container_name` in place, so those sessions read as *running*: stop/restart actions for a container that is gone, and workspace requests that only ever 503. The backend's own task-list derivation already maps it to `absent`.

## Testing

End-to-end on a dev stack with a fresh headless task (`deepseek_harness` / `qwen3.8-27b`), changes view open from first paint:

| t | UI | API log |
|---|---|---|
| 7s | "Connecting to the sandbox" | `09:18:14` 503, RevDial no connection |
| 19s | diff loaded, **no reload** | `09:18:20` workspaces retrieved |

Also verified against a genuinely dead sandbox: "Connecting" for 29s, then one clean transition to "Desktop not running" + Start desktop, with no per-poll flicker.

Frontend unit tests cover the poll backoff, the reachability classifier (including the refetch-blanks-the-error case), both placeholders, and `terminated_idle`. `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)