### PR TITLE
feat: show Claude subscription owner and plan in agent settings

### DIFF
--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -241,6 +241,17 @@ type AppClaudeSubscriptionStatus struct {
 	OwnerName             string     `json:"owner_name"`                        // human-readable owner (email / full name)
 	IsCurrentUser         bool       `json:"is_current_user"`                   // true when the editor IS the owner
 	SubscriptionOwnerType string     `json:"subscription_owner_type,omitempty"` // "user" or "org" — where the effective sub resolved
+	// Identity of the Claude subscription itself, populated when Connected.
+	// SubscriptionType is the plan ("pro" / "max"), empty for setup-token
+	// connections where the plan is unknown.
+	// SubscriptionOwnerName is the subscription owner's email (user-owned) or
+	// org name (org-owned) — i.e. WHOSE subscription authenticates the agent.
+	// SubscriptionOwnerIsCurrentUser is true when that owner is the requesting
+	// user's own subscription ("is it mine?" — yes).
+	SubscriptionType               string `json:"subscription_type,omitempty"`
+	SubscriptionOwnerID            string `json:"subscription_owner_id,omitempty"`
+	SubscriptionOwnerName          string `json:"subscription_owner_name,omitempty"`
+	SubscriptionOwnerIsCurrentUser bool   `json:"subscription_owner_is_current_user"`
 	Status                string     `json:"status,omitempty"`
 	LastValidatedAt       *time.Time `json:"last_validated_at,omitempty"`
 	LastError             string     `json:"last_error,omitempty"`
@@ -298,6 +309,14 @@ func (apiServer *HelixAPIServer) getAppClaudeSubscriptionStatus(_ http.ResponseW
 	status.Connected = true
 	status.Valid = sub.Status == "active"
 	status.SubscriptionOwnerType = string(sub.OwnerType)
+	status.SubscriptionType = sub.SubscriptionType
+	status.SubscriptionOwnerID = sub.OwnerID
+	status.SubscriptionOwnerIsCurrentUser = sub.OwnerType == types.OwnerTypeUser && sub.OwnerID == user.ID
+	if sub.OwnerType == types.OwnerTypeUser {
+		status.SubscriptionOwnerName = apiServer.displayNameForUser(req.Context(), sub.OwnerID)
+	} else if org, err := apiServer.lookupOrg(req.Context(), sub.OwnerID); err == nil && org != nil {
+		status.SubscriptionOwnerName = org.Name
+	}
 	status.Status = sub.Status
 	status.LastValidatedAt = sub.LastValidatedAt
 	status.LastError = sub.LastError

--- a/api/pkg/server/claude_subscription_status_test.go
+++ b/api/pkg/server/claude_subscription_status_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+
+	"go.uber.org/mock/gomock"
+)
+
+type AppClaudeSubscriptionStatusSuite struct {
+	suite.Suite
+	ctrl   *gomock.Controller
+	store  *store.MockStore
+	server *HelixAPIServer
+}
+
+func TestAppClaudeSubscriptionStatusSuite(t *testing.T) {
+	suite.Run(t, new(AppClaudeSubscriptionStatusSuite))
+}
+
+func (s *AppClaudeSubscriptionStatusSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.server = &HelixAPIServer{Cfg: &config.ServerConfig{}, Store: s.store}
+}
+
+func (s *AppClaudeSubscriptionStatusSuite) statusRequest(viewer types.User, appID string) *http.Request {
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/agents/"+appID+"/claude-subscription-status", nil)
+	s.Require().NoError(err)
+	req = mux.SetURLVars(req, map[string]string{"id": appID})
+	return req.WithContext(setRequestUser(req.Context(), viewer))
+}
+
+// A just-validated subscription so the handler does not re-probe (and does not
+// need to decrypt credentials).
+func freshSub() (sub *types.ClaudeSubscription, now time.Time) {
+	now = time.Now()
+	sub = &types.ClaudeSubscription{ID: "sub_1", Status: "active", LastValidatedAt: &now}
+	return sub, now
+}
+
+// A user-owned subscription must surface the owner's email and the plan, and
+// flag it as the viewer's own when they are the owner.
+func (s *AppClaudeSubscriptionStatusSuite) TestUserOwnedSubExposesOwnerAndPlan() {
+	viewer := types.User{ID: "usr_me"}
+	app := &types.App{ID: "app_1", Owner: "usr_me"}
+	sub, _ := freshSub()
+	sub.OwnerID = "usr_me"
+	sub.OwnerType = types.OwnerTypeUser
+	sub.SubscriptionType = "max"
+
+	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(app, nil)
+	s.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_me"}).
+		Return(&types.User{ID: "usr_me", Email: "me@helix.ml"}, nil).AnyTimes()
+	s.store.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "usr_me", "").Return(sub, nil)
+
+	status, httpErr := s.server.getAppClaudeSubscriptionStatus(nil, s.statusRequest(viewer, "app_1"))
+	s.Nil(httpErr)
+	s.Require().NotNil(status)
+
+	s.True(status.Connected)
+	s.True(status.Valid)
+	s.True(status.IsCurrentUser)
+	s.Equal("user", status.SubscriptionOwnerType)
+	s.Equal("max", status.SubscriptionType)
+	s.Equal("usr_me", status.SubscriptionOwnerID)
+	s.Equal("me@helix.ml", status.SubscriptionOwnerName)
+	s.True(status.SubscriptionOwnerIsCurrentUser)
+}
+
+// An org-owned subscription has no owner email — the org name is shown instead,
+// and it can never be the viewer's own.
+func (s *AppClaudeSubscriptionStatusSuite) TestOrgOwnedSubExposesOrgName() {
+	viewer := types.User{ID: "usr_me"}
+	app := &types.App{ID: "app_1", Owner: "usr_me"}
+	sub, _ := freshSub()
+	sub.OwnerID = "org_1"
+	sub.OwnerType = types.OwnerTypeOrg
+	sub.SubscriptionType = "pro"
+
+	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(app, nil)
+	s.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_me"}).
+		Return(&types.User{ID: "usr_me", Email: "me@helix.ml"}, nil).AnyTimes()
+	s.store.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "usr_me", "").Return(sub, nil)
+	s.store.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org_1"}).
+		Return(&types.Organization{ID: "org_1", Name: "Acme"}, nil)
+
+	status, httpErr := s.server.getAppClaudeSubscriptionStatus(nil, s.statusRequest(viewer, "app_1"))
+	s.Nil(httpErr)
+	s.Require().NotNil(status)
+
+	s.True(status.Connected)
+	s.False(status.SubscriptionOwnerIsCurrentUser)
+	s.Equal("org", status.SubscriptionOwnerType)
+	s.Equal("pro", status.SubscriptionType)
+	s.Equal("Acme", status.SubscriptionOwnerName)
+}
+
+// Without a connected subscription the identity fields stay empty.
+func (s *AppClaudeSubscriptionStatusSuite) TestNotConnectedLeavesIdentityEmpty() {
+	viewer := types.User{ID: "usr_me"}
+	app := &types.App{ID: "app_1", Owner: "usr_me"}
+
+	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(app, nil)
+	s.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_me"}).
+		Return(&types.User{ID: "usr_me", Email: "me@helix.ml"}, nil).AnyTimes()
+	s.store.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "usr_me", "").
+		Return(nil, store.ErrNotFound)
+
+	status, httpErr := s.server.getAppClaudeSubscriptionStatus(nil, s.statusRequest(viewer, "app_1"))
+	s.Nil(httpErr)
+	s.Require().NotNil(status)
+
+	s.False(status.Connected)
+	s.Empty(status.SubscriptionType)
+	s.Empty(status.SubscriptionOwnerID)
+	s.Empty(status.SubscriptionOwnerName)
+	s.False(status.SubscriptionOwnerIsCurrentUser)
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -25690,8 +25690,21 @@ const docTemplate = `{
                 "status": {
                     "type": "string"
                 },
+                "subscription_owner_id": {
+                    "type": "string"
+                },
+                "subscription_owner_is_current_user": {
+                    "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
+                },
                 "subscription_owner_type": {
                     "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "subscription_type": {
+                    "description": "Identity of the Claude subscription itself, populated when Connected.\nSubscriptionType is the plan (\"pro\" / \"max\"), empty for setup-token\nconnections where the plan is unknown.\nSubscriptionOwnerName is the subscription owner's email (user-owned) or\norg name (org-owned) — i.e. WHOSE subscription authenticates the agent.\nSubscriptionOwnerIsCurrentUser is true when that owner is the requesting\nuser's own subscription (\"is it mine?\" — yes).",
                     "type": "string"
                 },
                 "valid": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -25686,8 +25686,21 @@
                 "status": {
                     "type": "string"
                 },
+                "subscription_owner_id": {
+                    "type": "string"
+                },
+                "subscription_owner_is_current_user": {
+                    "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
+                },
                 "subscription_owner_type": {
                     "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "subscription_type": {
+                    "description": "Identity of the Claude subscription itself, populated when Connected.\nSubscriptionType is the plan (\"pro\" / \"max\"), empty for setup-token\nconnections where the plan is unknown.\nSubscriptionOwnerName is the subscription owner's email (user-owned) or\norg name (org-owned) — i.e. WHOSE subscription authenticates the agent.\nSubscriptionOwnerIsCurrentUser is true when that owner is the requesting\nuser's own subscription (\"is it mine?\" — yes).",
                     "type": "string"
                 },
                 "valid": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1896,8 +1896,24 @@ definitions:
         type: string
       status:
         type: string
+      subscription_owner_id:
+        type: string
+      subscription_owner_is_current_user:
+        type: boolean
+      subscription_owner_name:
+        type: string
       subscription_owner_type:
         description: '"user" or "org" — where the effective sub resolved'
+        type: string
+      subscription_type:
+        description: |-
+          Identity of the Claude subscription itself, populated when Connected.
+          SubscriptionType is the plan ("pro" / "max"), empty for setup-token
+          connections where the plan is unknown.
+          SubscriptionOwnerName is the subscription owner's email (user-owned) or
+          org name (org-owned) — i.e. WHOSE subscription authenticates the agent.
+          SubscriptionOwnerIsCurrentUser is true when that owner is the requesting
+          user's own subscription ("is it mine?" — yes).
         type: string
       valid:
         description: that subscription passed its last liveness probe

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1234,8 +1234,21 @@ export interface ServerAppClaudeSubscriptionStatus {
   /** human-readable owner (email / full name) */
   owner_name?: string;
   status?: string;
+  subscription_owner_id?: string;
+  subscription_owner_is_current_user?: boolean;
+  subscription_owner_name?: string;
   /** "user" or "org" — where the effective sub resolved */
   subscription_owner_type?: string;
+  /**
+   * Identity of the Claude subscription itself, populated when Connected.
+   * SubscriptionType is the plan ("pro" / "max"), empty for setup-token
+   * connections where the plan is unknown.
+   * SubscriptionOwnerName is the subscription owner's email (user-owned) or
+   * org name (org-owned) — i.e. WHOSE subscription authenticates the agent.
+   * SubscriptionOwnerIsCurrentUser is true when that owner is the requesting
+   * user's own subscription ("is it mine?" — yes).
+   */
+  subscription_type?: string;
   /** that subscription passed its last liveness probe */
   valid?: boolean;
 }

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -184,6 +184,17 @@ const BarsIcon = ({ effort }: { effort: string }) => {
   )
 }
 
+// "luke@helix.ml · Max" — whose Claude subscription authenticates the agent and its plan.
+function formatSubscriptionOwner(
+  status: api.ServerAppClaudeSubscriptionStatus | undefined
+): string {
+  if (!status?.connected) return ''
+  const plan = status.subscription_type
+    ? status.subscription_type.charAt(0).toUpperCase() + status.subscription_type.slice(1)
+    : ''
+  return [status.subscription_owner_name, plan].filter(Boolean).join(' · ')
+}
+
 const AppSettings: FC<AppSettingsProps> = ({
   id,
   app,
@@ -281,6 +292,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   const ownerClaudeValid = ownerClaudeStatus !== undefined
     ? !!ownerClaudeStatus.valid
     : (claudeSubscriptions?.length ?? 0) > 0
+  const claudeSubOwnerLabel = formatSubscriptionOwner(ownerClaudeStatus)
   const hasAnthropicProvider = providerEndpoints.some(ep => ep.name === 'anthropic')
   const hasOpenAIProvider = providerEndpoints.some(ep => ep.name === 'openai')
 
@@ -844,6 +856,11 @@ const AppSettings: FC<AppSettingsProps> = ({
                             ) : (
                               <Typography variant="caption" color="text.secondary">(not connected)</Typography>
                             )}
+                            {code_agent_runtime === 'claude_code' && claudeSubOwnerLabel ? (
+                              <Typography variant="caption" color="text.secondary">
+                                {claudeSubOwnerLabel}
+                              </Typography>
+                            ) : null}
                           </Box>
                         }
                       />

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1896,8 +1896,24 @@ definitions:
         type: string
       status:
         type: string
+      subscription_owner_id:
+        type: string
+      subscription_owner_is_current_user:
+        type: boolean
+      subscription_owner_name:
+        type: string
       subscription_owner_type:
         description: '"user" or "org" — where the effective sub resolved'
+        type: string
+      subscription_type:
+        description: |-
+          Identity of the Claude subscription itself, populated when Connected.
+          SubscriptionType is the plan ("pro" / "max"), empty for setup-token
+          connections where the plan is unknown.
+          SubscriptionOwnerName is the subscription owner's email (user-owned) or
+          org name (org-owned) — i.e. WHOSE subscription authenticates the agent.
+          SubscriptionOwnerIsCurrentUser is true when that owner is the requesting
+          user's own subscription ("is it mine?" — yes).
         type: string
       valid:
         description: that subscription passed its last liveness probe

--- a/openapi.json
+++ b/openapi.json
@@ -30276,8 +30276,21 @@
                     "status": {
                         "type": "string"
                     },
+                    "subscription_owner_id": {
+                        "type": "string"
+                    },
+                    "subscription_owner_is_current_user": {
+                        "type": "boolean"
+                    },
+                    "subscription_owner_name": {
+                        "type": "string"
+                    },
                     "subscription_owner_type": {
                         "description": "\"user\" or \"org\" — where the effective sub resolved",
+                        "type": "string"
+                    },
+                    "subscription_type": {
+                        "description": "Identity of the Claude subscription itself, populated when Connected.\nSubscriptionType is the plan (\"pro\" / \"max\"), empty for setup-token\nconnections where the plan is unknown.\nSubscriptionOwnerName is the subscription owner's email (user-owned) or\norg name (org-owned) — i.e. WHOSE subscription authenticates the agent.\nSubscriptionOwnerIsCurrentUser is true when that owner is the requesting\nuser's own subscription (\"is it mine?\" — yes).",
                         "type": "string"
                     },
                     "valid": {

--- a/swagger.json
+++ b/swagger.json
@@ -25686,8 +25686,21 @@
                 "status": {
                     "type": "string"
                 },
+                "subscription_owner_id": {
+                    "type": "string"
+                },
+                "subscription_owner_is_current_user": {
+                    "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
+                },
                 "subscription_owner_type": {
                     "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "subscription_type": {
+                    "description": "Identity of the Claude subscription itself, populated when Connected.\nSubscriptionType is the plan (\"pro\" / \"max\"), empty for setup-token\nconnections where the plan is unknown.\nSubscriptionOwnerName is the subscription owner's email (user-owned) or\norg name (org-owned) — i.e. WHOSE subscription authenticates the agent.\nSubscriptionOwnerIsCurrentUser is true when that owner is the requesting\nuser's own subscription (\"is it mine?\" — yes).",
                     "type": "string"
                 },
                 "valid": {


### PR DESCRIPTION
Answers "which subscription is this agent using — is it mine?": the agent settings Credentials row now shows whose Claude subscription would authenticate the agent and its plan, e.g. `luke@helix.ml - Max` as a small caption next to the Claude Subscription radio.

## Changes

- `GET /api/v1/agents/{id}/claude-subscription-status` gains: `subscription_type` (plan, "pro"/"max"; empty for setup-token), `subscription_owner_id`, `subscription_owner_name` (owner email for user-owned subs, org name for org-owned), `subscription_owner_is_current_user`.
- `AppSettings.tsx` renders the caption via `formatSubscriptionOwner()` when a Claude subscription is connected; nothing renders when not connected.
- Unit tests for user-owned, org-owned, and not-connected cases (`TestAppClaudeSubscriptionStatusSuite`).
- OpenAPI regenerated.

## Verification

E2E in the inner Helix (browser):
- User-owned sub seeded -> row shows `test@helix.local - Max`
- Delete user sub -> falls through to org sub -> row shows `testorg - Pro`
- No subs -> no caption (verified API response has no identity fields)