### PR TITLE
Forward sandbox_state so the Open PR button is not permanently disabled

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.test.tsx
@@ -119,3 +119,41 @@ describe.each(["inline", "stacked"] as const)(
     });
   },
 );
+
+// sandbox_state is REQUIRED on SpecTaskForActions, and this is what keeps it
+// that way. Every test above supplies it, which is precisely why the suite
+// stayed green while both real call sites — SpecTaskDetailContent.renderTaskActions
+// and TaskCard — rebuilt the task as a subset object and dropped it. An absent
+// field reads as "sandbox stopped", which disabled Open PR while Reject (which
+// does not consult it) stayed enabled: the button was permanently grey on
+// desktop and mobile alike, with no way to merge from the UI.
+//
+// If someone makes the field optional again, the @ts-expect-error below becomes
+// an unused suppression and the type-check fails. That is deliberate: this class
+// of bug is invisible to a runtime test that constructs its own fixtures.
+describe("SpecTaskForActions", () => {
+  it("requires sandbox_state so a call site cannot silently omit it", () => {
+    // @ts-expect-error - sandbox_state is required and deliberately missing here
+    const missingSandboxState: SpecTaskForActions = {
+      id: "spt_1",
+      status: "implementation",
+      branch_name: "feature/x",
+      base_branch: "main",
+      last_push_at: "2026-08-19T11:18:13.000Z",
+    };
+    expect(missingSandboxState.id).toBe("spt_1");
+  });
+
+  // The production case from 2026-08-19: the agent had pushed and the sandbox
+  // was live, but the call site never forwarded sandbox_state.
+  it("enables Open PR when the sandbox is running and the agent has pushed", () => {
+    render(
+      <SpecTaskActionButtons
+        task={implementationTask({ sandbox_state: "running" })}
+        hasExternalRepo
+        externalRepoType="github"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Open PR/i })).toBeEnabled();
+  });
+});

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -153,8 +153,17 @@ export interface SpecTaskForActions {
   repo_pull_requests?: RepoPR[];
   last_push_at?: string;
   rebase_requested_at?: string;
-  /** "running" | "starting" | "absent" — derived server-side from the session's live container state. */
-  sandbox_state?: string;
+  /** "running" | "starting" | "absent" — derived server-side from the session's live container state.
+   *
+   * REQUIRED, deliberately. It gates whether the agent can still be told to
+   * commit and push, so a caller that forgets it reads as "sandbox stopped" and
+   * silently disables Open PR forever. Both call sites did exactly that, which
+   * left the button permanently grey in the task detail view while Reject —
+   * which does not consult this field — stayed enabled. Keeping it required
+   * makes the compiler catch the next call site instead of a user discovering
+   * they cannot merge. Pass `undefined` explicitly if the task truly has no
+   * session. */
+  sandbox_state: string | undefined;
 }
 
 interface SpecTaskActionButtonsProps {

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1341,6 +1341,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           planning_session_id: task.planning_session_id,
           metadata: task.metadata as { error?: string },
           last_push_at: task.last_push_at,
+          rebase_requested_at: task.rebase_requested_at,
+          sandbox_state: task.sandbox_state,
         }}
         variant={variant}
         onStartPlanning={handleStartPlanning}

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1263,6 +1263,7 @@ function TaskCardInner({
                 just_do_it_mode: task.just_do_it_mode,
                 archived: task.archived,
                 metadata: task.metadata,
+                sandbox_state: task.sandbox_state,
               }}
               variant="stacked"
               startPlanningButtonRef={startPlanningButtonRef}
@@ -1357,6 +1358,7 @@ function TaskCardInner({
                   id: task.id,
                   status: "spec_generation",
                   archived: task.archived,
+                  sandbox_state: task.sandbox_state,
                 }}
                 variant="stacked"
               />
@@ -1374,6 +1376,7 @@ function TaskCardInner({
                 status: "spec_review",
                 design_docs_pushed_at: task.design_docs_pushed_at,
                 archived: task.archived,
+                sandbox_state: task.sandbox_state,
               }}
               variant="stacked"
               onReviewSpec={() => onReviewDocs(task)}
@@ -1391,6 +1394,7 @@ function TaskCardInner({
               branch_name: task.branch_name,
               archived: task.archived,
               last_push_at: task.last_push_at,
+              sandbox_state: task.sandbox_state,
             }}
             variant="stacked"
             onReject={(shiftKey) => {
@@ -1507,6 +1511,7 @@ function TaskCardInner({
                       status: "pull_request",
                       repo_pull_requests: task.repo_pull_requests,
                       archived: task.archived,
+                      sandbox_state: task.sandbox_state,
                     }}
                     variant="stacked"
                   />


### PR DESCRIPTION
## Summary

`SpecTaskActionButtons` gates Open PR on whether the agent can still be told to
commit and push, which it derives from `sandbox_state`. Both call sites rebuild
the task as a subset object and **neither forwarded that field**. So
`sandbox_state` was always `undefined`, `sandboxStopped` was always `true`, and
the button was disabled with no way to reach it from the UI.

Reject stayed enabled throughout, because its condition does not consult
`sandbox_state`. That is why the toolbar read as "actions work, this one just
isn't available yet" rather than as a bug. Reported on mobile first and then
confirmed on desktop — it was never layout-specific.

On the build currently deployed to meta.helix.ml the damage is total. There the
term is a standalone `sandbox_state !== "running"` rather than today's
`!hasPushed && sandboxStopped`, so Open PR can **never** light up. Confirmed by
reading the deployed bundle directly:

```js
V = !!e.last_push_at
W = e.sandbox_state !== "running"
disabled: K || b.isPending || !V || J || W
```

On `main` the window is narrower but still wrong: before the first push, a live
sandbox reads as stopped and the button is dead exactly when the user is waiting
on it.

The server was never at fault — `GET /api/v1/spec-tasks/{id}` returns
`sandbox_state: "running"`. The data was there the whole time; the frontend
dropped it on the way to the component.

## Changes

- Forward `sandbox_state` from `SpecTaskDetailContent.renderTaskActions` and
  from all five `TaskCard` call sites.
- Also forward `rebase_requested_at` from the detail view, which was omitted the
  same way and silently disabled the rebase-pending tooltip.
- Make `sandbox_state` **required** on `SpecTaskForActions`. Every existing test
  supplied it, which is exactly why the suite stayed green while both real call
  sites dropped it — a runtime test that constructs its own fixture cannot catch
  a caller that forgets a field. Making it required moves the check to the
  compiler, where it belongs.
- Add a `@ts-expect-error` assertion pinning the field as required, so it cannot
  quietly go optional again.

## Testing

- `vitest run SpecTaskActionButtons.test.tsx` — 16 passed, including a new test
  for the production case (sandbox running, agent has pushed, Open PR enabled).
- The type guard was verified to actually bite rather than decorate: reverting
  `sandbox_state` to optional makes the type-check fail with
  `TS2578: Unused '@ts-expect-error' directive`. Restored afterwards.
- `tsc -b` reports no errors in the three changed files. Unrelated MUI overload
  errors appear elsewhere in the tree in this sandbox because dependencies were
  installed with `npm` against a committed `yarn.lock`; both lockfiles were
  reverted and are not part of this change.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01m0crxm3x6hnaz0t7ys5f1vnz)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002895_why-the-fuck-did-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002895_why-the-fuck-did-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002895_why-the-fuck-did-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)