### PR TITLE
Download files from the spec task workspace browser

### DIFF
--- a/api/pkg/desktop/desktop.go
+++ b/api/pkg/desktop/desktop.go
@@ -558,6 +558,7 @@ func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)
 	mux.HandleFunc("/workspace/files", s.handleWorkspaceFiles)
 	mux.HandleFunc("/workspace/file", s.handleWorkspaceFile)
+	mux.HandleFunc("/workspace/file/download", s.handleWorkspaceFileDownload)
 	mux.HandleFunc("/workspace/skills", s.handleWorkspaceSkills)
 	mux.HandleFunc("/workspace/checkpoints/capture", s.handleWorkspaceCheckpointCapture)
 	mux.HandleFunc("/workspace/checkpoints/diff", s.handleWorkspaceCheckpointDiff)

--- a/api/pkg/desktop/workspace_review.go
+++ b/api/pkg/desktop/workspace_review.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"os/exec"
@@ -260,6 +261,41 @@ func (s *Server) handleWorkspaceFile(w http.ResponseWriter, r *http.Request) {
 		Workspace: workspace, Path: rel, Contents: content, ByteLength: size,
 		ContentHash: hashString(content), Truncated: truncated, Binary: binary,
 	})
+}
+
+func (s *Server) handleWorkspaceFileDownload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	workDir, _, err := resolveReviewWorkspace(r.URL.Query().Get("workspace"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resolved, rel, err := resolveWorkspaceFile(workDir, r.URL.Query().Get("path"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !workspaceFileIsBrowsable(r.Context(), workDir, rel) {
+		http.Error(w, "path is not a browsable workspace file", http.StatusBadRequest)
+		return
+	}
+	file, err := os.Open(resolved)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("open workspace file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		http.Error(w, "path is not a regular file", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": filepath.Base(rel)}))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	http.ServeContent(w, r, filepath.Base(rel), info.ModTime(), file)
 }
 
 func (s *Server) handleWorkspaceFileWrite(w http.ResponseWriter, r *http.Request) {

--- a/api/pkg/desktop/workspace_review_test.go
+++ b/api/pkg/desktop/workspace_review_test.go
@@ -143,6 +143,23 @@ func TestWorkspaceFileRejectsSymlinkEscape(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "secret")
 }
 
+func TestWorkspaceFileDownloadReturnsCompleteBinaryFile(t *testing.T) {
+	repoDir := setupTestGitRepo(t)
+	workspace := useReviewTestWorkspace(t, repoDir)
+	server := newTestServer(t)
+	contents := bytes.Repeat([]byte{0, 1, 2, 255}, workspaceFileLimit/2)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "artifact.bin"), contents, 0o644))
+
+	req := httptest.NewRequest(http.MethodGet, "/workspace/file/download?workspace="+workspace+"&path=artifact.bin", nil)
+	w := httptest.NewRecorder()
+	server.handleWorkspaceFileDownload(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, contents, w.Body.Bytes())
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "artifact.bin")
+}
+
 // TestWorkspaceReviewRepresentsDualStateFileCoherently is the acceptance
 // criterion the whole review contract exists for: the previous endpoint asked
 // for a file's committed patch first and only fell back to its working patch

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1191,6 +1191,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-review/turn/{interactionID}", apiServer.getWorkspaceTurnReview).Methods("GET")
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-files", apiServer.getWorkspaceFiles).Methods("GET")
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-file", apiServer.getWorkspaceFile).Methods("GET")
+	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-file/download", apiServer.downloadWorkspaceFile).Methods("GET")
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-file", apiServer.putWorkspaceFile).Methods("PUT")
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspace-skills", apiServer.getWorkspaceSkills).Methods("GET")
 	authRouter.HandleFunc("/external-agents/{sessionID}/workspaces", apiServer.getExternalAgentWorkspaces).Methods("GET") // List git workspaces in container

--- a/api/pkg/server/workspace_review_handlers.go
+++ b/api/pkg/server/workspace_review_handlers.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/types"
@@ -103,6 +105,40 @@ func (apiServer *HelixAPIServer) getWorkspaceFiles(w http.ResponseWriter, req *h
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getWorkspaceFile(w http.ResponseWriter, req *http.Request) {
 	apiServer.proxyAuthorizedWorkspaceGET(w, req, "/workspace/file", &types.WorkspaceFileResponse{})
+}
+
+// downloadWorkspaceFile streams a complete, binary-safe workspace file from the task desktop.
+func (apiServer *HelixAPIServer) downloadWorkspaceFile(w http.ResponseWriter, req *http.Request) {
+	session, ok := apiServer.authorizeWorkspaceReviewRequest(w, req, types.ActionGet)
+	if !ok {
+		return
+	}
+	conn, err := apiServer.dialDesktop(req.Context(), session.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer conn.Close()
+	applyDesktopDeadline(req.Context(), conn)
+	desktopURL := &url.URL{Scheme: "http", Host: "localhost:9876", Path: "/workspace/file/download", RawQuery: req.URL.RawQuery}
+	desktopReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, desktopURL.String(), nil)
+	if err != nil || desktopReq.Write(conn) != nil {
+		http.Error(w, "failed to request workspace file", http.StatusBadGateway)
+		return
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), desktopReq)
+	if err != nil {
+		http.Error(w, "failed to read workspace file", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	for _, header := range []string{"Content-Type", "Content-Length", "Content-Disposition", "Last-Modified", "X-Content-Type-Options"} {
+		if value := resp.Header.Get(header); value != "" {
+			w.Header().Set(header, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // putWorkspaceFile godoc

--- a/frontend/src/components/workspace-inspector/WorkspaceFileTree.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceFileTree.tsx
@@ -13,7 +13,8 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { ClipboardCopy, Copy, RefreshCw, Search, X } from "lucide-react";
+import { ClipboardCopy, Copy, Download, RefreshCw, Search, X } from "lucide-react";
+import axios from "axios";
 import type { TypesWorkspaceFileEntry } from "../../api/api";
 import useSnackbar from "../../hooks/useSnackbar";
 import { matchesAllTokens } from "../../utils/searchUtils";
@@ -122,6 +123,29 @@ const WorkspaceFileContextMenu: FC<WorkspaceFileContextMenuProps> = ({
     }
   };
 
+  const downloadFile = async () => {
+    try {
+      const params = new URLSearchParams({ path: item.path });
+      if (workspace) params.set("workspace", workspace);
+      const response = await axios.get(
+        `/api/v1/external-agents/${encodeURIComponent(sessionId)}/workspace-file/download?${params}`,
+        { responseType: "blob" },
+      );
+      const objectURL = URL.createObjectURL(response.data);
+      const link = document.createElement("a");
+      link.href = objectURL;
+      link.download = item.path.split("/").pop() || "download";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(objectURL), 0);
+    } catch {
+      snackbar.error("Could not download file");
+    } finally {
+      context.close();
+    }
+  };
+
   const contentsLabel = fileQuery.isLoading
     ? "Loading contents…"
     : fileQuery.isError
@@ -148,6 +172,12 @@ const WorkspaceFileContextMenu: FC<WorkspaceFileContextMenuProps> = ({
         <ListItemIcon><Copy size={15} /></ListItemIcon>
         {workspacePath ? "Copy full path" : "Workspace path unavailable"}
       </MenuItem>
+      {item.kind === "file" && (
+        <MenuItem onClick={downloadFile}>
+          <ListItemIcon><Download size={15} /></ListItemIcon>
+          Download
+        </MenuItem>
+      )}
       {item.kind === "file" && (
         <MenuItem
           onClick={copyContents}


### PR DESCRIPTION
## Summary
Add a Download action to the desktop workspace file browser so users can save task files locally. The new authorized streaming endpoint supports complete large and binary files while preserving the workspace browser's path-containment, ignored-file, and symlink protections.

## Testing
- `go test ./api/pkg/desktop -run 'TestWorkspaceFile' -count=1 -timeout=60s` — passed, including a new complete binary download test above the preview size limit.
- `go test ./api/pkg/server -run 'TestWorkspaceReviewHandlersSuite' -count=1 -timeout=60s` — passed.
- `git diff --check` — passed.
- Frontend type-check was attempted but could not run because frontend dependencies are not installed in the checkout (`tsc: not found`).

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m0e1ywyhmfdyrytm8yztvx8y)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002901_within-a-spec-task-when/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002901_within-a-spec-task-when/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002901_within-a-spec-task-when/tasks.md)

🚀 Built with [Helix](https://helix.ml)