### PR TITLE
fix(frontend): clamp stale prompt selection offsets

### DIFF
--- a/frontend/src/components/common/SandboxPromptEditor.test.tsx
+++ b/frontend/src/components/common/SandboxPromptEditor.test.tsx
@@ -56,6 +56,19 @@ describe('SandboxPromptEditor', () => {
     expect(getSandboxPromptEditorCursor(editor)).toBe(expectedOffset)
   })
 
+  it('clamps a stale selection offset to the current text length', () => {
+    const root = document.createElement('div')
+    const text = document.createTextNode('draft')
+    root.append(text)
+    const getSelection = vi.spyOn(window, 'getSelection').mockReturnValue({
+      anchorNode: text,
+      anchorOffset: 10,
+    } as unknown as Selection)
+
+    expect(getSandboxPromptEditorCursor(root)).toBe(5)
+    getSelection.mockRestore()
+  })
+
   it('emits canonical source when text is added after a token', () => {
     const { container, onValueChange } = renderEditor()
     const editor = container.querySelector<HTMLElement>('[data-prompt-input="true"]')!

--- a/frontend/src/components/common/SandboxPromptEditor.tsx
+++ b/frontend/src/components/common/SandboxPromptEditor.tsx
@@ -31,7 +31,10 @@ export function getSandboxPromptEditorCursor(root: HTMLElement): number {
   if (!selection?.anchorNode || !root.contains(selection.anchorNode)) return readSandboxPromptEditor(root).length
   const range = document.createRange()
   range.setStart(root, 0)
-  range.setEnd(selection.anchorNode, selection.anchorOffset)
+  const maxOffset = selection.anchorNode instanceof CharacterData
+    ? selection.anchorNode.length
+    : selection.anchorNode.childNodes.length
+  range.setEnd(selection.anchorNode, Math.min(selection.anchorOffset, maxOffset))
   return serializedNodeText(range.cloneContents()).length
 }
 


### PR DESCRIPTION
## Summary

- Clamp stale contenteditable selection offsets before calling `Range.setEnd`
- Prevent mobile Safari `IndexSizeError` crashes in the sandbox prompt editor
- Add a focused regression test

## Testing

- `yarn test src/components/common/SandboxPromptEditor.test.tsx`