### PR TITLE
fix(web-service): preserve local vhost URL port

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -918,10 +918,10 @@ type WebServer struct {
 	// Example: p8080-ses_abc123.dev.helix.example.com → session ses_abc123, port 8080
 	DevSubdomain string `envconfig:"DEV_SUBDOMAIN" description:"Subdomain prefix for dev container port proxying. Format: 'dev' or 'dev.helix.example.com'"`
 
-	// PreviewURLHTTPS controls the public scheme used in generated sandbox
-	// preview URLs. It is independent of VHostTLSMode because TLS may terminate
-	// at an upstream ingress rather than in the Helix API process.
-	PreviewURLHTTPS bool `envconfig:"PREVIEW_URL_HTTPS" default:"true" description:"Generate sandbox preview URLs with HTTPS. Set false for HTTP-only development deployments."`
+	// PreviewURLHTTPS controls the public scheme used in generated vhost URLs.
+	// It is independent of VHostTLSMode because TLS may terminate at an upstream
+	// ingress rather than in the Helix API process.
+	PreviewURLHTTPS bool `envconfig:"PREVIEW_URL_HTTPS" default:"true" description:"Generate public vhost URLs with HTTPS. Set false for HTTP-only development deployments."`
 
 	// SandboxAPIURL is the URL that sandbox containers use to connect back to the API.
 	// This is needed when the main SERVER_URL goes through a reverse proxy that doesn't

--- a/api/pkg/server/project_web_service_handlers.go
+++ b/api/pkg/server/project_web_service_handlers.go
@@ -103,6 +103,9 @@ func (s *HelixAPIServer) getProjectWebService(_ http.ResponseWriter, r *http.Req
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
+	for _, domain := range domains {
+		s.setVHostRouteURL(domain)
+	}
 
 	deploys, err := s.Store.ListWebServiceDeploys(r.Context(), project.ID, 20)
 	if err != nil {

--- a/api/pkg/server/session_preview_handlers.go
+++ b/api/pkg/server/session_preview_handlers.go
@@ -42,7 +42,7 @@ func (s *HelixAPIServer) listSessionPreviewTokens(_ http.ResponseWriter, r *http
 		return nil, system.NewHTTPError500(err.Error())
 	}
 	for _, route := range routes {
-		s.setSessionPreviewURL(route)
+		s.setVHostRouteURL(route)
 	}
 	return routes, nil
 }
@@ -98,7 +98,7 @@ func (s *HelixAPIServer) mintSessionPreviewToken(_ http.ResponseWriter, r *http.
 	if err := s.Store.CreateVHostRoute(r.Context(), route); err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
-	s.setSessionPreviewURL(route)
+	s.setVHostRouteURL(route)
 	return route, nil
 }
 
@@ -148,11 +148,14 @@ func (s *HelixAPIServer) rotateSessionPreviewToken(_ http.ResponseWriter, r *htt
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
-	s.setSessionPreviewURL(updated)
+	s.setVHostRouteURL(updated)
 	return updated, nil
 }
 
-func (s *HelixAPIServer) setSessionPreviewURL(route *types.VHostRoute) {
+// setVHostRouteURL populates the public ingress URL for any vhost route.
+// The scheme comes from PREVIEW_URL_HTTPS and the development port comes
+// from SERVER_URL, so project web-service and sandbox-preview links agree.
+func (s *HelixAPIServer) setVHostRouteURL(route *types.VHostRoute) {
 	if route == nil {
 		return
 	}

--- a/api/pkg/server/session_preview_handlers_test.go
+++ b/api/pkg/server/session_preview_handlers_test.go
@@ -8,33 +8,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetSessionPreviewURL(t *testing.T) {
+func TestSetVHostRouteURL(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		https       bool
 		serverURL   string
+		hostname    string
 		expectedURL string
 	}{
 		{
 			name:        "https by default",
 			https:       true,
 			serverURL:   "https://helix.example.com",
+			hostname:    "share-test.preview.example.com",
 			expectedURL: "https://share-test.preview.example.com",
 		},
 		{
-			name:        "http with development port",
+			name:        "project web service with development port",
 			https:       false,
-			serverURL:   "http://localhost:8080",
-			expectedURL: "http://share-test.preview.example.com:8080",
+			serverURL:   "http://100.108.100.25:8080/",
+			hostname:    "manual-test-standalone-html.ns.helix.ml",
+			expectedURL: "http://manual-test-standalone-html.ns.helix.ml:8080",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &HelixAPIServer{Cfg: &config.ServerConfig{}}
 			s.Cfg.WebServer.PreviewURLHTTPS = tc.https
 			s.Cfg.WebServer.URL = tc.serverURL
-			route := &types.VHostRoute{Hostname: "share-test.preview.example.com"}
+			route := &types.VHostRoute{Hostname: tc.hostname}
 
-			s.setSessionPreviewURL(route)
+			s.setVHostRouteURL(route)
 
 			require.Equal(t, tc.expectedURL, route.URL)
 		})

--- a/api/pkg/types/vhost.go
+++ b/api/pkg/types/vhost.go
@@ -24,7 +24,7 @@ const (
 type VHostRoute struct {
 	ID         string          `gorm:"primaryKey" json:"id"`
 	Hostname   string          `gorm:"uniqueIndex" json:"hostname"` // always lowercased
-	URL        string          `gorm:"-" json:"url,omitempty"`      // public URL, populated by preview API handlers
+	URL        string          `gorm:"-" json:"url,omitempty"`      // public URL, populated by API handlers returning routes
 	TargetKind VHostTargetKind `gorm:"index" json:"target_kind"`
 	TargetID   string          `gorm:"index" json:"target_id"`
 	Port       int             `json:"port"` // destination port inside the container

--- a/design/2026-08-20-local-vhost-public-urls.md
+++ b/design/2026-08-20-local-vhost-public-urls.md
@@ -1,0 +1,16 @@
+# Local vhost public URLs
+
+Project web-service links were assembled in the frontend as
+`https://<hostname>/`. This bypassed the server's vhost URL configuration and
+made every link invalid in HTTP development deployments whose Helix API is
+published on a non-default port.
+
+The API now populates `VHostRoute.URL` for both sandbox previews and project
+web-service domains using the same rules:
+
+- `PREVIEW_URL_HTTPS` selects HTTP or HTTPS.
+- The explicit port in `SERVER_URL` is preserved.
+- No port is added when `SERVER_URL` does not specify one.
+
+The project web-service UI opens and copies that API-provided URL instead of
+reconstructing it from the hostname.

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -522,9 +522,10 @@ const DomainList: FC<{
                   <Tooltip title="Open">
                     <IconButton
                       size="small"
-                      href={`https://${d.hostname}/`}
+                      href={d.url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      disabled={!d.url}
                     >
                       <LaunchIcon fontSize="small" />
                     </IconButton>
@@ -533,7 +534,8 @@ const DomainList: FC<{
                 <Tooltip title="Copy URL">
                   <IconButton
                     size="small"
-                    onClick={() => onCopy(`https://${d.hostname}/`, 'URL')}
+                    onClick={() => d.url && onCopy(d.url, 'URL')}
+                    disabled={!d.url}
                   >
                     <ContentCopyIcon fontSize="small" />
                   </IconButton>


### PR DESCRIPTION
## Summary

- return canonical public URLs for project web-service vhost routes
- preserve `PREVIEW_URL_HTTPS` and the explicit `SERVER_URL` port
- make the web-service UI open and copy the API-provided URL

## Root cause

The project web-service UI rebuilt every domain as `https://<hostname>/`. In local HTTP deployments this dropped port 8080 and sent traffic to an unrelated TLS listener on port 443.

## Verification

- `go test ./pkg/server -run TestSetVHostRouteURL -count=1`
- `go test ./pkg/config -run TestPreviewURLHTTPSConfig -count=1`
- `go test ./pkg/org/...`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- live routing check: `http://manual-test-standalone-html.ns.helix.ml:8080/` reaches the artifact access gate; the old HTTPS URL fails TLS negotiation