### PR TITLE
feat(artifacts): add project-scoped static artifact hosting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,10 @@ These rules keep our list pages visually consistent. When in doubt, mirror `Sand
 - Toggle sits **directly above the table/grid, right-aligned**, in its own row inside the page `Stack`. Don't park it in `topbarContent` — the topbar is reserved for the primary action button (e.g. "New Sandbox").
 - Page header (`<Typography variant="h5">Title</Typography>` + secondary description) sits above the toggle in the same `Stack`.
 
+#### Copyable snippets
+- **Always use `MarkdownCodeBlock` from `frontend/src/components/session/MarkdownCodeBlock.tsx` for copyable commands, prompts, configuration, or code snippets.** It is the canonical AgentChat treatment and provides consistent language chrome, line wrapping, syntax styling, and icon-only copy feedback.
+- Pass the real language (`bash`, `json`, `yaml`, etc.); use `text` and `defaultWrapped` for prose prompts. Do not build bespoke `<pre>` panels, nested background cards, or labeled copy buttons for snippets.
+
 ## Architecture
 - **ACP**: `LLM ←(OpenAI API)→ Qwen Code Agent ←(ACP)→ Zed IDE`
 - **RBAC**: `authorizeUserToResource()` — unified AccessGrants

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -62,6 +62,7 @@ WORKDIR /app/api
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     echo "Building Go binaries..." && \
+    CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /helix . && \
     CGO_ENABLED=1 go build -buildvcs=false -ldflags "-s -w" -o /desktop-bridge ./cmd/desktop-bridge && \
     CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /settings-sync-daemon ./cmd/settings-sync-daemon && \
     CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /docker-wrapper ./cmd/docker-wrapper
@@ -975,5 +976,6 @@ RUN chmod +x /usr/local/bin/start-zed-helix.sh \
 
 # Helix Go binaries - at the very end since they're the lightest to rebuild
 COPY --from=go-build-env /desktop-bridge /usr/local/bin/desktop-bridge
+COPY --from=go-build-env /helix /usr/local/bin/helix
 COPY --from=go-build-env /settings-sync-daemon /usr/local/bin/settings-sync-daemon
 COPY --from=go-build-env /docker-wrapper /opt/helix/docker-wrapper

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -60,6 +60,7 @@ WORKDIR /app/api
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     echo "Building Go binaries..." && \
+    CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /helix . && \
     CGO_ENABLED=1 go build -buildvcs=false -ldflags "-s -w" -o /desktop-bridge ./cmd/desktop-bridge && \
     CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /settings-sync-daemon ./cmd/settings-sync-daemon && \
     CGO_ENABLED=0 go build -buildvcs=false -ldflags "-s -w" -o /logind-stub ./cmd/logind-stub && \
@@ -1441,6 +1442,7 @@ RUN set -e && \
 
 # Helix Go binaries - at the very end since they're the lightest to rebuild
 COPY --from=go-build-env /desktop-bridge /usr/local/bin/desktop-bridge
+COPY --from=go-build-env /helix /usr/local/bin/helix
 COPY --from=go-build-env /settings-sync-daemon /usr/local/bin/settings-sync-daemon
 COPY --from=go-build-env /logind-stub /usr/local/bin/logind-stub
 COPY --from=go-build-env /mutter-lease-launcher /usr/local/bin/mutter-lease-launcher

--- a/api/cmd/helix/root.go
+++ b/api/cmd/helix/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/cli/api"
 	"github.com/helixml/helix/api/pkg/cli/app"
+	"github.com/helixml/helix/api/pkg/cli/artifact"
 	"github.com/helixml/helix/api/pkg/cli/chat"
 	"github.com/helixml/helix/api/pkg/cli/fs"
 	"github.com/helixml/helix/api/pkg/cli/knowledge"
@@ -43,6 +44,7 @@ func NewRootCmd() *cobra.Command {
 
 	// CLI commands (available on all platforms)
 	RootCmd.AddCommand(app.New())
+	RootCmd.AddCommand(artifact.New())
 	RootCmd.AddCommand(app.NewApplyCmd()) // Shortcut for apply
 	RootCmd.AddCommand(chat.New())
 	RootCmd.AddCommand(knowledge.New())

--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -1,0 +1,405 @@
+package artifact
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/cli"
+	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "artifact",
+		Aliases: []string{"artifacts"},
+		Short:   "Publish and manage project static artifacts",
+	}
+	cmd.AddCommand(newCreateCommand(), newUpdateCommand(), newListCommand(), newGetCommand(), newDeleteCommand())
+	return cmd
+}
+
+type uploadFlags struct {
+	projectID     string
+	name          string
+	description   string
+	entrypoint    string
+	visibility    string
+	subdomain     bool
+	jsonOutput    bool
+	sourceSession string
+	sourceTask    string
+}
+
+func newCreateCommand() *cobra.Command {
+	flags := uploadFlags{}
+	cmd := &cobra.Command{
+		Use:   "create <html-file-or-directory>",
+		Short: "Create a static artifact from HTML or a compiled SPA directory",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectID := firstNonEmpty(flags.projectID, os.Getenv("HELIX_PROJECT_ID"))
+			if projectID == "" {
+				return errors.New("project is required: pass --project or set HELIX_PROJECT_ID")
+			}
+			if strings.TrimSpace(flags.name) == "" {
+				return errors.New("name is required")
+			}
+			visibility, err := artifactVisibility(flags.visibility, types.ArtifactVisibilityProject)
+			if err != nil {
+				return err
+			}
+			if flags.subdomain && visibility != types.ArtifactVisibilityPublic {
+				return errors.New("--subdomain requires --visibility public")
+			}
+			content, closeContent, err := openArtifactContent(args[0])
+			if err != nil {
+				return err
+			}
+			defer closeContent()
+			apiClient, err := newClient()
+			if err != nil {
+				return err
+			}
+			sourceSession, sourceTask := resolveArtifactProvenance(cmd, &flags, projectID)
+			name, description, entrypoint, withSubdomain := flags.name, flags.description, flags.entrypoint, flags.subdomain
+			artifact, err := apiClient.CreateArtifact(cmd.Context(), projectID, &client.ArtifactUploadRequest{
+				Name: &name, Description: &description, Entrypoint: optionalString(entrypoint), Visibility: &visibility,
+				WithSubdomain: &withSubdomain, SourceSessionID: sourceSession,
+				SourceSpecTaskID: sourceTask, Content: content,
+			})
+			if err != nil {
+				return err
+			}
+			return printArtifact(cmd, artifact, flags.jsonOutput)
+		},
+	}
+	addUploadFlags(cmd, &flags, true)
+	return cmd
+}
+
+func newUpdateCommand() *cobra.Command {
+	flags := uploadFlags{}
+	cmd := &cobra.Command{
+		Use:   "update <artifact-id> [html-file-or-directory]",
+		Short: "Update artifact metadata or publish a new content version",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var content *client.ArtifactContent
+			closeContent := func() {}
+			var err error
+			if len(args) == 2 {
+				content, closeContent, err = openArtifactContent(args[1])
+				if err != nil {
+					return err
+				}
+				defer closeContent()
+			}
+			if len(args) == 1 && !anyUploadFlagChanged(cmd) {
+				return errors.New("no changes specified")
+			}
+			apiClient, err := newClient()
+			if err != nil {
+				return err
+			}
+			input := &client.ArtifactUploadRequest{Content: content}
+			if content != nil {
+				current, err := apiClient.GetArtifact(cmd.Context(), args[0])
+				if err != nil {
+					return err
+				}
+				input.SourceSessionID, input.SourceSpecTaskID = resolveArtifactProvenance(cmd, &flags, current.ProjectID)
+			}
+			if cmd.Flags().Changed("name") {
+				input.Name = &flags.name
+			}
+			if cmd.Flags().Changed("description") {
+				input.Description = &flags.description
+			}
+			if cmd.Flags().Changed("entrypoint") {
+				input.Entrypoint = &flags.entrypoint
+			}
+			if cmd.Flags().Changed("visibility") {
+				visibility, err := artifactVisibility(flags.visibility, "")
+				if err != nil {
+					return err
+				}
+				input.Visibility = &visibility
+			}
+			if cmd.Flags().Changed("subdomain") {
+				input.WithSubdomain = &flags.subdomain
+			}
+			artifact, err := apiClient.UpdateArtifact(cmd.Context(), args[0], input)
+			if err != nil {
+				return err
+			}
+			return printArtifact(cmd, artifact, flags.jsonOutput)
+		},
+	}
+	addUploadFlags(cmd, &flags, false)
+	return cmd
+}
+
+func newListCommand() *cobra.Command {
+	var projectID string
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List artifacts in a project",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			projectID = firstNonEmpty(projectID, os.Getenv("HELIX_PROJECT_ID"))
+			if projectID == "" {
+				return errors.New("project is required: pass --project or set HELIX_PROJECT_ID")
+			}
+			apiClient, err := newClient()
+			if err != nil {
+				return err
+			}
+			artifacts, err := apiClient.ListArtifacts(cmd.Context(), projectID)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(artifacts)
+			}
+			table := cli.NewSimpleTable(cmd.OutOrStdout(), []string{"ID", "Name", "Kind", "Visibility", "Version", "Updated", "URL"})
+			for _, artifact := range artifacts {
+				version := ""
+				if artifact.ActiveVersion != nil {
+					version = fmt.Sprintf("%d", artifact.ActiveVersion.Version)
+				}
+				if err := cli.AppendRow(table, []string{artifact.ID, artifact.Name, string(artifact.Kind), string(artifact.Visibility), version, artifact.UpdatedAt.Format(time.RFC3339), artifact.URL}); err != nil {
+					return err
+				}
+			}
+			return cli.RenderTable(table)
+		},
+	}
+	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Project ID (env: HELIX_PROJECT_ID)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print JSON")
+	return cmd
+}
+
+func newGetCommand() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "get <artifact-id>",
+		Short: "Show an artifact",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiClient, err := newClient()
+			if err != nil {
+				return err
+			}
+			artifact, err := apiClient.GetArtifact(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return printArtifact(cmd, artifact, jsonOutput)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print JSON")
+	return cmd
+}
+
+func newDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <artifact-id>",
+		Short: "Delete an artifact and all of its static files",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiClient, err := newClient()
+			if err != nil {
+				return err
+			}
+			if err := apiClient.DeleteArtifact(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted artifact %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func addUploadFlags(cmd *cobra.Command, flags *uploadFlags, includeProject bool) {
+	if includeProject {
+		cmd.Flags().StringVarP(&flags.projectID, "project", "p", "", "Project ID (env: HELIX_PROJECT_ID)")
+	}
+	cmd.Flags().StringVarP(&flags.name, "name", "n", "", "Artifact name")
+	cmd.Flags().StringVar(&flags.description, "description", "", "Artifact description")
+	cmd.Flags().StringVar(&flags.entrypoint, "entrypoint", "", "HTML entrypoint (default: index.html)")
+	cmd.Flags().StringVar(&flags.visibility, "visibility", "project", "Visibility: project or public")
+	cmd.Flags().BoolVar(&flags.subdomain, "subdomain", false, "Serve the public artifact on a dedicated subdomain")
+	cmd.Flags().StringVar(&flags.sourceSession, "source-session", "", "Source session ID (defaults to HELIX_SESSION_ID)")
+	cmd.Flags().StringVar(&flags.sourceTask, "source-spec-task", "", "Source spec task ID (defaults to HELIX_SPEC_TASK_ID)")
+	cmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Print JSON")
+	if includeProject {
+		_ = cmd.MarkFlagRequired("name")
+	}
+}
+
+func anyUploadFlagChanged(cmd *cobra.Command) bool {
+	for _, name := range []string{"name", "description", "entrypoint", "visibility", "subdomain"} {
+		if cmd.Flags().Changed(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveArtifactProvenance(cmd *cobra.Command, flags *uploadFlags, projectID string) (string, string) {
+	sessionID := flags.sourceSession
+	if !cmd.Flags().Changed("source-session") && projectID == os.Getenv("HELIX_PROJECT_ID") {
+		sessionID = os.Getenv("HELIX_SESSION_ID")
+	}
+	taskID := flags.sourceTask
+	if !cmd.Flags().Changed("source-spec-task") && projectID == os.Getenv("HELIX_PROJECT_ID") {
+		taskID = os.Getenv("HELIX_SPEC_TASK_ID")
+	}
+	return sessionID, taskID
+}
+
+func newClient() (*client.HelixClient, error) {
+	apiURL := firstNonEmpty(os.Getenv("HELIX_URL"), os.Getenv("HELIX_API_URL"), "http://localhost:8080")
+	apiKey := firstNonEmpty(os.Getenv("HELIX_API_KEY"), os.Getenv("USER_API_TOKEN"))
+	if apiKey == "" {
+		return nil, errors.New("authentication is required: set HELIX_API_KEY or USER_API_TOKEN")
+	}
+	return client.NewClient(strings.TrimRight(apiURL, "/"), apiKey, false)
+}
+
+func openArtifactContent(sourcePath string) (*client.ArtifactContent, func(), error) {
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("inspect artifact source: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, func() {}, fmt.Errorf("artifact source must not be a symbolic link: %s", sourcePath)
+	}
+	if !info.IsDir() {
+		if !info.Mode().IsRegular() {
+			return nil, func() {}, fmt.Errorf("artifact source must be a regular file or directory: %s", sourcePath)
+		}
+		file, err := os.Open(sourcePath)
+		if err != nil {
+			return nil, func() {}, fmt.Errorf("open artifact file: %w", err)
+		}
+		return &client.ArtifactContent{Filename: filepath.Base(sourcePath), Reader: file}, func() { _ = file.Close() }, nil
+	}
+	temp, err := os.CreateTemp("", "helix-artifact-*.zip")
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("create artifact archive: %w", err)
+	}
+	cleanup := func() {
+		_ = temp.Close()
+		_ = os.Remove(temp.Name())
+	}
+	if err := writeArtifactArchive(temp, sourcePath); err != nil {
+		cleanup()
+		return nil, func() {}, err
+	}
+	if _, err := temp.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("rewind artifact archive: %w", err)
+	}
+	return &client.ArtifactContent{Filename: "artifact.zip", Reader: temp}, cleanup, nil
+}
+
+func writeArtifactArchive(destination *os.File, root string) error {
+	writer := zip.NewWriter(destination)
+	err := filepath.WalkDir(root, func(filename string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if filename == root || entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("artifact source contains a non-regular file: %s", filename)
+		}
+		relative, err := filepath.Rel(root, filename)
+		if err != nil {
+			return err
+		}
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relative)
+		header.Method = zip.Deflate
+		part, err := writer.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		source, err := os.Open(filename)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(part, source)
+		closeErr := source.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if closeErr := writer.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("build artifact archive: %w", err)
+	}
+	return nil
+}
+
+func printArtifact(cmd *cobra.Command, artifact *types.Artifact, jsonOutput bool) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(artifact)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\nID: %s\nURL: %s\n", artifact.Name, artifact.ID, artifact.URL)
+	if artifact.SubdomainURL != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Subdomain: %s\n", artifact.SubdomainURL)
+	}
+	return nil
+}
+
+func artifactVisibility(value string, fallback types.ArtifactVisibility) (types.ArtifactVisibility, error) {
+	if strings.TrimSpace(value) == "" {
+		return fallback, nil
+	}
+	visibility := types.ArtifactVisibility(value)
+	if visibility != types.ArtifactVisibilityProject && visibility != types.ArtifactVisibilityPublic {
+		return "", errors.New("visibility must be project or public")
+	}
+	return visibility, nil
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -57,9 +57,6 @@ func newCreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if flags.subdomain && visibility != types.ArtifactVisibilityPublic {
-				return errors.New("--subdomain requires --visibility public")
-			}
 			content, closeContent, err := openArtifactContent(args[0])
 			if err != nil {
 				return err
@@ -238,7 +235,8 @@ func addUploadFlags(cmd *cobra.Command, flags *uploadFlags, includeProject bool)
 	cmd.Flags().StringVar(&flags.description, "description", "", "Artifact description")
 	cmd.Flags().StringVar(&flags.entrypoint, "entrypoint", "", "HTML entrypoint (default: index.html)")
 	cmd.Flags().StringVar(&flags.visibility, "visibility", "project", "Visibility: project or public")
-	cmd.Flags().BoolVar(&flags.subdomain, "subdomain", false, "Serve the public artifact on a dedicated subdomain")
+	cmd.Flags().BoolVar(&flags.subdomain, "subdomain", false, "Deprecated: public artifacts automatically receive a share subdomain")
+	_ = cmd.Flags().MarkDeprecated("subdomain", "public artifacts automatically receive a share subdomain")
 	cmd.Flags().StringVar(&flags.sourceSession, "source-session", "", "Source session ID (defaults to HELIX_SESSION_ID)")
 	cmd.Flags().StringVar(&flags.sourceTask, "source-spec-task", "", "Source spec task ID (defaults to HELIX_SPEC_TASK_ID)")
 	cmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Print JSON")

--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -42,8 +42,8 @@ type uploadFlags struct {
 func newCreateCommand() *cobra.Command {
 	flags := uploadFlags{}
 	cmd := &cobra.Command{
-		Use:   "create <html-file-or-directory>",
-		Short: "Create a static artifact from HTML or a compiled SPA directory",
+		Use:   "create <file-or-directory>",
+		Short: "Create an artifact from HTML, a compiled SPA, PDF, or image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectID := firstNonEmpty(flags.projectID, os.Getenv("HELIX_PROJECT_ID"))
@@ -86,7 +86,7 @@ func newCreateCommand() *cobra.Command {
 func newUpdateCommand() *cobra.Command {
 	flags := uploadFlags{}
 	cmd := &cobra.Command{
-		Use:   "update <artifact-id> [html-file-or-directory]",
+		Use:   "update <artifact-id> [file-or-directory]",
 		Short: "Update artifact metadata or publish a new content version",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -233,7 +233,7 @@ func addUploadFlags(cmd *cobra.Command, flags *uploadFlags, includeProject bool)
 	}
 	cmd.Flags().StringVarP(&flags.name, "name", "n", "", "Artifact name")
 	cmd.Flags().StringVar(&flags.description, "description", "", "Artifact description")
-	cmd.Flags().StringVar(&flags.entrypoint, "entrypoint", "", "HTML entrypoint (default: index.html)")
+	cmd.Flags().StringVar(&flags.entrypoint, "entrypoint", "", "HTML bundle entrypoint (default: index.html)")
 	cmd.Flags().StringVar(&flags.visibility, "visibility", "project", "Visibility: project or public")
 	cmd.Flags().BoolVar(&flags.subdomain, "subdomain", false, "Deprecated: public artifacts automatically receive a share subdomain")
 	_ = cmd.Flags().MarkDeprecated("subdomain", "public artifacts automatically receive a share subdomain")

--- a/api/pkg/cli/artifact/cmd_test.go
+++ b/api/pkg/cli/artifact/cmd_test.go
@@ -1,0 +1,66 @@
+package artifact
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenArtifactContentArchivesDirectoryRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "assets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "index.html"), []byte("<h1>Hello</h1>"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "assets", "app.js"), []byte("ok"), 0o600))
+
+	content, cleanup, err := openArtifactContent(root)
+	require.NoError(t, err)
+	defer cleanup()
+	archiveFile, ok := content.Reader.(*os.File)
+	require.True(t, ok)
+	info, err := archiveFile.Stat()
+	require.NoError(t, err)
+	archive, err := zip.NewReader(archiveFile, info.Size())
+	require.NoError(t, err)
+	require.Len(t, archive.File, 2)
+	require.Equal(t, "assets/app.js", archive.File[0].Name)
+	require.Equal(t, "index.html", archive.File[1].Name)
+}
+
+func TestNewClientUsesAgentEnvironment(t *testing.T) {
+	t.Setenv("HELIX_URL", "")
+	t.Setenv("HELIX_API_KEY", "")
+	t.Setenv("HELIX_API_URL", "http://helix-api:8080")
+	t.Setenv("USER_API_TOKEN", "agent-token")
+	_, err := newClient()
+	require.NoError(t, err)
+}
+
+func TestOpenArtifactContentRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "index.html")
+	require.NoError(t, os.WriteFile(target, []byte("<h1>Hello</h1>"), 0o600))
+	link := filepath.Join(root, "artifact.html")
+	require.NoError(t, os.Symlink(target, link))
+
+	_, _, err := openArtifactContent(link)
+	require.ErrorContains(t, err, "must not be a symbolic link")
+}
+
+func TestResolveArtifactProvenanceUsesOnlyCurrentProject(t *testing.T) {
+	t.Setenv("HELIX_PROJECT_ID", "prj_current")
+	t.Setenv("HELIX_SESSION_ID", "ses_current")
+	t.Setenv("HELIX_SPEC_TASK_ID", "spt_current")
+	flags := uploadFlags{}
+	cmd := newUpdateCommand()
+
+	sessionID, taskID := resolveArtifactProvenance(cmd, &flags, "prj_current")
+	require.Equal(t, "ses_current", sessionID)
+	require.Equal(t, "spt_current", taskID)
+
+	sessionID, taskID = resolveArtifactProvenance(cmd, &flags, "prj_other")
+	require.Empty(t, sessionID)
+	require.Empty(t, taskID)
+}

--- a/api/pkg/client/artifact.go
+++ b/api/pkg/client/artifact.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type ArtifactContent struct {
+	Filename string
+	Reader   io.Reader
+}
+
+type ArtifactUploadRequest struct {
+	Name             *string
+	Description      *string
+	Entrypoint       *string
+	Visibility       *types.ArtifactVisibility
+	WithSubdomain    *bool
+	SourceSessionID  string
+	SourceSpecTaskID string
+	Content          *ArtifactContent
+}
+
+func (c *HelixClient) ListArtifacts(ctx context.Context, projectID string) ([]*types.Artifact, error) {
+	var response types.ArtifactsListResponse
+	if err := c.makeRequest(ctx, http.MethodGet, "/projects/"+projectID+"/artifacts", nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Artifacts, nil
+}
+
+func (c *HelixClient) GetArtifact(ctx context.Context, artifactID string) (*types.Artifact, error) {
+	var artifact types.Artifact
+	if err := c.makeRequest(ctx, http.MethodGet, "/artifacts/"+artifactID, nil, &artifact); err != nil {
+		return nil, err
+	}
+	return &artifact, nil
+}
+
+func (c *HelixClient) CreateArtifact(ctx context.Context, projectID string, input *ArtifactUploadRequest) (*types.Artifact, error) {
+	return c.uploadArtifact(ctx, http.MethodPost, "/projects/"+projectID+"/artifacts", input)
+}
+
+func (c *HelixClient) UpdateArtifact(ctx context.Context, artifactID string, input *ArtifactUploadRequest) (*types.Artifact, error) {
+	return c.uploadArtifact(ctx, http.MethodPut, "/artifacts/"+artifactID, input)
+}
+
+func (c *HelixClient) DeleteArtifact(ctx context.Context, artifactID string) error {
+	return c.makeRequest(ctx, http.MethodDelete, "/artifacts/"+artifactID, nil, nil)
+}
+
+func (c *HelixClient) uploadArtifact(ctx context.Context, method, requestPath string, input *ArtifactUploadRequest) (*types.Artifact, error) {
+	if input == nil {
+		return nil, fmt.Errorf("artifact input is required")
+	}
+	pipeReader, pipeWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(pipeWriter)
+
+	requestCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, method, c.url+requestPath, pipeReader)
+	if err != nil {
+		_ = pipeReader.Close()
+		_ = pipeWriter.Close()
+		return nil, fmt.Errorf("create artifact request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	go func() {
+		err := writeArtifactMultipart(multipartWriter, input)
+		if closeErr := multipartWriter.Close(); err == nil {
+			err = closeErr
+		}
+		_ = pipeWriter.CloseWithError(err)
+	}()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("upload artifact: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		message, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if readErr != nil {
+			return nil, fmt.Errorf("artifact API returned status %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("artifact API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(message)))
+	}
+	var artifact types.Artifact
+	if err := json.NewDecoder(resp.Body).Decode(&artifact); err != nil {
+		return nil, fmt.Errorf("decode artifact response: %w", err)
+	}
+	return &artifact, nil
+}
+
+func writeArtifactMultipart(writer *multipart.Writer, input *ArtifactUploadRequest) error {
+	fields := []struct {
+		name  string
+		value *string
+	}{
+		{name: "name", value: input.Name},
+		{name: "description", value: input.Description},
+		{name: "entrypoint", value: input.Entrypoint},
+	}
+	for _, field := range fields {
+		if field.value != nil {
+			if err := writer.WriteField(field.name, *field.value); err != nil {
+				return fmt.Errorf("write artifact field %s: %w", field.name, err)
+			}
+		}
+	}
+	if input.Visibility != nil {
+		if err := writer.WriteField("visibility", string(*input.Visibility)); err != nil {
+			return fmt.Errorf("write artifact visibility: %w", err)
+		}
+	}
+	if input.WithSubdomain != nil {
+		if err := writer.WriteField("with_subdomain", strconv.FormatBool(*input.WithSubdomain)); err != nil {
+			return fmt.Errorf("write artifact subdomain setting: %w", err)
+		}
+	}
+	if input.SourceSessionID != "" {
+		if err := writer.WriteField("source_session_id", input.SourceSessionID); err != nil {
+			return fmt.Errorf("write source session: %w", err)
+		}
+	}
+	if input.SourceSpecTaskID != "" {
+		if err := writer.WriteField("source_spec_task_id", input.SourceSpecTaskID); err != nil {
+			return fmt.Errorf("write source spec task: %w", err)
+		}
+	}
+	if input.Content == nil {
+		return nil
+	}
+	if input.Content.Filename == "" || input.Content.Reader == nil {
+		return fmt.Errorf("artifact content filename and reader are required")
+	}
+	part, err := writer.CreateFormFile("artifact", input.Content.Filename)
+	if err != nil {
+		return fmt.Errorf("create artifact multipart file: %w", err)
+	}
+	if _, err := io.Copy(part, input.Content.Reader); err != nil {
+		return fmt.Errorf("write artifact content: %w", err)
+	}
+	return nil
+}

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -93,6 +93,13 @@ type Client interface {
 	// Projects
 	ApplyProject(ctx context.Context, req *types.ProjectApplyRequest) (*types.ProjectApplyResponse, error)
 
+	// Project artifacts
+	ListArtifacts(ctx context.Context, projectID string) ([]*types.Artifact, error)
+	GetArtifact(ctx context.Context, artifactID string) (*types.Artifact, error)
+	CreateArtifact(ctx context.Context, projectID string, input *ArtifactUploadRequest) (*types.Artifact, error)
+	UpdateArtifact(ctx context.Context, artifactID string, input *ArtifactUploadRequest) (*types.Artifact, error)
+	DeleteArtifact(ctx context.Context, artifactID string) error
+
 	// System Settings
 	GetSystemSettings(ctx context.Context) (*types.SystemSettingsResponse, error)
 	UpdateSystemSettings(ctx context.Context, settings *types.SystemSettingsRequest) (*types.SystemSettingsResponse, error)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -918,10 +918,10 @@ type WebServer struct {
 	// Example: p8080-ses_abc123.dev.helix.example.com → session ses_abc123, port 8080
 	DevSubdomain string `envconfig:"DEV_SUBDOMAIN" description:"Subdomain prefix for dev container port proxying. Format: 'dev' or 'dev.helix.example.com'"`
 
-	// PreviewURLHTTPS controls the public scheme used in generated sandbox
-	// preview URLs. It is independent of VHostTLSMode because TLS may terminate
-	// at an upstream ingress rather than in the Helix API process.
-	PreviewURLHTTPS bool `envconfig:"PREVIEW_URL_HTTPS" default:"true" description:"Generate sandbox preview URLs with HTTPS. Set false for HTTP-only development deployments."`
+	// PreviewURLHTTPS controls the public scheme used in generated vhost URLs.
+	// It is independent of VHostTLSMode because TLS may terminate at an upstream
+	// ingress rather than in the Helix API process.
+	PreviewURLHTTPS bool `envconfig:"PREVIEW_URL_HTTPS" default:"true" description:"Generate vhost URLs with HTTPS. Set false for HTTP-only development deployments."`
 
 	// SandboxAPIURL is the URL that sandbox containers use to connect back to the API.
 	// This is needed when the main SERVER_URL goes through a reverse proxy that doesn't

--- a/api/pkg/filestore/filestore.go
+++ b/api/pkg/filestore/filestore.go
@@ -70,3 +70,13 @@ func GetAppPrefix(filestorePrefix, appID string) string {
 func GetSpecTaskAttachmentsPrefix(filestorePrefix, specTaskID string) string {
 	return filepath.Join(filestorePrefix, "spec-tasks", specTaskID, "attachments")
 }
+
+// GetArtifactVersionPrefix returns the immutable filestore root for one
+// project artifact deployment.
+func GetArtifactVersionPrefix(filestorePrefix, projectID, artifactID, versionID string) string {
+	return filepath.Join(filestorePrefix, "projects", projectID, "artifacts", artifactID, "versions", versionID)
+}
+
+func GetArtifactPrefix(filestorePrefix, projectID, artifactID string) string {
+	return filepath.Join(filestorePrefix, "projects", projectID, "artifacts", artifactID)
+}

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -768,11 +768,7 @@ func (s *HelixAPIServer) populateArtifactURLs(r *http.Request, artifact *types.A
 		return fmt.Errorf("list artifact subdomains: %w", err)
 	}
 	if len(routes) > 0 && artifact.Visibility == types.ArtifactVisibilityPublic {
-		scheme := "https"
-		if parsed, parseErr := url.Parse(origin); parseErr == nil && parsed.Scheme == "http" {
-			scheme = "http"
-		}
-		artifact.SubdomainURL = scheme + "://" + routes[0].Hostname + "/"
+		artifact.SubdomainURL = s.vhostRouteURL(routes[0].Hostname) + "/"
 	}
 	return nil
 }
@@ -815,9 +811,9 @@ func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Reque
 		http.NotFound(w, r)
 		return
 	}
-	scheme := artifactOriginScheme(artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	vhostOrigin := s.vhostRouteURL(routes[0].Hostname)
 	if artifact.Visibility == types.ArtifactVisibilityPublic {
-		http.Redirect(w, r, scheme+"://"+routes[0].Hostname+redirectPath, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, vhostOrigin+redirectPath, http.StatusTemporaryRedirect)
 		return
 	}
 	if artifact.Visibility == types.ArtifactVisibilityProject {
@@ -835,7 +831,7 @@ func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Reque
 			http.Error(w, "create artifact access", http.StatusInternalServerError)
 			return
 		}
-		action := scheme + "://" + routes[0].Hostname + "/_helix/access"
+		action := vhostOrigin + "/_helix/access"
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -877,13 +873,6 @@ func artifactAccessRedirectPath(requested, rawQuery string) (string, error) {
 		redirectPath += "?" + rawQuery
 	}
 	return redirectPath, nil
-}
-
-func artifactOriginScheme(origin string) string {
-	if parsed, err := url.Parse(origin); err == nil && parsed.Scheme == "http" {
-		return "http"
-	}
-	return "https"
 }
 
 func (s *HelixAPIServer) signArtifactAccessToken(userID, artifactID, artifactPath, audience string, ttl time.Duration) (string, error) {

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -1,0 +1,1077 @@
+package server
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/filestore"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/helixml/helix/api/pkg/vhost"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	artifactMaxArchiveBytes = 100 << 20
+	artifactMaxFileBytes    = 25 << 20
+	artifactMaxTotalBytes   = 100 << 20
+	artifactMaxFiles        = 5000
+	artifactMaxPathBytes    = 1024
+	artifactBootstrapTTL    = time.Minute
+	artifactSessionTTL      = 8 * time.Hour
+	artifactAccessCookie    = "helix_artifact_access"
+	artifactBootstrapAud    = "helix-artifact-bootstrap"
+	artifactSessionAud      = "helix-artifact-session"
+)
+
+type artifactUploadFile struct {
+	Metadata types.ArtifactFile
+	Data     []byte
+}
+
+type artifactUpload struct {
+	Files         []artifactUploadFile
+	Entrypoint    string
+	ContentSHA256 string
+}
+
+type artifactAccessClaims struct {
+	ArtifactID   string `json:"artifact_id"`
+	ArtifactPath string `json:"artifact_path,omitempty"`
+	jwt.RegisteredClaims
+}
+
+var artifactAccessBootstrapTemplate = template.Must(template.New("artifact-access").Parse(`<!doctype html>
+<html><head><meta charset="utf-8"><title>Opening artifact</title></head><body>
+<form id="artifact-access" method="post" action="{{.Action}}"><input type="hidden" name="token" value="{{.Token}}"><noscript><button type="submit">Open artifact</button></noscript></form>
+<script>document.getElementById('artifact-access').submit()</script>
+</body></html>`))
+
+// listProjectArtifacts godoc
+// @Summary List project artifacts
+// @Description List static artifacts in a project. Access is inherited from the project.
+// @Tags Artifacts
+// @Produce json
+// @Param id path string true "Project ID"
+// @Success 200 {object} types.ArtifactsListResponse
+// @Router /api/v1/projects/{id}/artifacts [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Request) {
+	project, herr := s.requireProjectAccess(r, types.ActionList)
+	if herr != nil {
+		writeArtifactHTTPError(w, herr.StatusCode, herr.Message)
+		return
+	}
+	artifacts, err := s.Store.ListArtifacts(r.Context(), &store.ListArtifactsQuery{ProjectID: project.ID})
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	for _, artifact := range artifacts {
+		if err := s.populateArtifactURLs(r, artifact); err != nil {
+			writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	writeArtifactJSON(w, http.StatusOK, &types.ArtifactsListResponse{Artifacts: artifacts})
+}
+
+// createProjectArtifact godoc
+// @Summary Create a project artifact
+// @Description Upload one HTML file or a ZIP containing a compiled static SPA.
+// @Tags Artifacts
+// @Accept multipart/form-data
+// @Produce json
+// @Param id path string true "Project ID"
+// @Param name formData string true "Artifact name"
+// @Param description formData string false "Description"
+// @Param entrypoint formData string false "HTML entrypoint (default index.html)"
+// @Param visibility formData string false "project or public"
+// @Param with_subdomain formData bool false "Allocate a public default subdomain"
+// @Param artifact formData file true "HTML file or ZIP bundle"
+// @Success 201 {object} types.Artifact
+// @Router /api/v1/projects/{id}/artifacts [post]
+// @Security BearerAuth
+func (s *HelixAPIServer) createProjectArtifact(w http.ResponseWriter, r *http.Request) {
+	project, herr := s.requireProjectAccess(r, types.ActionCreate)
+	if herr != nil {
+		writeArtifactHTTPError(w, herr.StatusCode, herr.Message)
+		return
+	}
+	if err := parseArtifactMultipart(w, r); err != nil {
+		writeArtifactHTTPError(w, artifactUploadStatus(err), err.Error())
+		return
+	}
+	defer removeArtifactMultipartFiles(r)
+
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		writeArtifactHTTPError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	visibility, err := parseArtifactVisibility(r.FormValue("visibility"), types.ArtifactVisibilityProject)
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	withSubdomain, err := artifactFormBool(r, "with_subdomain")
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if withSubdomain && visibility != types.ArtifactVisibilityPublic {
+		writeArtifactHTTPError(w, http.StatusBadRequest, "with_subdomain requires visibility=public")
+		return
+	}
+	if (withSubdomain || visibility == types.ArtifactVisibilityProject) && s.vhostBaseDomain() == "" {
+		writeArtifactHTTPError(w, http.StatusBadRequest, "artifact subdomains are not configured on this Helix instance")
+		return
+	}
+
+	upload, err := readArtifactUpload(r, r.FormValue("entrypoint"), true, false)
+	if err != nil {
+		writeArtifactHTTPError(w, artifactUploadStatus(err), err.Error())
+		return
+	}
+	if err := s.validateArtifactProvenance(r, project.ID); err != nil {
+		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	user := getRequestUser(r)
+	artifactID := system.GenerateArtifactID()
+	versionID := system.GenerateArtifactVersionID()
+	storagePrefix := filestore.GetArtifactVersionPrefix(s.Cfg.Controller.FilePrefixGlobal, project.ID, artifactID, versionID)
+	if err := s.writeArtifactUpload(r, storagePrefix, upload); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	now := time.Now()
+	artifact := &types.Artifact{
+		ID: artifactID, ProjectID: project.ID, OrganizationID: project.OrganizationID,
+		Name: name, Description: r.FormValue("description"), Kind: artifactKind(upload.Files),
+		Entrypoint: upload.Entrypoint, Visibility: visibility, ActiveVersionID: versionID,
+		CreatedBy: user.ID, UpdatedBy: user.ID, CreatedAt: now, UpdatedAt: now,
+	}
+	version := artifactVersionFromUpload(r, artifactID, versionID, storagePrefix, 1, user.ID, upload)
+	if err := s.Store.CreateArtifact(r.Context(), artifact, version); err != nil {
+		s.cleanupArtifactStorage(r, storagePrefix)
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	artifact.ActiveVersion = version
+	if withSubdomain || visibility == types.ArtifactVisibilityProject {
+		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
+			s.rollbackCreatedArtifact(r, artifact, storagePrefix)
+			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
+			return
+		}
+	}
+	if err := s.populateArtifactURLs(r, artifact); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeArtifactJSON(w, http.StatusCreated, artifact)
+}
+
+// getArtifact godoc
+// @Summary Get an artifact
+// @Tags Artifacts
+// @Produce json
+// @Param artifact_id path string true "Artifact ID"
+// @Success 200 {object} types.Artifact
+// @Router /api/v1/artifacts/{artifact_id} [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) getArtifact(w http.ResponseWriter, r *http.Request) {
+	artifact, ok := s.requireArtifactAccess(w, r, types.ActionGet)
+	if !ok {
+		return
+	}
+	if err := s.populateArtifactURLs(r, artifact); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeArtifactJSON(w, http.StatusOK, artifact)
+}
+
+// updateArtifact godoc
+// @Summary Update an artifact
+// @Description Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.
+// @Tags Artifacts
+// @Accept multipart/form-data
+// @Produce json
+// @Param artifact_id path string true "Artifact ID"
+// @Param name formData string false "Artifact name"
+// @Param description formData string false "Description"
+// @Param entrypoint formData string false "HTML entrypoint"
+// @Param visibility formData string false "project or public"
+// @Param with_subdomain formData bool false "Allocate or retain a public default subdomain"
+// @Param artifact formData file false "Replacement HTML file or ZIP bundle"
+// @Success 200 {object} types.Artifact
+// @Router /api/v1/artifacts/{artifact_id} [put]
+// @Security BearerAuth
+func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) {
+	artifact, ok := s.requireArtifactAccess(w, r, types.ActionUpdate)
+	if !ok {
+		return
+	}
+	previousVisibility := artifact.Visibility
+	if err := parseArtifactMultipart(w, r); err != nil {
+		writeArtifactHTTPError(w, artifactUploadStatus(err), err.Error())
+		return
+	}
+	defer removeArtifactMultipartFiles(r)
+
+	if value, exists := artifactFormField(r, "name"); exists {
+		if strings.TrimSpace(value) == "" {
+			writeArtifactHTTPError(w, http.StatusBadRequest, "name cannot be empty")
+			return
+		}
+		artifact.Name = strings.TrimSpace(value)
+	}
+	if value, exists := artifactFormField(r, "description"); exists {
+		artifact.Description = value
+	}
+	if value, exists := artifactFormField(r, "visibility"); exists {
+		visibility, err := parseArtifactVisibility(value, artifact.Visibility)
+		if err != nil {
+			writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		artifact.Visibility = visibility
+	}
+	withSubdomain, err := artifactFormBool(r, "with_subdomain")
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	withSubdomainSet := artifactFormHasField(r, "with_subdomain")
+	if withSubdomain && artifact.Visibility != types.ArtifactVisibilityPublic {
+		writeArtifactHTTPError(w, http.StatusBadRequest, "with_subdomain requires visibility=public")
+		return
+	}
+	if (withSubdomain || artifact.Visibility == types.ArtifactVisibilityProject) && s.vhostBaseDomain() == "" {
+		writeArtifactHTTPError(w, http.StatusBadRequest, "artifact subdomains are not configured on this Helix instance")
+		return
+	}
+	if err := s.validateArtifactProvenance(r, artifact.ProjectID); err != nil {
+		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	existingRoutes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, "inspect artifact subdomain: "+err.Error())
+		return
+	}
+	wantsRoute := artifact.Visibility == types.ArtifactVisibilityProject || withSubdomain
+	if artifact.Visibility == types.ArtifactVisibilityPublic && !withSubdomainSet && previousVisibility == types.ArtifactVisibilityPublic {
+		wantsRoute = len(existingRoutes) > 0
+	}
+
+	requestedEntrypoint := artifact.Entrypoint
+	entrypointSet := false
+	if value, exists := artifactFormField(r, "entrypoint"); exists {
+		requestedEntrypoint = value
+		entrypointSet = true
+	}
+	hasUpload := len(r.MultipartForm.File["artifact"]) > 0
+	var version *types.ArtifactVersion
+	var storagePrefix string
+	if hasUpload {
+		upload, err := readArtifactUpload(r, requestedEntrypoint, true, !entrypointSet)
+		if err != nil {
+			writeArtifactHTTPError(w, artifactUploadStatus(err), err.Error())
+			return
+		}
+		artifact.Entrypoint = upload.Entrypoint
+		versionID := system.GenerateArtifactVersionID()
+		storagePrefix = filestore.GetArtifactVersionPrefix(s.Cfg.Controller.FilePrefixGlobal, artifact.ProjectID, artifact.ID, versionID)
+		if err := s.writeArtifactUpload(r, storagePrefix, upload); err != nil {
+			writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		version = artifactVersionFromUpload(r, artifact.ID, versionID, storagePrefix, 0, getRequestUser(r).ID, upload)
+	} else {
+		entrypoint, err := validateArtifactEntrypoint(artifact.ActiveVersion.Files, requestedEntrypoint)
+		if err != nil {
+			writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		artifact.Entrypoint = entrypoint
+	}
+	artifact.UpdatedBy = getRequestUser(r).ID
+	createdPrivateRoute := false
+	if artifact.Visibility == types.ArtifactVisibilityProject {
+		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
+			if storagePrefix != "" {
+				s.cleanupArtifactStorage(r, storagePrefix)
+			}
+			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
+			return
+		}
+		createdPrivateRoute = len(existingRoutes) == 0
+	}
+	if err := s.Store.UpdateArtifact(r.Context(), artifact, version); err != nil {
+		if storagePrefix != "" {
+			s.cleanupArtifactStorage(r, storagePrefix)
+		}
+		if createdPrivateRoute {
+			if cleanupErr := s.Store.DeleteVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID); cleanupErr != nil {
+				log.Error().Err(cleanupErr).Str("artifact_id", artifact.ID).Msg("failed to roll back artifact private route")
+			}
+		}
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if !wantsRoute {
+		if err := s.Store.DeleteVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID); err != nil {
+			writeArtifactHTTPError(w, http.StatusInternalServerError, "remove artifact subdomain: "+err.Error())
+			return
+		}
+	} else if artifact.Visibility == types.ArtifactVisibilityPublic {
+		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
+			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
+			return
+		}
+	}
+	updated, err := s.Store.GetArtifact(r.Context(), artifact.ID)
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := s.populateArtifactURLs(r, updated); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeArtifactJSON(w, http.StatusOK, updated)
+}
+
+// deleteArtifact godoc
+// @Summary Delete an artifact
+// @Tags Artifacts
+// @Param artifact_id path string true "Artifact ID"
+// @Success 204
+// @Router /api/v1/artifacts/{artifact_id} [delete]
+// @Security BearerAuth
+func (s *HelixAPIServer) deleteArtifact(w http.ResponseWriter, r *http.Request) {
+	artifact, ok := s.requireArtifactAccess(w, r, types.ActionDelete)
+	if !ok {
+		return
+	}
+	if err := s.deleteArtifactResources(r.Context(), artifact); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *HelixAPIServer) deleteArtifactResources(ctx context.Context, artifact *types.Artifact) error {
+	if err := s.Store.DeleteVHostRoutesByTarget(ctx, types.VHostTargetArtifact, artifact.ID); err != nil {
+		return fmt.Errorf("delete artifact subdomains: %w", err)
+	}
+	storagePrefix := filestore.GetArtifactPrefix(s.Cfg.Controller.FilePrefixGlobal, artifact.ProjectID, artifact.ID)
+	if err := s.Controller.Options.Filestore.Delete(ctx, storagePrefix+"/"); err != nil {
+		return fmt.Errorf("delete artifact files: %w", err)
+	}
+	if err := s.Store.DeleteArtifact(ctx, artifact.ID); err != nil {
+		return fmt.Errorf("delete artifact: %w", err)
+	}
+	return nil
+}
+
+// listArtifactVersions godoc
+// @Summary List artifact versions
+// @Tags Artifacts
+// @Produce json
+// @Param artifact_id path string true "Artifact ID"
+// @Success 200 {object} types.ArtifactVersionsListResponse
+// @Router /api/v1/artifacts/{artifact_id}/versions [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) listArtifactVersions(w http.ResponseWriter, r *http.Request) {
+	artifact, ok := s.requireArtifactAccess(w, r, types.ActionGet)
+	if !ok {
+		return
+	}
+	versions, err := s.Store.ListArtifactVersions(r.Context(), artifact.ID)
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeArtifactJSON(w, http.StatusOK, &types.ArtifactVersionsListResponse{Versions: versions})
+}
+
+func (s *HelixAPIServer) requireArtifactAccess(w http.ResponseWriter, r *http.Request, action types.Action) (*types.Artifact, bool) {
+	artifactID := mux.Vars(r)["artifact_id"]
+	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, store.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeArtifactHTTPError(w, status, "artifact not found")
+		return nil, false
+	}
+	user := getRequestUser(r)
+	if user == nil || user.ID == "" {
+		writeArtifactHTTPError(w, http.StatusUnauthorized, "unauthorized")
+		return nil, false
+	}
+	if err := s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, action); err != nil {
+		writeArtifactHTTPError(w, http.StatusForbidden, err.Error())
+		return nil, false
+	}
+	return artifact, true
+}
+
+func parseArtifactMultipart(w http.ResponseWriter, r *http.Request) error {
+	r.Body = http.MaxBytesReader(w, r.Body, artifactMaxArchiveBytes+(2<<20))
+	if err := r.ParseMultipartForm(4 << 20); err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "too large") {
+			return fmt.Errorf("artifact upload exceeds %d bytes", artifactMaxArchiveBytes)
+		}
+		return fmt.Errorf("invalid multipart form: %w", err)
+	}
+	return nil
+}
+
+func removeArtifactMultipartFiles(r *http.Request) {
+	if r.MultipartForm != nil {
+		_ = r.MultipartForm.RemoveAll()
+	}
+}
+
+func readArtifactUpload(r *http.Request, requestedEntrypoint string, required, allowEntrypointFallback bool) (*artifactUpload, error) {
+	headers := r.MultipartForm.File["artifact"]
+	if len(headers) == 0 {
+		if required {
+			return nil, errors.New("artifact file is required (use field name 'artifact')")
+		}
+		return nil, nil
+	}
+	if len(headers) != 1 {
+		return nil, errors.New("exactly one artifact file or ZIP is required")
+	}
+	header := headers[0]
+	if header.Size > artifactMaxArchiveBytes {
+		return nil, fmt.Errorf("artifact upload exceeds %d bytes", artifactMaxArchiveBytes)
+	}
+	source, err := header.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open artifact upload: %w", err)
+	}
+	body, err := io.ReadAll(io.LimitReader(source, artifactMaxArchiveBytes+1))
+	closeErr := source.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read artifact upload: %w", err)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close artifact upload: %w", closeErr)
+	}
+	if len(body) > artifactMaxArchiveBytes {
+		return nil, fmt.Errorf("artifact upload exceeds %d bytes", artifactMaxArchiveBytes)
+	}
+
+	var files []artifactUploadFile
+	if strings.EqualFold(path.Ext(header.Filename), ".zip") || strings.Contains(strings.ToLower(header.Header.Get("Content-Type")), "zip") {
+		files, err = readArtifactZIP(body)
+	} else {
+		filename, pathErr := normalizeArtifactPath(path.Base(header.Filename))
+		if pathErr != nil {
+			return nil, pathErr
+		}
+		if len(body) > artifactMaxFileBytes {
+			return nil, fmt.Errorf("artifact file exceeds %d bytes", artifactMaxFileBytes)
+		}
+		files = []artifactUploadFile{newArtifactUploadFile(filename, body)}
+	}
+	if err != nil {
+		return nil, err
+	}
+	metadata := make([]types.ArtifactFile, len(files))
+	for i := range files {
+		metadata[i] = files[i].Metadata
+	}
+	entrypoint, err := defaultAndValidateArtifactEntrypoint(metadata, requestedEntrypoint, allowEntrypointFallback)
+	if err != nil {
+		return nil, err
+	}
+	return &artifactUpload{Files: files, Entrypoint: entrypoint, ContentSHA256: artifactAggregateHash(files)}, nil
+}
+
+func readArtifactZIP(body []byte) ([]artifactUploadFile, error) {
+	reader, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid ZIP artifact: %w", err)
+	}
+	if len(reader.File) > artifactMaxFiles {
+		return nil, fmt.Errorf("artifact contains too many entries (%d > %d)", len(reader.File), artifactMaxFiles)
+	}
+	files := make([]artifactUploadFile, 0, len(reader.File))
+	seen := make(map[string]struct{}, len(reader.File))
+	var total int64
+	for _, entry := range reader.File {
+		if entry.FileInfo().IsDir() {
+			continue
+		}
+		if entry.Flags&0x1 != 0 {
+			return nil, fmt.Errorf("encrypted ZIP entry is not supported: %s", entry.Name)
+		}
+		if entry.Mode()&os.ModeSymlink != 0 || !entry.Mode().IsRegular() {
+			return nil, fmt.Errorf("artifact entry must be a regular file: %s", entry.Name)
+		}
+		filename, err := normalizeArtifactPath(entry.Name)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seen[filename]; exists {
+			return nil, fmt.Errorf("duplicate artifact path: %s", filename)
+		}
+		seen[filename] = struct{}{}
+		if entry.UncompressedSize64 > artifactMaxFileBytes {
+			return nil, fmt.Errorf("artifact file %s exceeds %d bytes", filename, artifactMaxFileBytes)
+		}
+		source, err := entry.Open()
+		if err != nil {
+			return nil, fmt.Errorf("open ZIP entry %s: %w", filename, err)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(source, artifactMaxFileBytes+1))
+		closeErr := source.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read ZIP entry %s: %w", filename, readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close ZIP entry %s: %w", filename, closeErr)
+		}
+		if len(data) > artifactMaxFileBytes {
+			return nil, fmt.Errorf("artifact file %s exceeds %d bytes", filename, artifactMaxFileBytes)
+		}
+		total += int64(len(data))
+		if total > artifactMaxTotalBytes {
+			return nil, fmt.Errorf("artifact uncompressed size exceeds %d bytes", artifactMaxTotalBytes)
+		}
+		files = append(files, newArtifactUploadFile(filename, data))
+	}
+	if len(files) == 0 {
+		return nil, errors.New("artifact ZIP contains no files")
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Metadata.Path < files[j].Metadata.Path })
+	return files, nil
+}
+
+func normalizeArtifactPath(filename string) (string, error) {
+	if filename == "" || len(filename) > artifactMaxPathBytes || strings.Contains(filename, "\\") || strings.HasPrefix(filename, "/") {
+		return "", fmt.Errorf("invalid artifact path: %q", filename)
+	}
+	cleaned := path.Clean(filename)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || cleaned != filename {
+		return "", fmt.Errorf("invalid artifact path: %q", filename)
+	}
+	return cleaned, nil
+}
+
+func newArtifactUploadFile(filename string, data []byte) artifactUploadFile {
+	digest := sha256.Sum256(data)
+	return artifactUploadFile{
+		Metadata: types.ArtifactFile{
+			Path: filename, Size: int64(len(data)), ContentType: artifactContentType(filename, data),
+			SHA256: hex.EncodeToString(digest[:]),
+		},
+		Data: data,
+	}
+}
+
+func artifactContentType(filename string, data []byte) string {
+	contentType := mime.TypeByExtension(strings.ToLower(path.Ext(filename)))
+	if contentType != "" {
+		return contentType
+	}
+	return http.DetectContentType(data)
+}
+
+func defaultAndValidateArtifactEntrypoint(files []types.ArtifactFile, requested string, allowFallback bool) (string, error) {
+	entrypoint := strings.TrimSpace(requested)
+	if entrypoint != "" {
+		validated, err := validateArtifactEntrypoint(files, entrypoint)
+		if err == nil || !allowFallback {
+			return validated, err
+		}
+		entrypoint = ""
+	}
+	if entrypoint == "" {
+		entrypoint = "index.html"
+		found := false
+		for _, file := range files {
+			if file.Path == entrypoint {
+				found = true
+				break
+			}
+		}
+		if !found && len(files) == 1 {
+			entrypoint = files[0].Path
+		}
+	}
+	return validateArtifactEntrypoint(files, entrypoint)
+}
+
+func validateArtifactEntrypoint(files []types.ArtifactFile, requested string) (string, error) {
+	entrypoint, err := normalizeArtifactPath(strings.TrimSpace(requested))
+	if err != nil {
+		return "", fmt.Errorf("invalid entrypoint: %w", err)
+	}
+	if !strings.EqualFold(path.Ext(entrypoint), ".html") && !strings.EqualFold(path.Ext(entrypoint), ".htm") {
+		return "", errors.New("artifact entrypoint must be an HTML file")
+	}
+	for _, file := range files {
+		if file.Path == entrypoint {
+			return entrypoint, nil
+		}
+	}
+	return "", fmt.Errorf("artifact entrypoint does not exist: %s", entrypoint)
+}
+
+func artifactAggregateHash(files []artifactUploadFile) string {
+	hasher := sha256.New()
+	for _, file := range files {
+		_, _ = io.WriteString(hasher, file.Metadata.Path)
+		_, _ = io.WriteString(hasher, "\x00")
+		_, _ = io.WriteString(hasher, file.Metadata.SHA256)
+		_, _ = io.WriteString(hasher, "\n")
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func artifactKind(files []artifactUploadFile) types.ArtifactKind {
+	if len(files) == 1 {
+		return types.ArtifactKindSingleFile
+	}
+	return types.ArtifactKindSPA
+}
+
+func artifactVersionFromUpload(r *http.Request, artifactID, versionID, storagePrefix string, versionNumber int, userID string, upload *artifactUpload) *types.ArtifactVersion {
+	files := make([]types.ArtifactFile, len(upload.Files))
+	var totalBytes int64
+	for i := range upload.Files {
+		files[i] = upload.Files[i].Metadata
+		totalBytes += upload.Files[i].Metadata.Size
+	}
+	return &types.ArtifactVersion{
+		ID: versionID, ArtifactID: artifactID, Version: versionNumber, StoragePrefix: storagePrefix,
+		Files: files, FileCount: len(files), TotalBytes: totalBytes, ContentSHA256: upload.ContentSHA256,
+		SourceSessionID: r.FormValue("source_session_id"), SourceSpecTaskID: r.FormValue("source_spec_task_id"),
+		CreatedBy: userID, CreatedAt: time.Now(),
+	}
+}
+
+func (s *HelixAPIServer) writeArtifactUpload(r *http.Request, storagePrefix string, upload *artifactUpload) error {
+	for _, file := range upload.Files {
+		filename := path.Join(storagePrefix, file.Metadata.Path)
+		if _, err := s.Controller.Options.Filestore.WriteFile(r.Context(), filename, bytes.NewReader(file.Data)); err != nil {
+			s.cleanupArtifactStorage(r, storagePrefix)
+			return fmt.Errorf("write artifact file %s: %w", file.Metadata.Path, err)
+		}
+	}
+	return nil
+}
+
+func (s *HelixAPIServer) cleanupArtifactStorage(r *http.Request, storagePrefix string) {
+	if err := s.Controller.Options.Filestore.Delete(r.Context(), storagePrefix+"/"); err != nil {
+		log.Warn().Err(err).Str("storage_prefix", storagePrefix).Msg("failed to clean up artifact storage")
+	}
+}
+
+func (s *HelixAPIServer) rollbackCreatedArtifact(r *http.Request, artifact *types.Artifact, storagePrefix string) {
+	if err := s.Store.DeleteArtifact(r.Context(), artifact.ID); err != nil {
+		log.Error().Err(err).Str("artifact_id", artifact.ID).Msg("failed to roll back artifact metadata")
+	}
+	s.cleanupArtifactStorage(r, storagePrefix)
+}
+
+func (s *HelixAPIServer) validateArtifactProvenance(r *http.Request, projectID string) error {
+	if sessionID := strings.TrimSpace(r.FormValue("source_session_id")); sessionID != "" {
+		session, err := s.Store.GetSession(r.Context(), sessionID)
+		if err != nil {
+			return fmt.Errorf("source session not found: %w", err)
+		}
+		if session.ProjectID != projectID {
+			return errors.New("source session belongs to another project")
+		}
+	}
+	if taskID := strings.TrimSpace(r.FormValue("source_spec_task_id")); taskID != "" {
+		task, err := s.Store.GetSpecTask(r.Context(), taskID)
+		if err != nil {
+			return fmt.Errorf("source spec task not found: %w", err)
+		}
+		if task.ProjectID != projectID {
+			return errors.New("source spec task belongs to another project")
+		}
+	}
+	return nil
+}
+
+func parseArtifactVisibility(value string, fallback types.ArtifactVisibility) (types.ArtifactVisibility, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback, nil
+	}
+	visibility := types.ArtifactVisibility(value)
+	if visibility != types.ArtifactVisibilityProject && visibility != types.ArtifactVisibilityPublic {
+		return "", errors.New("visibility must be project or public")
+	}
+	return visibility, nil
+}
+
+func artifactFormField(r *http.Request, name string) (string, bool) {
+	values, ok := r.MultipartForm.Value[name]
+	if !ok || len(values) == 0 {
+		return "", false
+	}
+	return values[len(values)-1], true
+}
+
+func artifactFormHasField(r *http.Request, name string) bool {
+	_, ok := artifactFormField(r, name)
+	return ok
+}
+
+func artifactFormBool(r *http.Request, name string) (bool, error) {
+	value, ok := artifactFormField(r, name)
+	if !ok || strings.TrimSpace(value) == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("%s must be true or false", name)
+	}
+	return parsed, nil
+}
+
+func artifactUploadStatus(err error) int {
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "exceeds") || strings.Contains(message, "too large") {
+		return http.StatusRequestEntityTooLarge
+	}
+	return http.StatusBadRequest
+}
+
+func (s *HelixAPIServer) ensureArtifactSubdomain(r *http.Request, artifact *types.Artifact) (*types.VHostRoute, error) {
+	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list artifact subdomains: %w", err)
+	}
+	if len(routes) > 0 {
+		return routes[0], nil
+	}
+	base := s.vhostBaseDomain()
+	hostname, err := vhost.AllocateDefaultSubdomain(r.Context(), artifact.Name, base, s.vhostReserveOpts(), 50)
+	if err != nil {
+		return nil, fmt.Errorf("allocate artifact subdomain: %w", err)
+	}
+	now := time.Now()
+	route := &types.VHostRoute{
+		Hostname: hostname, TargetKind: types.VHostTargetArtifact, TargetID: artifact.ID,
+		IsDefault: true, VerifiedAt: &now,
+	}
+	if err := s.Store.CreateVHostRoute(r.Context(), route); err != nil {
+		return nil, fmt.Errorf("create artifact subdomain: %w", err)
+	}
+	return route, nil
+}
+
+func (s *HelixAPIServer) populateArtifactURLs(r *http.Request, artifact *types.Artifact) error {
+	origin := artifactRequestOrigin(r, s.Cfg.WebServer.URL)
+	artifact.URL = strings.TrimRight(origin, "/") + "/artifacts/" + artifact.ID + "/"
+	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+	if err != nil {
+		return fmt.Errorf("list artifact subdomains: %w", err)
+	}
+	if len(routes) > 0 && artifact.Visibility == types.ArtifactVisibilityPublic {
+		scheme := "https"
+		if parsed, parseErr := url.Parse(origin); parseErr == nil && parsed.Scheme == "http" {
+			scheme = "http"
+		}
+		artifact.SubdomainURL = scheme + "://" + routes[0].Hostname + "/"
+	}
+	return nil
+}
+
+func artifactRequestOrigin(r *http.Request, configured string) string {
+	if configured = strings.TrimRight(strings.TrimSpace(configured), "/"); configured != "" {
+		return configured
+	}
+	if r.Host != "" {
+		scheme := r.Header.Get("X-Forwarded-Proto")
+		if scheme == "" {
+			if r.TLS != nil {
+				scheme = "https"
+			} else {
+				scheme = "http"
+			}
+		}
+		return scheme + "://" + r.Host
+	}
+	return ""
+}
+
+// serveArtifactPath serves an artifact on the canonical Helix origin. Public
+// artifacts need no login; project artifacts inherit project read access.
+func (s *HelixAPIServer) serveArtifactPath(w http.ResponseWriter, r *http.Request) {
+	artifactID := mux.Vars(r)["artifact_id"]
+	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if artifact.Visibility != types.ArtifactVisibilityPublic {
+		user := getRequestUser(r)
+		if user == nil || user.ID == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if err := s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, types.ActionGet); err != nil {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+		if err != nil || len(routes) == 0 {
+			http.Error(w, "private artifact origin unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		redirectPath, err := artifactAccessRedirectPath(mux.Vars(r)["artifact_path"], r.URL.RawQuery)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		token, err := s.signArtifactAccessToken(user.ID, artifact.ID, redirectPath, artifactBootstrapAud, artifactBootstrapTTL)
+		if err != nil {
+			http.Error(w, "create artifact access", http.StatusInternalServerError)
+			return
+		}
+		scheme := artifactOriginScheme(artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+		action := scheme + "://" + routes[0].Hostname + "/_helix/access"
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'unsafe-inline'; form-action "+action+"; base-uri 'none'; frame-ancestors 'self'")
+		if r.Method == http.MethodHead {
+			return
+		}
+		if err := artifactAccessBootstrapTemplate.Execute(w, struct{ Action, Token string }{Action: action, Token: token}); err != nil {
+			log.Warn().Err(err).Str("artifact_id", artifact.ID).Msg("render artifact access bootstrap")
+		}
+		return
+	}
+	s.serveArtifactFile(w, r, artifact, mux.Vars(r)["artifact_path"], true)
+}
+
+func artifactAccessRedirectPath(requested, rawQuery string) (string, error) {
+	requested = strings.TrimPrefix(requested, "/")
+	rawQuery = strings.TrimPrefix(rawQuery, "?")
+	if requested == "" {
+		redirectPath := "/"
+		if rawQuery != "" {
+			redirectPath += "?" + rawQuery
+		}
+		return redirectPath, nil
+	}
+	trailingSlash := strings.HasSuffix(requested, "/")
+	if trailingSlash {
+		requested = strings.TrimSuffix(requested, "/")
+	}
+	cleaned, err := normalizeArtifactPath(requested)
+	if err != nil {
+		return "", err
+	}
+	redirectPath := "/" + cleaned
+	if trailingSlash {
+		redirectPath += "/"
+	}
+	if rawQuery != "" {
+		redirectPath += "?" + rawQuery
+	}
+	return redirectPath, nil
+}
+
+func artifactOriginScheme(origin string) string {
+	if parsed, err := url.Parse(origin); err == nil && parsed.Scheme == "http" {
+		return "http"
+	}
+	return "https"
+}
+
+func (s *HelixAPIServer) signArtifactAccessToken(userID, artifactID, artifactPath, audience string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	claims := artifactAccessClaims{
+		ArtifactID: artifactID, ArtifactPath: artifactPath,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "helix", Subject: userID, Audience: jwt.ClaimStrings{audience},
+			IssuedAt: jwt.NewNumericDate(now), NotBefore: jwt.NewNumericDate(now.Add(-5 * time.Second)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+		},
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(s.Cfg.Auth.Regular.JWTSecret))
+}
+
+func (s *HelixAPIServer) parseArtifactAccessToken(raw, artifactID, audience string) (*artifactAccessClaims, error) {
+	claims := &artifactAccessClaims{}
+	token, err := jwt.ParseWithClaims(raw, claims, func(token *jwt.Token) (interface{}, error) {
+		return []byte(s.Cfg.Auth.Regular.JWTSecret), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}), jwt.WithIssuer("helix"), jwt.WithAudience(audience))
+	if err != nil || !token.Valid {
+		return nil, errors.New("invalid artifact access token")
+	}
+	if claims.ArtifactID != artifactID || claims.Subject == "" {
+		return nil, errors.New("artifact access token does not match artifact")
+	}
+	return claims, nil
+}
+
+func (s *HelixAPIServer) servePrivateArtifactVHost(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string) {
+	if requestedPath == "_helix/access" {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid artifact access", http.StatusBadRequest)
+			return
+		}
+		raw := r.FormValue("token")
+		claims, err := s.parseArtifactAccessToken(raw, artifact.ID, artifactBootstrapAud)
+		if err != nil {
+			http.Error(w, "invalid artifact access", http.StatusUnauthorized)
+			return
+		}
+		session, err := s.signArtifactAccessToken(claims.Subject, artifact.ID, "", artifactSessionAud, artifactSessionTTL)
+		if err != nil {
+			http.Error(w, "create artifact session", http.StatusInternalServerError)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name: artifactAccessCookie, Value: session, Path: "/", MaxAge: int(artifactSessionTTL.Seconds()),
+			Secure: NewCookieManager(s.Cfg).SecureCookies, HttpOnly: true, SameSite: http.SameSiteLaxMode,
+		})
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		http.Redirect(w, r, claims.ArtifactPath, http.StatusSeeOther)
+		return
+	}
+	cookie, err := r.Cookie(artifactAccessCookie)
+	if err != nil {
+		http.Error(w, "artifact access required", http.StatusUnauthorized)
+		return
+	}
+	claims, err := s.parseArtifactAccessToken(cookie.Value, artifact.ID, artifactSessionAud)
+	if err != nil {
+		http.Error(w, "artifact access required", http.StatusUnauthorized)
+		return
+	}
+	if err := s.authorizeUserToProjectByID(r.Context(), &types.User{ID: claims.Subject}, artifact.ProjectID, types.ActionGet); err != nil {
+		http.Error(w, "artifact access denied", http.StatusForbidden)
+		return
+	}
+	s.serveArtifactFile(w, r, artifact, requestedPath, false)
+}
+
+func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string, sandboxed bool) {
+	filename, metadata, ok := resolveArtifactFile(artifact, requestedPath)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	etag := `"` + artifact.ActiveVersion.ID + ":" + metadata.SHA256 + `"`
+	setArtifactSecurityHeaders(w.Header(), sandboxed)
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("ETag", etag)
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	if r.Method == http.MethodHead {
+		w.Header().Set("Content-Type", metadata.ContentType)
+		w.Header().Set("Content-Length", strconv.FormatInt(metadata.Size, 10))
+		return
+	}
+	reader, err := s.Controller.Options.Filestore.OpenFile(r.Context(), path.Join(artifact.ActiveVersion.StoragePrefix, filename))
+	if err != nil {
+		http.Error(w, "artifact file unavailable", http.StatusInternalServerError)
+		return
+	}
+	defer reader.Close()
+	w.Header().Set("Content-Type", metadata.ContentType)
+	w.Header().Set("Content-Length", strconv.FormatInt(metadata.Size, 10))
+	if _, err := io.Copy(w, reader); err != nil {
+		log.Warn().Err(err).Str("artifact_id", artifact.ID).Str("path", filename).Msg("serve artifact file")
+	}
+}
+
+func resolveArtifactFile(artifact *types.Artifact, requested string) (string, types.ArtifactFile, bool) {
+	requested = strings.TrimPrefix(requested, "/")
+	directoryRequest := strings.HasSuffix(requested, "/")
+	if requested == "" {
+		requested = artifact.Entrypoint
+	} else if directoryRequest {
+		requested += "index.html"
+	}
+	cleaned, err := normalizeArtifactPath(requested)
+	if err != nil {
+		return "", types.ArtifactFile{}, false
+	}
+	for _, file := range artifact.ActiveVersion.Files {
+		if file.Path == cleaned {
+			return cleaned, file, true
+		}
+	}
+	if artifact.Kind == types.ArtifactKindSPA && (path.Ext(cleaned) == "" || directoryRequest) {
+		for _, file := range artifact.ActiveVersion.Files {
+			if file.Path == artifact.Entrypoint {
+				return artifact.Entrypoint, file, true
+			}
+		}
+	}
+	return "", types.ArtifactFile{}, false
+}
+
+func setArtifactSecurityHeaders(header http.Header, sandboxed bool) {
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Referrer-Policy", "no-referrer")
+	header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
+	if sandboxed {
+		header.Set("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads; default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; frame-ancestors 'self'; base-uri 'none'; form-action 'none'")
+	} else {
+		header.Set("Content-Security-Policy", "default-src 'self' data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'")
+	}
+}
+
+func writeArtifactHTTPError(w http.ResponseWriter, status int, message string) {
+	writeArtifactJSON(w, status, &types.APIError{Message: message, Type: "artifact_error"})
+}
+
+func writeArtifactJSON(w http.ResponseWriter, status int, value interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if status != http.StatusNoContent {
+		_ = json.NewEncoder(w).Encode(value)
+	}
+}

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"mime"
 	"net/http"
@@ -21,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/filestore"
 	"github.com/helixml/helix/api/pkg/store"
@@ -37,11 +35,7 @@ const (
 	artifactMaxTotalBytes   = 100 << 20
 	artifactMaxFiles        = 5000
 	artifactMaxPathBytes    = 1024
-	artifactBootstrapTTL    = time.Minute
-	artifactSessionTTL      = 8 * time.Hour
-	artifactAccessCookie    = "helix_artifact_access"
-	artifactBootstrapAud    = "helix-artifact-bootstrap"
-	artifactSessionAud      = "helix-artifact-session"
+	artifactPrivateRouteTTL = 8 * time.Hour
 )
 
 type artifactUploadFile struct {
@@ -54,18 +48,6 @@ type artifactUpload struct {
 	Entrypoint    string
 	ContentSHA256 string
 }
-
-type artifactAccessClaims struct {
-	ArtifactID   string `json:"artifact_id"`
-	ArtifactPath string `json:"artifact_path,omitempty"`
-	jwt.RegisteredClaims
-}
-
-var artifactAccessBootstrapTemplate = template.Must(template.New("artifact-access").Parse(`<!doctype html>
-<html><head><meta charset="utf-8"><title>Opening artifact</title></head><body>
-<form id="artifact-access" method="post" action="{{.Action}}"><input type="hidden" name="token" value="{{.Token}}"><noscript><button type="submit">Open artifact</button></noscript></form>
-<script>document.getElementById('artifact-access').submit()</script>
-</body></html>`))
 
 // listProjectArtifacts godoc
 // @Summary List project artifacts
@@ -98,7 +80,7 @@ func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Req
 
 // createProjectArtifact godoc
 // @Summary Create a project artifact
-// @Description Upload one HTML file or a ZIP containing a compiled static SPA.
+// @Description Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.
 // @Tags Artifacts
 // @Accept multipart/form-data
 // @Produce json
@@ -108,7 +90,7 @@ func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Req
 // @Param entrypoint formData string false "HTML entrypoint (default index.html)"
 // @Param visibility formData string false "project or public"
 // @Param with_subdomain formData bool false "Deprecated: public artifacts always receive a share subdomain"
-// @Param artifact formData file true "HTML file or ZIP bundle"
+// @Param artifact formData file true "HTML, PDF, image, or ZIP bundle"
 // @Success 201 {object} types.Artifact
 // @Router /api/v1/projects/{id}/artifacts [post]
 // @Security BearerAuth
@@ -207,9 +189,77 @@ func (s *HelixAPIServer) getArtifact(w http.ResponseWriter, r *http.Request) {
 	writeArtifactJSON(w, http.StatusOK, artifact)
 }
 
+// getArtifactViewer godoc
+// @Summary Get artifact viewer metadata
+// @Description Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.
+// @Tags Artifacts
+// @Produce json
+// @Param artifact_id path string true "Artifact ID"
+// @Success 200 {object} types.ArtifactViewerResponse
+// @Router /api/v1/public/artifacts/{artifact_id} [get]
+func (s *HelixAPIServer) getArtifactViewer(w http.ResponseWriter, r *http.Request) {
+	artifactID := mux.Vars(r)["artifact_id"]
+	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, store.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeArtifactHTTPError(w, status, "artifact not found")
+		return
+	}
+
+	user := getRequestUser(r)
+	userID := ""
+	if user != nil {
+		userID = user.ID
+	}
+	if artifact.Visibility != types.ArtifactVisibilityPublic {
+		if userID == "" {
+			writeArtifactHTTPError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if err := s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, types.ActionGet); err != nil {
+			writeArtifactHTTPError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+
+	project, err := s.Store.GetProject(r.Context(), artifact.ProjectID)
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, "load artifact project")
+		return
+	}
+	organization, err := s.Store.GetOrganization(r.Context(), &store.GetOrganizationQuery{ID: artifact.OrganizationID})
+	if err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, "load artifact organization")
+		return
+	}
+	if err := s.populateArtifactURLs(r, artifact); err != nil {
+		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	canEdit := userID != "" && s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, types.ActionUpdate) == nil
+	writeArtifactJSON(w, http.StatusOK, &types.ArtifactViewerResponse{
+		ID:               artifact.ID,
+		ProjectID:        artifact.ProjectID,
+		ProjectName:      project.Name,
+		OrganizationID:   artifact.OrganizationID,
+		OrganizationName: organization.Name,
+		Name:             artifact.Name,
+		Description:      artifact.Description,
+		Kind:             artifact.Kind,
+		Visibility:       artifact.Visibility,
+		ActiveVersionID:  artifact.ActiveVersionID,
+		SubdomainURL:     artifact.SubdomainURL,
+		CanEdit:          canEdit,
+	})
+}
+
 // updateArtifact godoc
 // @Summary Update an artifact
-// @Description Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.
+// @Description Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.
 // @Tags Artifacts
 // @Accept multipart/form-data
 // @Produce json
@@ -219,7 +269,7 @@ func (s *HelixAPIServer) getArtifact(w http.ResponseWriter, r *http.Request) {
 // @Param entrypoint formData string false "HTML entrypoint"
 // @Param visibility formData string false "project or public"
 // @Param with_subdomain formData bool false "Allocate or retain a public default subdomain"
-// @Param artifact formData file false "Replacement HTML file or ZIP bundle"
+// @Param artifact formData file false "Replacement HTML, PDF, image, or ZIP content"
 // @Success 200 {object} types.Artifact
 // @Router /api/v1/artifacts/{artifact_id} [put]
 // @Security BearerAuth
@@ -285,6 +335,7 @@ func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		artifact.Entrypoint = upload.Entrypoint
+		artifact.Kind = artifactKind(upload.Files)
 		versionID := system.GenerateArtifactVersionID()
 		storagePrefix = filestore.GetArtifactVersionPrefix(s.Cfg.Controller.FilePrefixGlobal, artifact.ProjectID, artifact.ID, versionID)
 		if err := s.writeArtifactUpload(r, storagePrefix, upload); err != nil {
@@ -356,6 +407,9 @@ func (s *HelixAPIServer) deleteArtifact(w http.ResponseWriter, r *http.Request) 
 func (s *HelixAPIServer) deleteArtifactResources(ctx context.Context, artifact *types.Artifact) error {
 	if err := s.Store.DeleteVHostRoutesByTarget(ctx, types.VHostTargetArtifact, artifact.ID); err != nil {
 		return fmt.Errorf("delete artifact subdomains: %w", err)
+	}
+	if err := s.Store.DeleteVHostRoutesByTarget(ctx, types.VHostTargetArtifactPrivate, artifact.ID); err != nil {
+		return fmt.Errorf("delete private artifact viewer routes: %w", err)
 	}
 	storagePrefix := filestore.GetArtifactPrefix(s.Cfg.Controller.FilePrefixGlobal, artifact.ProjectID, artifact.ID)
 	if err := s.Controller.Options.Filestore.Delete(ctx, storagePrefix+"/"); err != nil {
@@ -606,15 +660,34 @@ func validateArtifactEntrypoint(files []types.ArtifactFile, requested string) (s
 	if err != nil {
 		return "", fmt.Errorf("invalid entrypoint: %w", err)
 	}
-	if !strings.EqualFold(path.Ext(entrypoint), ".html") && !strings.EqualFold(path.Ext(entrypoint), ".htm") {
-		return "", errors.New("artifact entrypoint must be an HTML file")
-	}
+	var entrypointFile *types.ArtifactFile
 	for _, file := range files {
 		if file.Path == entrypoint {
-			return entrypoint, nil
+			matched := file
+			entrypointFile = &matched
+			break
 		}
 	}
-	return "", fmt.Errorf("artifact entrypoint does not exist: %s", entrypoint)
+	if entrypointFile == nil {
+		return "", fmt.Errorf("artifact entrypoint does not exist: %s", entrypoint)
+	}
+	if len(files) == 1 {
+		switch artifactKindFromFiles(files) {
+		case types.ArtifactKindPDF, types.ArtifactKindImage:
+			return entrypoint, nil
+		case types.ArtifactKindSingleFile:
+			if artifactFileIsHTML(*entrypointFile) {
+				return entrypoint, nil
+			}
+			fallthrough
+		default:
+			return "", errors.New("single-file artifact must be HTML, PDF, or an image")
+		}
+	}
+	if !artifactFileIsHTML(*entrypointFile) {
+		return "", errors.New("artifact bundle entrypoint must be an HTML file")
+	}
+	return entrypoint, nil
 }
 
 func artifactAggregateHash(files []artifactUploadFile) string {
@@ -629,10 +702,31 @@ func artifactAggregateHash(files []artifactUploadFile) string {
 }
 
 func artifactKind(files []artifactUploadFile) types.ArtifactKind {
-	if len(files) == 1 {
+	metadata := make([]types.ArtifactFile, len(files))
+	for i := range files {
+		metadata[i] = files[i].Metadata
+	}
+	return artifactKindFromFiles(metadata)
+}
+
+func artifactKindFromFiles(files []types.ArtifactFile) types.ArtifactKind {
+	if len(files) != 1 {
+		return types.ArtifactKindSPA
+	}
+	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(files[0].ContentType, ";", 2)[0]))
+	switch {
+	case contentType == "application/pdf":
+		return types.ArtifactKindPDF
+	case strings.HasPrefix(contentType, "image/"):
+		return types.ArtifactKindImage
+	default:
 		return types.ArtifactKindSingleFile
 	}
-	return types.ArtifactKindSPA
+}
+
+func artifactFileIsHTML(file types.ArtifactFile) bool {
+	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(file.ContentType, ";", 2)[0]))
+	return contentType == "text/html" && (strings.EqualFold(path.Ext(file.Path), ".html") || strings.EqualFold(path.Ext(file.Path), ".htm"))
 }
 
 func artifactVersionFromUpload(r *http.Request, artifactID, versionID, storagePrefix string, versionNumber int, userID string, upload *artifactUpload) *types.ArtifactVersion {
@@ -791,9 +885,10 @@ func artifactRequestOrigin(r *http.Request, configured string) string {
 	return ""
 }
 
-// serveArtifactEmbed moves the viewer iframe onto the artifact's isolated
-// origin. Public artifacts redirect directly; private artifacts require
-// project access and exchange a short-lived grant for an origin-only session.
+// serveArtifactEmbed moves the viewer iframe onto an isolated artifact origin.
+// Public artifacts use their stable share hostname. Private artifacts require
+// project access and use a short-lived, user-bound hostname so browsers do not
+// need third-party cookies to load the iframe.
 func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Request) {
 	artifactID := mux.Vars(r)["artifact_id"]
 	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
@@ -801,19 +896,18 @@ func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Reque
 		http.NotFound(w, r)
 		return
 	}
-	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
-	if err != nil || len(routes) == 0 {
-		http.Error(w, "artifact origin unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	redirectPath, err := artifactAccessRedirectPath(mux.Vars(r)["artifact_path"], r.URL.RawQuery)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	vhostOrigin := s.vhostRouteURL(routes[0].Hostname)
 	if artifact.Visibility == types.ArtifactVisibilityPublic {
-		http.Redirect(w, r, vhostOrigin+redirectPath, http.StatusTemporaryRedirect)
+		routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+		if err != nil || len(routes) == 0 {
+			http.Error(w, "artifact origin unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		http.Redirect(w, r, s.vhostRouteURL(routes[0].Hostname)+redirectPath, http.StatusTemporaryRedirect)
 		return
 	}
 	if artifact.Visibility == types.ArtifactVisibilityProject {
@@ -826,22 +920,13 @@ func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Reque
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
-		token, err := s.signArtifactAccessToken(user.ID, artifact.ID, redirectPath, artifactBootstrapAud, artifactBootstrapTTL)
+		route, err := s.ensurePrivateArtifactRoute(r, artifact, user.ID)
 		if err != nil {
-			http.Error(w, "create artifact access", http.StatusInternalServerError)
+			http.Error(w, "create private artifact origin", http.StatusInternalServerError)
 			return
 		}
-		action := vhostOrigin + "/_helix/access"
 		w.Header().Set("Cache-Control", "no-store")
-		w.Header().Set("Referrer-Policy", "no-referrer")
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'unsafe-inline'; form-action "+action+"; base-uri 'none'; frame-ancestors 'self'")
-		if r.Method == http.MethodHead {
-			return
-		}
-		if err := artifactAccessBootstrapTemplate.Execute(w, struct{ Action, Token string }{Action: action, Token: token}); err != nil {
-			log.Warn().Err(err).Str("artifact_id", artifact.ID).Msg("render artifact access bootstrap")
-		}
+		http.Redirect(w, r, s.vhostRouteURL(route.Hostname)+redirectPath, http.StatusTemporaryRedirect)
 		return
 	}
 	http.NotFound(w, r)
@@ -875,79 +960,89 @@ func artifactAccessRedirectPath(requested, rawQuery string) (string, error) {
 	return redirectPath, nil
 }
 
-func (s *HelixAPIServer) signArtifactAccessToken(userID, artifactID, artifactPath, audience string, ttl time.Duration) (string, error) {
+func (s *HelixAPIServer) ensurePrivateArtifactRoute(r *http.Request, artifact *types.Artifact, userID string) (*types.VHostRoute, error) {
+	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifactPrivate, artifact.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list private artifact routes: %w", err)
+	}
 	now := time.Now()
-	claims := artifactAccessClaims{
-		ArtifactID: artifactID, ArtifactPath: artifactPath,
-		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer: "helix", Subject: userID, Audience: jwt.ClaimStrings{audience},
-			IssuedAt: jwt.NewNumericDate(now), NotBefore: jwt.NewNumericDate(now.Add(-5 * time.Second)),
-			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
-		},
+	for _, route := range routes {
+		if route.ExpiresAt == nil || !route.ExpiresAt.After(now) {
+			if err := s.Store.DeleteVHostRoute(r.Context(), route.ID); err != nil {
+				return nil, fmt.Errorf("delete expired private artifact route: %w", err)
+			}
+			continue
+		}
+		if route.AccessUserID == userID {
+			return route, nil
+		}
 	}
-	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(s.Cfg.Auth.Regular.JWTSecret))
-}
 
-func (s *HelixAPIServer) parseArtifactAccessToken(raw, artifactID, audience string) (*artifactAccessClaims, error) {
-	claims := &artifactAccessClaims{}
-	token, err := jwt.ParseWithClaims(raw, claims, func(token *jwt.Token) (interface{}, error) {
-		return []byte(s.Cfg.Auth.Regular.JWTSecret), nil
-	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}), jwt.WithIssuer("helix"), jwt.WithAudience(audience))
-	if err != nil || !token.Valid {
-		return nil, errors.New("invalid artifact access token")
+	base := s.vhostBaseDomain()
+	if base == "" {
+		return nil, errors.New("artifact subdomains are not configured")
 	}
-	if claims.ArtifactID != artifactID || claims.Subject == "" {
-		return nil, errors.New("artifact access token does not match artifact")
-	}
-	return claims, nil
-}
-
-func (s *HelixAPIServer) servePrivateArtifactVHost(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string) {
-	if requestedPath == "_helix/access" {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "invalid artifact access", http.StatusBadRequest)
-			return
-		}
-		raw := r.FormValue("token")
-		claims, err := s.parseArtifactAccessToken(raw, artifact.ID, artifactBootstrapAud)
-		if err != nil {
-			http.Error(w, "invalid artifact access", http.StatusUnauthorized)
-			return
-		}
-		session, err := s.signArtifactAccessToken(claims.Subject, artifact.ID, "", artifactSessionAud, artifactSessionTTL)
-		if err != nil {
-			http.Error(w, "create artifact session", http.StatusInternalServerError)
-			return
-		}
-		http.SetCookie(w, &http.Cookie{
-			Name: artifactAccessCookie, Value: session, Path: "/", MaxAge: int(artifactSessionTTL.Seconds()),
-			Secure: NewCookieManager(s.Cfg).SecureCookies, HttpOnly: true, SameSite: http.SameSiteLaxMode,
-		})
-		w.Header().Set("Cache-Control", "no-store")
-		w.Header().Set("Referrer-Policy", "no-referrer")
-		http.Redirect(w, r, claims.ArtifactPath, http.StatusSeeOther)
-		return
-	}
-	cookie, err := r.Cookie(artifactAccessCookie)
+	routeID := system.GenerateVHostRouteID()
+	hostname, err := vhost.AllocateDefaultSubdomain(r.Context(), "private-"+routeID, base, s.vhostReserveOpts(), 1)
 	if err != nil {
+		return nil, fmt.Errorf("allocate private artifact route: %w", err)
+	}
+	expiresAt := now.Add(artifactPrivateRouteTTL)
+	route := &types.VHostRoute{
+		ID: routeID, Hostname: hostname, TargetKind: types.VHostTargetArtifactPrivate, TargetID: artifact.ID,
+		VerifiedAt: &now, AccessUserID: userID, ExpiresAt: &expiresAt,
+	}
+	if err := s.Store.CreateVHostRoute(r.Context(), route); err != nil {
+		return nil, fmt.Errorf("create private artifact route: %w", err)
+	}
+	return route, nil
+}
+
+func (s *HelixAPIServer) servePrivateArtifactVHost(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, route *types.VHostRoute, requestedPath string) {
+	userID, ok := activePrivateArtifactRouteUser(route, time.Now())
+	if !ok {
 		http.Error(w, "artifact access required", http.StatusUnauthorized)
 		return
 	}
-	claims, err := s.parseArtifactAccessToken(cookie.Value, artifact.ID, artifactSessionAud)
-	if err != nil {
-		http.Error(w, "artifact access required", http.StatusUnauthorized)
-		return
-	}
-	if err := s.authorizeUserToProjectByID(r.Context(), &types.User{ID: claims.Subject}, artifact.ProjectID, types.ActionGet); err != nil {
+	if err := s.authorizeUserToProjectByID(r.Context(), &types.User{ID: userID}, artifact.ProjectID, types.ActionGet); err != nil {
 		http.Error(w, "artifact access denied", http.StatusForbidden)
 		return
 	}
 	s.serveArtifactFile(w, r, artifact, requestedPath)
+}
+
+func activePrivateArtifactRouteUser(route *types.VHostRoute, now time.Time) (string, bool) {
+	if route == nil || route.TargetKind != types.VHostTargetArtifactPrivate || route.AccessUserID == "" || route.ExpiresAt == nil || !route.ExpiresAt.After(now) {
+		return "", false
+	}
+	return route.AccessUserID, true
+}
+
+// serveArtifactDocument delivers non-HTML documents on the trusted viewer
+// origin. Chrome blocks its extension-backed PDF viewer inside a cross-origin
+// iframe, so PDFs use this permission-checked, MIME-locked route instead of an
+// artifact vhost.
+func (s *HelixAPIServer) serveArtifactDocument(w http.ResponseWriter, r *http.Request) {
+	artifactID := mux.Vars(r)["artifact_id"]
+	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
+	if err != nil || artifact.Kind != types.ArtifactKindPDF {
+		http.NotFound(w, r)
+		return
+	}
+	if artifact.Visibility != types.ArtifactVisibilityPublic {
+		user := getRequestUser(r)
+		if user == nil || user.ID == "" {
+			http.Error(w, "artifact access required", http.StatusUnauthorized)
+			return
+		}
+		if err := s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, types.ActionGet); err != nil {
+			http.Error(w, "artifact access denied", http.StatusForbidden)
+			return
+		}
+	}
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{"filename": path.Base(artifact.Entrypoint)}))
+	setArtifactDocumentSecurityHeaders(w.Header(), artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	s.serveArtifactFile(w, r, artifact, "")
 }
 
 func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string) {
@@ -957,7 +1052,9 @@ func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	etag := `"` + artifact.ActiveVersion.ID + ":" + metadata.SHA256 + `"`
-	setArtifactSecurityHeaders(w.Header(), artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	if w.Header().Get("Content-Security-Policy") == "" {
+		setArtifactSecurityHeaders(w.Header(), artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	}
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("ETag", etag)
 	if r.Header.Get("If-None-Match") == etag {
@@ -1013,11 +1110,22 @@ func setArtifactSecurityHeaders(header http.Header, viewerOrigin string) {
 	header.Set("X-Content-Type-Options", "nosniff")
 	header.Set("Referrer-Policy", "no-referrer")
 	header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
-	frameAncestor := "'none'"
-	if parsed, err := url.Parse(strings.TrimSpace(viewerOrigin)); err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != "" {
-		frameAncestor = parsed.Scheme + "://" + parsed.Host
-	}
+	frameAncestor := artifactFrameAncestor(viewerOrigin)
 	header.Set("Content-Security-Policy", "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self' https:; frame-ancestors "+frameAncestor)
+}
+
+func setArtifactDocumentSecurityHeaders(header http.Header, viewerOrigin string) {
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Referrer-Policy", "no-referrer")
+	header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
+	header.Set("Content-Security-Policy", "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors "+artifactFrameAncestor(viewerOrigin))
+}
+
+func artifactFrameAncestor(viewerOrigin string) string {
+	if parsed, err := url.Parse(strings.TrimSpace(viewerOrigin)); err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != "" {
+		return parsed.Scheme + "://" + parsed.Host
+	}
+	return "'none'"
 }
 
 func writeArtifactHTTPError(w http.ResponseWriter, status int, message string) {

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -107,7 +107,7 @@ func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Req
 // @Param description formData string false "Description"
 // @Param entrypoint formData string false "HTML entrypoint (default index.html)"
 // @Param visibility formData string false "project or public"
-// @Param with_subdomain formData bool false "Allocate a public default subdomain"
+// @Param with_subdomain formData bool false "Deprecated: public artifacts always receive a share subdomain"
 // @Param artifact formData file true "HTML file or ZIP bundle"
 // @Success 201 {object} types.Artifact
 // @Router /api/v1/projects/{id}/artifacts [post]
@@ -134,16 +134,11 @@ func (s *HelixAPIServer) createProjectArtifact(w http.ResponseWriter, r *http.Re
 		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	withSubdomain, err := artifactFormBool(r, "with_subdomain")
-	if err != nil {
+	if _, err := artifactFormBool(r, "with_subdomain"); err != nil {
 		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if withSubdomain && visibility != types.ArtifactVisibilityPublic {
-		writeArtifactHTTPError(w, http.StatusBadRequest, "with_subdomain requires visibility=public")
-		return
-	}
-	if (withSubdomain || visibility == types.ArtifactVisibilityProject) && s.vhostBaseDomain() == "" {
+	if s.vhostBaseDomain() == "" {
 		writeArtifactHTTPError(w, http.StatusBadRequest, "artifact subdomains are not configured on this Helix instance")
 		return
 	}
@@ -180,12 +175,10 @@ func (s *HelixAPIServer) createProjectArtifact(w http.ResponseWriter, r *http.Re
 		return
 	}
 	artifact.ActiveVersion = version
-	if withSubdomain || visibility == types.ArtifactVisibilityProject {
-		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
-			s.rollbackCreatedArtifact(r, artifact, storagePrefix)
-			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
-			return
-		}
+	if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
+		s.rollbackCreatedArtifact(r, artifact, storagePrefix)
+		writeArtifactHTTPError(w, http.StatusConflict, err.Error())
+		return
 	}
 	if err := s.populateArtifactURLs(r, artifact); err != nil {
 		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
@@ -235,7 +228,6 @@ func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
-	previousVisibility := artifact.Visibility
 	if err := parseArtifactMultipart(w, r); err != nil {
 		writeArtifactHTTPError(w, artifactUploadStatus(err), err.Error())
 		return
@@ -260,17 +252,11 @@ func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) 
 		}
 		artifact.Visibility = visibility
 	}
-	withSubdomain, err := artifactFormBool(r, "with_subdomain")
-	if err != nil {
+	if _, err := artifactFormBool(r, "with_subdomain"); err != nil {
 		writeArtifactHTTPError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	withSubdomainSet := artifactFormHasField(r, "with_subdomain")
-	if withSubdomain && artifact.Visibility != types.ArtifactVisibilityPublic {
-		writeArtifactHTTPError(w, http.StatusBadRequest, "with_subdomain requires visibility=public")
-		return
-	}
-	if (withSubdomain || artifact.Visibility == types.ArtifactVisibilityProject) && s.vhostBaseDomain() == "" {
+	if s.vhostBaseDomain() == "" {
 		writeArtifactHTTPError(w, http.StatusBadRequest, "artifact subdomains are not configured on this Helix instance")
 		return
 	}
@@ -283,11 +269,6 @@ func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) 
 		writeArtifactHTTPError(w, http.StatusInternalServerError, "inspect artifact subdomain: "+err.Error())
 		return
 	}
-	wantsRoute := artifact.Visibility == types.ArtifactVisibilityProject || withSubdomain
-	if artifact.Visibility == types.ArtifactVisibilityPublic && !withSubdomainSet && previousVisibility == types.ArtifactVisibilityPublic {
-		wantsRoute = len(existingRoutes) > 0
-	}
-
 	requestedEntrypoint := artifact.Entrypoint
 	entrypointSet := false
 	if value, exists := artifactFormField(r, "entrypoint"); exists {
@@ -320,41 +301,27 @@ func (s *HelixAPIServer) updateArtifact(w http.ResponseWriter, r *http.Request) 
 		artifact.Entrypoint = entrypoint
 	}
 	artifact.UpdatedBy = getRequestUser(r).ID
-	createdPrivateRoute := false
-	if artifact.Visibility == types.ArtifactVisibilityProject {
-		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
-			if storagePrefix != "" {
-				s.cleanupArtifactStorage(r, storagePrefix)
-			}
-			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
-			return
+	createdRoute := len(existingRoutes) == 0
+	if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
+		if storagePrefix != "" {
+			s.cleanupArtifactStorage(r, storagePrefix)
 		}
-		createdPrivateRoute = len(existingRoutes) == 0
+		writeArtifactHTTPError(w, http.StatusConflict, err.Error())
+		return
 	}
 	if err := s.Store.UpdateArtifact(r.Context(), artifact, version); err != nil {
 		if storagePrefix != "" {
 			s.cleanupArtifactStorage(r, storagePrefix)
 		}
-		if createdPrivateRoute {
+		if createdRoute {
 			if cleanupErr := s.Store.DeleteVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID); cleanupErr != nil {
-				log.Error().Err(cleanupErr).Str("artifact_id", artifact.ID).Msg("failed to roll back artifact private route")
+				log.Error().Err(cleanupErr).Str("artifact_id", artifact.ID).Msg("failed to roll back artifact route")
 			}
 		}
 		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	if !wantsRoute {
-		if err := s.Store.DeleteVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID); err != nil {
-			writeArtifactHTTPError(w, http.StatusInternalServerError, "remove artifact subdomain: "+err.Error())
-			return
-		}
-	} else if artifact.Visibility == types.ArtifactVisibilityPublic {
-		if _, err := s.ensureArtifactSubdomain(r, artifact); err != nil {
-			writeArtifactHTTPError(w, http.StatusConflict, err.Error())
-			return
-		}
-	}
 	updated, err := s.Store.GetArtifact(r.Context(), artifact.ID)
 	if err != nil {
 		writeArtifactHTTPError(w, http.StatusInternalServerError, err.Error())
@@ -749,11 +716,6 @@ func artifactFormField(r *http.Request, name string) (string, bool) {
 	return values[len(values)-1], true
 }
 
-func artifactFormHasField(r *http.Request, name string) bool {
-	_, ok := artifactFormField(r, name)
-	return ok
-}
-
 func artifactFormBool(r *http.Request, name string) (bool, error) {
 	value, ok := artifactFormField(r, name)
 	if !ok || strings.TrimSpace(value) == "" {
@@ -800,7 +762,7 @@ func (s *HelixAPIServer) ensureArtifactSubdomain(r *http.Request, artifact *type
 
 func (s *HelixAPIServer) populateArtifactURLs(r *http.Request, artifact *types.Artifact) error {
 	origin := artifactRequestOrigin(r, s.Cfg.WebServer.URL)
-	artifact.URL = strings.TrimRight(origin, "/") + "/artifacts/" + artifact.ID + "/"
+	artifact.URL = strings.TrimRight(origin, "/") + "/artifacts/" + artifact.ID
 	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
 	if err != nil {
 		return fmt.Errorf("list artifact subdomains: %w", err)
@@ -833,16 +795,32 @@ func artifactRequestOrigin(r *http.Request, configured string) string {
 	return ""
 }
 
-// serveArtifactPath serves an artifact on the canonical Helix origin. Public
-// artifacts need no login; project artifacts inherit project read access.
-func (s *HelixAPIServer) serveArtifactPath(w http.ResponseWriter, r *http.Request) {
+// serveArtifactEmbed moves the viewer iframe onto the artifact's isolated
+// origin. Public artifacts redirect directly; private artifacts require
+// project access and exchange a short-lived grant for an origin-only session.
+func (s *HelixAPIServer) serveArtifactEmbed(w http.ResponseWriter, r *http.Request) {
 	artifactID := mux.Vars(r)["artifact_id"]
 	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	if artifact.Visibility != types.ArtifactVisibilityPublic {
+	routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
+	if err != nil || len(routes) == 0 {
+		http.Error(w, "artifact origin unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	redirectPath, err := artifactAccessRedirectPath(mux.Vars(r)["artifact_path"], r.URL.RawQuery)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	scheme := artifactOriginScheme(artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	if artifact.Visibility == types.ArtifactVisibilityPublic {
+		http.Redirect(w, r, scheme+"://"+routes[0].Hostname+redirectPath, http.StatusTemporaryRedirect)
+		return
+	}
+	if artifact.Visibility == types.ArtifactVisibilityProject {
 		user := getRequestUser(r)
 		if user == nil || user.ID == "" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -852,22 +830,11 @@ func (s *HelixAPIServer) serveArtifactPath(w http.ResponseWriter, r *http.Reques
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
-		routes, err := s.Store.ListVHostRoutesByTarget(r.Context(), types.VHostTargetArtifact, artifact.ID)
-		if err != nil || len(routes) == 0 {
-			http.Error(w, "private artifact origin unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		redirectPath, err := artifactAccessRedirectPath(mux.Vars(r)["artifact_path"], r.URL.RawQuery)
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
 		token, err := s.signArtifactAccessToken(user.ID, artifact.ID, redirectPath, artifactBootstrapAud, artifactBootstrapTTL)
 		if err != nil {
 			http.Error(w, "create artifact access", http.StatusInternalServerError)
 			return
 		}
-		scheme := artifactOriginScheme(artifactRequestOrigin(r, s.Cfg.WebServer.URL))
 		action := scheme + "://" + routes[0].Hostname + "/_helix/access"
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Referrer-Policy", "no-referrer")
@@ -881,7 +848,7 @@ func (s *HelixAPIServer) serveArtifactPath(w http.ResponseWriter, r *http.Reques
 		}
 		return
 	}
-	s.serveArtifactFile(w, r, artifact, mux.Vars(r)["artifact_path"], true)
+	http.NotFound(w, r)
 }
 
 func artifactAccessRedirectPath(requested, rawQuery string) (string, error) {
@@ -991,17 +958,17 @@ func (s *HelixAPIServer) servePrivateArtifactVHost(w http.ResponseWriter, r *htt
 		http.Error(w, "artifact access denied", http.StatusForbidden)
 		return
 	}
-	s.serveArtifactFile(w, r, artifact, requestedPath, false)
+	s.serveArtifactFile(w, r, artifact, requestedPath)
 }
 
-func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string, sandboxed bool) {
+func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string) {
 	filename, metadata, ok := resolveArtifactFile(artifact, requestedPath)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
 	etag := `"` + artifact.ActiveVersion.ID + ":" + metadata.SHA256 + `"`
-	setArtifactSecurityHeaders(w.Header(), sandboxed)
+	setArtifactSecurityHeaders(w.Header(), artifactRequestOrigin(r, s.Cfg.WebServer.URL))
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("ETag", etag)
 	if r.Header.Get("If-None-Match") == etag {
@@ -1053,20 +1020,15 @@ func resolveArtifactFile(artifact *types.Artifact, requested string) (string, ty
 	return "", types.ArtifactFile{}, false
 }
 
-func setArtifactSecurityHeaders(header http.Header, sandboxed bool) {
+func setArtifactSecurityHeaders(header http.Header, viewerOrigin string) {
 	header.Set("X-Content-Type-Options", "nosniff")
 	header.Set("Referrer-Policy", "no-referrer")
 	header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
-	if sandboxed {
-		// CSP sandbox gives the document an opaque origin. ES modules therefore
-		// require an explicit CORS response even when loaded from the artifact's
-		// canonical URL. These files are public; credentials remain unavailable to
-		// the opaque origin and private artifacts are served on an isolated host.
-		header.Set("Access-Control-Allow-Origin", "*")
-		header.Set("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads; default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; frame-ancestors 'self'; base-uri 'none'; form-action 'none'")
-	} else {
-		header.Set("Content-Security-Policy", "default-src 'self' data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'")
+	frameAncestor := "'none'"
+	if parsed, err := url.Parse(strings.TrimSpace(viewerOrigin)); err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != "" {
+		frameAncestor = parsed.Scheme + "://" + parsed.Host
 	}
+	header.Set("Content-Security-Policy", "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self' https:; frame-ancestors "+frameAncestor)
 }
 
 func writeArtifactHTTPError(w http.ResponseWriter, status int, message string) {

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -1058,6 +1058,11 @@ func setArtifactSecurityHeaders(header http.Header, sandboxed bool) {
 	header.Set("Referrer-Policy", "no-referrer")
 	header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
 	if sandboxed {
+		// CSP sandbox gives the document an opaque origin. ES modules therefore
+		// require an explicit CORS response even when loaded from the artifact's
+		// canonical URL. These files are public; credentials remain unavailable to
+		// the opaque origin and private artifacts are served on an isolated host.
+		header.Set("Access-Control-Allow-Origin", "*")
 		header.Set("Content-Security-Policy", "sandbox allow-scripts allow-forms allow-modals allow-popups allow-downloads; default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; frame-ancestors 'self'; base-uri 'none'; form-action 'none'")
 	} else {
 		header.Set("Content-Security-Policy", "default-src 'self' data: blob: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'")

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +66,11 @@ func TestArtifactSecurityHeaders(t *testing.T) {
 	invalid := http.Header{}
 	setArtifactSecurityHeaders(invalid, "javascript:alert(1)")
 	require.Contains(t, invalid.Get("Content-Security-Policy"), "frame-ancestors 'none'")
+
+	document := http.Header{}
+	setArtifactDocumentSecurityHeaders(document, "https://helix.example/path")
+	require.Equal(t, "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors https://helix.example", document.Get("Content-Security-Policy"))
+	require.NotContains(t, document.Get("Content-Security-Policy"), "unsafe-inline")
 }
 
 func TestArtifactRequestOrigin(t *testing.T) {
@@ -79,7 +83,7 @@ func TestArtifactRequestOrigin(t *testing.T) {
 }
 
 func TestDefaultAndValidateArtifactEntrypoint(t *testing.T) {
-	files := []types.ArtifactFile{{Path: "replacement.html"}}
+	files := []types.ArtifactFile{{Path: "replacement.html", ContentType: "text/html; charset=utf-8"}}
 
 	entrypoint, err := defaultAndValidateArtifactEntrypoint(files, "index.html", true)
 	require.NoError(t, err)
@@ -87,6 +91,41 @@ func TestDefaultAndValidateArtifactEntrypoint(t *testing.T) {
 
 	_, err = defaultAndValidateArtifactEntrypoint(files, "index.html", false)
 	require.ErrorContains(t, err, "entrypoint does not exist")
+}
+
+func TestValidateArtifactEntrypointSupportsDocuments(t *testing.T) {
+	tests := []struct {
+		name         string
+		file         types.ArtifactFile
+		expectedKind types.ArtifactKind
+	}{
+		{name: "PDF", file: types.ArtifactFile{Path: "report.pdf", ContentType: "application/pdf"}, expectedKind: types.ArtifactKindPDF},
+		{name: "image", file: types.ArtifactFile{Path: "diagram.png", ContentType: "image/png"}, expectedKind: types.ArtifactKindImage},
+		{name: "HTML", file: types.ArtifactFile{Path: "page.html", ContentType: "text/html; charset=utf-8"}, expectedKind: types.ArtifactKindSingleFile},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entrypoint, err := validateArtifactEntrypoint([]types.ArtifactFile{test.file}, test.file.Path)
+			require.NoError(t, err)
+			require.Equal(t, test.file.Path, entrypoint)
+			require.Equal(t, test.expectedKind, artifactKindFromFiles([]types.ArtifactFile{test.file}))
+		})
+	}
+}
+
+func TestValidateArtifactEntrypointRejectsUnsupportedSingleFile(t *testing.T) {
+	_, err := validateArtifactEntrypoint([]types.ArtifactFile{{Path: "script.js", ContentType: "text/javascript"}}, "script.js")
+	require.ErrorContains(t, err, "must be HTML, PDF, or an image")
+}
+
+func TestValidateArtifactEntrypointRequiresHTMLForBundle(t *testing.T) {
+	files := []types.ArtifactFile{
+		{Path: "report.pdf", ContentType: "application/pdf"},
+		{Path: "cover.png", ContentType: "image/png"},
+	}
+	_, err := validateArtifactEntrypoint(files, "report.pdf")
+	require.ErrorContains(t, err, "bundle entrypoint must be an HTML file")
 }
 
 func TestArtifactAccessRedirectPath(t *testing.T) {
@@ -100,19 +139,24 @@ func TestArtifactAccessRedirectPath(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestArtifactAccessToken(t *testing.T) {
-	server := &HelixAPIServer{Cfg: &config.ServerConfig{}}
-	server.Cfg.Auth.Regular.JWTSecret = "artifact-test-secret"
-	raw, err := server.signArtifactAccessToken("usr_test", "art_test", "/settings", artifactBootstrapAud, time.Minute)
-	require.NoError(t, err)
-	claims, err := server.parseArtifactAccessToken(raw, "art_test", artifactBootstrapAud)
-	require.NoError(t, err)
-	require.Equal(t, "usr_test", claims.Subject)
-	require.Equal(t, "/settings", claims.ArtifactPath)
-	_, err = server.parseArtifactAccessToken(raw, "art_other", artifactBootstrapAud)
-	require.Error(t, err)
-	_, err = server.parseArtifactAccessToken(raw, "art_test", artifactSessionAud)
-	require.Error(t, err)
+func TestActivePrivateArtifactRouteUser(t *testing.T) {
+	now := time.Now()
+	future := now.Add(time.Hour)
+	userID, ok := activePrivateArtifactRouteUser(&types.VHostRoute{
+		TargetKind:   types.VHostTargetArtifactPrivate,
+		AccessUserID: "usr_test",
+		ExpiresAt:    &future,
+	}, now)
+	require.True(t, ok)
+	require.Equal(t, "usr_test", userID)
+
+	past := now.Add(-time.Second)
+	_, ok = activePrivateArtifactRouteUser(&types.VHostRoute{
+		TargetKind:   types.VHostTargetArtifactPrivate,
+		AccessUserID: "usr_test",
+		ExpiresAt:    &past,
+	}, now)
+	require.False(t, ok)
 }
 
 func artifactTestZIP(t *testing.T, files map[string]string) []byte {

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -62,11 +62,13 @@ func TestArtifactSecurityHeaders(t *testing.T) {
 	require.Contains(t, canonical.Get("Content-Security-Policy"), "sandbox allow-scripts")
 	require.Contains(t, canonical.Get("Content-Security-Policy"), "connect-src 'none'")
 	require.NotContains(t, canonical.Get("Content-Security-Policy"), "allow-same-origin")
+	require.Equal(t, "*", canonical.Get("Access-Control-Allow-Origin"))
 
 	subdomain := http.Header{}
 	setArtifactSecurityHeaders(subdomain, false)
 	require.NotContains(t, subdomain.Get("Content-Security-Policy"), "sandbox")
 	require.Contains(t, subdomain.Get("Content-Security-Policy"), "connect-src 'self' https: wss:")
+	require.Empty(t, subdomain.Get("Access-Control-Allow-Origin"))
 }
 
 func TestArtifactRequestOrigin(t *testing.T) {

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"archive/zip"
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadArtifactZIP(t *testing.T) {
+	archive := artifactTestZIP(t, map[string]string{
+		"index.html":    "<h1>Hello</h1>",
+		"assets/app.js": "document.body.dataset.ready = 'yes'",
+	})
+	files, err := readArtifactZIP(archive)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	require.Equal(t, "assets/app.js", files[0].Metadata.Path)
+	require.Equal(t, "text/html; charset=utf-8", files[1].Metadata.ContentType)
+}
+
+func TestReadArtifactZIPRejectsTraversal(t *testing.T) {
+	archive := artifactTestZIP(t, map[string]string{"../index.html": "nope"})
+	_, err := readArtifactZIP(archive)
+	require.ErrorContains(t, err, "invalid artifact path")
+}
+
+func TestResolveArtifactFile(t *testing.T) {
+	artifact := &types.Artifact{
+		ID: "art_test", Kind: types.ArtifactKindSPA, Entrypoint: "index.html",
+		ActiveVersion: &types.ArtifactVersion{ID: "artv_test", Files: []types.ArtifactFile{
+			{Path: "index.html", SHA256: "one"},
+			{Path: "assets/app.js", SHA256: "two"},
+		}},
+	}
+
+	filename, _, ok := resolveArtifactFile(artifact, "")
+	require.True(t, ok)
+	require.Equal(t, "index.html", filename)
+	filename, _, ok = resolveArtifactFile(artifact, "assets/app.js")
+	require.True(t, ok)
+	require.Equal(t, "assets/app.js", filename)
+	filename, _, ok = resolveArtifactFile(artifact, "settings/profile")
+	require.True(t, ok)
+	require.Equal(t, "index.html", filename)
+	filename, _, ok = resolveArtifactFile(artifact, "settings/")
+	require.True(t, ok)
+	require.Equal(t, "index.html", filename)
+	_, _, ok = resolveArtifactFile(artifact, "../secret")
+	require.False(t, ok)
+}
+
+func TestArtifactSecurityHeaders(t *testing.T) {
+	canonical := http.Header{}
+	setArtifactSecurityHeaders(canonical, true)
+	require.Contains(t, canonical.Get("Content-Security-Policy"), "sandbox allow-scripts")
+	require.Contains(t, canonical.Get("Content-Security-Policy"), "connect-src 'none'")
+	require.NotContains(t, canonical.Get("Content-Security-Policy"), "allow-same-origin")
+
+	subdomain := http.Header{}
+	setArtifactSecurityHeaders(subdomain, false)
+	require.NotContains(t, subdomain.Get("Content-Security-Policy"), "sandbox")
+	require.Contains(t, subdomain.Get("Content-Security-Policy"), "connect-src 'self' https: wss:")
+}
+
+func TestArtifactRequestOrigin(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "http://api:8080/artifacts/art_123", nil)
+	require.Equal(t, "https://helix.example", artifactRequestOrigin(r, "https://helix.example/"))
+	require.Equal(t, "http://api:8080", artifactRequestOrigin(r, ""))
+
+	r.Header.Set("X-Forwarded-Proto", "https")
+	require.Equal(t, "https://api:8080", artifactRequestOrigin(r, ""))
+}
+
+func TestDefaultAndValidateArtifactEntrypoint(t *testing.T) {
+	files := []types.ArtifactFile{{Path: "replacement.html"}}
+
+	entrypoint, err := defaultAndValidateArtifactEntrypoint(files, "index.html", true)
+	require.NoError(t, err)
+	require.Equal(t, "replacement.html", entrypoint)
+
+	_, err = defaultAndValidateArtifactEntrypoint(files, "index.html", false)
+	require.ErrorContains(t, err, "entrypoint does not exist")
+}
+
+func TestArtifactAccessRedirectPath(t *testing.T) {
+	redirectPath, err := artifactAccessRedirectPath("settings/", "tab=billing")
+	require.NoError(t, err)
+	require.Equal(t, "/settings/?tab=billing", redirectPath)
+	redirectPath, err = artifactAccessRedirectPath("", "preview=true")
+	require.NoError(t, err)
+	require.Equal(t, "/?preview=true", redirectPath)
+	_, err = artifactAccessRedirectPath("../secrets", "")
+	require.Error(t, err)
+}
+
+func TestArtifactAccessToken(t *testing.T) {
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}}
+	server.Cfg.Auth.Regular.JWTSecret = "artifact-test-secret"
+	raw, err := server.signArtifactAccessToken("usr_test", "art_test", "/settings", artifactBootstrapAud, time.Minute)
+	require.NoError(t, err)
+	claims, err := server.parseArtifactAccessToken(raw, "art_test", artifactBootstrapAud)
+	require.NoError(t, err)
+	require.Equal(t, "usr_test", claims.Subject)
+	require.Equal(t, "/settings", claims.ArtifactPath)
+	_, err = server.parseArtifactAccessToken(raw, "art_other", artifactBootstrapAud)
+	require.Error(t, err)
+	_, err = server.parseArtifactAccessToken(raw, "art_test", artifactSessionAud)
+	require.Error(t, err)
+}
+
+func artifactTestZIP(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for filename, body := range files {
+		part, err := writer.Create(filename)
+		require.NoError(t, err)
+		_, err = part.Write([]byte(body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+	return buffer.Bytes()
+}

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -57,18 +57,16 @@ func TestResolveArtifactFile(t *testing.T) {
 }
 
 func TestArtifactSecurityHeaders(t *testing.T) {
-	canonical := http.Header{}
-	setArtifactSecurityHeaders(canonical, true)
-	require.Contains(t, canonical.Get("Content-Security-Policy"), "sandbox allow-scripts")
-	require.Contains(t, canonical.Get("Content-Security-Policy"), "connect-src 'none'")
-	require.NotContains(t, canonical.Get("Content-Security-Policy"), "allow-same-origin")
-	require.Equal(t, "*", canonical.Get("Access-Control-Allow-Origin"))
+	header := http.Header{}
+	setArtifactSecurityHeaders(header, "https://helix.example/path")
+	require.Contains(t, header.Get("Content-Security-Policy"), "connect-src 'self' https: wss:")
+	require.Contains(t, header.Get("Content-Security-Policy"), "frame-ancestors https://helix.example")
+	require.Equal(t, "no-referrer", header.Get("Referrer-Policy"))
+	require.Contains(t, header.Get("Permissions-Policy"), "camera=()")
 
-	subdomain := http.Header{}
-	setArtifactSecurityHeaders(subdomain, false)
-	require.NotContains(t, subdomain.Get("Content-Security-Policy"), "sandbox")
-	require.Contains(t, subdomain.Get("Content-Security-Policy"), "connect-src 'self' https: wss:")
-	require.Empty(t, subdomain.Get("Access-Control-Allow-Origin"))
+	invalid := http.Header{}
+	setArtifactSecurityHeaders(invalid, "javascript:alert(1)")
+	require.Contains(t, invalid.Get("Content-Security-Policy"), "frame-ancestors 'none'")
 }
 
 func TestArtifactRequestOrigin(t *testing.T) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -2739,7 +2739,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2790,7 +2790,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML file or ZIP bundle",
+                        "description": "Replacement HTML, PDF, image, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13432,7 +13432,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13484,7 +13484,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "file",
-                        "description": "HTML file or ZIP bundle",
+                        "description": "HTML, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -15829,6 +15829,35 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/types.Provider"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/public/artifacts/{artifact_id}": {
+            "get": {
+                "description": "Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get artifact viewer metadata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactViewerResponse"
                         }
                     }
                 }
@@ -28798,11 +28827,15 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "single_file",
-                "spa"
+                "spa",
+                "pdf",
+                "image"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
-                "ArtifactKindSPA"
+                "ArtifactKindSPA",
+                "ArtifactKindPDF",
+                "ArtifactKindImage"
             ]
         },
         "types.ArtifactVersion": {
@@ -28854,6 +28887,47 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/types.ArtifactVersion"
                     }
+                }
+            }
+        },
+        "types.ArtifactViewerResponse": {
+            "type": "object",
+            "properties": {
+                "active_version_id": {
+                    "type": "string"
+                },
+                "can_edit": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_name": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
                 }
             }
         },
@@ -41345,12 +41419,14 @@ const docTemplate = `{
             "enum": [
                 "project_web_service",
                 "sandbox_preview",
-                "artifact_static"
+                "artifact_static",
+                "artifact_private"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
                 "VHostTargetSandboxPreview",
-                "VHostTargetArtifact"
+                "VHostTargetArtifact",
+                "VHostTargetArtifactPrivate"
             ]
         },
         "types.WIPLimits": {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -13478,7 +13478,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "Allocate a public default subdomain",
+                        "description": "Deprecated: public artifacts always receive a share subdomain",
                         "name": "with_subdomain",
                         "in": "formData"
                     },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -2701,6 +2701,168 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/artifacts/{artifact_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Update an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate or retain a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "Replacement HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Delete an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/artifacts/{artifact_id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List artifact versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactVersionsListResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/attention-events": {
             "get": {
                 "description": "Returns attention events that need human action for the current user. Only returns events that have not been dismissed and are not currently snoozed.",
@@ -13226,6 +13388,113 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.CreateAccessGrantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/artifacts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List static artifacts in a project. Access is inherited from the project.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List project artifacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactsListResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Create a project artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint (default index.html)",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
                         }
                     }
                 }
@@ -28452,6 +28721,164 @@ const docTemplate = `{
                 }
             }
         },
+        "types.Artifact": {
+            "type": "object",
+            "properties": {
+                "active_version": {
+                    "$ref": "#/definitions/types.ArtifactVersion"
+                },
+                "active_version_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "$ref": "#/definitions/gorm.DeletedAt"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "entrypoint": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
+                }
+            }
+        },
+        "types.ArtifactFile": {
+            "type": "object",
+            "properties": {
+                "content_type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactKind": {
+            "type": "string",
+            "enum": [
+                "single_file",
+                "spa"
+            ],
+            "x-enum-varnames": [
+                "ArtifactKindSingleFile",
+                "ArtifactKindSPA"
+            ]
+        },
+        "types.ArtifactVersion": {
+            "type": "object",
+            "properties": {
+                "artifact_id": {
+                    "type": "string"
+                },
+                "content_sha256": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "file_count": {
+                    "type": "integer"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactFile"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "source_session_id": {
+                    "type": "string"
+                },
+                "source_spec_task_id": {
+                    "type": "string"
+                },
+                "total_bytes": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactVersionsListResponse": {
+            "type": "object",
+            "properties": {
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactVersion"
+                    }
+                }
+            }
+        },
+        "types.ArtifactVisibility": {
+            "type": "string",
+            "enum": [
+                "project",
+                "public"
+            ],
+            "x-enum-varnames": [
+                "ArtifactVisibilityProject",
+                "ArtifactVisibilityPublic"
+            ]
+        },
+        "types.ArtifactsListResponse": {
+            "type": "object",
+            "properties": {
+                "artifacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Artifact"
+                    }
+                }
+            }
+        },
         "types.AssistantAPI": {
             "type": "object",
             "properties": {
@@ -40887,7 +41314,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "port": {
-                    "description": "destination port inside the container",
+                    "description": "destination port inside the container; zero for static artifacts",
                     "type": "integer"
                 },
                 "rotated_at": {
@@ -40917,11 +41344,13 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "project_web_service",
-                "sandbox_preview"
+                "sandbox_preview",
+                "artifact_static"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
-                "VHostTargetSandboxPreview"
+                "VHostTargetSandboxPreview",
+                "VHostTargetArtifact"
             ]
         },
         "types.WIPLimits": {

--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -448,6 +448,21 @@ func (apiServer *HelixAPIServer) deleteOrganization(rw http.ResponseWriter, r *h
 	// backstop, so a teardown failure must not block the org delete.
 	apiServer.stopOrgDesktops(r.Context(), orgID)
 
+	// Public artifacts remain independently addressable, so deleting only the
+	// project rows would orphan live content. Remove every artifact route and
+	// blob owned by the organization before deleting its database graph.
+	artifacts, err := apiServer.Store.ListArtifacts(r.Context(), &store.ListArtifactsQuery{OrganizationID: orgID})
+	if err != nil {
+		http.Error(rw, "Could not list organization artifacts: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	for _, artifact := range artifacts {
+		if err := apiServer.deleteArtifactResources(r.Context(), artifact); err != nil {
+			http.Error(rw, "Could not delete organization artifact: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	err = apiServer.Store.DeleteOrganization(r.Context(), orgID)
 	if err != nil {
 		log.Err(err).Msg("error deleting organization")

--- a/api/pkg/server/organization_handlers_test.go
+++ b/api/pkg/server/organization_handlers_test.go
@@ -286,6 +286,9 @@ func TestDeleteOrganization_DeletesRepositoriesBeforeOrganization(t *testing.T) 
 			OrganizationID:        orgID,
 			IncludeExternalAgents: true,
 		}).Return([]*types.Session{}, int64(0), nil),
+		mockStore.EXPECT().ListArtifacts(gomock.Any(), &store.ListArtifactsQuery{
+			OrganizationID: orgID,
+		}).Return([]*types.Artifact{}, nil),
 		mockStore.EXPECT().DeleteOrganization(gomock.Any(), orgID).Return(nil),
 	)
 

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -1009,6 +1009,18 @@ func (s *HelixAPIServer) deleteProject(_ http.ResponseWriter, r *http.Request) (
 		}
 	}
 
+	// Static artifacts inherit project ownership, so project deletion must
+	// remove their routes, blobs, and metadata before archiving the project.
+	artifacts, err := s.Store.ListArtifacts(r.Context(), &store.ListArtifactsQuery{ProjectID: projectID})
+	if err != nil {
+		return nil, system.NewHTTPError500(fmt.Sprintf("list project artifacts: %s", err))
+	}
+	for _, artifact := range artifacts {
+		if err := s.deleteArtifactResources(r.Context(), artifact); err != nil {
+			return nil, system.NewHTTPError500(err.Error())
+		}
+	}
+
 	// Now soft delete the project
 	err = s.Store.DeleteProject(r.Context(), projectID)
 	if err != nil {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1515,6 +1515,15 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	// IMPORTANT: Must be before registerDefaultHandler to avoid being proxied to frontend
 	apiServer.gitHTTPServer.RegisterRoutes(router)
 
+	// Static artifacts live outside /api/v1. Authentication is optional here:
+	// public artifacts are anonymous while project artifacts authorize the
+	// extracted user against their owning project in the handler.
+	artifactRouter := router.PathPrefix("/artifacts/").Subrouter()
+	artifactRouter.Use(apiServer.authMiddleware.extractMiddleware)
+	artifactRouter.HandleFunc("/{artifact_id}", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
+	artifactRouter.HandleFunc("/{artifact_id}/", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
+	artifactRouter.HandleFunc("/{artifact_id}/{artifact_path:.*}", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
+
 	// Set a custom NotFoundHandler for /api/v1/ routes to log unknown paths
 	subRouter.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Error().
@@ -1540,6 +1549,8 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/projects", system.Wrapper(apiServer.createProject)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/projects/apply", system.Wrapper(apiServer.applyProject)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/projects/{id}", system.Wrapper(apiServer.getProject)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/projects/{id}/artifacts", apiServer.listProjectArtifacts).Methods(http.MethodGet)
+	authRouter.HandleFunc("/projects/{id}/artifacts", apiServer.createProjectArtifact).Methods(http.MethodPost)
 	authRouter.HandleFunc("/projects/{id}/spec-task-agents", system.Wrapper(apiServer.listProjectSpecTaskAgents)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/projects/{id}", system.Wrapper(apiServer.updateProject)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/projects/{id}", system.Wrapper(apiServer.deleteProject)).Methods(http.MethodDelete)
@@ -1587,6 +1598,10 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 
 	// Project audit log routes
 	authRouter.HandleFunc("/projects/{id}/audit-logs", system.Wrapper(apiServer.listProjectAuditLogs)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.getArtifact).Methods(http.MethodGet)
+	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.updateArtifact).Methods(http.MethodPut)
+	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.deleteArtifact).Methods(http.MethodDelete)
+	authRouter.HandleFunc("/artifacts/{artifact_id}/versions", apiServer.listArtifactVersions).Methods(http.MethodGet)
 
 	// Sample project routes (simple in-memory)
 	authRouter.HandleFunc("/sample-projects/simple", system.Wrapper(apiServer.listSimpleSampleProjects)).Methods(http.MethodGet)

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1515,14 +1515,12 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	// IMPORTANT: Must be before registerDefaultHandler to avoid being proxied to frontend
 	apiServer.gitHTTPServer.RegisterRoutes(router)
 
-	// Static artifacts live outside /api/v1. Authentication is optional here:
-	// public artifacts are anonymous while project artifacts authorize the
-	// extracted user against their owning project in the handler.
-	artifactRouter := router.PathPrefix("/artifacts/").Subrouter()
-	artifactRouter.Use(apiServer.authMiddleware.extractMiddleware)
-	artifactRouter.HandleFunc("/{artifact_id}", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
-	artifactRouter.HandleFunc("/{artifact_id}/", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
-	artifactRouter.HandleFunc("/{artifact_id}/{artifact_path:.*}", apiServer.serveArtifactPath).Methods(http.MethodGet, http.MethodHead)
+	// /artifacts/{id} is a frontend viewer. Its iframe enters the isolated
+	// artifact origin through these narrowly scoped embed routes.
+	artifactEmbedHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.serveArtifactEmbed))
+	router.Handle("/artifacts/{artifact_id}/embed", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
+	router.Handle("/artifacts/{artifact_id}/embed/", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
+	router.Handle("/artifacts/{artifact_id}/embed/{artifact_path:.*}", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
 
 	// Set a custom NotFoundHandler for /api/v1/ routes to log unknown paths
 	subRouter.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1521,6 +1521,10 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	router.Handle("/artifacts/{artifact_id}/embed", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
 	router.Handle("/artifacts/{artifact_id}/embed/", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
 	router.Handle("/artifacts/{artifact_id}/embed/{artifact_path:.*}", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
+	artifactDocumentHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.serveArtifactDocument))
+	router.Handle("/artifacts/{artifact_id}/document", artifactDocumentHandler).Methods(http.MethodGet, http.MethodHead)
+	artifactViewerHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.getArtifactViewer))
+	insecureRouter.Handle("/public/artifacts/{artifact_id}", artifactViewerHandler).Methods(http.MethodGet)
 
 	// Set a custom NotFoundHandler for /api/v1/ routes to log unknown paths
 	subRouter.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/pkg/server/session_preview_handlers.go
+++ b/api/pkg/server/session_preview_handlers.go
@@ -156,15 +156,19 @@ func (s *HelixAPIServer) setSessionPreviewURL(route *types.VHostRoute) {
 	if route == nil {
 		return
 	}
+	route.URL = s.vhostRouteURL(route.Hostname)
+}
+
+func (s *HelixAPIServer) vhostRouteURL(hostname string) string {
 	scheme := "http"
 	if s.Cfg.WebServer.PreviewURLHTTPS {
 		scheme = "https"
 	}
-	host := strings.TrimSpace(route.Hostname)
+	host := strings.TrimSpace(hostname)
 	if serverURL, err := url.Parse(s.Cfg.WebServer.URL); err == nil && serverURL.Port() != "" {
 		host += ":" + serverURL.Port()
 	}
-	route.URL = scheme + "://" + host
+	return scheme + "://" + host
 }
 
 // deleteSessionPreviewToken godoc

--- a/api/pkg/server/session_preview_handlers_test.go
+++ b/api/pkg/server/session_preview_handlers_test.go
@@ -27,6 +27,12 @@ func TestSetSessionPreviewURL(t *testing.T) {
 			serverURL:   "http://localhost:8080",
 			expectedURL: "http://share-test.preview.example.com:8080",
 		},
+		{
+			name:        "https with nonstandard port",
+			https:       true,
+			serverURL:   "https://helix.example.com:8443",
+			expectedURL: "https://share-test.preview.example.com:8443",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &HelixAPIServer{Cfg: &config.ServerConfig{}}

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -13474,7 +13474,7 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "Allocate a public default subdomain",
+                        "description": "Deprecated: public artifacts always receive a share subdomain",
                         "name": "with_subdomain",
                         "in": "formData"
                     },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -2697,6 +2697,168 @@
                 }
             }
         },
+        "/api/v1/artifacts/{artifact_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Update an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate or retain a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "Replacement HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Delete an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/artifacts/{artifact_id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List artifact versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactVersionsListResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/attention-events": {
             "get": {
                 "description": "Returns attention events that need human action for the current user. Only returns events that have not been dismissed and are not currently snoozed.",
@@ -13222,6 +13384,113 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.CreateAccessGrantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/artifacts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List static artifacts in a project. Access is inherited from the project.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List project artifacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactsListResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Create a project artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint (default index.html)",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
                         }
                     }
                 }
@@ -28448,6 +28717,164 @@
                 }
             }
         },
+        "types.Artifact": {
+            "type": "object",
+            "properties": {
+                "active_version": {
+                    "$ref": "#/definitions/types.ArtifactVersion"
+                },
+                "active_version_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "$ref": "#/definitions/gorm.DeletedAt"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "entrypoint": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
+                }
+            }
+        },
+        "types.ArtifactFile": {
+            "type": "object",
+            "properties": {
+                "content_type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactKind": {
+            "type": "string",
+            "enum": [
+                "single_file",
+                "spa"
+            ],
+            "x-enum-varnames": [
+                "ArtifactKindSingleFile",
+                "ArtifactKindSPA"
+            ]
+        },
+        "types.ArtifactVersion": {
+            "type": "object",
+            "properties": {
+                "artifact_id": {
+                    "type": "string"
+                },
+                "content_sha256": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "file_count": {
+                    "type": "integer"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactFile"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "source_session_id": {
+                    "type": "string"
+                },
+                "source_spec_task_id": {
+                    "type": "string"
+                },
+                "total_bytes": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactVersionsListResponse": {
+            "type": "object",
+            "properties": {
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactVersion"
+                    }
+                }
+            }
+        },
+        "types.ArtifactVisibility": {
+            "type": "string",
+            "enum": [
+                "project",
+                "public"
+            ],
+            "x-enum-varnames": [
+                "ArtifactVisibilityProject",
+                "ArtifactVisibilityPublic"
+            ]
+        },
+        "types.ArtifactsListResponse": {
+            "type": "object",
+            "properties": {
+                "artifacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Artifact"
+                    }
+                }
+            }
+        },
         "types.AssistantAPI": {
             "type": "object",
             "properties": {
@@ -40883,7 +41310,7 @@
                     "type": "boolean"
                 },
                 "port": {
-                    "description": "destination port inside the container",
+                    "description": "destination port inside the container; zero for static artifacts",
                     "type": "integer"
                 },
                 "rotated_at": {
@@ -40913,11 +41340,13 @@
             "type": "string",
             "enum": [
                 "project_web_service",
-                "sandbox_preview"
+                "sandbox_preview",
+                "artifact_static"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
-                "VHostTargetSandboxPreview"
+                "VHostTargetSandboxPreview",
+                "VHostTargetArtifact"
             ]
         },
         "types.WIPLimits": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -2735,7 +2735,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2786,7 +2786,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML file or ZIP bundle",
+                        "description": "Replacement HTML, PDF, image, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13428,7 +13428,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13480,7 +13480,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "HTML file or ZIP bundle",
+                        "description": "HTML, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -15825,6 +15825,35 @@
                             "items": {
                                 "$ref": "#/definitions/types.Provider"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/public/artifacts/{artifact_id}": {
+            "get": {
+                "description": "Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get artifact viewer metadata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactViewerResponse"
                         }
                     }
                 }
@@ -28794,11 +28823,15 @@
             "type": "string",
             "enum": [
                 "single_file",
-                "spa"
+                "spa",
+                "pdf",
+                "image"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
-                "ArtifactKindSPA"
+                "ArtifactKindSPA",
+                "ArtifactKindPDF",
+                "ArtifactKindImage"
             ]
         },
         "types.ArtifactVersion": {
@@ -28850,6 +28883,47 @@
                     "items": {
                         "$ref": "#/definitions/types.ArtifactVersion"
                     }
+                }
+            }
+        },
+        "types.ArtifactViewerResponse": {
+            "type": "object",
+            "properties": {
+                "active_version_id": {
+                    "type": "string"
+                },
+                "can_edit": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_name": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
                 }
             }
         },
@@ -41341,12 +41415,14 @@
             "enum": [
                 "project_web_service",
                 "sandbox_preview",
-                "artifact_static"
+                "artifact_static",
+                "artifact_private"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
                 "VHostTargetSandboxPreview",
-                "VHostTargetArtifact"
+                "VHostTargetArtifact",
+                "VHostTargetArtifactPrivate"
             ]
         },
         "types.WIPLimits": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3857,10 +3857,14 @@ definitions:
     enum:
     - single_file
     - spa
+    - pdf
+    - image
     type: string
     x-enum-varnames:
     - ArtifactKindSingleFile
     - ArtifactKindSPA
+    - ArtifactKindPDF
+    - ArtifactKindImage
   types.ArtifactVersion:
     properties:
       artifact_id:
@@ -3894,6 +3898,33 @@ definitions:
         items:
           $ref: '#/definitions/types.ArtifactVersion'
         type: array
+    type: object
+  types.ArtifactViewerResponse:
+    properties:
+      active_version_id:
+        type: string
+      can_edit:
+        type: boolean
+      description:
+        type: string
+      id:
+        type: string
+      kind:
+        $ref: '#/definitions/types.ArtifactKind'
+      name:
+        type: string
+      organization_id:
+        type: string
+      organization_name:
+        type: string
+      project_id:
+        type: string
+      project_name:
+        type: string
+      subdomain_url:
+        type: string
+      visibility:
+        $ref: '#/definitions/types.ArtifactVisibility'
     type: object
   types.ArtifactVisibility:
     enum:
@@ -13156,11 +13187,13 @@ definitions:
     - project_web_service
     - sandbox_preview
     - artifact_static
+    - artifact_private
     type: string
     x-enum-varnames:
     - VHostTargetProjectWebService
     - VHostTargetSandboxPreview
     - VHostTargetArtifact
+    - VHostTargetArtifactPrivate
   types.WIPLimits:
     properties:
       implementation:
@@ -15259,8 +15292,8 @@ paths:
     put:
       consumes:
       - multipart/form-data
-      description: Patch metadata and optionally upload a replacement HTML file or
-        ZIP bundle as a new version.
+      description: Patch metadata and optionally upload replacement HTML, PDF, image,
+        or ZIP content as a new version.
       parameters:
       - description: Artifact ID
         in: path
@@ -15287,7 +15320,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: Replacement HTML file or ZIP bundle
+      - description: Replacement HTML, PDF, image, or ZIP content
         in: formData
         name: artifact
         type: file
@@ -22018,7 +22051,8 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: Upload one HTML file or a ZIP containing a compiled static SPA.
+      description: Upload one HTML, PDF, or image file, or a ZIP containing a compiled
+        static SPA.
       parameters:
       - description: Project ID
         in: path
@@ -22046,7 +22080,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: HTML file or ZIP bundle
+      - description: HTML, PDF, image, or ZIP bundle
         in: formData
         name: artifact
         required: true
@@ -23640,6 +23674,26 @@ paths:
             type: array
       security:
       - BearerAuth: []
+  /api/v1/public/artifacts/{artifact_id}:
+    get:
+      description: Returns safe display metadata for public artifacts without authentication.
+        Private artifacts require project access.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactViewerResponse'
+      summary: Get artifact viewer metadata
+      tags:
+      - Artifacts
   /api/v1/quotas:
     get:
       description: Get quotas for the user. Returns current usage and limits for desktops,

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3805,6 +3805,111 @@ definitions:
       type:
         $ref: '#/definitions/types.APIKeyType'
     type: object
+  types.Artifact:
+    properties:
+      active_version:
+        $ref: '#/definitions/types.ArtifactVersion'
+      active_version_id:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      deleted_at:
+        $ref: '#/definitions/gorm.DeletedAt'
+      description:
+        type: string
+      entrypoint:
+        type: string
+      id:
+        type: string
+      kind:
+        $ref: '#/definitions/types.ArtifactKind'
+      name:
+        type: string
+      organization_id:
+        type: string
+      project_id:
+        type: string
+      subdomain_url:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+      url:
+        type: string
+      visibility:
+        $ref: '#/definitions/types.ArtifactVisibility'
+    type: object
+  types.ArtifactFile:
+    properties:
+      content_type:
+        type: string
+      path:
+        type: string
+      sha256:
+        type: string
+      size:
+        type: integer
+    type: object
+  types.ArtifactKind:
+    enum:
+    - single_file
+    - spa
+    type: string
+    x-enum-varnames:
+    - ArtifactKindSingleFile
+    - ArtifactKindSPA
+  types.ArtifactVersion:
+    properties:
+      artifact_id:
+        type: string
+      content_sha256:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      file_count:
+        type: integer
+      files:
+        items:
+          $ref: '#/definitions/types.ArtifactFile'
+        type: array
+      id:
+        type: string
+      source_session_id:
+        type: string
+      source_spec_task_id:
+        type: string
+      total_bytes:
+        type: integer
+      version:
+        type: integer
+    type: object
+  types.ArtifactVersionsListResponse:
+    properties:
+      versions:
+        items:
+          $ref: '#/definitions/types.ArtifactVersion'
+        type: array
+    type: object
+  types.ArtifactVisibility:
+    enum:
+    - project
+    - public
+    type: string
+    x-enum-varnames:
+    - ArtifactVisibilityProject
+    - ArtifactVisibilityPublic
+  types.ArtifactsListResponse:
+    properties:
+      artifacts:
+        items:
+          $ref: '#/definitions/types.Artifact'
+        type: array
+    type: object
   types.AssistantAPI:
     properties:
       description:
@@ -13023,7 +13128,7 @@ definitions:
           User-added custom domains and preview tokens are false.
         type: boolean
       port:
-        description: destination port inside the container
+        description: destination port inside the container; zero for static artifacts
         type: integer
       rotated_at:
         type: string
@@ -13050,10 +13155,12 @@ definitions:
     enum:
     - project_web_service
     - sandbox_preview
+    - artifact_static
     type: string
     x-enum-varnames:
     - VHostTargetProjectWebService
     - VHostTargetSandboxPreview
+    - VHostTargetArtifact
   types.WIPLimits:
     properties:
       implementation:
@@ -15114,6 +15221,108 @@ paths:
       summary: Create a new API key
       tags:
       - api-keys
+  /api/v1/artifacts/{artifact_id}:
+    delete:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - BearerAuth: []
+      summary: Delete an artifact
+      tags:
+      - Artifacts
+    get:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Get an artifact
+      tags:
+      - Artifacts
+    put:
+      consumes:
+      - multipart/form-data
+      description: Patch metadata and optionally upload a replacement HTML file or
+        ZIP bundle as a new version.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      - description: Artifact name
+        in: formData
+        name: name
+        type: string
+      - description: Description
+        in: formData
+        name: description
+        type: string
+      - description: HTML entrypoint
+        in: formData
+        name: entrypoint
+        type: string
+      - description: project or public
+        in: formData
+        name: visibility
+        type: string
+      - description: Allocate or retain a public default subdomain
+        in: formData
+        name: with_subdomain
+        type: boolean
+      - description: Replacement HTML file or ZIP bundle
+        in: formData
+        name: artifact
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Update an artifact
+      tags:
+      - Artifacts
+  /api/v1/artifacts/{artifact_id}/versions:
+    get:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactVersionsListResponse'
+      security:
+      - BearerAuth: []
+      summary: List artifact versions
+      tags:
+      - Artifacts
   /api/v1/attention-events:
     get:
       description: Returns attention events that need human action for the current
@@ -21784,6 +21993,76 @@ paths:
       summary: Grant access to a project to a team or organization member
       tags:
       - projects
+  /api/v1/projects/{id}/artifacts:
+    get:
+      description: List static artifacts in a project. Access is inherited from the
+        project.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactsListResponse'
+      security:
+      - BearerAuth: []
+      summary: List project artifacts
+      tags:
+      - Artifacts
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload one HTML file or a ZIP containing a compiled static SPA.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Artifact name
+        in: formData
+        name: name
+        required: true
+        type: string
+      - description: Description
+        in: formData
+        name: description
+        type: string
+      - description: HTML entrypoint (default index.html)
+        in: formData
+        name: entrypoint
+        type: string
+      - description: project or public
+        in: formData
+        name: visibility
+        type: string
+      - description: Allocate a public default subdomain
+        in: formData
+        name: with_subdomain
+        type: boolean
+      - description: HTML file or ZIP bundle
+        in: formData
+        name: artifact
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Create a project artifact
+      tags:
+      - Artifacts
   /api/v1/projects/{id}/audit-logs:
     get:
       consumes:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -22042,7 +22042,7 @@ paths:
         in: formData
         name: visibility
         type: string
-      - description: Allocate a public default subdomain
+      - description: 'Deprecated: public artifacts always receive a share subdomain'
         in: formData
         name: with_subdomain
         type: boolean

--- a/api/pkg/server/vhost_middleware.go
+++ b/api/pkg/server/vhost_middleware.go
@@ -157,7 +157,7 @@ func (m *VHostMiddleware) serveVHostLookup(w http.ResponseWriter, r *http.Reques
 		m.dispatchSandboxPreview(w, r, route)
 	case types.VHostTargetProjectWebService:
 		m.dispatchProjectWebService(w, r, route)
-	case types.VHostTargetArtifact:
+	case types.VHostTargetArtifact, types.VHostTargetArtifactPrivate:
 		m.dispatchArtifact(w, r, route)
 	default:
 		http.Error(w, "unknown route target kind", http.StatusInternalServerError)
@@ -171,7 +171,7 @@ func (m *VHostMiddleware) dispatchArtifact(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if artifact.Visibility != types.ArtifactVisibilityPublic {
-		m.apiServer.servePrivateArtifactVHost(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"))
+		m.apiServer.servePrivateArtifactVHost(w, r, artifact, route, strings.TrimPrefix(r.URL.Path, "/"))
 		return
 	}
 	m.apiServer.serveArtifactFile(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"))

--- a/api/pkg/server/vhost_middleware.go
+++ b/api/pkg/server/vhost_middleware.go
@@ -174,7 +174,7 @@ func (m *VHostMiddleware) dispatchArtifact(w http.ResponseWriter, r *http.Reques
 		m.apiServer.servePrivateArtifactVHost(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"))
 		return
 	}
-	m.apiServer.serveArtifactFile(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"), false)
+	m.apiServer.serveArtifactFile(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"))
 }
 
 // dispatchSandboxPreview proxies a preview-token request to the

--- a/api/pkg/server/vhost_middleware.go
+++ b/api/pkg/server/vhost_middleware.go
@@ -75,7 +75,7 @@ func hostnameOf(serverURL string) string {
 // VHostMiddleware dispatches incoming requests by Host header:
 //   - canonical hostname → fall through to the main mux
 //   - <share-*>.<base>   → look up vhost_routes (sandbox_preview)
-//   - other host with a matching vhost_routes row → project web service
+//   - other host with a matching vhost_routes row → project web service or artifact
 //   - everything else    → fall through to the main mux (404s from there)
 //
 // This replaces the old SubdomainProxyMiddleware (deleted) and the
@@ -119,8 +119,9 @@ func (m *VHostMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 3. Project web services — any other hostname that has a verified row.
-	m.serveVHostLookup(w, r, host, types.VHostTargetProjectWebService)
+	// 3. Project web services and static artifacts — any other hostname that
+	// has a verified row. The route row determines the target kind.
+	m.serveVHostLookup(w, r, host, "")
 }
 
 // serveVHostLookup resolves a hostname via vhost_routes and dispatches
@@ -140,7 +141,7 @@ func (m *VHostMiddleware) serveVHostLookup(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "vhost lookup failed", http.StatusInternalServerError)
 		return
 	}
-	if route.TargetKind != expectedKind {
+	if expectedKind != "" && route.TargetKind != expectedKind {
 		// Misrouted (likely a misconfiguration or someone trying to use
 		// the wrong dispatch branch). Treat as unknown.
 		m.next.ServeHTTP(w, r)
@@ -156,9 +157,24 @@ func (m *VHostMiddleware) serveVHostLookup(w http.ResponseWriter, r *http.Reques
 		m.dispatchSandboxPreview(w, r, route)
 	case types.VHostTargetProjectWebService:
 		m.dispatchProjectWebService(w, r, route)
+	case types.VHostTargetArtifact:
+		m.dispatchArtifact(w, r, route)
 	default:
 		http.Error(w, "unknown route target kind", http.StatusInternalServerError)
 	}
+}
+
+func (m *VHostMiddleware) dispatchArtifact(w http.ResponseWriter, r *http.Request, route *types.VHostRoute) {
+	artifact, err := m.apiServer.Store.GetArtifact(r.Context(), route.TargetID)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if artifact.Visibility != types.ArtifactVisibilityPublic {
+		m.apiServer.servePrivateArtifactVHost(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"))
+		return
+	}
+	m.apiServer.serveArtifactFile(w, r, artifact, strings.TrimPrefix(r.URL.Path, "/"), false)
 }
 
 // dispatchSandboxPreview proxies a preview-token request to the

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -213,6 +213,8 @@ func (s *PostgresStore) runMigrations() error {
 		&types.Transaction{},
 		&types.TopUp{},
 		&types.Project{},
+		&types.Artifact{},
+		&types.ArtifactVersion{},
 		&types.ProjectAuditLog{}, // Audit trail for project activity
 		&types.OrgAuditLog{},     // Audit trail for Helix org activity
 		&types.SampleProject{},

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -753,6 +753,14 @@ type Store interface {
 	GetProjectsCount(ctx context.Context, query *GetProjectsCountQuery) (int64, error)
 	UpdateProject(ctx context.Context, project *types.Project) error
 	DeleteProject(ctx context.Context, projectID string) error
+
+	// Project artifacts
+	CreateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error
+	GetArtifact(ctx context.Context, artifactID string) (*types.Artifact, error)
+	ListArtifacts(ctx context.Context, query *ListArtifactsQuery) ([]*types.Artifact, error)
+	UpdateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error
+	ListArtifactVersions(ctx context.Context, artifactID string) ([]*types.ArtifactVersion, error)
+	DeleteArtifact(ctx context.Context, artifactID string) error
 	SetProjectPrimaryRepository(ctx context.Context, projectID string, repoID string) error
 	AttachRepositoryToProject(ctx context.Context, projectID string, repoID string) error
 	DetachRepositoryFromProject(ctx context.Context, projectID string, repoID string) error // NOTE: signature changed to include projectID

--- a/api/pkg/store/store_artifacts.go
+++ b/api/pkg/store/store_artifacts.go
@@ -117,7 +117,6 @@ func (s *PostgresStore) UpdateArtifact(ctx context.Context, artifact *types.Arti
 				return fmt.Errorf("create artifact version: %w", err)
 			}
 			artifact.ActiveVersionID = version.ID
-			artifact.Kind = artifactKindForFileCount(version.FileCount)
 		} else {
 			var activeVersion types.ArtifactVersion
 			if err := tx.Where("id = ?", current.ActiveVersionID).First(&activeVersion).Error; err != nil {
@@ -147,13 +146,6 @@ func artifactFilesContain(files []types.ArtifactFile, filename string) bool {
 		}
 	}
 	return false
-}
-
-func artifactKindForFileCount(fileCount int) types.ArtifactKind {
-	if fileCount == 1 {
-		return types.ArtifactKindSingleFile
-	}
-	return types.ArtifactKindSPA
 }
 
 func (s *PostgresStore) ListArtifactVersions(ctx context.Context, artifactID string) ([]*types.ArtifactVersion, error) {

--- a/api/pkg/store/store_artifacts.go
+++ b/api/pkg/store/store_artifacts.go
@@ -1,0 +1,185 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type ListArtifactsQuery struct {
+	ProjectID      string
+	OrganizationID string
+}
+
+func (s *PostgresStore) CreateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error {
+	if artifact == nil || version == nil {
+		return errors.New("artifact and version are required")
+	}
+	if artifact.ID == "" || artifact.ProjectID == "" || version.ID == "" {
+		return errors.New("artifact ID, project ID, and version ID are required")
+	}
+	if artifact.ActiveVersionID != version.ID || version.ArtifactID != artifact.ID {
+		return errors.New("artifact active version and version artifact do not match")
+	}
+	return s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(artifact).Error; err != nil {
+			return fmt.Errorf("create artifact: %w", err)
+		}
+		if err := tx.Create(version).Error; err != nil {
+			return fmt.Errorf("create artifact version: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *PostgresStore) GetArtifact(ctx context.Context, artifactID string) (*types.Artifact, error) {
+	if artifactID == "" {
+		return nil, errors.New("artifact ID is required")
+	}
+	var artifact types.Artifact
+	if err := s.gdb.WithContext(ctx).Where("id = ?", artifactID).First(&artifact).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get artifact: %w", err)
+	}
+	if err := s.loadArtifactActiveVersion(ctx, &artifact); err != nil {
+		return nil, err
+	}
+	return &artifact, nil
+}
+
+func (s *PostgresStore) ListArtifacts(ctx context.Context, query *ListArtifactsQuery) ([]*types.Artifact, error) {
+	if query == nil || (query.ProjectID == "" && query.OrganizationID == "") {
+		return nil, errors.New("project ID or organization ID is required")
+	}
+	var artifacts []*types.Artifact
+	db := s.gdb.WithContext(ctx)
+	if query.ProjectID != "" {
+		db = db.Where("project_id = ?", query.ProjectID)
+	}
+	if query.OrganizationID != "" {
+		db = db.Where("organization_id = ?", query.OrganizationID)
+	}
+	if err := db.Order("updated_at DESC").Find(&artifacts).Error; err != nil {
+		return nil, fmt.Errorf("list artifacts: %w", err)
+	}
+	for _, artifact := range artifacts {
+		if err := s.loadArtifactActiveVersion(ctx, artifact); err != nil {
+			return nil, err
+		}
+	}
+	return artifacts, nil
+}
+
+func (s *PostgresStore) loadArtifactActiveVersion(ctx context.Context, artifact *types.Artifact) error {
+	var version types.ArtifactVersion
+	if err := s.gdb.WithContext(ctx).Where("id = ?", artifact.ActiveVersionID).First(&version).Error; err != nil {
+		return fmt.Errorf("get active version for artifact %s: %w", artifact.ID, err)
+	}
+	artifact.ActiveVersion = &version
+	return nil
+}
+
+func (s *PostgresStore) UpdateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error {
+	if artifact == nil || artifact.ID == "" {
+		return errors.New("artifact ID is required")
+	}
+	return s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var current types.Artifact
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", artifact.ID).First(&current).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock artifact: %w", err)
+		}
+		entrypointFiles := []types.ArtifactFile(nil)
+		if version != nil {
+			if version.ID == "" {
+				return errors.New("version ID is required")
+			}
+			var lastVersion int
+			if err := tx.Model(&types.ArtifactVersion{}).
+				Where("artifact_id = ?", artifact.ID).
+				Select("COALESCE(MAX(version), 0)").
+				Scan(&lastVersion).Error; err != nil {
+				return fmt.Errorf("get latest artifact version: %w", err)
+			}
+			version.ArtifactID = artifact.ID
+			version.Version = lastVersion + 1
+			entrypointFiles = version.Files
+			if err := tx.Create(version).Error; err != nil {
+				return fmt.Errorf("create artifact version: %w", err)
+			}
+			artifact.ActiveVersionID = version.ID
+			artifact.Kind = artifactKindForFileCount(version.FileCount)
+		} else {
+			var activeVersion types.ArtifactVersion
+			if err := tx.Where("id = ?", current.ActiveVersionID).First(&activeVersion).Error; err != nil {
+				return fmt.Errorf("get current artifact version: %w", err)
+			}
+			entrypointFiles = activeVersion.Files
+		}
+		if !artifactFilesContain(entrypointFiles, artifact.Entrypoint) {
+			return fmt.Errorf("artifact entrypoint does not exist in active version: %s", artifact.Entrypoint)
+		}
+		artifact.UpdatedAt = time.Now()
+		fields := []string{"name", "description", "entrypoint", "visibility", "updated_by", "updated_at"}
+		if version != nil {
+			fields = append(fields, "active_version_id", "kind")
+		}
+		if err := tx.Model(&current).Select(fields).Updates(artifact).Error; err != nil {
+			return fmt.Errorf("update artifact: %w", err)
+		}
+		return nil
+	})
+}
+
+func artifactFilesContain(files []types.ArtifactFile, filename string) bool {
+	for _, file := range files {
+		if file.Path == filename {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactKindForFileCount(fileCount int) types.ArtifactKind {
+	if fileCount == 1 {
+		return types.ArtifactKindSingleFile
+	}
+	return types.ArtifactKindSPA
+}
+
+func (s *PostgresStore) ListArtifactVersions(ctx context.Context, artifactID string) ([]*types.ArtifactVersion, error) {
+	if artifactID == "" {
+		return nil, errors.New("artifact ID is required")
+	}
+	var versions []*types.ArtifactVersion
+	if err := s.gdb.WithContext(ctx).
+		Where("artifact_id = ?", artifactID).
+		Order("version DESC").
+		Find(&versions).Error; err != nil {
+		return nil, fmt.Errorf("list artifact versions: %w", err)
+	}
+	return versions, nil
+}
+
+func (s *PostgresStore) DeleteArtifact(ctx context.Context, artifactID string) error {
+	if artifactID == "" {
+		return errors.New("artifact ID is required")
+	}
+	result := s.gdb.WithContext(ctx).Delete(&types.Artifact{}, "id = ?", artifactID)
+	if result.Error != nil {
+		return fmt.Errorf("delete artifact: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -356,6 +356,20 @@ func (mr *MockStoreMockRecorder) CreateApp(ctx, tool any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApp", reflect.TypeOf((*MockStore)(nil).CreateApp), ctx, tool)
 }
 
+// CreateArtifact mocks base method.
+func (m *MockStore) CreateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateArtifact", ctx, artifact, version)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateArtifact indicates an expected call of CreateArtifact.
+func (mr *MockStoreMockRecorder) CreateArtifact(ctx, artifact, version any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateArtifact", reflect.TypeOf((*MockStore)(nil).CreateArtifact), ctx, artifact, version)
+}
+
 // CreateAttentionEvent mocks base method.
 func (m *MockStore) CreateAttentionEvent(ctx context.Context, event *types.AttentionEvent) (*types.AttentionEvent, error) {
 	m.ctrl.T.Helper()
@@ -1397,6 +1411,20 @@ func (m *MockStore) DeleteApp(ctx context.Context, id string) error {
 func (mr *MockStoreMockRecorder) DeleteApp(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApp", reflect.TypeOf((*MockStore)(nil).DeleteApp), ctx, id)
+}
+
+// DeleteArtifact mocks base method.
+func (m *MockStore) DeleteArtifact(ctx context.Context, artifactID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteArtifact", ctx, artifactID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteArtifact indicates an expected call of DeleteArtifact.
+func (mr *MockStoreMockRecorder) DeleteArtifact(ctx, artifactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteArtifact", reflect.TypeOf((*MockStore)(nil).DeleteArtifact), ctx, artifactID)
 }
 
 // DeleteClaudeSubscription mocks base method.
@@ -2493,6 +2521,21 @@ func (m *MockStore) GetAppWithTools(ctx context.Context, id string) (*types.App,
 func (mr *MockStoreMockRecorder) GetAppWithTools(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppWithTools", reflect.TypeOf((*MockStore)(nil).GetAppWithTools), ctx, id)
+}
+
+// GetArtifact mocks base method.
+func (m *MockStore) GetArtifact(ctx context.Context, artifactID string) (*types.Artifact, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArtifact", ctx, artifactID)
+	ret0, _ := ret[0].(*types.Artifact)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetArtifact indicates an expected call of GetArtifact.
+func (mr *MockStoreMockRecorder) GetArtifact(ctx, artifactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArtifact", reflect.TypeOf((*MockStore)(nil).GetArtifact), ctx, artifactID)
 }
 
 // GetAttentionEvent mocks base method.
@@ -4429,6 +4472,36 @@ func (m *MockStore) ListApps(ctx context.Context, q *ListAppsQuery) ([]*types.Ap
 func (mr *MockStoreMockRecorder) ListApps(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApps", reflect.TypeOf((*MockStore)(nil).ListApps), ctx, q)
+}
+
+// ListArtifactVersions mocks base method.
+func (m *MockStore) ListArtifactVersions(ctx context.Context, artifactID string) ([]*types.ArtifactVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListArtifactVersions", ctx, artifactID)
+	ret0, _ := ret[0].([]*types.ArtifactVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListArtifactVersions indicates an expected call of ListArtifactVersions.
+func (mr *MockStoreMockRecorder) ListArtifactVersions(ctx, artifactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListArtifactVersions", reflect.TypeOf((*MockStore)(nil).ListArtifactVersions), ctx, artifactID)
+}
+
+// ListArtifacts mocks base method.
+func (m *MockStore) ListArtifacts(ctx context.Context, query *ListArtifactsQuery) ([]*types.Artifact, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListArtifacts", ctx, query)
+	ret0, _ := ret[0].([]*types.Artifact)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListArtifacts indicates an expected call of ListArtifacts.
+func (mr *MockStoreMockRecorder) ListArtifacts(ctx, query any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListArtifacts", reflect.TypeOf((*MockStore)(nil).ListArtifacts), ctx, query)
 }
 
 // ListAttentionEvents mocks base method.
@@ -6387,6 +6460,20 @@ func (m *MockStore) UpdateApp(ctx context.Context, tool *types.App) (*types.App,
 func (mr *MockStoreMockRecorder) UpdateApp(ctx, tool any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApp", reflect.TypeOf((*MockStore)(nil).UpdateApp), ctx, tool)
+}
+
+// UpdateArtifact mocks base method.
+func (m *MockStore) UpdateArtifact(ctx context.Context, artifact *types.Artifact, version *types.ArtifactVersion) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateArtifact", ctx, artifact, version)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateArtifact indicates an expected call of UpdateArtifact.
+func (mr *MockStoreMockRecorder) UpdateArtifact(ctx, artifact, version any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateArtifact", reflect.TypeOf((*MockStore)(nil).UpdateArtifact), ctx, artifact, version)
 }
 
 // UpdateAttentionEvent mocks base method.

--- a/api/pkg/system/uuid.go
+++ b/api/pkg/system/uuid.go
@@ -55,6 +55,8 @@ const (
 	VHostRoutePrefix           = "vhr_"
 	WebServiceDeployPrefix     = "wsd_"
 	PromptHistoryPrefix        = "prompt_"
+	ArtifactPrefix             = "art_"
+	ArtifactVersionPrefix      = "artv_"
 )
 
 func GenerateUUID() string {
@@ -250,6 +252,14 @@ func GeneratePromptHistoryID() string {
 
 func GenerateWebServiceDeployID() string {
 	return fmt.Sprintf("%s%s", WebServiceDeployPrefix, newID())
+}
+
+func GenerateArtifactID() string {
+	return fmt.Sprintf("%s%s", ArtifactPrefix, newID())
+}
+
+func GenerateArtifactVersionID() string {
+	return fmt.Sprintf("%s%s", ArtifactVersionPrefix, newID())
 }
 
 // GenerateGitRepositoryID mints a unique id for a git repository row.

--- a/api/pkg/types/artifact.go
+++ b/api/pkg/types/artifact.go
@@ -11,6 +11,8 @@ type ArtifactKind string
 const (
 	ArtifactKindSingleFile ArtifactKind = "single_file"
 	ArtifactKindSPA        ArtifactKind = "spa"
+	ArtifactKindPDF        ArtifactKind = "pdf"
+	ArtifactKindImage      ArtifactKind = "image"
 )
 
 type ArtifactVisibility string
@@ -72,4 +74,22 @@ type ArtifactsListResponse struct {
 
 type ArtifactVersionsListResponse struct {
 	Versions []*ArtifactVersion `json:"versions"`
+}
+
+// ArtifactViewerResponse contains only the metadata needed by the public
+// artifact viewer. Project members receive the same shape with CanEdit set
+// when they may change sharing settings.
+type ArtifactViewerResponse struct {
+	ID               string             `json:"id"`
+	ProjectID        string             `json:"project_id"`
+	ProjectName      string             `json:"project_name"`
+	OrganizationID   string             `json:"organization_id"`
+	OrganizationName string             `json:"organization_name"`
+	Name             string             `json:"name"`
+	Description      string             `json:"description,omitempty"`
+	Kind             ArtifactKind       `json:"kind"`
+	Visibility       ArtifactVisibility `json:"visibility"`
+	ActiveVersionID  string             `json:"active_version_id"`
+	SubdomainURL     string             `json:"subdomain_url,omitempty"`
+	CanEdit          bool               `json:"can_edit"`
 }

--- a/api/pkg/types/artifact.go
+++ b/api/pkg/types/artifact.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type ArtifactKind string
+
+const (
+	ArtifactKindSingleFile ArtifactKind = "single_file"
+	ArtifactKindSPA        ArtifactKind = "spa"
+)
+
+type ArtifactVisibility string
+
+const (
+	ArtifactVisibilityProject ArtifactVisibility = "project"
+	ArtifactVisibilityPublic  ArtifactVisibility = "public"
+)
+
+type ArtifactFile struct {
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+	SHA256      string `json:"sha256"`
+}
+
+// Artifact is the stable project-scoped identity of a static page or app.
+// Content is immutable and versioned separately in ArtifactVersion.
+type Artifact struct {
+	ID              string             `json:"id" gorm:"primaryKey"`
+	ProjectID       string             `json:"project_id" gorm:"index;not null"`
+	OrganizationID  string             `json:"organization_id" gorm:"index"`
+	Name            string             `json:"name" gorm:"not null"`
+	Description     string             `json:"description,omitempty"`
+	Kind            ArtifactKind       `json:"kind" gorm:"not null"`
+	Entrypoint      string             `json:"entrypoint" gorm:"not null"`
+	Visibility      ArtifactVisibility `json:"visibility" gorm:"not null;default:project"`
+	ActiveVersionID string             `json:"active_version_id" gorm:"index;not null"`
+	CreatedBy       string             `json:"created_by" gorm:"index;not null"`
+	UpdatedBy       string             `json:"updated_by" gorm:"index;not null"`
+	CreatedAt       time.Time          `json:"created_at"`
+	UpdatedAt       time.Time          `json:"updated_at"`
+	DeletedAt       gorm.DeletedAt     `json:"deleted_at,omitempty" gorm:"index"`
+
+	ActiveVersion *ArtifactVersion `json:"active_version,omitempty" gorm:"-"`
+	URL           string           `json:"url,omitempty" gorm:"-"`
+	SubdomainURL  string           `json:"subdomain_url,omitempty" gorm:"-"`
+}
+
+// ArtifactVersion is an immutable deployment of an Artifact.
+type ArtifactVersion struct {
+	ID               string         `json:"id" gorm:"primaryKey"`
+	ArtifactID       string         `json:"artifact_id" gorm:"uniqueIndex:idx_artifact_version,priority:1;index;not null"`
+	Version          int            `json:"version" gorm:"uniqueIndex:idx_artifact_version,priority:2;not null"`
+	StoragePrefix    string         `json:"-" gorm:"not null"`
+	Files            []ArtifactFile `json:"files" gorm:"type:jsonb;serializer:json;not null"`
+	FileCount        int            `json:"file_count" gorm:"not null"`
+	TotalBytes       int64          `json:"total_bytes" gorm:"not null"`
+	ContentSHA256    string         `json:"content_sha256" gorm:"not null"`
+	SourceSessionID  string         `json:"source_session_id,omitempty" gorm:"index"`
+	SourceSpecTaskID string         `json:"source_spec_task_id,omitempty" gorm:"index"`
+	CreatedBy        string         `json:"created_by" gorm:"index;not null"`
+	CreatedAt        time.Time      `json:"created_at"`
+}
+
+type ArtifactsListResponse struct {
+	Artifacts []*Artifact `json:"artifacts"`
+}
+
+type ArtifactVersionsListResponse struct {
+	Versions []*ArtifactVersion `json:"versions"`
+}

--- a/api/pkg/types/vhost.go
+++ b/api/pkg/types/vhost.go
@@ -16,6 +16,10 @@ const (
 	// container for a "Share preview" dev URL. target_id is a session ID
 	// (ses_*) or sandbox ID (sbx_*).
 	VHostTargetSandboxPreview VHostTargetKind = "sandbox_preview"
+
+	// VHostTargetArtifact serves an Artifact's active static version directly
+	// from the filestore. target_id is an artifact ID (art_*).
+	VHostTargetArtifact VHostTargetKind = "artifact_static"
 )
 
 // VHostRoute maps a hostname to a routable target inside Helix. The same
@@ -27,7 +31,7 @@ type VHostRoute struct {
 	URL        string          `gorm:"-" json:"url,omitempty"`      // public URL, populated by preview API handlers
 	TargetKind VHostTargetKind `gorm:"index" json:"target_kind"`
 	TargetID   string          `gorm:"index" json:"target_id"`
-	Port       int             `json:"port"` // destination port inside the container
+	Port       int             `json:"port"` // destination port inside the container; zero for static artifacts
 
 	// IsDefault is true for project default subdomains (<slug>.<base>).
 	// User-added custom domains and preview tokens are false.

--- a/api/pkg/types/vhost.go
+++ b/api/pkg/types/vhost.go
@@ -20,11 +20,14 @@ const (
 	// VHostTargetArtifact serves an Artifact's active static version directly
 	// from the filestore. target_id is an artifact ID (art_*).
 	VHostTargetArtifact VHostTargetKind = "artifact_static"
+
+	// VHostTargetArtifactPrivate serves a private Artifact through a short-lived,
+	// user-bound hostname. target_id is an artifact ID (art_*).
+	VHostTargetArtifactPrivate VHostTargetKind = "artifact_private"
 )
 
-// VHostRoute maps a hostname to a routable target inside Helix. The same
-// table holds project web service routes (user-named hostnames) and sandbox
-// preview tokens (random share-* hostnames).
+// VHostRoute maps a hostname to a routable target inside Helix. The same table
+// holds project web services, sandbox preview tokens, and artifact origins.
 type VHostRoute struct {
 	ID         string          `gorm:"primaryKey" json:"id"`
 	Hostname   string          `gorm:"uniqueIndex" json:"hostname"` // always lowercased
@@ -45,6 +48,12 @@ type VHostRoute struct {
 	// VerificationToken is only meaningful for custom domains awaiting
 	// DNS-based verification. Null for default and preview rows.
 	VerificationToken string `json:"verification_token,omitempty"`
+
+	// AccessUserID and ExpiresAt are set only on private artifact viewer routes.
+	// They are deliberately excluded from API responses: the route hostname is
+	// an internal viewer capability, not a share URL.
+	AccessUserID string     `gorm:"index" json:"-"`
+	ExpiresAt    *time.Time `gorm:"index" json:"-"`
 
 	CreatedAt time.Time  `json:"created_at"`
 	RotatedAt *time.Time `json:"rotated_at,omitempty"`

--- a/design/2026-08-20-project-artifacts.md
+++ b/design/2026-08-20-project-artifacts.md
@@ -1,0 +1,248 @@
+# Project artifacts
+
+## Goal
+
+Let users and coding agents publish a self-contained HTML file or a compiled static SPA as a
+project resource. Artifacts inherit project RBAC for management and private viewing, are stored in
+Helix's filestore, and are served without starting a sandbox or application process.
+
+The project UI gains:
+
+- `/orgs/:org_id/projects/:id/artifacts` for inventory and management;
+- an **Artifacts** action from the project specs page;
+- a safe preview/open URL at `/artifacts/:artifact_id/`;
+- optional publishing on a dedicated Helix subdomain.
+
+The CLI gains `helix artifact create|update|list|get|delete`. `--project` defaults to
+`HELIX_PROJECT_ID`, so both SpecTask containers and helix-org Worker containers operate on their
+own project without rediscovering it.
+
+## Claude Artifacts reference
+
+Claude's current product establishes the useful interaction model, not a wire-compatible API:
+
+- artifacts are substantial, self-contained documents or apps shown separately from chat;
+- HTML, SVG, React components, documents, and diagrams are common artifact types;
+- edits produce selectable versions;
+- organization sharing additionally checks project access;
+- publishing creates a standalone URL and can be revoked;
+- Claude Code artifacts update a private live URL in place.
+
+Sources inspected on 2026-08-20:
+
+- https://support.claude.com/en/articles/9487310-what-are-artifacts-and-how-do-i-use-them
+- https://support.claude.com/en/articles/9547008-publish-and-share-artifacts
+
+Helix v1 deliberately implements static files only. AI calls, persistent application data, MCP
+calls from browser JavaScript, remixing, and collaborative data stores are separate products and
+must not be smuggled into the static hosting API.
+
+## Security boundary
+
+Agent-authored JavaScript is untrusted. Serving it as ordinary same-origin HTML on the Helix app
+hostname would let it read the CSRF cookie and issue authenticated API mutations as the viewer.
+`HttpOnly` on the session cookie does not prevent this.
+
+Public `/artifacts/:id/*` responses therefore use a CSP sandbox without `allow-same-origin`.
+Scripts can execute, but the document receives an opaque origin and cannot act as the Helix
+application. Responses also set `nosniff`, a restrictive permissions policy, and
+`frame-ancestors 'self'`.
+
+An opaque-origin private SPA cannot send Helix cookies on its script and stylesheet requests. A
+private canonical URL therefore serves only a trusted bootstrap form after project authorization.
+It POSTs a one-minute signed grant to the artifact's internal vhost; the grant never appears in a
+query string, redirect URL, referrer, or access-log path. The vhost exchanges it for a host-only,
+HttpOnly artifact session cookie and redirects to the requested artifact route with its query
+string intact. Every file request
+validates the signed cookie and re-checks the user's current project access, so membership changes
+take effect without waiting for cookie expiry. The isolated host receives no Helix session or CSRF
+cookies and can load a complete SPA normally.
+
+Published subdomains remain explicit. Public artifacts receive a directly shareable hostname only
+when requested. Switching a published artifact back to project visibility removes public access
+but provisions the isolated private-delivery route. Private delivery requires Helix's vhost base
+domain to be configured; insecure query-string bearer tokens are not a fallback.
+
+HTML is static content, not a server-side workload. Helix never runs `npm`, build scripts, server
+functions, or arbitrary code during upload or delivery. Agents build locally and upload the
+resulting directory.
+
+## Data model
+
+### `Artifact`
+
+- `id` (`art_…`, primary key)
+- `project_id` (indexed)
+- `organization_id` (indexed, denormalized for audit/search)
+- `name`, `description`
+- `kind`: `single_file` or `spa`
+- `entrypoint` (normally `index.html`)
+- `visibility`: `project` (default) or `public`
+- `active_version_id`
+- `created_by`, `updated_by`
+- timestamps and soft-delete timestamp
+
+An artifact is stable identity and mutable metadata. Access is always authorized against its
+project; there is no second artifact ACL that can drift from project grants.
+
+### `ArtifactVersion`
+
+- `id` (`artv_…`, primary key)
+- `artifact_id` (indexed)
+- monotonic `version`
+- filestore `storage_prefix`
+- immutable file manifest (`path`, size, media type, SHA-256)
+- total bytes, file count, aggregate content hash
+- optional `source_session_id` and `source_spec_task_id`
+- `created_by`, `created_at`
+
+Each upload writes a new unique filestore prefix before atomically inserting the version and
+moving `active_version_id`. Readers never observe a partially overwritten deployment. Concurrent
+updates lock the artifact row while assigning the next version number.
+
+Files live under:
+
+```text
+<FILE_PREFIX_GLOBAL>/projects/<project_id>/artifacts/<artifact_id>/versions/<version_id>/<path>
+```
+
+The server, not the client, constructs this prefix.
+
+## API
+
+Authenticated control-plane endpoints:
+
+```text
+GET    /api/v1/projects/{project_id}/artifacts
+POST   /api/v1/projects/{project_id}/artifacts
+GET    /api/v1/artifacts/{artifact_id}
+PUT    /api/v1/artifacts/{artifact_id}
+DELETE /api/v1/artifacts/{artifact_id}
+GET    /api/v1/artifacts/{artifact_id}/versions
+```
+
+Create and update accept multipart form data. The `artifact` part is either one static file or a
+ZIP containing a compiled SPA. Other fields are `name`, `description`, `entrypoint`, `visibility`,
+`with_subdomain`, `source_session_id`, and `source_spec_task_id`. An update without an `artifact`
+part changes metadata only.
+
+Validation happens before any write:
+
+- normalized relative paths only; reject absolute paths, `..`, backslashes, symlinks, and
+  duplicate normalized paths;
+- entrypoint must exist and must be HTML;
+- bounded compressed request, uncompressed total, individual file size, and file count;
+- reject encrypted or unsupported ZIP entries;
+- verify optional provenance belongs to the same project;
+- compute media types and hashes server-side.
+
+Static delivery entrypoint:
+
+```text
+GET /artifacts/{artifact_id}/
+GET /artifacts/{artifact_id}/{path...}
+```
+
+Directory paths resolve `index.html`. For SPAs, a missing extensionless route falls back to the
+declared entrypoint. `HEAD`, ETags, conditional requests, byte lengths, and `Cache-Control:
+no-cache` are supported. Public canonical delivery stays CSP-sandboxed. Private canonical delivery
+performs the signed POST bootstrap to the isolated vhost described above. The mutable URL therefore
+updates immediately while still permitting conditional browser caches.
+
+## RBAC
+
+- list/view/versions/private static view: project `Get`/`List`;
+- create: project `Create`;
+- metadata/content update and publish/unpublish: project `Update`;
+- delete: project `Delete`;
+- public subdomain delivery: no user identity, only when `visibility=public`;
+- private vhost delivery: signed artifact cookie plus a fresh project `Get` authorization on every
+  request.
+
+All handlers load the artifact, then authorize its canonical `project_id`. No request field can
+substitute another organization or project after creation.
+
+## CLI and agent workflow
+
+```bash
+helix artifact create ./index.html --project prj_... --name dashboard
+helix artifact create ./dist --project prj_... --name app --visibility public --subdomain
+helix artifact update art_... ./dist
+helix artifact update art_... --name "New name" --visibility project --subdomain=false
+helix artifact list --project prj_... --json
+helix artifact get art_...
+helix artifact delete art_...
+```
+
+The content path is a positional argument. The CLI uploads a regular file directly or builds a
+ZIP when the path is a directory, preserves POSIX relative paths, refuses symlinks, and uploads
+through the client package. `create` uses `HELIX_PROJECT_ID` when `--project` is omitted.
+
+The desktop images ship the `helix` CLI. Artifact commands additionally accept the runtime-native
+`HELIX_API_URL` and `USER_API_TOKEN` when `HELIX_URL`/`HELIX_API_KEY` are absent. This avoids
+duplicating credentials in container environment variables. Session/task provenance is attached
+automatically only when the target equals `HELIX_PROJECT_ID`; an org Worker can publish to another
+authorized project with `--project` without incorrectly claiming that its current session belongs
+to the target.
+
+This is the correct surface for SpecTask and helix-org agents. Adding four file-transfer MCP
+wrappers to the org-graph server would violate its small-surface rule and force large application
+bundles through JSON tool arguments. Agents create files with their shell/build tools and invoke
+one CLI upload command. The artifact skill documents that path and the current project default.
+
+## UI
+
+`ArtifactsPage` follows existing project list conventions:
+
+- generated API client wrapped by React Query in `artifactService.ts`;
+- page header and project breadcrumb;
+- **New Artifact** action;
+- `ViewModeToggle` with `SimpleTable` and `CardGrid` views;
+- cards/table show name, kind, visibility, current version, file count, update time, and URL;
+- one vertical-dot action menu for Open, Edit/publish version, and Delete;
+- create/update dialog accepts one HTML file or one ZIP bundle and exposes entrypoint and
+  publication options;
+- Open renders in a new tab and relies on the response CSP on the canonical hostname.
+
+The specs page gets an **Artifacts** labeled action and the router gets
+`org_project-artifacts` at `/orgs/:org_id/projects/:id/artifacts`.
+
+## Subdomains
+
+Add `artifact_static` to `VHostTargetKind`. `target_id` is the artifact ID. Default hostnames use
+the existing allocation and reservation logic. The vhost middleware dispatches the request to
+the artifact static handler instead of Hydra. Project-private artifacts always keep an internal
+vhost for isolated authenticated delivery; its URL is not advertised as a public subdomain.
+
+No port is used for artifact routes. Custom-domain management can reuse the existing vhost
+verification primitives after v1; the first implementation creates/revokes default subdomains
+only. A public artifact without `with_subdomain` has no vhost route and stays on the sandboxed
+canonical URL. This satisfies static subdomain serving without coupling artifacts to project
+web-service sandboxes.
+
+## Deletion and lifecycle
+
+Deleting an artifact removes its vhost routes, deletes its filestore subtree, and soft-deletes
+the metadata. Project and organization deletion invoke the same cleanup for all child artifacts
+before deleting their ownership graph. If filestore deletion fails, metadata remains so the
+operation can be retried; Helix does not knowingly leave a live row pointing at missing content.
+
+## Verification
+
+Automated verification covers ZIP parsing/traversal rejection, path resolution and SPA fallback,
+canonical/subdomain CSP policies, CLI directory archiving and agent environment fallback, vhost
+routing regressions, server/client/CLI compilation, TypeScript compilation, and a production
+frontend build.
+
+Live-stack verification exercises create → serve → update → serve changed content → delete
+→ 404 → recreate; anonymous private denial; the signed private-SPA bootstrap and authenticated
+multi-file asset seam; private/public route transitions; a public ZIP SPA's entrypoint, nested
+asset and client route; host-header subdomain dispatch; browser execution under the canonical CSP
+sandbox; UI routing/dialogs; and cleanup of metadata, blobs, and vhost rows.
+
+Desktop-image verification builds the Ubuntu image containing `/usr/local/bin/helix`. Its
+container smoke test uses the same `HELIX_API_URL`, `USER_API_TOKEN`, and `HELIX_PROJECT_ID` path
+that SpecTask and Worker sessions receive.
+
+For every update/delete test, exercise the immediately following normal operation. In particular:
+update then fetch the changed entrypoint; delete then recreate and open a same-named artifact.

--- a/design/2026-08-20-project-artifacts.md
+++ b/design/2026-08-20-project-artifacts.md
@@ -10,8 +10,8 @@ The project UI gains:
 
 - `/orgs/:org_id/projects/:id/artifacts` for inventory and management;
 - an **Artifacts** action from the project specs page;
-- a safe preview/open URL at `/artifacts/:artifact_id/`;
-- optional publishing on a dedicated Helix subdomain.
+- a permission-checked viewer at `/artifacts/:artifact_id` with a share control;
+- automatic isolated subdomain publishing when visibility is public.
 
 The CLI gains `helix artifact create|update|list|get|delete`. `--project` defaults to
 `HELIX_PROJECT_ID`, so both SpecTask containers and helix-org Worker containers operate on their
@@ -39,29 +39,21 @@ must not be smuggled into the static hosting API.
 
 ## Security boundary
 
-Agent-authored JavaScript is untrusted. Serving it as ordinary same-origin HTML on the Helix app
-hostname would let it read the CSRF cookie and issue authenticated API mutations as the viewer.
-`HttpOnly` on the session cookie does not prevent this.
+Agent-authored JavaScript is untrusted. `/artifacts/:id` therefore renders only the trusted Helix
+viewer toolbar. Artifact bytes load in a cross-origin iframe with a browser sandbox that permits
+scripts and same-origin access only inside the isolated artifact hostname. The artifact origin
+receives no Helix session or CSRF cookies. Its CSP restricts executable content to the artifact
+origin, disables objects and sensitive browser capabilities, suppresses referrers, and permits
+framing only by the configured Helix viewer origin.
 
-Public `/artifacts/:id/*` responses therefore use a CSP sandbox without `allow-same-origin`.
-Scripts can execute, but the document receives an opaque origin and cannot act as the Helix
-application. Responses also set `nosniff`, a restrictive permissions policy, and
-`frame-ancestors 'self'`.
-
-An opaque-origin private SPA cannot send Helix cookies on its script and stylesheet requests. A
-private canonical URL therefore serves only a trusted bootstrap form after project authorization.
-It POSTs a one-minute signed grant to the artifact's internal vhost; the grant never appears in a
+Private iframe navigation first enters `/artifacts/:id/embed`, which checks project access and
+POSTs a one-minute signed grant to the artifact's internal vhost. The grant never appears in a
 query string, redirect URL, referrer, or access-log path. The vhost exchanges it for a host-only,
-HttpOnly artifact session cookie and redirects to the requested artifact route with its query
-string intact. Every file request
-validates the signed cookie and re-checks the user's current project access, so membership changes
-take effect without waiting for cookie expiry. The isolated host receives no Helix session or CSRF
-cookies and can load a complete SPA normally.
-
-Published subdomains remain explicit. Public artifacts receive a directly shareable hostname only
-when requested. Switching a published artifact back to project visibility removes public access
-but provisions the isolated private-delivery route. Private delivery requires Helix's vhost base
-domain to be configured; insecure query-string bearer tokens are not a fallback.
+HttpOnly artifact session cookie. Every private file request validates the cookie and re-checks
+current project access. The private hostname is never returned as `subdomain_url` or linked by the
+UI. Public visibility exposes the same isolated hostname without user identity; returning to
+project visibility immediately removes anonymous access while retaining the internal route for
+the viewer.
 
 HTML is static content, not a server-side workload. Helix never runs `npm`, build scripts, server
 functions, or arbitrary code during upload or delivery. Agents build locally and upload the
@@ -123,7 +115,8 @@ GET    /api/v1/artifacts/{artifact_id}/versions
 
 Create and update accept multipart form data. The `artifact` part is either one static file or a
 ZIP containing a compiled SPA. Other fields are `name`, `description`, `entrypoint`, `visibility`,
-`with_subdomain`, `source_session_id`, and `source_spec_task_id`. An update without an `artifact`
+`source_session_id`, and `source_spec_task_id`. `with_subdomain` remains a deprecated compatibility
+field; public visibility now always allocates a share hostname. An update without an `artifact`
 part changes metadata only.
 
 Validation happens before any write:
@@ -136,18 +129,18 @@ Validation happens before any write:
 - verify optional provenance belongs to the same project;
 - compute media types and hashes server-side.
 
-Static delivery entrypoint:
+Viewer and isolated-origin entrypoints:
 
 ```text
-GET /artifacts/{artifact_id}/
-GET /artifacts/{artifact_id}/{path...}
+GET /artifacts/{artifact_id}                 # Helix viewer
+GET /artifacts/{artifact_id}/embed           # iframe origin handoff
+GET https://{artifact-subdomain}/{path...}   # static bytes
 ```
 
 Directory paths resolve `index.html`. For SPAs, a missing extensionless route falls back to the
 declared entrypoint. `HEAD`, ETags, conditional requests, byte lengths, and `Cache-Control:
-no-cache` are supported. Public canonical delivery stays CSP-sandboxed. Private canonical delivery
-performs the signed POST bootstrap to the isolated vhost described above. The mutable URL therefore
-updates immediately while still permitting conditional browser caches.
+no-cache` are supported. The stable viewer URL updates immediately while immutable content
+versions remain cache-addressable through ETags.
 
 ## RBAC
 
@@ -166,9 +159,9 @@ substitute another organization or project after creation.
 
 ```bash
 helix artifact create ./index.html --project prj_... --name dashboard
-helix artifact create ./dist --project prj_... --name app --visibility public --subdomain
+helix artifact create ./dist --project prj_... --name app --visibility public
 helix artifact update art_... ./dist
-helix artifact update art_... --name "New name" --visibility project --subdomain=false
+helix artifact update art_... --name "New name" --visibility project
 helix artifact list --project prj_... --json
 helix artifact get art_...
 helix artifact delete art_...
@@ -201,24 +194,20 @@ one CLI upload command. The artifact skill documents that path and the current p
 - cards/table show name, kind, visibility, current version, file count, update time, and URL;
 - one vertical-dot action menu for Open, Edit/publish version, and Delete;
 - create/update dialog accepts one HTML file or one ZIP bundle and exposes entrypoint and
-  publication options;
-- Open renders in a new tab and relies on the response CSP on the canonical hostname.
+  visibility;
+- Open renders `/artifacts/:id`, whose top bar shows visibility and a Share menu;
+- the viewer iframe loads only the isolated artifact origin with `sandbox` and `no-referrer`.
 
 The specs page gets an **Artifacts** labeled action and the router gets
 `org_project-artifacts` at `/orgs/:org_id/projects/:id/artifacts`.
 
 ## Subdomains
 
-Add `artifact_static` to `VHostTargetKind`. `target_id` is the artifact ID. Default hostnames use
-the existing allocation and reservation logic. The vhost middleware dispatches the request to
-the artifact static handler instead of Hydra. Project-private artifacts always keep an internal
-vhost for isolated authenticated delivery; its URL is not advertised as a public subdomain.
-
-No port is used for artifact routes. Custom-domain management can reuse the existing vhost
-verification primitives after v1; the first implementation creates/revokes default subdomains
-only. A public artifact without `with_subdomain` has no vhost route and stays on the sandboxed
-canonical URL. This satisfies static subdomain serving without coupling artifacts to project
-web-service sandboxes.
+Add `artifact_static` to `VHostTargetKind`. `target_id` is the artifact ID. Every artifact receives
+one default isolated hostname through the existing allocation and reservation logic. The vhost
+middleware dispatches it to the static handler instead of Hydra. Project-private artifacts use the
+hostname only through the authenticated viewer bootstrap and do not advertise it. Public artifacts
+return it as `subdomain_url`. No port or sandbox runtime is involved.
 
 ## Deletion and lifecycle
 
@@ -230,15 +219,15 @@ operation can be retried; Helix does not knowingly leave a live row pointing at 
 ## Verification
 
 Automated verification covers ZIP parsing/traversal rejection, path resolution and SPA fallback,
-canonical/subdomain CSP policies, CLI directory archiving and agent environment fallback, vhost
+viewer/subdomain CSP policies, CLI directory archiving and agent environment fallback, vhost
 routing regressions, server/client/CLI compilation, TypeScript compilation, and a production
 frontend build.
 
 Live-stack verification exercises create → serve → update → serve changed content → delete
 → 404 → recreate; anonymous private denial; the signed private-SPA bootstrap and authenticated
 multi-file asset seam; private/public route transitions; a public ZIP SPA's entrypoint, nested
-asset and client route; host-header subdomain dispatch; browser execution under the canonical CSP
-sandbox; UI routing/dialogs; and cleanup of metadata, blobs, and vhost rows.
+asset and client route; host-header subdomain dispatch; browser execution in the isolated iframe;
+viewer Share transitions; UI routing/dialogs; and cleanup of metadata, blobs, and vhost rows.
 
 Desktop-image verification builds the Ubuntu image containing `/usr/local/bin/helix`. Its
 container smoke test uses the same `HELIX_API_URL`, `USER_API_TOKEN`, and `HELIX_PROJECT_ID` path

--- a/design/2026-08-20-project-artifacts.md
+++ b/design/2026-08-20-project-artifacts.md
@@ -207,7 +207,9 @@ Add `artifact_static` to `VHostTargetKind`. `target_id` is the artifact ID. Ever
 one default isolated hostname through the existing allocation and reservation logic. The vhost
 middleware dispatches it to the static handler instead of Hydra. Project-private artifacts use the
 hostname only through the authenticated viewer bootstrap and do not advertise it. Public artifacts
-return it as `subdomain_url`. No port or sandbox runtime is involved.
+return it as `subdomain_url`. The URL uses the same external protocol and port configuration as
+spec-task previews (`PREVIEW_URL_HTTPS` plus the port from `SERVER_URL`); no sandbox runtime or
+artifact application port is involved.
 
 ## Deletion and lifecycle
 

--- a/design/2026-08-20-project-artifacts.md
+++ b/design/2026-08-20-project-artifacts.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Let users and coding agents publish a self-contained HTML file or a compiled static SPA as a
-project resource. Artifacts inherit project RBAC for management and private viewing, are stored in
-Helix's filestore, and are served without starting a sandbox or application process.
+Let users and coding agents publish a self-contained HTML file, a compiled static SPA, a PDF, or
+an image as a project resource. Artifacts inherit project RBAC for management and private viewing,
+are stored in Helix's filestore, and are served without starting a sandbox or application process.
 
 The project UI gains:
 
@@ -40,20 +40,30 @@ must not be smuggled into the static hosting API.
 ## Security boundary
 
 Agent-authored JavaScript is untrusted. `/artifacts/:id` therefore renders only the trusted Helix
-viewer toolbar. Artifact bytes load in a cross-origin iframe with a browser sandbox that permits
+viewer toolbar. HTML and SPA bytes load in a cross-origin iframe with a browser sandbox that permits
 scripts and same-origin access only inside the isolated artifact hostname. The artifact origin
 receives no Helix session or CSRF cookies. Its CSP restricts executable content to the artifact
 origin, disables objects and sensitive browser capabilities, suppresses referrers, and permits
 framing only by the configured Helix viewer origin.
 
 Private iframe navigation first enters `/artifacts/:id/embed`, which checks project access and
-POSTs a one-minute signed grant to the artifact's internal vhost. The grant never appears in a
-query string, redirect URL, referrer, or access-log path. The vhost exchanges it for a host-only,
-HttpOnly artifact session cookie. Every private file request validates the cookie and re-checks
-current project access. The private hostname is never returned as `subdomain_url` or linked by the
-UI. Public visibility exposes the same isolated hostname without user identity; returning to
-project visibility immediately removes anonymous access while retaining the internal route for
-the viewer.
+redirects the iframe to a random, expiring vhost route bound to that user and artifact. Every file
+request validates the route expiry and re-checks current project access. This avoids third-party
+cookies, which Safari blocks when local Helix runs on an IP address and artifact content runs on a
+wildcard hostname. The private hostname is suppressed from API responses and UI links, and the
+artifact response's `no-referrer` policy prevents it from leaking through subresource requests.
+Public visibility uses the stable isolated hostname without user identity; returning to project
+visibility immediately removes anonymous access from that stable route.
+
+Chrome's native PDF viewer cannot run inside that cross-origin sandbox. PDFs therefore use
+`/artifacts/:id/document`, a same-origin, permission-checked route restricted to `kind=pdf` and
+served as `application/pdf` with `nosniff`, inline disposition, and a `default-src 'none'` CSP.
+The browser extension renderer remains isolated while the viewer retains its Helix toolbar.
+
+The trusted `/artifacts/:id` viewer is also reachable without a Helix session when the artifact is
+public. Its unauthenticated API returns only viewer display metadata and `can_edit=false`; the
+toolbar offers Login instead of Share. Private viewer metadata still requires project `Get`, and
+the sharing control is rendered only when the response confirms project `Update` access.
 
 HTML is static content, not a server-side workload. Helix never runs `npm`, build scripts, server
 functions, or arbitrary code during upload or delivery. Agents build locally and upload the
@@ -67,7 +77,7 @@ resulting directory.
 - `project_id` (indexed)
 - `organization_id` (indexed, denormalized for audit/search)
 - `name`, `description`
-- `kind`: `single_file` or `spa`
+- `kind`: `single_file`, `spa`, `pdf`, or `image`
 - `entrypoint` (normally `index.html`)
 - `visibility`: `project` (default) or `public`
 - `active_version_id`
@@ -113,8 +123,8 @@ DELETE /api/v1/artifacts/{artifact_id}
 GET    /api/v1/artifacts/{artifact_id}/versions
 ```
 
-Create and update accept multipart form data. The `artifact` part is either one static file or a
-ZIP containing a compiled SPA. Other fields are `name`, `description`, `entrypoint`, `visibility`,
+Create and update accept multipart form data. The `artifact` part is HTML, PDF, an image, or a ZIP
+containing a compiled SPA. Other fields are `name`, `description`, `entrypoint`, `visibility`,
 `source_session_id`, and `source_spec_task_id`. `with_subdomain` remains a deprecated compatibility
 field; public visibility now always allocates a share hostname. An update without an `artifact`
 part changes metadata only.
@@ -123,7 +133,7 @@ Validation happens before any write:
 
 - normalized relative paths only; reject absolute paths, `..`, backslashes, symlinks, and
   duplicate normalized paths;
-- entrypoint must exist and must be HTML;
+- entrypoint must exist; bundles require HTML, while a single PDF or image is its own entrypoint;
 - bounded compressed request, uncompressed total, individual file size, and file count;
 - reject encrypted or unsupported ZIP entries;
 - verify optional provenance belongs to the same project;
@@ -134,6 +144,7 @@ Viewer and isolated-origin entrypoints:
 ```text
 GET /artifacts/{artifact_id}                 # Helix viewer
 GET /artifacts/{artifact_id}/embed           # iframe origin handoff
+GET /artifacts/{artifact_id}/document        # permission-checked native PDF delivery
 GET https://{artifact-subdomain}/{path...}   # static bytes
 ```
 
@@ -149,8 +160,9 @@ versions remain cache-addressable through ETags.
 - metadata/content update and publish/unpublish: project `Update`;
 - delete: project `Delete`;
 - public subdomain delivery: no user identity, only when `visibility=public`;
-- private vhost delivery: signed artifact cookie plus a fresh project `Get` authorization on every
-  request.
+- public viewer metadata: no user identity, reduced response shape, never editable;
+- private vhost delivery: unexpired user-bound route plus a fresh project `Get` authorization on
+  every request.
 
 All handlers load the artifact, then authorize its canonical `project_id`. No request field can
 substitute another organization or project after creation.
@@ -160,6 +172,8 @@ substitute another organization or project after creation.
 ```bash
 helix artifact create ./index.html --project prj_... --name dashboard
 helix artifact create ./dist --project prj_... --name app --visibility public
+helix artifact create ./report.pdf --project prj_... --name report
+helix artifact create ./diagram.png --project prj_... --name diagram
 helix artifact update art_... ./dist
 helix artifact update art_... --name "New name" --visibility project
 helix artifact list --project prj_... --json
@@ -192,11 +206,13 @@ one CLI upload command. The artifact skill documents that path and the current p
 - **New Artifact** action;
 - `ViewModeToggle` with `SimpleTable` and `CardGrid` views;
 - cards/table show name, kind, visibility, current version, file count, update time, and URL;
-- one vertical-dot action menu for Open, Edit/publish version, and Delete;
-- create/update dialog accepts one HTML file or one ZIP bundle and exposes entrypoint and
-  visibility;
+- one compact vertical-dot action menu with icons for Open, Edit/publish, and Delete;
+- create/update dialog accepts HTML, a ZIP bundle, PDF, or an image and exposes entrypoint only
+  where HTML routing needs one;
 - Open renders `/artifacts/:id`, whose top bar shows visibility and a Share menu;
-- the viewer iframe loads only the isolated artifact origin with `sandbox` and `no-referrer`.
+- HTML viewers load only the isolated artifact origin with `sandbox` and `no-referrer`; PDFs use
+  the permission-checked document route and browser-native renderer, while images use a contained
+  responsive image view.
 
 The specs page gets an **Artifacts** labeled action and the router gets
 `org_project-artifacts` at `/orgs/:org_id/projects/:id/artifacts`.
@@ -205,11 +221,12 @@ The specs page gets an **Artifacts** labeled action and the router gets
 
 Add `artifact_static` to `VHostTargetKind`. `target_id` is the artifact ID. Every artifact receives
 one default isolated hostname through the existing allocation and reservation logic. The vhost
-middleware dispatches it to the static handler instead of Hydra. Project-private artifacts use the
-hostname only through the authenticated viewer bootstrap and do not advertise it. Public artifacts
-return it as `subdomain_url`. The URL uses the same external protocol and port configuration as
-spec-task previews (`PREVIEW_URL_HTTPS` plus the port from `SERVER_URL`); no sandbox runtime or
-artifact application port is involved.
+middleware dispatches it to the static handler instead of Hydra. Private viewer loads receive an
+additional random, user-bound route with an eight-hour expiry; these routes are reused per user,
+removed when expired, and never advertised. Public artifacts return only the stable hostname as
+`subdomain_url`. URLs use the same external protocol and port configuration as spec-task previews
+(`PREVIEW_URL_HTTPS` plus the port from `SERVER_URL`); no sandbox runtime or artifact application
+port is involved.
 
 ## Deletion and lifecycle
 
@@ -220,7 +237,8 @@ operation can be retried; Helix does not knowingly leave a live row pointing at 
 
 ## Verification
 
-Automated verification covers ZIP parsing/traversal rejection, path resolution and SPA fallback,
+Automated verification covers ZIP parsing/traversal rejection, PDF/image kind and entrypoint
+validation, path resolution and SPA fallback,
 viewer/subdomain CSP policies, CLI directory archiving and agent environment fallback, vhost
 routing regressions, server/client/CLI compilation, TypeScript compilation, and a production
 frontend build.
@@ -228,7 +246,8 @@ frontend build.
 Live-stack verification exercises create → serve → update → serve changed content → delete
 → 404 → recreate; anonymous private denial; the signed private-SPA bootstrap and authenticated
 multi-file asset seam; private/public route transitions; a public ZIP SPA's entrypoint, nested
-asset and client route; host-header subdomain dispatch; browser execution in the isolated iframe;
+asset and client route; public PDF and image MIME delivery; Chrome's native PDF embedder and the
+responsive image viewer; host-header subdomain dispatch; browser execution in the isolated iframe;
 viewer Share transitions; UI routing/dialogs; and cleanup of metadata, blobs, and vhost rows.
 
 Desktop-image verification builds the Ubuntu image containing `/usr/local/bin/helix`. Its

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2427,6 +2427,65 @@ export interface TypesApiKey {
   type?: TypesAPIKeyType;
 }
 
+export interface TypesArtifact {
+  active_version?: TypesArtifactVersion;
+  active_version_id?: string;
+  created_at?: string;
+  created_by?: string;
+  deleted_at?: GormDeletedAt;
+  description?: string;
+  entrypoint?: string;
+  id?: string;
+  kind?: TypesArtifactKind;
+  name?: string;
+  organization_id?: string;
+  project_id?: string;
+  subdomain_url?: string;
+  updated_at?: string;
+  updated_by?: string;
+  url?: string;
+  visibility?: TypesArtifactVisibility;
+}
+
+export interface TypesArtifactFile {
+  content_type?: string;
+  path?: string;
+  sha256?: string;
+  size?: number;
+}
+
+export enum TypesArtifactKind {
+  ArtifactKindSingleFile = "single_file",
+  ArtifactKindSPA = "spa",
+}
+
+export interface TypesArtifactVersion {
+  artifact_id?: string;
+  content_sha256?: string;
+  created_at?: string;
+  created_by?: string;
+  file_count?: number;
+  files?: TypesArtifactFile[];
+  id?: string;
+  source_session_id?: string;
+  source_spec_task_id?: string;
+  total_bytes?: number;
+  version?: number;
+}
+
+export interface TypesArtifactVersionsListResponse {
+  versions?: TypesArtifactVersion[];
+}
+
+export enum TypesArtifactVisibility {
+  ArtifactVisibilityProject = "project",
+  ArtifactVisibilityPublic = "public",
+}
+
+export interface TypesArtifactsListResponse {
+  artifacts?: TypesArtifact[];
+}
+
 export interface TypesAssistantAPI {
   description?: string;
   headers?: Record<string, string>;
@@ -8188,7 +8247,7 @@ export interface TypesVHostRoute {
    * User-added custom domains and preview tokens are false.
    */
   is_default?: boolean;
-  /** destination port inside the container */
+  /** destination port inside the container; zero for static artifacts */
   port?: number;
   rotated_at?: string;
   target_id?: string;
@@ -8211,6 +8270,7 @@ export interface TypesVHostRoute {
 export enum TypesVHostTargetKind {
   VHostTargetProjectWebService = "project_web_service",
   VHostTargetSandboxPreview = "sandbox_preview",
+  VHostTargetArtifact = "artifact_static",
 }
 
 export interface TypesWIPLimits {
@@ -9777,6 +9837,96 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "POST",
         body: request,
         type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Artifacts
+     * @name V1ArtifactsDelete
+     * @summary Delete an artifact
+     * @request DELETE:/api/v1/artifacts/{artifact_id}
+     * @secure
+     */
+    v1ArtifactsDelete: (artifactId: string, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/api/v1/artifacts/${artifactId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Artifacts
+     * @name V1ArtifactsDetail
+     * @summary Get an artifact
+     * @request GET:/api/v1/artifacts/{artifact_id}
+     * @secure
+     */
+    v1ArtifactsDetail: (artifactId: string, params: RequestParams = {}) =>
+      this.request<TypesArtifact, any>({
+        path: `/api/v1/artifacts/${artifactId}`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.
+     *
+     * @tags Artifacts
+     * @name V1ArtifactsUpdate
+     * @summary Update an artifact
+     * @request PUT:/api/v1/artifacts/{artifact_id}
+     * @secure
+     */
+    v1ArtifactsUpdate: (
+      artifactId: string,
+      data: {
+        /** Artifact name */
+        name?: string;
+        /** Description */
+        description?: string;
+        /** HTML entrypoint */
+        entrypoint?: string;
+        /** project or public */
+        visibility?: string;
+        /** Allocate or retain a public default subdomain */
+        with_subdomain?: boolean;
+        /** Replacement HTML file or ZIP bundle */
+        artifact?: File;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesArtifact, any>({
+        path: `/api/v1/artifacts/${artifactId}`,
+        method: "PUT",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Artifacts
+     * @name V1ArtifactsVersionsDetail
+     * @summary List artifact versions
+     * @request GET:/api/v1/artifacts/{artifact_id}/versions
+     * @secure
+     */
+    v1ArtifactsVersionsDetail: (artifactId: string, params: RequestParams = {}) =>
+      this.request<TypesArtifactVersionsListResponse, any>({
+        path: `/api/v1/artifacts/${artifactId}/versions`,
+        method: "GET",
+        secure: true,
+        format: "json",
         ...params,
       }),
 
@@ -14876,6 +15026,61 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         body: request,
         secure: true,
         type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description List static artifacts in a project. Access is inherited from the project.
+     *
+     * @tags Artifacts
+     * @name V1ProjectsArtifactsDetail
+     * @summary List project artifacts
+     * @request GET:/api/v1/projects/{id}/artifacts
+     * @secure
+     */
+    v1ProjectsArtifactsDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesArtifactsListResponse, any>({
+        path: `/api/v1/projects/${id}/artifacts`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Upload one HTML file or a ZIP containing a compiled static SPA.
+     *
+     * @tags Artifacts
+     * @name V1ProjectsArtifactsCreate
+     * @summary Create a project artifact
+     * @request POST:/api/v1/projects/{id}/artifacts
+     * @secure
+     */
+    v1ProjectsArtifactsCreate: (
+      id: string,
+      data: {
+        /** Artifact name */
+        name: string;
+        /** Description */
+        description?: string;
+        /** HTML entrypoint (default index.html) */
+        entrypoint?: string;
+        /** project or public */
+        visibility?: string;
+        /** Allocate a public default subdomain */
+        with_subdomain?: boolean;
+        /** HTML file or ZIP bundle */
+        artifact: File;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesArtifact, any>({
+        path: `/api/v1/projects/${id}/artifacts`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.FormData,
+        format: "json",
         ...params,
       }),
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2457,6 +2457,8 @@ export interface TypesArtifactFile {
 export enum TypesArtifactKind {
   ArtifactKindSingleFile = "single_file",
   ArtifactKindSPA = "spa",
+  ArtifactKindPDF = "pdf",
+  ArtifactKindImage = "image",
 }
 
 export interface TypesArtifactVersion {
@@ -2475,6 +2477,21 @@ export interface TypesArtifactVersion {
 
 export interface TypesArtifactVersionsListResponse {
   versions?: TypesArtifactVersion[];
+}
+
+export interface TypesArtifactViewerResponse {
+  active_version_id?: string;
+  can_edit?: boolean;
+  description?: string;
+  id?: string;
+  kind?: TypesArtifactKind;
+  name?: string;
+  organization_id?: string;
+  organization_name?: string;
+  project_id?: string;
+  project_name?: string;
+  subdomain_url?: string;
+  visibility?: TypesArtifactVisibility;
 }
 
 export enum TypesArtifactVisibility {
@@ -8271,6 +8288,7 @@ export enum TypesVHostTargetKind {
   VHostTargetProjectWebService = "project_web_service",
   VHostTargetSandboxPreview = "sandbox_preview",
   VHostTargetArtifact = "artifact_static",
+  VHostTargetArtifactPrivate = "artifact_private",
 }
 
 export interface TypesWIPLimits {
@@ -9876,7 +9894,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.
+     * @description Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.
      *
      * @tags Artifacts
      * @name V1ArtifactsUpdate
@@ -9897,7 +9915,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         visibility?: string;
         /** Allocate or retain a public default subdomain */
         with_subdomain?: boolean;
-        /** Replacement HTML file or ZIP bundle */
+        /** Replacement HTML, PDF, image, or ZIP content */
         artifact?: File;
       },
       params: RequestParams = {},
@@ -15048,7 +15066,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Upload one HTML file or a ZIP containing a compiled static SPA.
+     * @description Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.
      *
      * @tags Artifacts
      * @name V1ProjectsArtifactsCreate
@@ -15069,7 +15087,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         visibility?: string;
         /** Deprecated: public artifacts always receive a share subdomain */
         with_subdomain?: boolean;
-        /** HTML file or ZIP bundle */
+        /** HTML, PDF, image, or ZIP bundle */
         artifact: File;
       },
       params: RequestParams = {},
@@ -16051,6 +16069,22 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/providers`,
         method: "GET",
         secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.
+     *
+     * @tags Artifacts
+     * @name V1PublicArtifactsDetail
+     * @summary Get artifact viewer metadata
+     * @request GET:/api/v1/public/artifacts/{artifact_id}
+     */
+    v1PublicArtifactsDetail: (artifactId: string, params: RequestParams = {}) =>
+      this.request<TypesArtifactViewerResponse, any>({
+        path: `/api/v1/public/artifacts/${artifactId}`,
+        method: "GET",
+        format: "json",
         ...params,
       }),
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -15067,7 +15067,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         entrypoint?: string;
         /** project or public */
         visibility?: string;
-        /** Allocate a public default subdomain */
+        /** Deprecated: public artifacts always receive a share subdomain */
         with_subdomain?: boolean;
         /** HTML file or ZIP bundle */
         artifact: File;

--- a/frontend/src/components/artifacts/ArtifactDialog.test.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ArtifactDialog from './ArtifactDialog'
+
+describe('ArtifactDialog', () => {
+  it('offers a project-specific agent prompt alongside manual upload', () => {
+    render(
+      <ArtifactDialog
+        open
+        projectName="Example project"
+        saving={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Upload manually')).toBeInTheDocument()
+    expect(screen.getByText('Or')).toBeInTheDocument()
+    expect(screen.getByText('Create with an agent')).toBeInTheDocument()
+    expect(screen.getByText('Create and upload an artifact to the Helix project "Example project".')).toBeInTheDocument()
+    expect(document.querySelector('[data-chat-code-block]')).toBeInTheDocument()
+    expect(document.querySelector('[data-chat-code-block]')).toHaveAttribute('data-wrap', 'true')
+    expect(screen.getByRole('button', { name: 'Disable line wrap' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy code' })).toBeInTheDocument()
+  })
+
+  it('accepts PDF and image uploads without asking for an HTML entrypoint', () => {
+    render(
+      <ArtifactDialog
+        open
+        projectName="Example project"
+        saving={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.accept).toContain('.pdf')
+    expect(input.accept).toContain('image/*')
+    expect(screen.getByLabelText('Entrypoint')).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { files: [new File(['pdf'], 'report.pdf', { type: 'application/pdf' })] } })
+
+    expect(screen.getByText('report.pdf')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Entrypoint')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/artifacts/ArtifactDialog.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.tsx
@@ -1,12 +1,10 @@
 import { ChangeEvent, FC, useEffect, useState } from 'react'
 import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
-import Checkbox from '@mui/material/Checkbox'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
-import FormControlLabel from '@mui/material/FormControlLabel'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
@@ -30,7 +28,6 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
   const [description, setDescription] = useState('')
   const [entrypoint, setEntrypoint] = useState('')
   const [visibility, setVisibility] = useState<'project' | 'public'>('project')
-  const [withSubdomain, setWithSubdomain] = useState(false)
   const [file, setFile] = useState<File>()
 
   useEffect(() => {
@@ -39,14 +36,8 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
     setDescription(artifact?.description ?? '')
     setEntrypoint(artifact?.entrypoint ?? '')
     setVisibility(artifact?.visibility === 'public' ? 'public' : 'project')
-    setWithSubdomain(!!artifact?.subdomain_url)
     setFile(undefined)
   }, [open, artifact?.id])
-
-  const handleVisibility = (value: 'project' | 'public') => {
-    setVisibility(value)
-    if (value === 'project') setWithSubdomain(false)
-  }
 
   const handleFile = (event: ChangeEvent<HTMLInputElement>) => {
     setFile(event.target.files?.[0])
@@ -66,16 +57,12 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
             select
             label="Visibility"
             value={visibility}
-            onChange={(event) => handleVisibility(event.target.value as 'project' | 'public')}
+            onChange={(event) => setVisibility(event.target.value as 'project' | 'public')}
+            helperText={visibility === 'public' ? 'Public artifacts receive an isolated share subdomain.' : 'Only project members can open this artifact.'}
           >
             <MenuItem value="project">Project members</MenuItem>
             <MenuItem value="public">Public link</MenuItem>
           </TextField>
-          <FormControlLabel
-            control={<Checkbox checked={withSubdomain} onChange={(event) => setWithSubdomain(event.target.checked)} />}
-            label="Serve on a dedicated public subdomain"
-            disabled={visibility !== 'public'}
-          />
           <TextField
             label="Entrypoint"
             value={entrypoint}
@@ -103,7 +90,6 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
             description,
             entrypoint: entrypoint || undefined,
             visibility,
-            with_subdomain: withSubdomain,
             artifact: file,
           })}
         >

--- a/frontend/src/components/artifacts/ArtifactDialog.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, FC, useEffect, useState } from 'react'
 import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -11,19 +12,21 @@ import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { Upload } from 'lucide-react'
 
-import { TypesArtifact } from '../../api/api'
+import { TypesArtifact, TypesArtifactKind } from '../../api/api'
 import { ArtifactForm } from '../../services/artifactService'
+import MarkdownCodeBlock from '../session/MarkdownCodeBlock'
 
 type Props = {
   open: boolean
   artifact?: TypesArtifact
+  projectName?: string
   saving: boolean
   error?: string
   onClose: () => void
   onSubmit: (form: ArtifactForm) => Promise<void>
 }
 
-const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onSubmit }) => {
+const ArtifactDialog: FC<Props> = ({ open, artifact, projectName, saving, error, onClose, onSubmit }) => {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [entrypoint, setEntrypoint] = useState('')
@@ -44,40 +47,98 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
   }
 
   const canSave = !!name.trim() && (!!artifact || !!file) && !saving
+  const fileExtension = file?.name.split('.').pop()?.toLowerCase()
+  const selectedDocument = !!file && (
+    file.type === 'application/pdf' ||
+    file.type.startsWith('image/') ||
+    ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif'].includes(fileExtension ?? '')
+  )
+  const documentArtifact = artifact?.kind === TypesArtifactKind.ArtifactKindPDF || artifact?.kind === TypesArtifactKind.ArtifactKindImage
+  const showEntrypoint = file ? !selectedDocument : !documentArtifact
+  const agentPrompt = projectName
+    ? `Create and upload an artifact to the Helix project "${projectName}".`
+    : 'Create and upload an artifact to this Helix project.'
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth={artifact ? 'sm' : 'md'}>
       <DialogTitle>{artifact ? 'Update artifact' : 'New artifact'}</DialogTitle>
       <DialogContent>
-        <Stack spacing={2} sx={{ pt: 1 }}>
-          {error && <Alert severity="error">{error}</Alert>}
-          <TextField label="Name" value={name} onChange={(event) => setName(event.target.value)} required autoFocus />
-          <TextField label="Description" value={description} onChange={(event) => setDescription(event.target.value)} multiline minRows={2} />
-          <TextField
-            select
-            label="Visibility"
-            value={visibility}
-            onChange={(event) => setVisibility(event.target.value as 'project' | 'public')}
-            helperText={visibility === 'public' ? 'Public artifacts receive an isolated share subdomain.' : 'Only project members can open this artifact.'}
-          >
-            <MenuItem value="project">Project members</MenuItem>
-            <MenuItem value="public">Public link</MenuItem>
-          </TextField>
-          <TextField
-            label="Entrypoint"
-            value={entrypoint}
-            onChange={(event) => setEntrypoint(event.target.value)}
-            placeholder="index.html"
-            helperText="Leave blank when creating to use index.html."
-          />
-          <Button component="label" variant="outlined" startIcon={<Upload size={18} />} sx={{ alignSelf: 'flex-start' }}>
-            {artifact ? 'Publish new version' : 'Choose HTML or ZIP'}
-            <input hidden type="file" accept=".html,.htm,.zip,text/html,application/zip" onChange={handleFile} />
-          </Button>
-          <Typography variant="body2" color="text.secondary">
-            {file?.name ?? (artifact ? 'Keep the current content version' : 'No file selected')}
-          </Typography>
-        </Stack>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: artifact ? '1fr' : { xs: '1fr', md: 'minmax(0, 1fr) auto minmax(280px, 0.8fr)' },
+            gap: 3,
+            pt: 1,
+          }}
+        >
+          <Stack spacing={2}>
+            {!artifact && (
+              <Box>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>Upload manually</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Upload HTML, a compiled app ZIP, a PDF, or an image.
+                </Typography>
+              </Box>
+            )}
+            {error && <Alert severity="error">{error}</Alert>}
+            <TextField label="Name" value={name} onChange={(event) => setName(event.target.value)} required autoFocus />
+            <TextField label="Description" value={description} onChange={(event) => setDescription(event.target.value)} multiline minRows={2} />
+            <TextField
+              select
+              label="Visibility"
+              value={visibility}
+              onChange={(event) => setVisibility(event.target.value as 'project' | 'public')}
+              helperText={visibility === 'public' ? 'Public artifacts receive an isolated share subdomain.' : 'Only project members can open this artifact.'}
+            >
+              <MenuItem value="project">Project members</MenuItem>
+              <MenuItem value="public">Public link</MenuItem>
+            </TextField>
+            {showEntrypoint && (
+              <TextField
+                label="Entrypoint"
+                value={entrypoint}
+                onChange={(event) => setEntrypoint(event.target.value)}
+                placeholder="index.html"
+                helperText="Leave blank to use index.html. Only HTML and ZIP artifacts need an entrypoint."
+              />
+            )}
+            <Button component="label" variant="outlined" startIcon={<Upload size={18} />} sx={{ alignSelf: 'flex-start' }}>
+              {artifact ? 'Publish new version' : 'Choose artifact file'}
+              <input hidden type="file" accept=".html,.htm,.zip,.pdf,image/*,text/html,application/zip,application/pdf" onChange={handleFile} />
+            </Button>
+            <Typography variant="body2" color="text.secondary">
+              {file?.name ?? (artifact ? 'Keep the current content version' : 'No file selected')}
+            </Typography>
+          </Stack>
+
+          {!artifact && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: { xs: 'row', md: 'column' },
+                alignItems: 'center',
+                minWidth: { md: 24 },
+                minHeight: { md: '100%' },
+              }}
+            >
+              <Box sx={{ flex: 1, width: { xs: 'auto', md: '1px' }, height: { xs: '1px', md: 'auto' }, bgcolor: 'divider' }} />
+              <Typography variant="caption" color="text.secondary" sx={{ px: { xs: 1.5, md: 0 }, py: { xs: 0, md: 1 } }}>
+                Or
+              </Typography>
+              <Box sx={{ flex: 1, width: { xs: 'auto', md: '1px' }, height: { xs: '1px', md: 'auto' }, bgcolor: 'divider' }} />
+            </Box>
+          )}
+
+          {!artifact && (
+            <Box sx={{ alignSelf: 'start', minWidth: 0 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>Create with an agent</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                Tell an agent with access to this project what you want to build. It can create and upload the finished artifact here for you.
+              </Typography>
+              <MarkdownCodeBlock language="text" defaultWrapped>{agentPrompt}</MarkdownCodeBlock>
+            </Box>
+          )}
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={saving}>Cancel</Button>
@@ -88,7 +149,7 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onS
           onClick={() => onSubmit({
             name: name.trim(),
             description,
-            entrypoint: entrypoint || undefined,
+            entrypoint: showEntrypoint ? (entrypoint || undefined) : undefined,
             visibility,
             artifact: file,
           })}

--- a/frontend/src/components/artifacts/ArtifactDialog.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.tsx
@@ -1,0 +1,117 @@
+import { ChangeEvent, FC, useEffect, useState } from 'react'
+import Alert from '@mui/material/Alert'
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { Upload } from 'lucide-react'
+
+import { TypesArtifact } from '../../api/api'
+import { ArtifactForm } from '../../services/artifactService'
+
+type Props = {
+  open: boolean
+  artifact?: TypesArtifact
+  saving: boolean
+  error?: string
+  onClose: () => void
+  onSubmit: (form: ArtifactForm) => Promise<void>
+}
+
+const ArtifactDialog: FC<Props> = ({ open, artifact, saving, error, onClose, onSubmit }) => {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [entrypoint, setEntrypoint] = useState('')
+  const [visibility, setVisibility] = useState<'project' | 'public'>('project')
+  const [withSubdomain, setWithSubdomain] = useState(false)
+  const [file, setFile] = useState<File>()
+
+  useEffect(() => {
+    if (!open) return
+    setName(artifact?.name ?? '')
+    setDescription(artifact?.description ?? '')
+    setEntrypoint(artifact?.entrypoint ?? '')
+    setVisibility(artifact?.visibility === 'public' ? 'public' : 'project')
+    setWithSubdomain(!!artifact?.subdomain_url)
+    setFile(undefined)
+  }, [open, artifact?.id])
+
+  const handleVisibility = (value: 'project' | 'public') => {
+    setVisibility(value)
+    if (value === 'project') setWithSubdomain(false)
+  }
+
+  const handleFile = (event: ChangeEvent<HTMLInputElement>) => {
+    setFile(event.target.files?.[0])
+  }
+
+  const canSave = !!name.trim() && (!!artifact || !!file) && !saving
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{artifact ? 'Update artifact' : 'New artifact'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField label="Name" value={name} onChange={(event) => setName(event.target.value)} required autoFocus />
+          <TextField label="Description" value={description} onChange={(event) => setDescription(event.target.value)} multiline minRows={2} />
+          <TextField
+            select
+            label="Visibility"
+            value={visibility}
+            onChange={(event) => handleVisibility(event.target.value as 'project' | 'public')}
+          >
+            <MenuItem value="project">Project members</MenuItem>
+            <MenuItem value="public">Public link</MenuItem>
+          </TextField>
+          <FormControlLabel
+            control={<Checkbox checked={withSubdomain} onChange={(event) => setWithSubdomain(event.target.checked)} />}
+            label="Serve on a dedicated public subdomain"
+            disabled={visibility !== 'public'}
+          />
+          <TextField
+            label="Entrypoint"
+            value={entrypoint}
+            onChange={(event) => setEntrypoint(event.target.value)}
+            placeholder="index.html"
+            helperText="Leave blank when creating to use index.html."
+          />
+          <Button component="label" variant="outlined" startIcon={<Upload size={18} />} sx={{ alignSelf: 'flex-start' }}>
+            {artifact ? 'Publish new version' : 'Choose HTML or ZIP'}
+            <input hidden type="file" accept=".html,.htm,.zip,text/html,application/zip" onChange={handleFile} />
+          </Button>
+          <Typography variant="body2" color="text.secondary">
+            {file?.name ?? (artifact ? 'Keep the current content version' : 'No file selected')}
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          disabled={!canSave}
+          onClick={() => onSubmit({
+            name: name.trim(),
+            description,
+            entrypoint: entrypoint || undefined,
+            visibility,
+            with_subdomain: withSubdomain,
+            artifact: file,
+          })}
+        >
+          {saving ? 'Saving…' : artifact ? 'Update' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ArtifactDialog

--- a/frontend/src/components/artifacts/ArtifactVisibilityBadge.tsx
+++ b/frontend/src/components/artifacts/ArtifactVisibilityBadge.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import { alpha } from '@mui/material/styles'
+
+type Props = {
+  visibility?: string
+  privateLabel?: string
+}
+
+const ArtifactVisibilityBadge: FC<Props> = ({ visibility, privateLabel = 'Project' }) => {
+  const isPublic = visibility === 'public'
+
+  return (
+    <Chip
+      icon={<Box />}
+      label={isPublic ? 'Public' : privateLabel}
+      size="small"
+      sx={(theme) => {
+        const color = isPublic ? theme.palette.success.main : theme.palette.text.secondary
+        return {
+          height: 20,
+          color,
+          backgroundColor: alpha(color, 0.1),
+          border: `1px solid ${alpha(color, 0.3)}`,
+          borderRadius: '999px',
+          fontWeight: 500,
+          typography: 'caption',
+          '& .MuiChip-icon': {
+            width: 6,
+            height: 6,
+            marginLeft: '6px',
+            marginRight: '-2px',
+            borderRadius: '50%',
+            color: 'inherit',
+            backgroundColor: 'currentColor',
+          },
+          '& .MuiChip-label': {
+            paddingLeft: '6px',
+            paddingRight: '7px',
+            lineHeight: 1,
+          },
+        }
+      }}
+    />
+  )
+}
+
+export default ArtifactVisibilityBadge

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -2,8 +2,9 @@ import { FC, MouseEvent, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import Chip from '@mui/material/Chip'
 import IconButton from '@mui/material/IconButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
@@ -11,8 +12,9 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { EllipsisVertical, ExternalLink, Pencil, Trash2 } from 'lucide-react'
 
-import { TypesArtifact } from '../../api/api'
+import { TypesArtifact, TypesArtifactKind } from '../../api/api'
 import { ViewMode } from '../widgets/ViewModeToggle'
+import ArtifactVisibilityBadge from './ArtifactVisibilityBadge'
 import CardGrid from '../widgets/CardGrid'
 import SimpleTable from '../widgets/SimpleTable'
 
@@ -23,16 +25,16 @@ type Props = {
   onDelete: (artifact: TypesArtifact) => void
 }
 
-const ArtifactVisibilityBadge: FC<{ artifact: TypesArtifact }> = ({ artifact }) => (
-  <Chip
-    size="small"
-    label={artifact.visibility === 'public' ? 'Public' : 'Project'}
-    color={artifact.visibility === 'public' ? 'success' : 'default'}
-    variant="outlined"
-  />
-)
-
 const artifactURL = (artifact: TypesArtifact) => artifact.url || ''
+
+const artifactKindLabel = (artifact: TypesArtifact) => {
+  switch (artifact.kind) {
+    case TypesArtifactKind.ArtifactKindSPA: return 'Static SPA'
+    case TypesArtifactKind.ArtifactKindPDF: return 'PDF document'
+    case TypesArtifactKind.ArtifactKindImage: return 'Image'
+    default: return 'HTML page'
+  }
+}
 
 const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null)
@@ -84,37 +86,45 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
         </a>
       </Typography>
     ),
-    kind: <Typography variant="body2" color="text.secondary">{artifact.kind === 'spa' ? 'Static SPA' : 'HTML page'}</Typography>,
-    visibility: <ArtifactVisibilityBadge artifact={artifact} />,
+    kind: <Typography variant="body2" color="text.secondary">{artifactKindLabel(artifact)}</Typography>,
+    visibility: <ArtifactVisibilityBadge visibility={artifact.visibility} />,
     version: <Typography variant="body2" color="text.secondary">v{artifact.active_version?.version ?? 1}</Typography>,
     updated: <Typography variant="body2" color="text.secondary">{artifact.updated_at ? new Date(artifact.updated_at).toLocaleString() : '—'}</Typography>,
   })), [artifactKey])
 
   const menu = (
-    <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
-      <MenuItem onClick={(event) => {
+    <Menu
+      anchorEl={menuAnchor}
+      open={!!menuAnchor}
+      onClose={closeMenu}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      MenuListProps={{ dense: true, sx: { p: 0 } }}
+      PaperProps={{ sx: { minWidth: 164 } }}
+    >
+      <MenuItem dense onClick={(event) => {
         event.stopPropagation()
         if (currentArtifact) openArtifact(currentArtifact)
         closeMenu()
       }}>
-        <ExternalLink size={20} />
-        <Typography sx={{ ml: 1 }}>Open</Typography>
+        <ListItemIcon><ExternalLink size={16} /></ListItemIcon>
+        <ListItemText primary="Open" />
       </MenuItem>
-      <MenuItem onClick={(event) => {
+      <MenuItem dense onClick={(event) => {
         event.stopPropagation()
         if (currentArtifact) onEdit(currentArtifact)
         closeMenu()
       }}>
-        <Pencil size={20} />
-        <Typography sx={{ ml: 1 }}>Edit or publish version</Typography>
+        <ListItemIcon><Pencil size={16} /></ListItemIcon>
+        <ListItemText primary="Edit / publish" />
       </MenuItem>
-      <MenuItem onClick={(event) => {
+      <MenuItem dense onClick={(event) => {
         event.stopPropagation()
         if (currentArtifact) onDelete(currentArtifact)
         closeMenu()
       }}>
-        <Trash2 size={20} />
-        <Typography sx={{ ml: 1 }}>Delete</Typography>
+        <ListItemIcon><Trash2 size={16} /></ListItemIcon>
+        <ListItemText primary="Delete" />
       </MenuItem>
     </Menu>
   )
@@ -160,10 +170,10 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
               <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1}>
                 <Box sx={{ minWidth: 0 }}>
                   <Typography variant="subtitle1" sx={{ fontWeight: 600 }} noWrap>{artifact.name}</Typography>
-                  <Typography variant="body2" color="text.secondary">{artifact.kind === 'spa' ? 'Static SPA' : 'HTML page'}</Typography>
+                  <Typography variant="body2" color="text.secondary">{artifactKindLabel(artifact)}</Typography>
                 </Box>
                 <Stack direction="row" spacing={0.25} alignItems="center">
-                  <ArtifactVisibilityBadge artifact={artifact} />
+                  <ArtifactVisibilityBadge visibility={artifact.visibility} />
                   {actionButton(artifact)}
                 </Stack>
               </Stack>

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -13,6 +13,7 @@ import Typography from '@mui/material/Typography'
 import { EllipsisVertical, ExternalLink, Pencil, Trash2 } from 'lucide-react'
 
 import { TypesArtifact, TypesArtifactKind } from '../../api/api'
+import useRouter from '../../hooks/useRouter'
 import { ViewMode } from '../widgets/ViewModeToggle'
 import ArtifactVisibilityBadge from './ArtifactVisibilityBadge'
 import CardGrid from '../widgets/CardGrid'
@@ -37,13 +38,13 @@ const artifactKindLabel = (artifact: TypesArtifact) => {
 }
 
 const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
+  const router = useRouter()
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null)
   const [currentArtifact, setCurrentArtifact] = useState<TypesArtifact>()
   const artifactKey = artifacts.map((artifact) => `${artifact.id}:${artifact.updated_at}`).join('|')
 
   const openArtifact = (artifact: TypesArtifact) => {
-    const url = artifactURL(artifact)
-    if (url) window.open(url, '_blank', 'noopener,noreferrer')
+    if (artifact.id) router.navigate('artifact_viewer', { artifact_id: artifact.id })
   }
 
   const openMenu = (event: MouseEvent<HTMLElement>, artifact: TypesArtifact) => {
@@ -73,8 +74,6 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
       <Typography variant="body2" sx={{ fontWeight: 600 }}>
         <a
           href={artifactURL(artifact)}
-          target="_blank"
-          rel="noreferrer"
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -1,0 +1,188 @@
+import { FC, MouseEvent, useMemo, useState } from 'react'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { EllipsisVertical, ExternalLink, Pencil, Trash2 } from 'lucide-react'
+
+import { TypesArtifact } from '../../api/api'
+import { ViewMode } from '../widgets/ViewModeToggle'
+import CardGrid from '../widgets/CardGrid'
+import SimpleTable from '../widgets/SimpleTable'
+
+type Props = {
+  artifacts: TypesArtifact[]
+  mode: ViewMode
+  onEdit: (artifact: TypesArtifact) => void
+  onDelete: (artifact: TypesArtifact) => void
+}
+
+const ArtifactVisibilityBadge: FC<{ artifact: TypesArtifact }> = ({ artifact }) => (
+  <Chip
+    size="small"
+    label={artifact.visibility === 'public' ? 'Public' : 'Project'}
+    color={artifact.visibility === 'public' ? 'success' : 'default'}
+    variant="outlined"
+  />
+)
+
+const artifactURL = (artifact: TypesArtifact) => artifact.subdomain_url || artifact.url || ''
+
+const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null)
+  const [currentArtifact, setCurrentArtifact] = useState<TypesArtifact>()
+  const artifactKey = artifacts.map((artifact) => `${artifact.id}:${artifact.updated_at}`).join('|')
+
+  const openArtifact = (artifact: TypesArtifact) => {
+    const url = artifactURL(artifact)
+    if (url) window.open(url, '_blank', 'noopener,noreferrer')
+  }
+
+  const openMenu = (event: MouseEvent<HTMLElement>, artifact: TypesArtifact) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setCurrentArtifact(artifact)
+    setMenuAnchor(event.currentTarget)
+  }
+
+  const closeMenu = () => {
+    setMenuAnchor(null)
+    setCurrentArtifact(undefined)
+  }
+
+  const actionButton = (artifact: TypesArtifact) => (
+    <Tooltip title="Artifact actions">
+      <IconButton aria-label={`Actions for ${artifact.name}`} onClick={(event) => openMenu(event, artifact)}>
+        <EllipsisVertical size={18} />
+      </IconButton>
+    </Tooltip>
+  )
+
+  const tableData = useMemo(() => artifacts.map((artifact) => ({
+    id: artifact.id,
+    _data: artifact,
+    name: (
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        <a
+          href={artifactURL(artifact)}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            openArtifact(artifact)
+          }}
+          style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+          {artifact.name}
+        </a>
+      </Typography>
+    ),
+    kind: <Typography variant="body2" color="text.secondary">{artifact.kind === 'spa' ? 'Static SPA' : 'HTML page'}</Typography>,
+    visibility: <ArtifactVisibilityBadge artifact={artifact} />,
+    version: <Typography variant="body2" color="text.secondary">v{artifact.active_version?.version ?? 1}</Typography>,
+    updated: <Typography variant="body2" color="text.secondary">{artifact.updated_at ? new Date(artifact.updated_at).toLocaleString() : '—'}</Typography>,
+  })), [artifactKey])
+
+  const menu = (
+    <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+      <MenuItem onClick={(event) => {
+        event.stopPropagation()
+        if (currentArtifact) openArtifact(currentArtifact)
+        closeMenu()
+      }}>
+        <ExternalLink size={20} />
+        <Typography sx={{ ml: 1 }}>Open</Typography>
+      </MenuItem>
+      <MenuItem onClick={(event) => {
+        event.stopPropagation()
+        if (currentArtifact) onEdit(currentArtifact)
+        closeMenu()
+      }}>
+        <Pencil size={20} />
+        <Typography sx={{ ml: 1 }}>Edit or publish version</Typography>
+      </MenuItem>
+      <MenuItem onClick={(event) => {
+        event.stopPropagation()
+        if (currentArtifact) onDelete(currentArtifact)
+        closeMenu()
+      }}>
+        <Trash2 size={20} />
+        <Typography sx={{ ml: 1 }}>Delete</Typography>
+      </MenuItem>
+    </Menu>
+  )
+
+  if (mode === 'table') {
+    return (
+      <>
+        <SimpleTable
+          authenticated
+          fields={[
+            { name: 'name', title: 'Name' },
+            { name: 'kind', title: 'Type' },
+            { name: 'visibility', title: 'Visibility' },
+            { name: 'version', title: 'Version' },
+            { name: 'updated', title: 'Updated' },
+          ]}
+          data={tableData}
+          onRowClick={(row) => openArtifact(row._data as TypesArtifact)}
+          getActions={(row) => actionButton(row._data as TypesArtifact)}
+        />
+        {menu}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <CardGrid
+        items={artifacts}
+        getKey={(artifact) => artifact.id ?? ''}
+        renderCard={(artifact) => (
+          <Card
+            sx={{
+              border: '1px solid rgba(0, 0, 0, 0.08)', borderRadius: 1, boxShadow: 'none',
+              height: '100%', display: 'flex', flexDirection: 'column',
+              '&:hover': { borderColor: 'rgba(0,0,0,0.12)', backgroundColor: 'rgba(0,0,0,0.01)' },
+            }}
+          >
+            <CardContent
+              onClick={() => openArtifact(artifact)}
+              sx={{ p: 2, '&:last-child': { pb: 2 }, cursor: 'pointer', flex: 1 }}
+            >
+              <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1}>
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }} noWrap>{artifact.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">{artifact.kind === 'spa' ? 'Static SPA' : 'HTML page'}</Typography>
+                </Box>
+                <Stack direction="row" spacing={0.25} alignItems="center">
+                  <ArtifactVisibilityBadge artifact={artifact} />
+                  {actionButton(artifact)}
+                </Stack>
+              </Stack>
+              {artifact.description && (
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>{artifact.description}</Typography>
+              )}
+              <Box sx={{ mt: 2, background: 'linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)', border: '1px solid rgba(255,255,255,0.06)', borderRadius: 2, p: 1.5 }}>
+                <Stack direction="row" spacing={3}>
+                  <Box><Typography variant="caption" color="text.secondary">VERSION</Typography><Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontWeight: 600 }}>v{artifact.active_version?.version ?? 1}</Typography></Box>
+                  <Box><Typography variant="caption" color="text.secondary">FILES</Typography><Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontWeight: 600 }}>{artifact.active_version?.file_count ?? 1}</Typography></Box>
+                </Stack>
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+      />
+      {menu}
+    </>
+  )
+}
+
+export default ArtifactsView

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -32,7 +32,7 @@ const ArtifactVisibilityBadge: FC<{ artifact: TypesArtifact }> = ({ artifact }) 
   />
 )
 
-const artifactURL = (artifact: TypesArtifact) => artifact.subdomain_url || artifact.url || ''
+const artifactURL = (artifact: TypesArtifact) => artifact.url || ''
 
 const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null)

--- a/frontend/src/components/session/MarkdownCodeBlock.tsx
+++ b/frontend/src/components/session/MarkdownCodeBlock.tsx
@@ -15,12 +15,13 @@ const SyntaxHighlighter = SyntaxHighlighterTS as any;
 interface MarkdownCodeBlockProps {
   children: string;
   language?: string;
+  defaultWrapped?: boolean;
 }
 
 const MarkdownCodeBlock: FC<MarkdownCodeBlockProps> = React.memo(
-  ({ children, language = "text" }) => {
+  ({ children, language = "text", defaultWrapped = false }) => {
     const [copied, setCopied] = useState(false);
-    const [wrapped, setWrapped] = useState(false);
+    const [wrapped, setWrapped] = useState(defaultWrapped);
     const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const theme = useTheme();
     const chatColors = getChatColors(theme);

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -53,6 +53,8 @@ const Page: React.FC<{
   globalSearchResourceTypes?: TypesResource[],
   // notifications — the bell is part of the standard topbar; opt out per page
   notifications?: boolean,
+  // theme toggle — immersive viewers can opt out of global appearance controls
+  themeToggle?: boolean,
   children?: ReactNode,
 }> = ({
   topbarContent = null,
@@ -73,6 +75,7 @@ const Page: React.FC<{
   globalSearch = false,
   globalSearchResourceTypes,
   notifications = true,
+  themeToggle = true,
   children,
 }) => {
   const router = useRouter()
@@ -383,11 +386,13 @@ const Page: React.FC<{
                 }}
               >
                 { topbarContent }
-                <Tooltip title={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
-                  <IconButton onClick={toggleMode} size="small" sx={{ color: lightTheme.textColorFaded }}>
-                    {mode === 'dark' ? <LightModeIcon fontSize="small" /> : <DarkModeIcon fontSize="small" />}
-                  </IconButton>
-                </Tooltip>
+                {themeToggle && (
+                  <Tooltip title={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+                    <IconButton onClick={toggleMode} size="small" sx={{ color: lightTheme.textColorFaded }}>
+                      {mode === 'dark' ? <LightModeIcon fontSize="small" /> : <DarkModeIcon fontSize="small" />}
+                    </IconButton>
+                  </Tooltip>
+                )}
                 {notifications && <GlobalNotifications organizationId={organizationId} />}
               </Box>
             </AppBar>

--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -427,7 +427,7 @@ export const useAccountContext = (): IAccountContext => {
   useEffect(() => {
     if (!initialized) return
     if (user) return
-    const publicRoutes = ['login', 'password-reset', 'password-reset-complete']
+    const publicRoutes = ['login', 'password-reset', 'password-reset-complete', 'artifact_viewer']
     if (publicRoutes.includes(router.name)) return
 
     // Save current URL for post-login redirect

--- a/frontend/src/lib/navHistory.ts
+++ b/frontend/src/lib/navHistory.ts
@@ -51,6 +51,8 @@ function deriveTitle(routeName: string, params: Record<string, string>, nameCach
       return taskName ? `Review: ${truncate(taskName, 34)}` : 'Spec review'
     case 'org_project-specs':
       return 'Project board'
+    case 'org_project-artifacts':
+      return 'Project artifacts'
     case 'org_spec-tasks':
       return 'All tasks'
     case 'org_project-design-doc':

--- a/frontend/src/pages/ArtifactViewer.test.tsx
+++ b/frontend/src/pages/ArtifactViewer.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ArtifactViewer from './ArtifactViewer'
+
+const mocks = vi.hoisted(() => ({
+  account: { initialized: true, user: undefined as undefined | { id: string } },
+  artifactKind: 'single_file',
+  navigate: vi.fn(),
+  mutateAsync: vi.fn(),
+  pageProps: undefined as undefined | {
+    breadcrumbTitle?: string
+    breadcrumbs?: Array<{ title: string, routeName?: string, params?: Record<string, string> }>
+  },
+}))
+
+vi.mock('../hooks/useAccount', () => ({
+  default: () => mocks.account,
+}))
+
+vi.mock('../hooks/useRouter', () => ({
+  default: () => ({
+    params: { artifact_id: 'art_public' },
+    navigate: mocks.navigate,
+  }),
+}))
+
+vi.mock('../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('../services/artifactService', () => ({
+  useGetArtifactViewer: () => ({
+    data: {
+      id: 'art_public',
+      project_id: 'prj_test',
+      project_name: 'Public project',
+      organization_id: 'org_test',
+      organization_name: 'example-org',
+      name: 'Public artifact',
+      kind: mocks.artifactKind,
+      visibility: 'public',
+      active_version_id: 'artv_test',
+      subdomain_url: 'http://artifact.example.test/',
+      can_edit: !!mocks.account.user,
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useSetArtifactVisibility: () => ({
+    mutateAsync: mocks.mutateAsync,
+    isPending: false,
+  }),
+}))
+
+vi.mock('../components/system/Page', () => ({
+  default: (props: {
+    topbarContent: React.ReactNode
+    children: React.ReactNode
+    breadcrumbTitle?: string
+    breadcrumbs?: Array<{ title: string, routeName?: string, params?: Record<string, string> }>
+  }) => {
+    mocks.pageProps = props
+    return (
+      <div>
+        <header>{props.topbarContent}</header>
+        <main>{props.children}</main>
+      </div>
+    )
+  },
+}))
+
+describe('ArtifactViewer', () => {
+  beforeEach(() => {
+    mocks.account.user = undefined
+    mocks.artifactKind = 'single_file'
+    mocks.navigate.mockReset()
+    mocks.mutateAsync.mockReset()
+    mocks.pageProps = undefined
+    localStorage.clear()
+  })
+
+  afterEach(() => vi.clearAllMocks())
+
+  it('renders a public artifact with Login instead of Share when signed out', () => {
+    render(<ArtifactViewer />)
+
+    expect(screen.getByTitle('Public artifact')).toHaveAttribute('src', 'http://artifact.example.test/')
+    expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Share' })).not.toBeInTheDocument()
+    expect(mocks.pageProps?.breadcrumbTitle).toBe('Public artifact')
+    expect(mocks.pageProps?.breadcrumbs?.at(-1)).toEqual({
+      title: 'artifacts',
+      routeName: 'org_project-artifacts',
+      params: { org_id: 'example-org', id: 'prj_test' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }))
+    expect(localStorage.getItem('login_redirect_url')).toBe('/')
+    expect(mocks.navigate).toHaveBeenCalledWith('login')
+  })
+
+  it('renders Share for an authenticated editor', () => {
+    mocks.account.user = { id: 'usr_test' }
+    render(<ArtifactViewer />)
+
+    expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Login' })).not.toBeInTheDocument()
+  })
+
+  it('renders image artifacts as a contained image', () => {
+    mocks.artifactKind = 'image'
+    render(<ArtifactViewer />)
+
+    expect(screen.getByRole('img', { name: 'Public artifact' })).toHaveAttribute('src', 'http://artifact.example.test/')
+    expect(screen.queryByTitle('Public artifact')).not.toBeInTheDocument()
+  })
+
+  it('renders PDF artifacts in the browser frame', () => {
+    mocks.artifactKind = 'pdf'
+    render(<ArtifactViewer />)
+
+    expect(screen.getByTitle('Public artifact')).toHaveAttribute('src', '/artifacts/art_public/document')
+    expect(screen.getByTitle('Public artifact')).not.toHaveAttribute('sandbox')
+  })
+})

--- a/frontend/src/pages/ArtifactViewer.tsx
+++ b/frontend/src/pages/ArtifactViewer.tsx
@@ -1,5 +1,6 @@
 import { FC, MouseEvent, useState } from 'react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -8,7 +9,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { ArrowLeft, Copy, ExternalLink, Globe2, LockKeyhole, Share2 } from 'lucide-react'
+import { ArrowLeft, Copy, ExternalLink, Globe2, LockKeyhole } from 'lucide-react'
 
 import Page from '../components/system/Page'
 import useRouter from '../hooks/useRouter'
@@ -94,18 +95,14 @@ const ArtifactViewer: FC = () => {
             icon={isPublic ? <Globe2 size={14} /> : <LockKeyhole size={14} />}
             label={isPublic ? 'Public' : 'Private'}
           />
-          <Tooltip title="Share artifact">
-            <span>
-              <IconButton
-                aria-label="Share artifact"
-                onClick={openShareMenu}
-                disabled={visibilityMutation.isPending}
-                sx={{ width: 30, height: 30, color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
-              >
-                <Share2 size={18} />
-              </IconButton>
-            </span>
-          </Tooltip>
+          <Button
+            size="small"
+            onClick={openShareMenu}
+            disabled={visibilityMutation.isPending}
+            sx={{ textTransform: 'none', fontWeight: 500, minWidth: 'auto' }}
+          >
+            Share
+          </Button>
         </Stack>
       )}
     >

--- a/frontend/src/pages/ArtifactViewer.tsx
+++ b/frontend/src/pages/ArtifactViewer.tsx
@@ -1,43 +1,43 @@
 import { FC, MouseEvent, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
-import IconButton from '@mui/material/IconButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
-import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { ArrowLeft, Copy, ExternalLink, Globe2, LockKeyhole } from 'lucide-react'
+import { Copy, ExternalLink, Globe2, LockKeyhole } from 'lucide-react'
 
+import { TypesArtifactKind } from '../api/api'
+import ArtifactVisibilityBadge from '../components/artifacts/ArtifactVisibilityBadge'
 import Page from '../components/system/Page'
+import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
-import { useGetArtifact, useSetArtifactVisibility } from '../services/artifactService'
+import { useGetArtifactViewer, useSetArtifactVisibility } from '../services/artifactService'
 
 const ArtifactViewer: FC = () => {
+  const account = useAccount()
   const router = useRouter()
   const snackbar = useSnackbar()
   const artifactId = router.params.artifact_id as string
-  const { data: artifact, isLoading, error } = useGetArtifact(artifactId)
+  const { data: artifact, isLoading, error } = useGetArtifactViewer(artifactId)
   const visibilityMutation = useSetArtifactVisibility(artifactId)
   const [shareAnchor, setShareAnchor] = useState<HTMLElement | null>(null)
 
-  const isPublic = artifact?.visibility === 'public'
-  const frameURL = isPublic
-    ? artifact?.subdomain_url
-    : artifact ? `/artifacts/${artifact.id}/embed` : undefined
+  const organizationSlug = artifact?.organization_name || artifact?.organization_id || ''
+  const organizationTitle = artifact?.organization_name || 'Organization'
 
-  const goBack = () => {
-    if (window.history.length > 1) {
-      window.history.back()
-      return
-    }
-    if (artifact?.project_id && artifact.organization_id) {
-      router.navigate('org_project-artifacts', { org_id: artifact.organization_id, id: artifact.project_id })
-    }
-  }
+  const isPublic = artifact?.visibility === 'public'
+  const isImage = artifact?.kind === TypesArtifactKind.ArtifactKindImage
+  const isPDF = artifact?.kind === TypesArtifactKind.ArtifactKindPDF
+  const frameURL = isPDF
+    ? `/artifacts/${artifact.id}/document`
+    : isPublic
+      ? artifact?.subdomain_url
+      : artifact ? `/artifacts/${artifact.id}/embed` : undefined
 
   const setVisibility = async (visibility: 'project' | 'public') => {
     try {
@@ -58,6 +58,11 @@ const ArtifactViewer: FC = () => {
 
   const openShareMenu = (event: MouseEvent<HTMLElement>) => setShareAnchor(event.currentTarget)
 
+  const login = () => {
+    localStorage.setItem('login_redirect_url', window.location.pathname + window.location.search)
+    router.navigate('login')
+  }
+
   if (isLoading) {
     return <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}><CircularProgress /></Box>
   }
@@ -72,50 +77,73 @@ const ArtifactViewer: FC = () => {
 
   return (
     <Page
+      breadcrumbs={[
+        {
+          title: organizationTitle,
+          routeName: 'org_projects',
+          params: { org_id: organizationSlug },
+        },
+        {
+          title: 'Projects',
+          routeName: 'org_projects',
+          params: { org_id: organizationSlug },
+        },
+        {
+          title: artifact.project_name || 'Project',
+          routeName: 'org_project-specs',
+          params: { org_id: organizationSlug, id: artifact.project_id },
+        },
+        {
+          title: 'artifacts',
+          routeName: 'org_project-artifacts',
+          params: { org_id: organizationSlug, id: artifact.project_id },
+        },
+      ]}
       breadcrumbTitle={artifact.name || 'Artifact'}
-      breadcrumbShowHome={false}
       showDrawerButton={false}
       notifications={false}
       themeToggle={false}
       disableContentScroll
-      px={1}
-      topbarLeftContent={(
-        <Tooltip title="Back to artifacts">
-          <IconButton aria-label="Back to artifacts" onClick={goBack} sx={{ width: 30, height: 30, color: 'text.secondary' }}>
-            <ArrowLeft size={18} />
-          </IconButton>
-        </Tooltip>
-      )}
+      px={3}
       topbarContent={(
         <Stack direction="row" spacing={1} alignItems="center">
-          <Chip
-            size="small"
-            variant="outlined"
-            color={isPublic ? 'success' : 'default'}
-            icon={isPublic ? <Globe2 size={14} /> : <LockKeyhole size={14} />}
-            label={isPublic ? 'Public' : 'Private'}
-          />
-          <Button
-            size="small"
-            onClick={openShareMenu}
-            disabled={visibilityMutation.isPending}
-            sx={{ textTransform: 'none', fontWeight: 500, minWidth: 'auto' }}
-          >
-            Share
-          </Button>
+          <ArtifactVisibilityBadge visibility={artifact.visibility} privateLabel="Private" />
+          {account.initialized && !account.user ? (
+            <Button size="small" onClick={login} sx={{ textTransform: 'none', fontWeight: 500, minWidth: 'auto' }}>
+              Login
+            </Button>
+          ) : artifact.can_edit ? (
+            <Button
+              size="small"
+              onClick={openShareMenu}
+              disabled={visibilityMutation.isPending}
+              sx={{ textTransform: 'none', fontWeight: 500, minWidth: 'auto' }}
+            >
+              Share
+            </Button>
+          ) : null}
         </Stack>
       )}
     >
       <Box sx={{ flex: 1, minHeight: 0, p: 1, bgcolor: 'background.default' }}>
-        {frameURL ? (
+        {frameURL && isImage ? (
+          <Box sx={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center', overflow: 'auto' }}>
+            <Box
+              component="img"
+              src={frameURL}
+              alt={artifact.name || 'Artifact image'}
+              sx={{ display: 'block', maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            />
+          </Box>
+        ) : frameURL ? (
           <Box
             component="iframe"
             key={`${artifact.id}:${artifact.visibility}:${artifact.active_version_id}`}
             title={artifact.name || 'Artifact preview'}
             src={frameURL}
-            sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin"
+            sandbox={isPDF ? undefined : 'allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin'}
             referrerPolicy="no-referrer"
-            sx={{ display: 'block', width: '100%', height: '100%', border: '1px solid', borderColor: 'divider', borderRadius: 1, bgcolor: '#fff' }}
+            sx={{ display: 'block', width: '100%', height: '100%', border: 0, bgcolor: '#fff' }}
           />
         ) : (
           <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}>
@@ -127,17 +155,21 @@ const ArtifactViewer: FC = () => {
       <Menu anchorEl={shareAnchor} open={!!shareAnchor} onClose={() => setShareAnchor(null)}>
         {isPublic ? [
           <MenuItem key="copy" onClick={copyShareLink} disabled={!artifact.subdomain_url}>
-            <Copy size={20} /><Typography sx={{ ml: 1 }}>Copy public link</Typography>
+            <ListItemIcon><Copy size={16} /></ListItemIcon>
+            <ListItemText>Copy public link</ListItemText>
           </MenuItem>,
           <MenuItem key="open" onClick={() => artifact.subdomain_url && window.open(artifact.subdomain_url, '_blank', 'noopener,noreferrer')} disabled={!artifact.subdomain_url}>
-            <ExternalLink size={20} /><Typography sx={{ ml: 1 }}>Open public link</Typography>
+            <ListItemIcon><ExternalLink size={16} /></ListItemIcon>
+            <ListItemText>Open public link</ListItemText>
           </MenuItem>,
           <MenuItem key="private" onClick={() => setVisibility('project')}>
-            <LockKeyhole size={20} /><Typography sx={{ ml: 1 }}>Make private</Typography>
+            <ListItemIcon><LockKeyhole size={16} /></ListItemIcon>
+            <ListItemText>Make private</ListItemText>
           </MenuItem>,
         ] : (
           <MenuItem onClick={() => setVisibility('public')}>
-            <Globe2 size={20} /><Typography sx={{ ml: 1 }}>Publish publicly</Typography>
+            <ListItemIcon><Globe2 size={16} /></ListItemIcon>
+            <ListItemText>Publish publicly</ListItemText>
           </MenuItem>
         )}
       </Menu>

--- a/frontend/src/pages/ArtifactViewer.tsx
+++ b/frontend/src/pages/ArtifactViewer.tsx
@@ -1,0 +1,151 @@
+import { FC, MouseEvent, useState } from 'react'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { ArrowLeft, Copy, ExternalLink, Globe2, LockKeyhole, Share2 } from 'lucide-react'
+
+import Page from '../components/system/Page'
+import useRouter from '../hooks/useRouter'
+import useSnackbar from '../hooks/useSnackbar'
+import { useGetArtifact, useSetArtifactVisibility } from '../services/artifactService'
+
+const ArtifactViewer: FC = () => {
+  const router = useRouter()
+  const snackbar = useSnackbar()
+  const artifactId = router.params.artifact_id as string
+  const { data: artifact, isLoading, error } = useGetArtifact(artifactId)
+  const visibilityMutation = useSetArtifactVisibility(artifactId)
+  const [shareAnchor, setShareAnchor] = useState<HTMLElement | null>(null)
+
+  const isPublic = artifact?.visibility === 'public'
+  const frameURL = isPublic
+    ? artifact?.subdomain_url
+    : artifact ? `/artifacts/${artifact.id}/embed` : undefined
+
+  const goBack = () => {
+    if (window.history.length > 1) {
+      window.history.back()
+      return
+    }
+    if (artifact?.project_id && artifact.organization_id) {
+      router.navigate('org_project-artifacts', { org_id: artifact.organization_id, id: artifact.project_id })
+    }
+  }
+
+  const setVisibility = async (visibility: 'project' | 'public') => {
+    try {
+      await visibilityMutation.mutateAsync(visibility)
+      snackbar.success(visibility === 'public' ? 'Public share link enabled' : 'Artifact is private')
+      setShareAnchor(null)
+    } catch (mutationError) {
+      snackbar.error(mutationError instanceof Error ? mutationError.message : 'Failed to update artifact visibility')
+    }
+  }
+
+  const copyShareLink = async () => {
+    if (!artifact?.subdomain_url) return
+    await navigator.clipboard.writeText(artifact.subdomain_url)
+    snackbar.success('Public link copied')
+    setShareAnchor(null)
+  }
+
+  const openShareMenu = (event: MouseEvent<HTMLElement>) => setShareAnchor(event.currentTarget)
+
+  if (isLoading) {
+    return <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}><CircularProgress /></Box>
+  }
+
+  if (!artifact || error) {
+    return (
+      <Box sx={{ height: '100%', display: 'grid', placeItems: 'center', p: 3 }}>
+        <Typography color="text.secondary">You do not have access to this artifact, or it no longer exists.</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Page
+      breadcrumbTitle={artifact.name || 'Artifact'}
+      breadcrumbShowHome={false}
+      showDrawerButton={false}
+      notifications={false}
+      themeToggle={false}
+      disableContentScroll
+      px={1}
+      topbarLeftContent={(
+        <Tooltip title="Back to artifacts">
+          <IconButton aria-label="Back to artifacts" onClick={goBack} sx={{ width: 30, height: 30, color: 'text.secondary' }}>
+            <ArrowLeft size={18} />
+          </IconButton>
+        </Tooltip>
+      )}
+      topbarContent={(
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Chip
+            size="small"
+            variant="outlined"
+            color={isPublic ? 'success' : 'default'}
+            icon={isPublic ? <Globe2 size={14} /> : <LockKeyhole size={14} />}
+            label={isPublic ? 'Public' : 'Private'}
+          />
+          <Tooltip title="Share artifact">
+            <span>
+              <IconButton
+                aria-label="Share artifact"
+                onClick={openShareMenu}
+                disabled={visibilityMutation.isPending}
+                sx={{ width: 30, height: 30, color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
+              >
+                <Share2 size={18} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+      )}
+    >
+      <Box sx={{ flex: 1, minHeight: 0, p: 1, bgcolor: 'background.default' }}>
+        {frameURL ? (
+          <Box
+            component="iframe"
+            key={`${artifact.id}:${artifact.visibility}:${artifact.active_version_id}`}
+            title={artifact.name || 'Artifact preview'}
+            src={frameURL}
+            sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-same-origin"
+            referrerPolicy="no-referrer"
+            sx={{ display: 'block', width: '100%', height: '100%', border: '1px solid', borderColor: 'divider', borderRadius: 1, bgcolor: '#fff' }}
+          />
+        ) : (
+          <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}>
+            <Typography color="text.secondary">The public share origin is unavailable.</Typography>
+          </Box>
+        )}
+      </Box>
+
+      <Menu anchorEl={shareAnchor} open={!!shareAnchor} onClose={() => setShareAnchor(null)}>
+        {isPublic ? [
+          <MenuItem key="copy" onClick={copyShareLink} disabled={!artifact.subdomain_url}>
+            <Copy size={20} /><Typography sx={{ ml: 1 }}>Copy public link</Typography>
+          </MenuItem>,
+          <MenuItem key="open" onClick={() => artifact.subdomain_url && window.open(artifact.subdomain_url, '_blank', 'noopener,noreferrer')} disabled={!artifact.subdomain_url}>
+            <ExternalLink size={20} /><Typography sx={{ ml: 1 }}>Open public link</Typography>
+          </MenuItem>,
+          <MenuItem key="private" onClick={() => setVisibility('project')}>
+            <LockKeyhole size={20} /><Typography sx={{ ml: 1 }}>Make private</Typography>
+          </MenuItem>,
+        ] : (
+          <MenuItem onClick={() => setVisibility('public')}>
+            <Globe2 size={20} /><Typography sx={{ ml: 1 }}>Publish publicly</Typography>
+          </MenuItem>
+        )}
+      </Menu>
+    </Page>
+  )
+}
+
+export default ArtifactViewer

--- a/frontend/src/pages/Artifacts.tsx
+++ b/frontend/src/pages/Artifacts.tsx
@@ -91,16 +91,19 @@ const Artifacts: FC = () => {
     <Page
       breadcrumbTitle="Artifacts"
       orgBreadcrumbs
-      breadcrumbs={project?.name ? [{
-        title: project.name,
-        routeName: 'org_project-specs',
-        params: { id: projectId },
-      }] : []}
+      breadcrumbs={project?.name ? [
+        { title: 'Projects', routeName: 'projects' },
+        {
+          title: project.name,
+          routeName: 'project-specs',
+          params: { id: projectId },
+        },
+      ] : []}
     >
       <Container maxWidth="lg" sx={{ mb: 4, mt: 4 }}>
         <PageSectionHeader
           title="Artifacts"
-          description="Static HTML pages and compiled apps stored in this project. They inherit project access and run without a sandbox."
+          description="Artifacts are static pages and apps your agents create and upload to this project. They inherit project access and are served directly by Helix without a running sandbox."
           action={(
             <Button variant="contained" color="secondary" startIcon={<Plus size={18} />} onClick={openCreate}>
               New Artifact
@@ -112,7 +115,9 @@ const Artifacts: FC = () => {
             <LoadingSpinner />
           ) : artifacts.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 8 }}>
-              <Typography variant="body1" color="text.secondary">No artifacts have been published in this project.</Typography>
+              <Typography variant="body1" color="text.secondary">
+                No artifacts yet. Ask an agent to create and upload one, or publish HTML or a compiled app manually.
+              </Typography>
               <Button variant="contained" color="secondary" startIcon={<Plus size={18} />} onClick={openCreate} sx={{ mt: 2 }}>
                 Publish the first artifact
               </Button>
@@ -131,6 +136,7 @@ const Artifacts: FC = () => {
       <ArtifactDialog
         open={dialogOpen}
         artifact={editing}
+        projectName={project?.name}
         saving={saving}
         error={saveError}
         onClose={() => setDialogOpen(false)}

--- a/frontend/src/pages/Artifacts.tsx
+++ b/frontend/src/pages/Artifacts.tsx
@@ -1,0 +1,150 @@
+import { FC, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { Plus } from 'lucide-react'
+
+import { TypesArtifact } from '../api/api'
+import ArtifactDialog from '../components/artifacts/ArtifactDialog'
+import ArtifactsView from '../components/artifacts/ArtifactsView'
+import Page from '../components/system/Page'
+import PageSectionHeader from '../components/system/PageSectionHeader'
+import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
+import LoadingSpinner from '../components/widgets/LoadingSpinner'
+import ViewModeToggle from '../components/widgets/ViewModeToggle'
+import useRouter from '../hooks/useRouter'
+import useSnackbar from '../hooks/useSnackbar'
+import useViewMode from '../hooks/useViewMode'
+import { useGetProject } from '../services/projectService'
+import {
+  ArtifactForm,
+  useCreateArtifact,
+  useDeleteArtifact,
+  useListProjectArtifacts,
+  useUpdateArtifact,
+} from '../services/artifactService'
+
+const errorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message
+  return 'Artifact request failed'
+}
+
+const Artifacts: FC = () => {
+  const router = useRouter()
+  const snackbar = useSnackbar()
+  const projectId = router.params.id as string
+  const [viewMode, setViewMode] = useViewMode('artifacts-view-mode', 'table')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<TypesArtifact>()
+  const [deleting, setDeleting] = useState<TypesArtifact>()
+  const [saveError, setSaveError] = useState<string>()
+
+  const { data: project } = useGetProject(projectId, !!projectId)
+  const { data: artifacts = [], isLoading } = useListProjectArtifacts(projectId)
+  const createMutation = useCreateArtifact(projectId)
+  const updateMutation = useUpdateArtifact(projectId)
+  const deleteMutation = useDeleteArtifact(projectId)
+  const saving = createMutation.isPending || updateMutation.isPending
+
+  const openCreate = () => {
+    setEditing(undefined)
+    setSaveError(undefined)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (artifact: TypesArtifact) => {
+    setEditing(artifact)
+    setSaveError(undefined)
+    setDialogOpen(true)
+  }
+
+  const saveArtifact = async (form: ArtifactForm) => {
+    try {
+      if (editing?.id) {
+        await updateMutation.mutateAsync({ id: editing.id, form })
+        snackbar.success(`Artifact ${form.name} updated`)
+      } else {
+        await createMutation.mutateAsync(form)
+        snackbar.success(`Artifact ${form.name} created`)
+      }
+      setDialogOpen(false)
+      setEditing(undefined)
+    } catch (error) {
+      setSaveError(errorMessage(error))
+    }
+  }
+
+  const deleteArtifact = async () => {
+    if (!deleting?.id) return
+    try {
+      await deleteMutation.mutateAsync(deleting.id)
+      snackbar.success(`Artifact ${deleting.name || deleting.id} deleted`)
+      setDeleting(undefined)
+    } catch (error) {
+      snackbar.error(errorMessage(error))
+    }
+  }
+
+  return (
+    <Page
+      breadcrumbTitle="Artifacts"
+      orgBreadcrumbs
+      breadcrumbs={project?.name ? [{
+        title: project.name,
+        routeName: 'org_project-specs',
+        params: { id: projectId },
+      }] : []}
+    >
+      <Container maxWidth="lg" sx={{ mb: 4, mt: 4 }}>
+        <PageSectionHeader
+          title="Artifacts"
+          description="Static HTML pages and compiled apps stored in this project. They inherit project access and run without a sandbox."
+          action={(
+            <Button variant="contained" color="secondary" startIcon={<Plus size={18} />} onClick={openCreate}>
+              New Artifact
+            </Button>
+          )}
+        />
+        <Stack spacing={2}>
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : artifacts.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 8 }}>
+              <Typography variant="body1" color="text.secondary">No artifacts have been published in this project.</Typography>
+              <Button variant="contained" color="secondary" startIcon={<Plus size={18} />} onClick={openCreate} sx={{ mt: 2 }}>
+                Publish the first artifact
+              </Button>
+            </Box>
+          ) : (
+            <>
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <ViewModeToggle mode={viewMode} onChange={setViewMode} />
+              </Box>
+              <ArtifactsView artifacts={artifacts} mode={viewMode} onEdit={openEdit} onDelete={setDeleting} />
+            </>
+          )}
+        </Stack>
+      </Container>
+
+      <ArtifactDialog
+        open={dialogOpen}
+        artifact={editing}
+        saving={saving}
+        error={saveError}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={saveArtifact}
+      />
+      {deleting && (
+        <DeleteConfirmWindow
+          title={`artifact ${deleting.name || deleting.id}`}
+          onCancel={() => setDeleting(undefined)}
+          onSubmit={deleteArtifact}
+        />
+      )}
+    </Page>
+  )
+}
+
+export default Artifacts

--- a/frontend/src/pages/SpecTasksPage.tsx
+++ b/frontend/src/pages/SpecTasksPage.tsx
@@ -37,6 +37,7 @@ import {
   FolderOpen,
   GitMerge,
   UserPlus,
+  PanelsTopLeft,
 } from "lucide-react";
 
 import Page from "../components/system/Page";
@@ -880,6 +881,18 @@ const SpecTasksPage: FC = () => {
               alignItems: "center",
             }}
           >
+            <Button
+              variant="text"
+              color="secondary"
+              startIcon={<PanelsTopLeft size={18} />}
+              onClick={() => router.navigate("org_project-artifacts", {
+                org_id: router.params.org_id,
+                id: projectId,
+              })}
+              sx={{ flexShrink: 0, minHeight: 40, textTransform: "none", fontWeight: 500 }}
+            >
+              Artifacts
+            </Button>
             {!exploratorySessionData ? (
               <Tooltip title="Test your app and find tasks for your agents. Shared with your team.">
                 <Button

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -27,6 +27,7 @@ import ImportAgent from './pages/ImportAgent'
 import Tasks from './pages/Tasks'
 import Jobs from './pages/Jobs'
 import SpecTasksPage from './pages/SpecTasksPage'
+import Artifacts from './pages/Artifacts'
 import SpecTaskDetailPage from './pages/SpecTaskDetailPage'
 import SpecTaskReviewPage from './pages/SpecTaskReviewPage'
 import TeamDesktopPage from './pages/TeamDesktopPage'
@@ -271,6 +272,16 @@ const routes: IApplicationRoute[] = [
   },
   render: () => (
     <SpecTasksPage />
+  ),
+}, {
+  name: 'org_project-artifacts',
+  path: '/orgs/:org_id/projects/:id/artifacts',
+  meta: {
+    drawer: false,
+    title: 'Project Artifacts',
+  },
+  render: () => (
+    <Artifacts />
   ),
 }, {
   name: 'org_project-task-detail',

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -28,6 +28,7 @@ import Tasks from './pages/Tasks'
 import Jobs from './pages/Jobs'
 import SpecTasksPage from './pages/SpecTasksPage'
 import Artifacts from './pages/Artifacts'
+import ArtifactViewer from './pages/ArtifactViewer'
 import SpecTaskDetailPage from './pages/SpecTaskDetailPage'
 import SpecTaskReviewPage from './pages/SpecTaskReviewPage'
 import TeamDesktopPage from './pages/TeamDesktopPage'
@@ -97,6 +98,17 @@ const RouteRedirect = ({ route }: { route: string }) => {
 
 
 const routes: IApplicationRoute[] = [
+{
+  name: 'artifact_viewer',
+  path: '/artifacts/:artifact_id',
+  meta: {
+    drawer: false,
+    title: 'Artifact',
+  },
+  render: () => (
+    <ArtifactViewer />
+  ),
+},
 {
   name: 'org_projects',
   path: '/orgs/:org_id',

--- a/frontend/src/services/artifactService.test.ts
+++ b/frontend/src/services/artifactService.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { artifactMutationData } from './artifactService'
+
+describe('artifactMutationData', () => {
+  it('omits absent multipart fields instead of serializing undefined', () => {
+    expect(artifactMutationData({
+      name: 'Viewer smoke test',
+      visibility: 'project',
+    })).toEqual({
+      name: 'Viewer smoke test',
+      visibility: 'project',
+    })
+  })
+})

--- a/frontend/src/services/artifactService.ts
+++ b/frontend/src/services/artifactService.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { TypesArtifact } from '../api/api'
+import useApi from '../hooks/useApi'
+
+export type ArtifactForm = {
+  name: string
+  description?: string
+  entrypoint?: string
+  visibility: 'project' | 'public'
+  with_subdomain: boolean
+  artifact?: File
+}
+
+export const projectArtifactsQueryKey = (projectId: string) => ['project-artifacts', projectId]
+
+export const useListProjectArtifacts = (projectId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  return useQuery<TypesArtifact[]>({
+    queryKey: projectArtifactsQueryKey(projectId),
+    queryFn: async () => {
+      const response = await apiClient.v1ProjectsArtifactsDetail(projectId)
+      return response.data.artifacts ?? []
+    },
+    enabled: !!projectId,
+  })
+}
+
+export const useCreateArtifact = (projectId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (form: ArtifactForm) => {
+      if (!form.artifact) throw new Error('Choose an HTML file or ZIP bundle')
+      const response = await apiClient.v1ProjectsArtifactsCreate(projectId, {
+        ...form,
+        artifact: form.artifact,
+      })
+      return response.data
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(projectId) }),
+  })
+}
+
+export const useUpdateArtifact = (projectId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, form }: { id: string; form: ArtifactForm }) => {
+      const response = await apiClient.v1ArtifactsUpdate(id, form)
+      return response.data
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(projectId) }),
+  })
+}
+
+export const useDeleteArtifact = (projectId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (artifactId: string) => apiClient.v1ArtifactsDelete(artifactId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(projectId) }),
+  })
+}

--- a/frontend/src/services/artifactService.ts
+++ b/frontend/src/services/artifactService.ts
@@ -13,6 +13,15 @@ export type ArtifactForm = {
 
 export const projectArtifactsQueryKey = (projectId: string) => ['project-artifacts', projectId]
 export const artifactQueryKey = (artifactId: string) => ['artifact', artifactId]
+export const artifactViewerQueryKey = (artifactId: string) => ['artifact-viewer', artifactId]
+
+export const artifactMutationData = (form: ArtifactForm) => ({
+  name: form.name,
+  visibility: form.visibility,
+  ...(form.description !== undefined ? { description: form.description } : {}),
+  ...(form.entrypoint !== undefined ? { entrypoint: form.entrypoint } : {}),
+  ...(form.artifact !== undefined ? { artifact: form.artifact } : {}),
+})
 
 export const useGetArtifact = (artifactId: string) => {
   const api = useApi()
@@ -21,6 +30,19 @@ export const useGetArtifact = (artifactId: string) => {
     queryKey: artifactQueryKey(artifactId),
     queryFn: async () => {
       const response = await apiClient.v1ArtifactsDetail(artifactId)
+      return response.data
+    },
+    enabled: !!artifactId,
+  })
+}
+
+export const useGetArtifactViewer = (artifactId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  return useQuery({
+    queryKey: artifactViewerQueryKey(artifactId),
+    queryFn: async () => {
+      const response = await apiClient.v1PublicArtifactsDetail(artifactId)
       return response.data
     },
     enabled: !!artifactId,
@@ -38,6 +60,7 @@ export const useSetArtifactVisibility = (artifactId: string) => {
     },
     onSuccess: (artifact) => {
       queryClient.invalidateQueries({ queryKey: artifactQueryKey(artifactId) })
+      queryClient.invalidateQueries({ queryKey: artifactViewerQueryKey(artifactId) })
       if (artifact.project_id) {
         queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(artifact.project_id) })
       }
@@ -64,9 +87,9 @@ export const useCreateArtifact = (projectId: string) => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (form: ArtifactForm) => {
-      if (!form.artifact) throw new Error('Choose an HTML file or ZIP bundle')
+      if (!form.artifact) throw new Error('Choose an HTML, ZIP, PDF, or image file')
       const response = await apiClient.v1ProjectsArtifactsCreate(projectId, {
-        ...form,
+        ...artifactMutationData(form),
         artifact: form.artifact,
       })
       return response.data
@@ -81,7 +104,7 @@ export const useUpdateArtifact = (projectId: string) => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({ id, form }: { id: string; form: ArtifactForm }) => {
-      const response = await apiClient.v1ArtifactsUpdate(id, form)
+      const response = await apiClient.v1ArtifactsUpdate(id, artifactMutationData(form))
       return response.data
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(projectId) }),

--- a/frontend/src/services/artifactService.ts
+++ b/frontend/src/services/artifactService.ts
@@ -8,11 +8,42 @@ export type ArtifactForm = {
   description?: string
   entrypoint?: string
   visibility: 'project' | 'public'
-  with_subdomain: boolean
   artifact?: File
 }
 
 export const projectArtifactsQueryKey = (projectId: string) => ['project-artifacts', projectId]
+export const artifactQueryKey = (artifactId: string) => ['artifact', artifactId]
+
+export const useGetArtifact = (artifactId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  return useQuery<TypesArtifact>({
+    queryKey: artifactQueryKey(artifactId),
+    queryFn: async () => {
+      const response = await apiClient.v1ArtifactsDetail(artifactId)
+      return response.data
+    },
+    enabled: !!artifactId,
+  })
+}
+
+export const useSetArtifactVisibility = (artifactId: string) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (visibility: 'project' | 'public') => {
+      const response = await apiClient.v1ArtifactsUpdate(artifactId, { visibility })
+      return response.data
+    },
+    onSuccess: (artifact) => {
+      queryClient.invalidateQueries({ queryKey: artifactQueryKey(artifactId) })
+      if (artifact.project_id) {
+        queryClient.invalidateQueries({ queryKey: projectArtifactsQueryKey(artifact.project_id) })
+      }
+    },
+  })
+}
 
 export const useListProjectArtifacts = (projectId: string) => {
   const api = useApi()

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3857,10 +3857,14 @@ definitions:
     enum:
     - single_file
     - spa
+    - pdf
+    - image
     type: string
     x-enum-varnames:
     - ArtifactKindSingleFile
     - ArtifactKindSPA
+    - ArtifactKindPDF
+    - ArtifactKindImage
   types.ArtifactVersion:
     properties:
       artifact_id:
@@ -3894,6 +3898,33 @@ definitions:
         items:
           $ref: '#/definitions/types.ArtifactVersion'
         type: array
+    type: object
+  types.ArtifactViewerResponse:
+    properties:
+      active_version_id:
+        type: string
+      can_edit:
+        type: boolean
+      description:
+        type: string
+      id:
+        type: string
+      kind:
+        $ref: '#/definitions/types.ArtifactKind'
+      name:
+        type: string
+      organization_id:
+        type: string
+      organization_name:
+        type: string
+      project_id:
+        type: string
+      project_name:
+        type: string
+      subdomain_url:
+        type: string
+      visibility:
+        $ref: '#/definitions/types.ArtifactVisibility'
     type: object
   types.ArtifactVisibility:
     enum:
@@ -13156,11 +13187,13 @@ definitions:
     - project_web_service
     - sandbox_preview
     - artifact_static
+    - artifact_private
     type: string
     x-enum-varnames:
     - VHostTargetProjectWebService
     - VHostTargetSandboxPreview
     - VHostTargetArtifact
+    - VHostTargetArtifactPrivate
   types.WIPLimits:
     properties:
       implementation:
@@ -15259,8 +15292,8 @@ paths:
     put:
       consumes:
       - multipart/form-data
-      description: Patch metadata and optionally upload a replacement HTML file or
-        ZIP bundle as a new version.
+      description: Patch metadata and optionally upload replacement HTML, PDF, image,
+        or ZIP content as a new version.
       parameters:
       - description: Artifact ID
         in: path
@@ -15287,7 +15320,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: Replacement HTML file or ZIP bundle
+      - description: Replacement HTML, PDF, image, or ZIP content
         in: formData
         name: artifact
         type: file
@@ -22018,7 +22051,8 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: Upload one HTML file or a ZIP containing a compiled static SPA.
+      description: Upload one HTML, PDF, or image file, or a ZIP containing a compiled
+        static SPA.
       parameters:
       - description: Project ID
         in: path
@@ -22046,7 +22080,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: HTML file or ZIP bundle
+      - description: HTML, PDF, image, or ZIP bundle
         in: formData
         name: artifact
         required: true
@@ -23640,6 +23674,26 @@ paths:
             type: array
       security:
       - BearerAuth: []
+  /api/v1/public/artifacts/{artifact_id}:
+    get:
+      description: Returns safe display metadata for public artifacts without authentication.
+        Private artifacts require project access.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactViewerResponse'
+      summary: Get artifact viewer metadata
+      tags:
+      - Artifacts
   /api/v1/quotas:
     get:
       description: Get quotas for the user. Returns current usage and limits for desktops,

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3805,6 +3805,111 @@ definitions:
       type:
         $ref: '#/definitions/types.APIKeyType'
     type: object
+  types.Artifact:
+    properties:
+      active_version:
+        $ref: '#/definitions/types.ArtifactVersion'
+      active_version_id:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      deleted_at:
+        $ref: '#/definitions/gorm.DeletedAt'
+      description:
+        type: string
+      entrypoint:
+        type: string
+      id:
+        type: string
+      kind:
+        $ref: '#/definitions/types.ArtifactKind'
+      name:
+        type: string
+      organization_id:
+        type: string
+      project_id:
+        type: string
+      subdomain_url:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+      url:
+        type: string
+      visibility:
+        $ref: '#/definitions/types.ArtifactVisibility'
+    type: object
+  types.ArtifactFile:
+    properties:
+      content_type:
+        type: string
+      path:
+        type: string
+      sha256:
+        type: string
+      size:
+        type: integer
+    type: object
+  types.ArtifactKind:
+    enum:
+    - single_file
+    - spa
+    type: string
+    x-enum-varnames:
+    - ArtifactKindSingleFile
+    - ArtifactKindSPA
+  types.ArtifactVersion:
+    properties:
+      artifact_id:
+        type: string
+      content_sha256:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      file_count:
+        type: integer
+      files:
+        items:
+          $ref: '#/definitions/types.ArtifactFile'
+        type: array
+      id:
+        type: string
+      source_session_id:
+        type: string
+      source_spec_task_id:
+        type: string
+      total_bytes:
+        type: integer
+      version:
+        type: integer
+    type: object
+  types.ArtifactVersionsListResponse:
+    properties:
+      versions:
+        items:
+          $ref: '#/definitions/types.ArtifactVersion'
+        type: array
+    type: object
+  types.ArtifactVisibility:
+    enum:
+    - project
+    - public
+    type: string
+    x-enum-varnames:
+    - ArtifactVisibilityProject
+    - ArtifactVisibilityPublic
+  types.ArtifactsListResponse:
+    properties:
+      artifacts:
+        items:
+          $ref: '#/definitions/types.Artifact'
+        type: array
+    type: object
   types.AssistantAPI:
     properties:
       description:
@@ -13023,7 +13128,7 @@ definitions:
           User-added custom domains and preview tokens are false.
         type: boolean
       port:
-        description: destination port inside the container
+        description: destination port inside the container; zero for static artifacts
         type: integer
       rotated_at:
         type: string
@@ -13050,10 +13155,12 @@ definitions:
     enum:
     - project_web_service
     - sandbox_preview
+    - artifact_static
     type: string
     x-enum-varnames:
     - VHostTargetProjectWebService
     - VHostTargetSandboxPreview
+    - VHostTargetArtifact
   types.WIPLimits:
     properties:
       implementation:
@@ -15114,6 +15221,108 @@ paths:
       summary: Create a new API key
       tags:
       - api-keys
+  /api/v1/artifacts/{artifact_id}:
+    delete:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - BearerAuth: []
+      summary: Delete an artifact
+      tags:
+      - Artifacts
+    get:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Get an artifact
+      tags:
+      - Artifacts
+    put:
+      consumes:
+      - multipart/form-data
+      description: Patch metadata and optionally upload a replacement HTML file or
+        ZIP bundle as a new version.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      - description: Artifact name
+        in: formData
+        name: name
+        type: string
+      - description: Description
+        in: formData
+        name: description
+        type: string
+      - description: HTML entrypoint
+        in: formData
+        name: entrypoint
+        type: string
+      - description: project or public
+        in: formData
+        name: visibility
+        type: string
+      - description: Allocate or retain a public default subdomain
+        in: formData
+        name: with_subdomain
+        type: boolean
+      - description: Replacement HTML file or ZIP bundle
+        in: formData
+        name: artifact
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Update an artifact
+      tags:
+      - Artifacts
+  /api/v1/artifacts/{artifact_id}/versions:
+    get:
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: artifact_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactVersionsListResponse'
+      security:
+      - BearerAuth: []
+      summary: List artifact versions
+      tags:
+      - Artifacts
   /api/v1/attention-events:
     get:
       description: Returns attention events that need human action for the current
@@ -21784,6 +21993,76 @@ paths:
       summary: Grant access to a project to a team or organization member
       tags:
       - projects
+  /api/v1/projects/{id}/artifacts:
+    get:
+      description: List static artifacts in a project. Access is inherited from the
+        project.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ArtifactsListResponse'
+      security:
+      - BearerAuth: []
+      summary: List project artifacts
+      tags:
+      - Artifacts
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload one HTML file or a ZIP containing a compiled static SPA.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Artifact name
+        in: formData
+        name: name
+        required: true
+        type: string
+      - description: Description
+        in: formData
+        name: description
+        type: string
+      - description: HTML entrypoint (default index.html)
+        in: formData
+        name: entrypoint
+        type: string
+      - description: project or public
+        in: formData
+        name: visibility
+        type: string
+      - description: Allocate a public default subdomain
+        in: formData
+        name: with_subdomain
+        type: boolean
+      - description: HTML file or ZIP bundle
+        in: formData
+        name: artifact
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/types.Artifact'
+      security:
+      - BearerAuth: []
+      summary: Create a project artifact
+      tags:
+      - Artifacts
   /api/v1/projects/{id}/audit-logs:
     get:
       consumes:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -22042,7 +22042,7 @@ paths:
         in: formData
         name: visibility
         type: string
-      - description: Allocate a public default subdomain
+      - description: 'Deprecated: public artifacts always receive a share subdomain'
         in: formData
         name: with_subdomain
         type: boolean

--- a/openapi.json
+++ b/openapi.json
@@ -3217,6 +3217,176 @@
                 }
             }
         },
+        "/api/v1/artifacts/{artifact_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get an artifact",
+                "parameters": [
+                    {
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Artifact"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Update an artifact",
+                "parameters": [
+                    {
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "description": "Artifact name",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "Description",
+                                        "type": "string"
+                                    },
+                                    "entrypoint": {
+                                        "description": "HTML entrypoint",
+                                        "type": "string"
+                                    },
+                                    "visibility": {
+                                        "description": "project or public",
+                                        "type": "string"
+                                    },
+                                    "with_subdomain": {
+                                        "description": "Allocate or retain a public default subdomain",
+                                        "type": "boolean"
+                                    },
+                                    "artifact": {
+                                        "description": "Replacement HTML file or ZIP bundle",
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Artifact"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Delete an artifact",
+                "parameters": [
+                    {
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/artifacts/{artifact_id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List artifact versions",
+                "parameters": [
+                    {
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.ArtifactVersionsListResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/attention-events": {
             "get": {
                 "description": "Returns attention events that need human action for the current user. Only returns events that have not been dismissed and are not currently snoozed.",
@@ -15766,6 +15936,119 @@
                             "*/*": {
                                 "schema": {
                                     "$ref": "#/components/schemas/types.CreateAccessGrantResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/artifacts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List static artifacts in a project. Access is inherited from the project.",
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List project artifacts",
+                "parameters": [
+                    {
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.ArtifactsListResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Create a project artifact",
+                "parameters": [
+                    {
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "description": "Artifact name",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "Description",
+                                        "type": "string"
+                                    },
+                                    "entrypoint": {
+                                        "description": "HTML entrypoint (default index.html)",
+                                        "type": "string"
+                                    },
+                                    "visibility": {
+                                        "description": "project or public",
+                                        "type": "string"
+                                    },
+                                    "with_subdomain": {
+                                        "description": "Allocate a public default subdomain",
+                                        "type": "boolean"
+                                    },
+                                    "artifact": {
+                                        "description": "HTML file or ZIP bundle",
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "artifact"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Artifact"
                                 }
                             }
                         }
@@ -33038,6 +33321,164 @@
                     }
                 }
             },
+            "types.Artifact": {
+                "type": "object",
+                "properties": {
+                    "active_version": {
+                        "$ref": "#/components/schemas/types.ArtifactVersion"
+                    },
+                    "active_version_id": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "created_by": {
+                        "type": "string"
+                    },
+                    "deleted_at": {
+                        "$ref": "#/components/schemas/gorm.DeletedAt"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "entrypoint": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "$ref": "#/components/schemas/types.ArtifactKind"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "subdomain_url": {
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    },
+                    "updated_by": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "visibility": {
+                        "$ref": "#/components/schemas/types.ArtifactVisibility"
+                    }
+                }
+            },
+            "types.ArtifactFile": {
+                "type": "object",
+                "properties": {
+                    "content_type": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.ArtifactKind": {
+                "type": "string",
+                "enum": [
+                    "single_file",
+                    "spa"
+                ],
+                "x-enum-varnames": [
+                    "ArtifactKindSingleFile",
+                    "ArtifactKindSPA"
+                ]
+            },
+            "types.ArtifactVersion": {
+                "type": "object",
+                "properties": {
+                    "artifact_id": {
+                        "type": "string"
+                    },
+                    "content_sha256": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "created_by": {
+                        "type": "string"
+                    },
+                    "file_count": {
+                        "type": "integer"
+                    },
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.ArtifactFile"
+                        }
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "source_session_id": {
+                        "type": "string"
+                    },
+                    "source_spec_task_id": {
+                        "type": "string"
+                    },
+                    "total_bytes": {
+                        "type": "integer"
+                    },
+                    "version": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.ArtifactVersionsListResponse": {
+                "type": "object",
+                "properties": {
+                    "versions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.ArtifactVersion"
+                        }
+                    }
+                }
+            },
+            "types.ArtifactVisibility": {
+                "type": "string",
+                "enum": [
+                    "project",
+                    "public"
+                ],
+                "x-enum-varnames": [
+                    "ArtifactVisibilityProject",
+                    "ArtifactVisibilityPublic"
+                ]
+            },
+            "types.ArtifactsListResponse": {
+                "type": "object",
+                "properties": {
+                    "artifacts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.Artifact"
+                        }
+                    }
+                }
+            },
             "types.AssistantAPI": {
                 "type": "object",
                 "properties": {
@@ -45473,7 +45914,7 @@
                         "type": "boolean"
                     },
                     "port": {
-                        "description": "destination port inside the container",
+                        "description": "destination port inside the container; zero for static artifacts",
                         "type": "integer"
                     },
                     "rotated_at": {
@@ -45503,11 +45944,13 @@
                 "type": "string",
                 "enum": [
                     "project_web_service",
-                    "sandbox_preview"
+                    "sandbox_preview",
+                    "artifact_static"
                 ],
                 "x-enum-varnames": [
                     "VHostTargetProjectWebService",
-                    "VHostTargetSandboxPreview"
+                    "VHostTargetSandboxPreview",
+                    "VHostTargetArtifact"
                 ]
             },
             "types.WIPLimits": {

--- a/openapi.json
+++ b/openapi.json
@@ -16024,7 +16024,7 @@
                                         "type": "string"
                                     },
                                     "with_subdomain": {
-                                        "description": "Allocate a public default subdomain",
+                                        "description": "Deprecated: public artifacts always receive a share subdomain",
                                         "type": "boolean"
                                     },
                                     "artifact": {

--- a/openapi.json
+++ b/openapi.json
@@ -3258,7 +3258,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
                 "tags": [
                     "Artifacts"
                 ],
@@ -3301,7 +3301,7 @@
                                         "type": "boolean"
                                     },
                                     "artifact": {
-                                        "description": "Replacement HTML file or ZIP bundle",
+                                        "description": "Replacement HTML, PDF, image, or ZIP content",
                                         "type": "string",
                                         "format": "binary"
                                     }
@@ -15985,7 +15985,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "tags": [
                     "Artifacts"
                 ],
@@ -16028,7 +16028,7 @@
                                         "type": "boolean"
                                     },
                                     "artifact": {
-                                        "description": "HTML file or ZIP bundle",
+                                        "description": "HTML, PDF, image, or ZIP bundle",
                                         "type": "string",
                                         "format": "binary"
                                     }
@@ -18872,6 +18872,38 @@
                                     "items": {
                                         "$ref": "#/components/schemas/types.Provider"
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/public/artifacts/{artifact_id}": {
+            "get": {
+                "description": "Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.",
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get artifact viewer metadata",
+                "parameters": [
+                    {
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.ArtifactViewerResponse"
                                 }
                             }
                         }
@@ -33398,11 +33430,15 @@
                 "type": "string",
                 "enum": [
                     "single_file",
-                    "spa"
+                    "spa",
+                    "pdf",
+                    "image"
                 ],
                 "x-enum-varnames": [
                     "ArtifactKindSingleFile",
-                    "ArtifactKindSPA"
+                    "ArtifactKindSPA",
+                    "ArtifactKindPDF",
+                    "ArtifactKindImage"
                 ]
             },
             "types.ArtifactVersion": {
@@ -33454,6 +33490,47 @@
                         "items": {
                             "$ref": "#/components/schemas/types.ArtifactVersion"
                         }
+                    }
+                }
+            },
+            "types.ArtifactViewerResponse": {
+                "type": "object",
+                "properties": {
+                    "active_version_id": {
+                        "type": "string"
+                    },
+                    "can_edit": {
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "$ref": "#/components/schemas/types.ArtifactKind"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "organization_name": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "project_name": {
+                        "type": "string"
+                    },
+                    "subdomain_url": {
+                        "type": "string"
+                    },
+                    "visibility": {
+                        "$ref": "#/components/schemas/types.ArtifactVisibility"
                     }
                 }
             },
@@ -45945,12 +46022,14 @@
                 "enum": [
                     "project_web_service",
                     "sandbox_preview",
-                    "artifact_static"
+                    "artifact_static",
+                    "artifact_private"
                 ],
                 "x-enum-varnames": [
                     "VHostTargetProjectWebService",
                     "VHostTargetSandboxPreview",
-                    "VHostTargetArtifact"
+                    "VHostTargetArtifact",
+                    "VHostTargetArtifactPrivate"
                 ]
             },
             "types.WIPLimits": {

--- a/swagger.json
+++ b/swagger.json
@@ -13474,7 +13474,7 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "Allocate a public default subdomain",
+                        "description": "Deprecated: public artifacts always receive a share subdomain",
                         "name": "with_subdomain",
                         "in": "formData"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -2697,6 +2697,168 @@
                 }
             }
         },
+        "/api/v1/artifacts/{artifact_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Update an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate or retain a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "Replacement HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Delete an artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/artifacts/{artifact_id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List artifact versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactVersionsListResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/attention-events": {
             "get": {
                 "description": "Returns attention events that need human action for the current user. Only returns events that have not been dismissed and are not currently snoozed.",
@@ -13222,6 +13384,113 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.CreateAccessGrantResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/artifacts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List static artifacts in a project. Access is inherited from the project.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "List project artifacts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactsListResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Create a project artifact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact name",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "HTML entrypoint (default index.html)",
+                        "name": "entrypoint",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "project or public",
+                        "name": "visibility",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Allocate a public default subdomain",
+                        "name": "with_subdomain",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "HTML file or ZIP bundle",
+                        "name": "artifact",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.Artifact"
                         }
                     }
                 }
@@ -28448,6 +28717,164 @@
                 }
             }
         },
+        "types.Artifact": {
+            "type": "object",
+            "properties": {
+                "active_version": {
+                    "$ref": "#/definitions/types.ArtifactVersion"
+                },
+                "active_version_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "deleted_at": {
+                    "$ref": "#/definitions/gorm.DeletedAt"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "entrypoint": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
+                }
+            }
+        },
+        "types.ArtifactFile": {
+            "type": "object",
+            "properties": {
+                "content_type": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactKind": {
+            "type": "string",
+            "enum": [
+                "single_file",
+                "spa"
+            ],
+            "x-enum-varnames": [
+                "ArtifactKindSingleFile",
+                "ArtifactKindSPA"
+            ]
+        },
+        "types.ArtifactVersion": {
+            "type": "object",
+            "properties": {
+                "artifact_id": {
+                    "type": "string"
+                },
+                "content_sha256": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "file_count": {
+                    "type": "integer"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactFile"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "source_session_id": {
+                    "type": "string"
+                },
+                "source_spec_task_id": {
+                    "type": "string"
+                },
+                "total_bytes": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.ArtifactVersionsListResponse": {
+            "type": "object",
+            "properties": {
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ArtifactVersion"
+                    }
+                }
+            }
+        },
+        "types.ArtifactVisibility": {
+            "type": "string",
+            "enum": [
+                "project",
+                "public"
+            ],
+            "x-enum-varnames": [
+                "ArtifactVisibilityProject",
+                "ArtifactVisibilityPublic"
+            ]
+        },
+        "types.ArtifactsListResponse": {
+            "type": "object",
+            "properties": {
+                "artifacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Artifact"
+                    }
+                }
+            }
+        },
         "types.AssistantAPI": {
             "type": "object",
             "properties": {
@@ -40883,7 +41310,7 @@
                     "type": "boolean"
                 },
                 "port": {
-                    "description": "destination port inside the container",
+                    "description": "destination port inside the container; zero for static artifacts",
                     "type": "integer"
                 },
                 "rotated_at": {
@@ -40913,11 +41340,13 @@
             "type": "string",
             "enum": [
                 "project_web_service",
-                "sandbox_preview"
+                "sandbox_preview",
+                "artifact_static"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
-                "VHostTargetSandboxPreview"
+                "VHostTargetSandboxPreview",
+                "VHostTargetArtifact"
             ]
         },
         "types.WIPLimits": {

--- a/swagger.json
+++ b/swagger.json
@@ -2735,7 +2735,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload a replacement HTML file or ZIP bundle as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2786,7 +2786,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML file or ZIP bundle",
+                        "description": "Replacement HTML, PDF, image, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13428,7 +13428,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML file or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13480,7 +13480,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "HTML file or ZIP bundle",
+                        "description": "HTML, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -15825,6 +15825,35 @@
                             "items": {
                                 "$ref": "#/definitions/types.Provider"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/public/artifacts/{artifact_id}": {
+            "get": {
+                "description": "Returns safe display metadata for public artifacts without authentication. Private artifacts require project access.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Get artifact viewer metadata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "artifact_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ArtifactViewerResponse"
                         }
                     }
                 }
@@ -28794,11 +28823,15 @@
             "type": "string",
             "enum": [
                 "single_file",
-                "spa"
+                "spa",
+                "pdf",
+                "image"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
-                "ArtifactKindSPA"
+                "ArtifactKindSPA",
+                "ArtifactKindPDF",
+                "ArtifactKindImage"
             ]
         },
         "types.ArtifactVersion": {
@@ -28850,6 +28883,47 @@
                     "items": {
                         "$ref": "#/definitions/types.ArtifactVersion"
                     }
+                }
+            }
+        },
+        "types.ArtifactViewerResponse": {
+            "type": "object",
+            "properties": {
+                "active_version_id": {
+                    "type": "string"
+                },
+                "can_edit": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/types.ArtifactKind"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_name": {
+                    "type": "string"
+                },
+                "subdomain_url": {
+                    "type": "string"
+                },
+                "visibility": {
+                    "$ref": "#/definitions/types.ArtifactVisibility"
                 }
             }
         },
@@ -41341,12 +41415,14 @@
             "enum": [
                 "project_web_service",
                 "sandbox_preview",
-                "artifact_static"
+                "artifact_static",
+                "artifact_private"
             ],
             "x-enum-varnames": [
                 "VHostTargetProjectWebService",
                 "VHostTargetSandboxPreview",
-                "VHostTargetArtifact"
+                "VHostTargetArtifact",
+                "VHostTargetArtifactPrivate"
             ]
         },
         "types.WIPLimits": {


### PR DESCRIPTION
## Summary

- add project-scoped artifacts with inherited project RBAC, immutable versions, filestore persistence, and public/private visibility
- serve single-file HTML, compiled static SPAs, PDFs, and images through the Helix viewer and isolated artifact subdomains
- add secure private viewer routing, CSP policies, public sharing controls, breadcrumbs, same-tab navigation, and compact artifact actions
- expose artifact management in project UI, Spec Tasks, agent tools, generated API clients, and the Helix CLI
- preserve configured protocol and port for local artifact subdomains

## Security

- HTML and SPAs execute only on isolated artifact origins inside a sandboxed iframe
- private artifacts use expiring user-bound vhost routes and re-check project access
- public artifact metadata is reduced and anonymous viewers cannot edit
- PDFs use a permission-checked same-origin document route with `application/pdf`, `nosniff`, inline disposition, and `default-src 'none'` CSP so Chrome can use its native PDF renderer
- images render as inert responsive images; public subdomain delivery remains limited to public artifacts

## Verification

- `go test ./pkg/server -run 'Artifact|VHost' -count=1`
- `go test ./pkg/cli/artifact -count=1`
- `go build ./pkg/server ./pkg/store ./pkg/types`
- `yarn vitest run src/components/artifacts/ArtifactDialog.test.tsx src/pages/ArtifactViewer.test.tsx src/services/artifactService.test.ts`
- `yarn tsc --noEmit`
- `yarn build`
- live-tested HTML, SPA, PDF, and image creation and rendering on the local stack
- live-tested PDF public/private transitions: anonymous private access returns 401, authorized access returns 200, and public access uses Chrome's native viewer
- live-tested artifact name, row/card, and menu navigation in the current tab followed by browser Back