### PR TITLE
fix(claude): act on the right subscription, not whichever came first

### DIFF
--- a/frontend/src/components/account/ClaudeSubscriptionConnect.target.test.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.target.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ClaudeSubscriptionConnect from './ClaudeSubscriptionConnect'
+
+// The list endpoint returns the user's own subscriptions first, then appends
+// the subscriptions of every organisation they belong to. The button variant
+// used to act on subscriptions[0], so a user with no personal subscription
+// operated on an org's row without ever being told.
+const deleteSubscription = vi.fn()
+
+let subscriptions: Array<Record<string, unknown>> = []
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => ({
+    get: vi.fn(async () => subscriptions),
+    post: vi.fn(async () => null),
+    delete: vi.fn(async () => null),
+    getApiClient: () => ({
+      v1ClaudeSubscriptionsCreate: vi.fn(),
+      v1ClaudeSubscriptionsDelete: deleteSubscription,
+      v1ClaudeSubscriptionsOauthStartCreate: vi.fn(),
+      v1ClaudeSubscriptionsOauthCompleteCreate: vi.fn(),
+    }),
+  }),
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn(), setSnackbar: vi.fn() }),
+}))
+
+vi.mock('../../hooks/useAccount', () => ({
+  default: () => ({
+    admin: false,
+    user: { id: 'usr_me' },
+    organizationTools: { organizations: [] },
+  }),
+}))
+
+const orgSub = {
+  id: 'csub_org',
+  owner_type: 'org',
+  owner_id: 'org_shared',
+  name: 'Shared Claude Subscription',
+  status: 'active',
+  credential_type: 'oauth',
+  access_token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+}
+
+const personalSub = {
+  id: 'csub_mine',
+  owner_type: 'user',
+  owner_id: 'usr_me',
+  name: 'My Claude Subscription',
+  status: 'active',
+  credential_type: 'oauth',
+  access_token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+}
+
+async function renderButton(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <ClaudeSubscriptionConnect variant="button" {...props} />
+    </QueryClientProvider>,
+  )
+  return result
+}
+
+// The row button and its confirmation dialog share the "Disconnect" label, so
+// open the dialog first and confirm inside it.
+async function confirmDisconnect() {
+  fireEvent.click(await screen.findByRole('button', { name: 'Disconnect' }))
+  const dialog = await screen.findByRole('dialog')
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Disconnect' }))
+}
+
+describe('ClaudeSubscriptionConnect — which subscription the button acts on', () => {
+  beforeEach(() => {
+    deleteSubscription.mockReset()
+    subscriptions = []
+  })
+
+  it('offers to connect when the only subscription belongs to an org', async () => {
+    // The regression: this said "Disconnect", contradicting the card around it,
+    // which correctly reads "not connected" — and left no way to connect one.
+    subscriptions = [orgSub]
+    await renderButton()
+
+    expect(await screen.findByRole('button', { name: 'Connect' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Disconnect' })).not.toBeInTheDocument()
+  })
+
+  it('never offers to disconnect an org subscription from a personal control', async () => {
+    subscriptions = [orgSub]
+    await renderButton()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Connect' }))
+    expect(deleteSubscription).not.toHaveBeenCalled()
+  })
+
+  it('acts on the personal subscription when there is one', async () => {
+    // Own row first, org row appended — the ordering that made [0] look right.
+    subscriptions = [personalSub, orgSub]
+    await renderButton()
+
+    await confirmDisconnect()
+    await waitFor(() => expect(deleteSubscription).toHaveBeenCalledWith(personalSub.id))
+  })
+
+  it('acts on the org subscription when asked to manage that org', async () => {
+    // With orgId the control is explicitly the org's, so the org row is right.
+    subscriptions = [personalSub, orgSub]
+    await renderButton({ orgId: 'org_shared' })
+
+    await confirmDisconnect()
+    await waitFor(() => expect(deleteSubscription).toHaveBeenCalledWith(orgSub.id))
+  })
+
+  it('offers to connect when the named org has no subscription', async () => {
+    subscriptions = [personalSub]
+    await renderButton({ orgId: 'org_without_one' })
+
+    expect(await screen.findByRole('button', { name: 'Connect' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -525,11 +525,23 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
 
   const tokenValidationError = connectMethod === 'setup_token' ? validateSetupToken(tokenValue) : ''
 
-  const firstSub = subscriptions?.[0]
-  const isSetupToken = firstSub?.credential_type === 'setup_token'
+  // The button and inline variants speak for exactly one subscription: the org's
+  // when orgId names one, otherwise the signed-in user's own.
+  //
+  // These used to read subscriptions[0]. The list returns the user's own rows
+  // first and then appends every org they are a *member* of, so a user with no
+  // personal subscription who simply belongs to an org that has one saw
+  // "Disconnect" on a card that reads "not connected" — and if they owned that
+  // org, clicking it deleted the org's shared subscription from a control that
+  // never named it. It also left them no way to connect a personal one.
+  const targetSub = orgId
+    ? subscriptions?.find((sub) => sub.owner_type === 'org' && sub.owner_id === orgId)
+    : subscriptions?.find((sub) => sub.owner_type === 'user')
+  const hasTargetSub = !!targetSub
+  const isSetupToken = targetSub?.credential_type === 'setup_token'
   // See the card above: status, not the clock, is what says a credential needs
   // the user's attention now that refresh happens in the background.
-  const isExpired = !!firstSub && firstSub.status !== 'active'
+  const isExpired = !!targetSub && targetSub.status !== 'active'
 
   // Owner picker — only meaningful in the account variant, where you manage every
   // subscription you can see. The other variants are scoped by the `orgId` prop.
@@ -1081,7 +1093,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
     const connectButtonSx = { textTransform: 'none' } as const
     return (
       <>
-        {hasSubscription ? (
+        {hasTargetSub ? (
           isExpired && !isSetupToken ? (
             <Button
               size="small"
@@ -1099,8 +1111,8 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
               variant="outlined"
               color="error"
               onClick={() => {
-                if (subscriptions?.[0]?.id) {
-                  setDeleteTarget(subscriptions[0].id)
+                if (targetSub?.id) {
+                  setDeleteTarget(targetSub.id)
                   setDisconnectDialogOpen(true)
                 }
               }}
@@ -1129,7 +1141,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   return (
     <>
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-        {hasSubscription ? (
+        {hasTargetSub ? (
           <>
             <Box component={CircleCheck} size={18} sx={{ color: 'success.main' }} />
             <Typography variant="body2" color="success.main">


### PR DESCRIPTION
The Claude connect button acted on `subscriptions[0]`. The list endpoint returns the user's own subscriptions first, then appends the subscriptions of every organisation they are a **member** of — so for a user with no personal subscription who simply belongs to an org that has one, `[0]` was the org's row.

## What that did

On the providers page the Anthropic card correctly read **"not connected"** (it checks `owner_type === 'user'`) while the button inside it read **"Disconnect"**. The card contradicted itself, and there was no way to connect a personal subscription from that page at all.

Worse, if that user owned the org, clicking Disconnect **deleted the organisation's shared subscription**. The backend permits it, and the confirmation dialog never names which subscription is going.

## Fix

The button and inline variants now resolve the one subscription they speak for: the org's when `orgId` names one, otherwise the signed-in user's own.

Every Claude call site passes no `orgId` today, so in practice they all correctly mean "mine". The org branch keeps the prop honest for the Codex-style usage it was built for.

The account variant is deliberately untouched — it lists every subscription on purpose, so "any row exists" remains the right question there.

## Tests

Five tests reproduce the exact shape that caused it (own row first, org row appended). They were checked against the previous code, where two of them fail — including the case where the only subscription is an org's.

Found by code review rather than by anything failing in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)