### PR TITLE
fix(frontend): make the account dialog usable on a phone

### DIFF
--- a/frontend/src/components/account/AccountDialog.test.tsx
+++ b/frontend/src/components/account/AccountDialog.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AccountDialog from './AccountDialog'
+
+// A phone-width viewport. `useMediaQuery` reads matchMedia, which jsdom does
+// not implement, so the queries the dialog asks are answered here.
+let narrow = true
+let short = false
+
+vi.mock('@mui/material/useMediaQuery', () => ({
+  default: (query: any) => (typeof query === 'string' && query.includes('max-height') ? short : narrow),
+}))
+
+// The settings pages themselves pull the whole account/services stack; the
+// navigation is what this covers.
+vi.mock('../../pages/Account', () => ({
+  default: ({ tab }: { tab: string }) => <div data-testid="account-pane">pane:{tab}</div>,
+}))
+
+const listItems = () => screen.queryAllByRole('button').map((b) => b.textContent)
+
+describe('AccountDialog on a phone', () => {
+  beforeEach(() => {
+    narrow = true
+    short = false
+  })
+
+  it('opens on the section list rather than a squeezed sidebar', () => {
+    render(<AccountDialog open onClose={() => {}} />)
+
+    expect(screen.getByText('Account')).toBeInTheDocument()
+    expect(screen.queryByTestId('account-pane')).not.toBeInTheDocument()
+    expect(listItems()).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('General Settings'),
+        expect.stringContaining('Git Config'),
+        expect.stringContaining('Chat'),
+        expect.stringContaining('API Keys'),
+      ]),
+    )
+  })
+
+  it('pushes to a section and comes back with the back button', () => {
+    render(<AccountDialog open onClose={() => {}} />)
+
+    fireEvent.click(screen.getByText('API Keys'))
+
+    expect(screen.getByTestId('account-pane')).toHaveTextContent('pane:api_keys')
+    // The header becomes the section, with a way back to the list.
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Back to account settings'))
+
+    expect(screen.queryByTestId('account-pane')).not.toBeInTheDocument()
+    expect(screen.getByText('Account')).toBeInTheDocument()
+  })
+
+  it('reports the selected section so the URL can follow it', () => {
+    const onTabChange = vi.fn()
+    render(<AccountDialog open onClose={() => {}} onTabChange={onTabChange} />)
+
+    fireEvent.click(screen.getByText('Chat'))
+
+    expect(onTabChange).toHaveBeenCalledWith('chat')
+  })
+
+  it('opens straight into a deep-linked section', () => {
+    render(<AccountDialog open onClose={() => {}} initialTab="git_config" />)
+
+    expect(screen.getByTestId('account-pane')).toHaveTextContent('pane:git_config')
+    expect(screen.getByLabelText('Back to account settings')).toBeInTheDocument()
+  })
+
+  it('ignores a tab that is not a section', () => {
+    render(<AccountDialog open onClose={() => {}} initialTab="not_a_section" />)
+
+    expect(screen.queryByTestId('account-pane')).not.toBeInTheDocument()
+  })
+})
+
+describe('AccountDialog on a wide screen', () => {
+  beforeEach(() => {
+    narrow = false
+    short = false
+  })
+
+  it('keeps the sidebar and the pane side by side, with no back button', () => {
+    render(<AccountDialog open onClose={() => {}} />)
+
+    expect(screen.getByTestId('account-pane')).toHaveTextContent('pane:general')
+    expect(screen.queryByLabelText('Back to account settings')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Chat'))
+
+    expect(screen.getByTestId('account-pane')).toHaveTextContent('pane:chat')
+  })
+})

--- a/frontend/src/components/account/AccountDialog.tsx
+++ b/frontend/src/components/account/AccountDialog.tsx
@@ -1,0 +1,224 @@
+import { FC, useCallback, useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import DialogContent from '@mui/material/DialogContent'
+import IconButton from '@mui/material/IconButton'
+import List from '@mui/material/List'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import Typography from '@mui/material/Typography'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
+
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+
+import DarkDialog from '../dialog/DarkDialog'
+import Account from '../../pages/Account'
+import AccountSidebar from './AccountSidebar'
+import {
+  ACCOUNT_SECTIONS,
+  DEFAULT_ACCOUNT_TAB,
+  accountSectionLabel,
+  isAccountTab,
+} from './accountSections'
+
+interface AccountDialogProps {
+  open: boolean
+  onClose: () => void
+  // Section to land on when the dialog is opened from a deep link.
+  initialTab?: string
+  onTabChange?: (tab: string) => void
+}
+
+// Comfortable touch target for the phone list rows, per the platform HIG
+// minimum of 44px.
+const TOUCH_ROW_HEIGHT = 56
+
+/**
+ * Account settings.
+ *
+ * Wide viewports get the usual sidebar-plus-pane split. Phones can't afford a
+ * 240px sidebar next to a settings form, so they get the master/detail pattern
+ * every mobile settings app uses instead: a full-screen list of sections that
+ * pushes to one section at a time, with a back arrow in the header.
+ */
+const AccountDialog: FC<AccountDialogProps> = ({ open, onClose, initialTab, onTabChange }) => {
+  const theme = useTheme()
+  // Below `sm` there is no room for a sidebar alongside content. Short
+  // viewports (landscape phones) keep the split but still want every pixel of
+  // height, so they go full-screen without changing navigation.
+  const isNarrow = useMediaQuery(theme.breakpoints.down('sm'))
+  const isShort = useMediaQuery('(max-height: 600px)')
+  const fullScreen = isNarrow || isShort
+
+  const [tab, setTab] = useState(isAccountTab(initialTab) ? initialTab! : DEFAULT_ACCOUNT_TAB)
+  // On phones the list is the root of the navigation stack; a deep link to a
+  // section opens straight into it.
+  const [showSection, setShowSection] = useState(isAccountTab(initialTab))
+
+  useEffect(() => {
+    if (!open) return
+    const deepLinked = isAccountTab(initialTab)
+    setTab(deepLinked ? initialTab! : DEFAULT_ACCOUNT_TAB)
+    setShowSection(deepLinked)
+  }, [open, initialTab])
+
+  const selectTab = useCallback((next: string) => {
+    setTab(next)
+    setShowSection(true)
+    onTabChange?.(next)
+  }, [onTabChange])
+
+  const goBackToList = useCallback(() => {
+    setShowSection(false)
+  }, [])
+
+  // Only the phone layout has a list to go back to.
+  const showBackButton = isNarrow && showSection
+  const title = showBackButton ? accountSectionLabel(tab) : 'Account'
+
+  return (
+    <DarkDialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xl"
+      fullWidth
+      fullScreen={fullScreen}
+      PaperProps={{
+        sx: fullScreen
+          ? {
+              height: '100%',
+              maxHeight: '100%',
+              m: 0,
+              borderRadius: 0,
+              border: 'none',
+              boxShadow: 'none',
+              // The translucent glass surface reads as a floating card. Once
+              // the dialog covers the whole screen it has to be opaque, or the
+              // page behind it shows through the settings forms.
+              backgroundColor: 'background.default',
+              background: (t) => t.palette.background.default,
+              backdropFilter: 'none',
+              WebkitBackdropFilter: 'none',
+              // Keep the chrome clear of the notch and the home indicator.
+              pt: 'env(safe-area-inset-top)',
+              pb: 'env(safe-area-inset-bottom)',
+            }
+          : {
+              height: '90vh',
+              maxHeight: '90vh',
+            },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: { xs: 1, sm: 3 },
+          py: 1.5,
+          flexShrink: 0,
+          borderBottom: fullScreen ? '1px solid' : 'none',
+          borderColor: 'divider',
+        }}
+      >
+        {showBackButton && (
+          <IconButton
+            onClick={goBackToList}
+            aria-label="Back to account settings"
+            sx={{
+              color: 'text.secondary',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            <ChevronLeft size={22} />
+          </IconButton>
+        )}
+        <Typography
+          variant="h6"
+          noWrap
+          sx={{
+            fontWeight: 600,
+            flex: 1,
+            minWidth: 0,
+            pl: showBackButton ? 0 : { xs: 1, sm: 0 },
+          }}
+        >
+          {title}
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="Close account settings"
+          sx={{
+            color: '#A0AEC0',
+            '&:hover': {
+              color: '#F1F1F1',
+              backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            },
+          }}
+        >
+          <X size={22} />
+        </IconButton>
+      </Box>
+      <DialogContent sx={{ p: 0, display: 'flex', overflow: 'hidden' }}>
+        {isNarrow ? (
+          showSection ? (
+            <Box sx={{ flex: 1, minWidth: 0, overflowY: 'auto', WebkitOverflowScrolling: 'touch' }}>
+              <Account tab={tab} />
+            </Box>
+          ) : (
+            <List sx={{ width: '100%', p: 1 }}>
+              {ACCOUNT_SECTIONS.map((section) => (
+                <ListItemButton
+                  key={section.id}
+                  data-account-section={section.id}
+                  onClick={() => selectTab(section.id)}
+                  sx={{
+                    borderRadius: '8px',
+                    minHeight: TOUCH_ROW_HEIGHT,
+                    px: 1.5,
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 40,
+                      color: 'text.secondary',
+                      '& svg': { width: 20, height: 20 },
+                    }}
+                  >
+                    {section.icon}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={section.label}
+                    primaryTypographyProps={{ fontSize: '1rem', fontWeight: 500 }}
+                  />
+                  <ChevronRight size={18} opacity={0.5} />
+                </ListItemButton>
+              ))}
+            </List>
+          )
+        ) : (
+          <Box sx={{ display: 'flex', height: '100%', width: '100%' }}>
+            <Box
+              sx={{
+                width: 240,
+                flexShrink: 0,
+                borderRight: '1px solid',
+                borderColor: 'divider',
+                overflowY: 'auto',
+                pr: 1,
+              }}
+            >
+              <AccountSidebar activeTab={tab} onTabChange={selectTab} />
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
+              <Account tab={tab} />
+            </Box>
+          </Box>
+        )}
+      </DialogContent>
+    </DarkDialog>
+  )
+}
+
+export default AccountDialog

--- a/frontend/src/components/account/AccountSidebar.tsx
+++ b/frontend/src/components/account/AccountSidebar.tsx
@@ -1,57 +1,24 @@
 import React, { FC } from 'react'
 
-import SettingsIcon from '@mui/icons-material/Settings'
-import VpnKeyIcon from '@mui/icons-material/VpnKey'
-import ChatIcon from '@mui/icons-material/Chat'
-import CommitIcon from '@mui/icons-material/Commit'
-
 import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
+import { ACCOUNT_SECTIONS, DEFAULT_ACCOUNT_TAB } from './accountSections'
 
 interface AccountSidebarProps {
   activeTab?: string
   onTabChange?: (tab: string) => void
 }
 
-const AccountSidebar: FC<AccountSidebarProps> = ({ activeTab = 'general', onTabChange }) => {
-  const handleNavigationClick = (tabValue: string) => {
-    if (onTabChange) {
-      onTabChange(tabValue)
-    }
-  }
-
+const AccountSidebar: FC<AccountSidebarProps> = ({ activeTab = DEFAULT_ACCOUNT_TAB, onTabChange }) => {
   const sections: ContextSidebarSection[] = [
     {
-      items: [
-        {
-          id: 'general',
-          label: 'General Settings',
-          icon: <SettingsIcon />,
-          isActive: activeTab === 'general',
-          onClick: () => handleNavigationClick('general')
-        },
-        {
-          id: 'git_config',
-          label: 'Git Config',
-          icon: <CommitIcon />,
-          isActive: activeTab === 'git_config',
-          onClick: () => handleNavigationClick('git_config')
-        },
-        {
-          id: 'chat',
-          label: 'Chat',
-          icon: <ChatIcon />,
-          isActive: activeTab === 'chat',
-          onClick: () => handleNavigationClick('chat')
-        },
-        {
-          id: 'api_keys',
-          label: 'API Keys',
-          icon: <VpnKeyIcon />,
-          isActive: activeTab === 'api_keys',
-          onClick: () => handleNavigationClick('api_keys')
-        }
-      ]
-    }
+      items: ACCOUNT_SECTIONS.map((section) => ({
+        id: section.id,
+        label: section.label,
+        icon: section.icon,
+        isActive: activeTab === section.id,
+        onClick: () => onTabChange?.(section.id),
+      })),
+    },
   ]
 
   return (

--- a/frontend/src/components/account/AccountSubscriptions.tsx
+++ b/frontend/src/components/account/AccountSubscriptions.tsx
@@ -1,6 +1,4 @@
 import { FC } from 'react'
-import Box from '@mui/material/Box'
-import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 
@@ -10,19 +8,14 @@ import CodexSubscriptionConnect from './CodexSubscriptionConnect'
 import { useCodexSubscriptions } from '../../services/codexSubscriptionsService'
 import { formatClaudeAccountDetail, formatClaudeOrganizationRef } from './claudeSubscriptionUtils'
 import { formatCodexAccountDetail, formatCodexAccountRef } from './codexSubscriptionUtils'
+import SettingsPanel from './SettingsPanel'
 import SubscriptionIdentity from './SubscriptionIdentity'
-import useLightTheme from '../../hooks/useLightTheme'
-import useThemeConfig from '../../hooks/useThemeConfig'
 
 // Account settings shows the same expandable harness rows as the org providers
 // page, so a subscription looks and reads the same wherever you meet it. The
 // difference is scope: enabling a harness is an org decision, so these rows
 // carry no toggle — only the credential you personally hold.
 const AccountSubscriptions: FC = () => {
-  const themeConfig = useThemeConfig()
-  const lightTheme = useLightTheme()
-  const panelBg = lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel
-
   const { data: claudeSubscriptions, isLoading: claudeLoading } = useClaudeSubscriptions()
   const { data: codexSubscriptions, isLoading: codexLoading } = useCodexSubscriptions()
 
@@ -79,12 +72,7 @@ const AccountSubscriptions: FC = () => {
   const codexHealth: HarnessHealth = codexSub ? 'ready' : 'unavailable'
 
   return (
-    // Grid container, not a plain Box, to match the panels around it. MUI's
-    // spacing applies a negative margin to the container, so a Box with the
-    // same padding paints its background 16px inside its Grid siblings — the
-    // card looked indented even though the text within it lined up.
-    <Grid container spacing={2} sx={{ mt: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-      <Grid item xs={12}>
+    <SettingsPanel>
       <Typography variant="h6">Coding agent subscriptions</Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
         Connect a Claude or ChatGPT subscription to authenticate coding agents in your desktop
@@ -113,8 +101,7 @@ const AccountSubscriptions: FC = () => {
           <CodexSubscriptionConnect />
         </Stack>
       </CodeAgentHarnessRow>
-      </Grid>
-    </Grid>
+    </SettingsPanel>
   )
 }
 

--- a/frontend/src/components/account/ApiKeysSettings.tsx
+++ b/frontend/src/components/account/ApiKeysSettings.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
@@ -6,7 +6,6 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
-import Grid from '@mui/material/Grid'
 import IconButton from '@mui/material/IconButton'
 import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
@@ -14,23 +13,16 @@ import Typography from '@mui/material/Typography'
 
 import { Copy, Eye, EyeOff, RefreshCcw } from 'lucide-react'
 
-import { Prism as SyntaxHighlighterPrism } from 'react-syntax-highlighter'
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-
-import useLightTheme from '../../hooks/useLightTheme'
+import MarkdownCodeBlock from '../session/MarkdownCodeBlock'
+import SettingsPanel from './SettingsPanel'
 import useSnackbar from '../../hooks/useSnackbar'
-import useThemeConfig from '../../hooks/useThemeConfig'
 import {
   useGetUserAPIKeys,
   useRegenerateUserAPIKey,
 } from '../../services/userService'
 
-const SyntaxHighlighter = SyntaxHighlighterPrism as unknown as React.FC<any>
-
 const ApiKeysSettings: FC = () => {
   const snackbar = useSnackbar()
-  const themeConfig = useThemeConfig()
-  const lightTheme = useLightTheme()
 
   const { data: apiKeys } = useGetUserAPIKeys()
   const regenerateApiKey = useRegenerateUserAPIKey()
@@ -80,144 +72,93 @@ export HELIX_API_KEY=${firstApiKey}
 
   return (
     <>
-      <Grid container spacing={2} sx={{ mb: 2, backgroundColor: lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12}>
-          <Box sx={{ mb: 3 }}>
-            <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>API Key</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Specify your key as a header 'Authorization: Bearer &lt;token&gt;' with every request
-            </Typography>
+      <SettingsPanel sx={{ mb: 0 }}>
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>API Key</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Specify your key as a header 'Authorization: Bearer &lt;token&gt;' with every request
+          </Typography>
 
-            {apiKeys && apiKeys.length > 0 ? (
-              apiKeys.map((apiKey) => (
-                <Box key={apiKey.key} sx={{ mb: 2 }}>
-                  <TextField
-                    fullWidth
-                    label="API Key"
-                    value={apiKey.key}
-                    type={showApiKey ? 'text' : 'password'}
-                    variant="outlined"
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            onClick={() => setShowApiKey(!showApiKey)}
-                            edge="end"
-                            sx={{ mr: 0.25 }}
-                          >
-                            {showApiKey ? <EyeOff size={18} /> : <Eye size={18} />}
-                          </IconButton>
-                          <IconButton
-                            onClick={() => handleCopy(apiKey.key || '')}
-                            edge="end"
-                            sx={{ mr: 0.25 }}
-                          >
-                            <Copy size={18} />
-                          </IconButton>
-                          <IconButton
-                            onClick={() => handleRegenerateApiKey(apiKey.key || '')}
-                            edge="end"
-                          >
-                            <RefreshCcw size={18} />
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                </Box>
-              ))
-            ) : (
-              <Box sx={{ mb: 2, p: 2, border: '1px dashed', borderColor: 'divider', borderRadius: 1 }}>
-                <Typography variant="body2" color="text.secondary" align="center">
-                  No API keys available. Creating a new key...
-                </Typography>
-              </Box>
-            )}
-          </Box>
-
-          <Box sx={{ mb: 3 }}>
-            <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>CLI Installation</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Install the Helix CLI to interact with the API from your terminal
-            </Typography>
-
-            <Box sx={{ position: 'relative' }}>
-              <Box sx={{ position: 'absolute', right: 8, top: 8, zIndex: 1 }}>
-                <Button
-                  size="small"
-                  onClick={() => handleCopy(cliInstall)}
-                  startIcon={<Copy size={16} />}
-                  sx={{
-                    backgroundColor: lightTheme.isLight ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.6)',
-                    '&:hover': {
-                      backgroundColor: lightTheme.isLight ? 'rgba(255, 255, 255, 0.95)' : 'rgba(0, 0, 0, 0.8)',
-                    },
+          {apiKeys && apiKeys.length > 0 ? (
+            apiKeys.map((apiKey) => (
+              <Box key={apiKey.key} sx={{ mb: 2 }}>
+                <TextField
+                  fullWidth
+                  label="API Key"
+                  value={apiKey.key}
+                  type={showApiKey ? 'text' : 'password'}
+                  variant="outlined"
+                  InputProps={{
+                    readOnly: true,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() => setShowApiKey(!showApiKey)}
+                          aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
+                          edge="end"
+                          sx={{ mr: 0.25 }}
+                        >
+                          {showApiKey ? <EyeOff size={18} /> : <Eye size={18} />}
+                        </IconButton>
+                        <IconButton
+                          onClick={() => handleCopy(apiKey.key || '')}
+                          aria-label="Copy API key"
+                          edge="end"
+                          sx={{ mr: 0.25 }}
+                        >
+                          <Copy size={18} />
+                        </IconButton>
+                        <IconButton
+                          onClick={() => handleRegenerateApiKey(apiKey.key || '')}
+                          aria-label="Regenerate API key"
+                          edge="end"
+                        >
+                          <RefreshCcw size={18} />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
                   }}
-                >
-                  Copy
-                </Button>
+                />
               </Box>
-              <SyntaxHighlighter
-                language="bash"
-                style={oneDark}
-                customStyle={{
-                  margin: 0,
-                  borderRadius: '4px',
-                  fontSize: '0.8rem',
-                }}
-              >
-                {cliInstall}
-              </SyntaxHighlighter>
+            ))
+          ) : (
+            <Box sx={{ mb: 2, p: 2, border: '1px dashed', borderColor: 'divider', borderRadius: 1 }}>
+              <Typography variant="body2" color="text.secondary" align="center">
+                No API keys available. Creating a new key...
+              </Typography>
             </Box>
-          </Box>
+          )}
+        </Box>
 
-          <Box>
-            <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>CLI Authentication</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Set your authentication credentials for the CLI
-            </Typography>
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>CLI Installation</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Install the Helix CLI to interact with the API from your terminal
+          </Typography>
+          <MarkdownCodeBlock language="bash" defaultWrapped>
+            {cliInstall}
+          </MarkdownCodeBlock>
+        </Box>
 
-            {apiKeys && apiKeys.length > 0 ? (
-              apiKeys.map((apiKey) => (
-                <Box key={apiKey.key} sx={{ position: 'relative' }}>
-                  <Box sx={{ position: 'absolute', right: 8, top: 8, zIndex: 1 }}>
-                    <Button
-                      size="small"
-                      onClick={() => handleCopy(cliLogin)}
-                      startIcon={<Copy size={16} />}
-                      sx={{
-                        backgroundColor: lightTheme.isLight ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.6)',
-                        '&:hover': {
-                          backgroundColor: lightTheme.isLight ? 'rgba(255, 255, 255, 0.95)' : 'rgba(0, 0, 0, 0.8)',
-                        },
-                      }}
-                    >
-                      Copy
-                    </Button>
-                  </Box>
-                  <SyntaxHighlighter
-                    language="bash"
-                    style={oneDark}
-                    customStyle={{
-                      margin: 0,
-                      borderRadius: '4px',
-                      fontSize: '0.8rem',
-                    }}
-                  >
-                    {cliLogin}
-                  </SyntaxHighlighter>
-                </Box>
-              ))
-            ) : (
-              <Box sx={{ p: 2, border: '1px dashed', borderColor: 'divider', borderRadius: 1 }}>
-                <Typography variant="body2" color="text.secondary" align="center">
-                  CLI authentication will be available once API key is created.
-                </Typography>
-              </Box>
-            )}
-          </Box>
-        </Grid>
-      </Grid>
+        <Box>
+          <Typography variant="h6" sx={{ mb: 2 }}>CLI Authentication</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Set your authentication credentials for the CLI
+          </Typography>
+
+          {apiKeys && apiKeys.length > 0 ? (
+            <MarkdownCodeBlock language="bash" defaultWrapped>
+              {cliLogin}
+            </MarkdownCodeBlock>
+          ) : (
+            <Box sx={{ p: 2, border: '1px dashed', borderColor: 'divider', borderRadius: 1 }}>
+              <Typography variant="body2" color="text.secondary" align="center">
+                CLI authentication will be available once API key is created.
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </SettingsPanel>
 
       <Dialog
         open={regenerateDialogOpen}

--- a/frontend/src/components/account/ChatSettings.tsx
+++ b/frontend/src/components/account/ChatSettings.tsx
@@ -3,7 +3,6 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Collapse from '@mui/material/Collapse'
 import FormControlLabel from '@mui/material/FormControlLabel'
-import Grid from '@mui/material/Grid'
 import Slider from '@mui/material/Slider'
 import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
@@ -11,9 +10,8 @@ import Typography from '@mui/material/Typography'
 
 import { ChevronDown, ChevronUp } from 'lucide-react'
 
-import useLightTheme from '../../hooks/useLightTheme'
+import SettingsPanel from './SettingsPanel'
 import useSnackbar from '../../hooks/useSnackbar'
-import useThemeConfig from '../../hooks/useThemeConfig'
 import {
   useGetConfig,
   useGetUserChatSettings,
@@ -42,9 +40,6 @@ const parseOptionalInt = (value: string): number | undefined => {
 
 const ChatSettings: FC = () => {
   const snackbar = useSnackbar()
-  const themeConfig = useThemeConfig()
-  const lightTheme = useLightTheme()
-  const panelBg = lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel
 
   const { data: serverConfig } = useGetConfig()
   const { data: chatSettings, isLoading: isLoadingChatSettings } = useGetUserChatSettings()
@@ -142,158 +137,173 @@ const ChatSettings: FC = () => {
 
   return (
     <>
-      <Grid container spacing={2} sx={{ mb: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12}>
-          <Typography variant="h6">Chat Defaults</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            These defaults apply when you chat with a model directly. Apps and agents
-            always use their own configuration and ignore these settings.
+      <SettingsPanel>
+        <Typography variant="h6">Chat Defaults</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          These defaults apply when you chat with a model directly. Apps and agents
+          always use their own configuration and ignore these settings.
+        </Typography>
+
+        <Box sx={{ mb: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+              mb: 1,
+            }}
+          >
+            <Typography variant="subtitle2">System Prompt</Typography>
+            <FormControlLabel
+              sx={{ mr: 0 }}
+              control={(
+                <Switch
+                  checked={systemPromptEnabled}
+                  onChange={(e) => setSystemPromptEnabled(e.target.checked)}
+                  disabled={disabled}
+                />
+              )}
+              label={systemPromptEnabled ? 'Enabled' : 'Disabled'}
+            />
+          </Box>
+          <TextField
+            fullWidth
+            multiline
+            minRows={4}
+            value={chatSystemPrompt}
+            onChange={(e) => setChatSystemPrompt(e.target.value)}
+            placeholder={defaultSystemPrompt || 'You are a helpful assistant…'}
+            variant="outlined"
+            disabled={disabled || !systemPromptEnabled}
+            helperText={
+              systemPromptEnabled
+                ? 'Pre-filled with the platform default. Edit to customise.'
+                : 'No system prompt will be sent to the model.'
+            }
+          />
+        </Box>
+
+        <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', mb: 1 }}>
+            <Typography variant="subtitle2">Temperature</Typography>
+            <Typography variant="body2" color="text.secondary">{temperature.toFixed(1)}</Typography>
+          </Box>
+          <Slider
+            value={temperature}
+            min={TEMPERATURE_MIN}
+            max={TEMPERATURE_MAX}
+            step={TEMPERATURE_STEP}
+            marks={temperatureMarks}
+            valueLabelDisplay="auto"
+            onChange={(_, value) => setTemperature(Array.isArray(value) ? value[0] : value)}
+            disabled={disabled}
+            // The slider thumb would otherwise overhang the panel padding at
+            // both ends of the track.
+            sx={{ mt: 1, mx: 1, width: 'calc(100% - 16px)' }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            Lower is more deterministic, higher is more creative.
           </Typography>
+        </Box>
 
-          <Box sx={{ mb: 3 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant="subtitle2">System Prompt</Typography>
-              <FormControlLabel
-                control={(
-                  <Switch
-                    checked={systemPromptEnabled}
-                    onChange={(e) => setSystemPromptEnabled(e.target.checked)}
-                    disabled={disabled}
-                  />
-                )}
-                label={systemPromptEnabled ? 'Enabled' : 'Disabled'}
-              />
-            </Box>
-            <TextField
-              fullWidth
-              multiline
-              minRows={4}
-              value={chatSystemPrompt}
-              onChange={(e) => setChatSystemPrompt(e.target.value)}
-              placeholder={defaultSystemPrompt || 'You are a helpful assistant…'}
-              variant="outlined"
-              disabled={disabled || !systemPromptEnabled}
-              helperText={
-                systemPromptEnabled
-                  ? 'Pre-filled with the platform default. Edit to customise.'
-                  : 'No system prompt will be sent to the model.'
-              }
-            />
-          </Box>
-
-          <Box sx={{ mb: 3 }}>
-            <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant="subtitle2">Temperature</Typography>
-              <Typography variant="body2" color="text.secondary">{temperature.toFixed(1)}</Typography>
-            </Box>
-            <Slider
-              value={temperature}
-              min={TEMPERATURE_MIN}
-              max={TEMPERATURE_MAX}
-              step={TEMPERATURE_STEP}
-              marks={temperatureMarks}
-              valueLabelDisplay="auto"
-              onChange={(_, value) => setTemperature(Array.isArray(value) ? value[0] : value)}
-              disabled={disabled}
-              sx={{ mt: 1 }}
-            />
-            <Typography variant="caption" color="text.secondary">
-              Lower is more deterministic, higher is more creative.
-            </Typography>
-          </Box>
-
-          <Box sx={{ mb: 2 }}>
-            <Button
-              variant="text"
-              size="small"
-              onClick={() => setAdvancedOpen((open) => !open)}
-              endIcon={advancedOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
-              sx={{ pl: 0 }}
+        <Box>
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => setAdvancedOpen((open) => !open)}
+            endIcon={advancedOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+            sx={{ pl: 0 }}
+          >
+            Advanced
+          </Button>
+          <Collapse in={advancedOpen} unmountOnExit>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(2, 1fr)',
+                  md: 'repeat(4, 1fr)',
+                },
+                gap: 2,
+                mt: 1.5,
+              }}
             >
-              Advanced
-            </Button>
-            <Collapse in={advancedOpen} unmountOnExit>
-              <Grid container spacing={2} sx={{ mt: 0.5 }}>
-                <Grid item xs={12} sm={6} md={3}>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Top P</Typography>
-                  <TextField
-                    fullWidth
-                    value={chatTopP}
-                    onChange={(e) => setChatTopP(e.target.value)}
-                    placeholder="e.g. 1"
-                    variant="outlined"
-                    disabled={disabled}
-                    helperText="0–1"
-                  />
-                </Grid>
-                <Grid item xs={12} sm={6} md={3}>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Max Tokens</Typography>
-                  <TextField
-                    fullWidth
-                    value={chatMaxTokens}
-                    onChange={(e) => setChatMaxTokens(e.target.value)}
-                    placeholder="e.g. 2048"
-                    variant="outlined"
-                    disabled={disabled}
-                    helperText="Response length cap"
-                  />
-                </Grid>
-                <Grid item xs={12} sm={6} md={3}>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Frequency Penalty</Typography>
-                  <TextField
-                    fullWidth
-                    value={chatFrequencyPenalty}
-                    onChange={(e) => setChatFrequencyPenalty(e.target.value)}
-                    placeholder="e.g. 0"
-                    variant="outlined"
-                    disabled={disabled}
-                    helperText="-2 to 2"
-                  />
-                </Grid>
-                <Grid item xs={12} sm={6} md={3}>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Presence Penalty</Typography>
-                  <TextField
-                    fullWidth
-                    value={chatPresencePenalty}
-                    onChange={(e) => setChatPresencePenalty(e.target.value)}
-                    placeholder="e.g. 0"
-                    variant="outlined"
-                    disabled={disabled}
-                    helperText="-2 to 2"
-                  />
-                </Grid>
-              </Grid>
-            </Collapse>
-          </Box>
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>Top P</Typography>
+                <TextField
+                  fullWidth
+                  value={chatTopP}
+                  onChange={(e) => setChatTopP(e.target.value)}
+                  placeholder="e.g. 1"
+                  variant="outlined"
+                  disabled={disabled}
+                  helperText="0–1"
+                />
+              </Box>
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>Max Tokens</Typography>
+                <TextField
+                  fullWidth
+                  value={chatMaxTokens}
+                  onChange={(e) => setChatMaxTokens(e.target.value)}
+                  placeholder="e.g. 2048"
+                  variant="outlined"
+                  disabled={disabled}
+                  helperText="Response length cap"
+                />
+              </Box>
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>Frequency Penalty</Typography>
+                <TextField
+                  fullWidth
+                  value={chatFrequencyPenalty}
+                  onChange={(e) => setChatFrequencyPenalty(e.target.value)}
+                  placeholder="e.g. 0"
+                  variant="outlined"
+                  disabled={disabled}
+                  helperText="-2 to 2"
+                />
+              </Box>
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>Presence Penalty</Typography>
+                <TextField
+                  fullWidth
+                  value={chatPresencePenalty}
+                  onChange={(e) => setChatPresencePenalty(e.target.value)}
+                  placeholder="e.g. 0"
+                  variant="outlined"
+                  disabled={disabled}
+                  helperText="-2 to 2"
+                />
+              </Box>
+            </Box>
+          </Collapse>
+        </Box>
+      </SettingsPanel>
 
-        </Grid>
-      </Grid>
-
-      <Grid
-        container
-        spacing={2}
+      <SettingsPanel
         sx={{
           position: 'sticky',
           bottom: 0,
-          backgroundColor: panelBg,
+          mb: 0,
           borderTop: '1px solid',
           borderColor: 'divider',
-          borderRadius: 2,
-          p: 2,
+          display: 'flex',
+          justifyContent: 'flex-end',
           zIndex: 1,
         }}
       >
-        <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Button
-            variant="contained"
-            color="secondary"
-            onClick={handleSave}
-            disabled={disabled}
-          >
-            {isSaving ? 'Saving…' : 'Save'}
-          </Button>
-        </Grid>
-      </Grid>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={handleSave}
+          disabled={disabled}
+        >
+          {isSaving ? 'Saving…' : 'Save'}
+        </Button>
+      </SettingsPanel>
     </>
   )
 }

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -4,7 +4,6 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import TextField from '@mui/material/TextField'
-import Grid from '@mui/material/Grid'
 import Chip from '@mui/material/Chip'
 import Dialog from '@mui/material/Dialog'
 import DialogTitle from '@mui/material/DialogTitle'
@@ -923,13 +922,21 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   if (variant === 'account') {
     return (
       <>
-        <Grid
-          container
-          spacing={2}
+        <Box
           sx={embedded ? {} : { mt: 2, backgroundColor: lightTheme.panelColor, p: 2, borderRadius: 2 }}
         >
-          <Grid item xs={12}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                // A phone has no room for prose beside the button; side by side
+                // the copy collapses into a ragged four-word column.
+                flexDirection: { xs: 'column', sm: 'row' },
+                justifyContent: 'space-between',
+                alignItems: { xs: 'stretch', sm: 'center' },
+                gap: { xs: 1.5, sm: 2 },
+                mb: 2,
+              }}
+            >
               <Box>
                 {!embedded && <Typography variant="h6">Claude Code Subscription</Typography>}
                 <Typography variant="body2" color="text.secondary">
@@ -988,6 +995,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                       border: '1px solid',
                       borderColor: subIsBroken ? 'error.main' : 'divider',
                       display: 'flex',
+                      flexDirection: { xs: 'column', sm: 'row' },
                       justifyContent: 'space-between',
                       // Top-aligned, not centred: the delegation list makes this row
                       // tall, and centring stranded Update Token / delete halfway down
@@ -1067,8 +1075,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                 </Typography>
               </Box>
             )}
-          </Grid>
-        </Grid>
+        </Box>
 
         {tokenDialog}
         {disconnectDialog}

--- a/frontend/src/components/account/GeneralSettings.tsx
+++ b/frontend/src/components/account/GeneralSettings.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
 import AccountSubscriptions from './AccountSubscriptions'
+import SettingsPanel from './SettingsPanel'
 import QuotaListView from '../quota/QuotaListView'
 import TokenUsage from '../usage/TokenUsage'
 import TotalCost from '../usage/TotalCost'
@@ -13,8 +13,6 @@ import TotalRequests from '../usage/TotalRequests'
 
 import useAccount from '../../hooks/useAccount'
 import useSnackbar from '../../hooks/useSnackbar'
-import useLightTheme from '../../hooks/useLightTheme'
-import useThemeConfig from '../../hooks/useThemeConfig'
 import { useGetQuota } from '../../services/quotaService'
 import {
   useGetConfig,
@@ -31,9 +29,6 @@ interface GeneralSettingsProps {
 const GeneralSettings: FC<GeneralSettingsProps> = ({ onOpenPasswordDialog }) => {
   const account = useAccount()
   const snackbar = useSnackbar()
-  const themeConfig = useThemeConfig()
-  const lightTheme = useLightTheme()
-  const panelBg = lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel
 
   const { data: usage } = useGetUserUsage()
   const { data: serverConfig } = useGetConfig()
@@ -64,64 +59,79 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ onOpenPasswordDialog }) => 
 
   return (
     <>
-      <Grid container spacing={2} sx={{ mb: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12} md={4}>
+      <SettingsPanel>
+        <Box
+          sx={{
+            display: 'grid',
+            // One stat per row on a phone, three across from tablet up.
+            gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' },
+            gap: 2,
+          }}
+        >
           <TokenUsage usageData={usage ? [{ metrics: usage }] : []} isLoading={false} />
-        </Grid>
-        <Grid item xs={12} md={4}>
           <TotalCost usageData={usage ? [{ metrics: usage }] : []} isLoading={false} />
-        </Grid>
-        <Grid item xs={12} md={4}>
           <TotalRequests usageData={usage ? [{ metrics: usage }] : []} isLoading={false} />
-        </Grid>
-      </Grid>
+        </Box>
+      </SettingsPanel>
 
       <AccountSubscriptions />
 
-      <Grid container spacing={2} sx={{ mt: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography variant="h6" gutterBottom>Full Name</Typography>
-            <form autoComplete="off" style={{ width: '50%' }}>
-              <TextField
-                fullWidth
-                value={fullName}
-                autoComplete="name"
-                data-form-type="other"
-                onChange={(e) => setFullName(e.target.value)}
-                onBlur={handleFullNameBlur}
-                variant="outlined"
-                disabled={updateAccount.isPending}
-              />
-            </form>
+      <SettingsPanel>
+        <Box
+          sx={{
+            display: 'flex',
+            // Side by side there is no room for a usable text field on a
+            // phone, so the label and input stack instead.
+            flexDirection: { xs: 'column', sm: 'row' },
+            justifyContent: 'space-between',
+            alignItems: { xs: 'stretch', sm: 'center' },
+            gap: { xs: 1, sm: 2 },
+          }}
+        >
+          <Typography variant="h6">Full Name</Typography>
+          <Box component="form" autoComplete="off" sx={{ width: { xs: '100%', sm: '50%' } }}>
+            <TextField
+              fullWidth
+              value={fullName}
+              autoComplete="name"
+              data-form-type="other"
+              onChange={(e) => setFullName(e.target.value)}
+              onBlur={handleFullNameBlur}
+              variant="outlined"
+              disabled={updateAccount.isPending}
+            />
           </Box>
-        </Grid>
-      </Grid>
+        </Box>
+      </SettingsPanel>
 
       {serverConfig?.auth_provider === TypesAuthProvider.AuthProviderRegular && (
-        <Grid container spacing={2} sx={{ mt: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-          <Grid item xs={12}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Typography variant="h6" gutterBottom>Update Password</Typography>
-              <Button
-                variant="contained"
-                color="secondary"
-                onClick={onOpenPasswordDialog}
-              >
-                Update Password
-              </Button>
-            </Box>
-          </Grid>
-        </Grid>
+        <SettingsPanel>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              justifyContent: 'space-between',
+              alignItems: { xs: 'stretch', sm: 'center' },
+              gap: { xs: 1.5, sm: 2 },
+            }}
+          >
+            <Typography variant="h6">Update Password</Typography>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={onOpenPasswordDialog}
+            >
+              Update Password
+            </Button>
+          </Box>
+        </SettingsPanel>
       )}
 
       {quotas && (
-        <Grid container spacing={2} sx={{ mt: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-          <Grid item xs={12}>
-            <Typography variant="h6" sx={{ mb: 2 }} gutterBottom>Quotas</Typography>
-            <QuotaListView />
-          </Grid>
-        </Grid>
+        <SettingsPanel sx={{ mb: 0 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>Quotas</Typography>
+          <QuotaListView />
+        </SettingsPanel>
       )}
     </>
   )

--- a/frontend/src/components/account/GitConfigSettings.tsx
+++ b/frontend/src/components/account/GitConfigSettings.tsx
@@ -1,21 +1,17 @@
 import React, { FC, useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
+import SettingsPanel from './SettingsPanel'
 import useAccount from '../../hooks/useAccount'
-import useLightTheme from '../../hooks/useLightTheme'
 import useSnackbar from '../../hooks/useSnackbar'
-import useThemeConfig from '../../hooks/useThemeConfig'
 import { useGetCurrentUser, useUpdateAccount } from '../../services/userService'
 
 const GitConfigSettings: FC = () => {
   const account = useAccount()
   const snackbar = useSnackbar()
-  const themeConfig = useThemeConfig()
-  const lightTheme = useLightTheme()
-  const panelBg = lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel
   const { data: currentUser } = useGetCurrentUser()
   const updateAccount = useUpdateAccount()
 
@@ -80,14 +76,18 @@ const GitConfigSettings: FC = () => {
 
   return (
     <>
-      <Grid container spacing={2} sx={{ backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12}>
-          <Typography variant="h6">Commit Identity</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2 }}>
-            Override the name and email used for commits created by Helix. Leave either field empty to use your account value.
-          </Typography>
-        </Grid>
-        <Grid item xs={12} md={6}>
+      <SettingsPanel>
+        <Typography variant="h6">Commit Identity</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2 }}>
+          Override the name and email used for commits created by Helix. Leave either field empty to use your account value.
+        </Typography>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' },
+            gap: 2,
+          }}
+        >
           <TextField
             fullWidth
             label="Commit username"
@@ -96,8 +96,6 @@ const GitConfigSettings: FC = () => {
             onChange={(e) => setGitCommitName(e.target.value)}
             disabled={updateAccount.isPending}
           />
-        </Grid>
-        <Grid item xs={12} md={6}>
           <TextField
             fullWidth
             label="Commit email"
@@ -107,8 +105,8 @@ const GitConfigSettings: FC = () => {
             onChange={(e) => setGitCommitEmail(e.target.value)}
             disabled={updateAccount.isPending}
           />
-        </Grid>
-        <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
           <Button
             variant="contained"
             onClick={handleCommitIdentitySave}
@@ -119,32 +117,39 @@ const GitConfigSettings: FC = () => {
           >
             Save commit identity
           </Button>
-        </Grid>
-      </Grid>
+        </Box>
+      </SettingsPanel>
 
-      <Grid container spacing={2} sx={{ mt: 2, backgroundColor: panelBg, p: 2, borderRadius: 2 }}>
-        <Grid item xs={12}>
-          <Typography variant="h6">Pull Request Footer</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2 }}>
-            Markdown appended to pull requests created by Helix. An empty footer disables it. Available template values: {'{{.HelixTaskURL}}'} and {'{{.SpecDocsURL}}'}.
-          </Typography>
-          <TextField
-            fullWidth
-            multiline
-            minRows={10}
-            value={prFooter}
-            onChange={(e) => {
-              setPRFooter(e.target.value)
-              setUsesDefaultPRFooter(false)
-            }}
-            disabled={updateAccount.isPending}
-            inputProps={{
-              'aria-label': 'Pull request footer template',
-              style: { fontFamily: 'monospace', fontSize: '0.85rem' },
-            }}
-          />
-        </Grid>
-        <Grid item xs={12} sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+      <SettingsPanel sx={{ mb: 0 }}>
+        <Typography variant="h6">Pull Request Footer</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 2 }}>
+          Markdown appended to pull requests created by Helix. An empty footer disables it. Available template values: {'{{.HelixTaskURL}}'} and {'{{.SpecDocsURL}}'}.
+        </Typography>
+        <TextField
+          fullWidth
+          multiline
+          minRows={10}
+          value={prFooter}
+          onChange={(e) => {
+            setPRFooter(e.target.value)
+            setUsesDefaultPRFooter(false)
+          }}
+          disabled={updateAccount.isPending}
+          inputProps={{
+            'aria-label': 'Pull request footer template',
+            style: { fontFamily: 'monospace', fontSize: '0.85rem' },
+          }}
+        />
+        <Box
+          sx={{
+            display: 'flex',
+            // Two full-width buttons stack rather than crowd on a phone.
+            flexDirection: { xs: 'column-reverse', sm: 'row' },
+            justifyContent: 'flex-end',
+            gap: 1,
+            mt: 2,
+          }}
+        >
           <Button
             variant="outlined"
             onClick={handlePRFooterReset}
@@ -162,8 +167,8 @@ const GitConfigSettings: FC = () => {
           >
             Save footer
           </Button>
-        </Grid>
-      </Grid>
+        </Box>
+      </SettingsPanel>
     </>
   )
 }

--- a/frontend/src/components/account/SettingsPanel.tsx
+++ b/frontend/src/components/account/SettingsPanel.tsx
@@ -1,0 +1,42 @@
+import { FC, ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import { SxProps, Theme } from '@mui/material/styles'
+
+import useLightTheme from '../../hooks/useLightTheme'
+import useThemeConfig from '../../hooks/useThemeConfig'
+
+interface SettingsPanelProps {
+  children: ReactNode
+  sx?: SxProps<Theme>
+}
+
+/**
+ * A card in the account settings pages.
+ *
+ * Each of these used to be a `Grid container spacing={2}` that carried the
+ * panel background itself. MUI implements spacing as a negative margin on the
+ * container, so the background painted 16px outside the box it was supposed to
+ * fill — on a phone the panels bled off the left edge while leaving a gap on
+ * the right. The background belongs to a plain Box; any grid goes inside it.
+ */
+const SettingsPanel: FC<SettingsPanelProps> = ({ children, sx }) => {
+  const themeConfig = useThemeConfig()
+  const lightTheme = useLightTheme()
+  const panelBg = lightTheme.isLight ? lightTheme.panelColor : themeConfig.darkPanel
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: panelBg,
+        p: { xs: 2, sm: 2 },
+        borderRadius: 2,
+        mb: 2,
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default SettingsPanel

--- a/frontend/src/components/account/accountSections.tsx
+++ b/frontend/src/components/account/accountSections.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react'
+
+import { GitCommitHorizontal, KeyRound, MessageSquare, Settings } from 'lucide-react'
+
+export interface AccountSection {
+  id: string
+  label: string
+  icon: ReactNode
+}
+
+// The desktop sidebar and the mobile section list are two presentations of the
+// same navigation, so the sections live here rather than in either component.
+export const ACCOUNT_SECTIONS: AccountSection[] = [
+  { id: 'general', label: 'General Settings', icon: <Settings /> },
+  { id: 'git_config', label: 'Git Config', icon: <GitCommitHorizontal /> },
+  { id: 'chat', label: 'Chat', icon: <MessageSquare /> },
+  { id: 'api_keys', label: 'API Keys', icon: <KeyRound /> },
+]
+
+export const DEFAULT_ACCOUNT_TAB = 'general'
+
+export const isAccountTab = (tab?: string): boolean =>
+  !!tab && ACCOUNT_SECTIONS.some((section) => section.id === tab)
+
+export const accountSectionLabel = (tab: string): string =>
+  ACCOUNT_SECTIONS.find((section) => section.id === tab)?.label || 'Account'

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -85,19 +85,23 @@ const Account: FC<AccountProps> = ({ tab = 'general' }) => {
 
   return (
     <>
-      <Container maxWidth="lg" sx={{ mb: 4 }}>
-        <Box sx={{ width: '100%', maxHeight: '100%', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'center' }}>
-          <Box sx={{ width: '100%', flexGrow: 1, overflowY: 'auto', px: 2 }}>
-            <Typography variant="h4" gutterBottom sx={{ mt: 4 }}></Typography>
-
-            {tab === 'general' && (
-              <GeneralSettings onOpenPasswordDialog={() => setPasswordDialogOpen(true)} />
-            )}
-            {tab === 'chat' && <ChatSettings />}
-            {tab === 'git_config' && <GitConfigSettings />}
-            {tab === 'api_keys' && <ApiKeysSettings />}
-          </Box>
-        </Box>
+      <Container
+        maxWidth="lg"
+        disableGutters
+        sx={{
+          // Phones can't spare the 32px of stacked container + inner gutter the
+          // desktop layout uses.
+          px: { xs: 1.5, sm: 4 },
+          pt: { xs: 2, sm: 4 },
+          pb: { xs: 3, sm: 4 },
+        }}
+      >
+        {tab === 'general' && (
+          <GeneralSettings onOpenPasswordDialog={() => setPasswordDialogOpen(true)} />
+        )}
+        {tab === 'chat' && <ChatSettings />}
+        {tab === 'git_config' && <GitConfigSettings />}
+        {tab === 'api_keys' && <ApiKeysSettings />}
       </Container>
 
       <DarkDialog

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -20,14 +20,13 @@ import Sidebar from "../components/system/Sidebar";
 import ProjectChatSidebar from "../components/session/ProjectChatSidebar";
 import FilesSidebar from "../components/files/FilesSidebar";
 import AdminPanelSidebar from "../components/admin/AdminPanelSidebar";
-import AccountSidebar from "../components/account/AccountSidebar";
 import OrgSidebar from "../components/orgs/OrgSidebar";
 import AppSidebar from "../components/app/AppSidebar";
 import ProjectSettingsSidebar from "../components/project/ProjectSettingsSidebar";
 import FullScreenDialog from "../components/dialog/FullScreenDialog";
 import Dashboard from "./Dashboard";
-import Account from "./Account";
 import ProjectSettings from "./ProjectSettings";
+import AccountDialog from "../components/account/AccountDialog";
 import OAuthConnections from "../components/account/OAuthConnections";
 import { SettingsDialogProvider, useSettingsDialog } from "../contexts/settingsDialog";
 
@@ -74,7 +73,6 @@ const SettingsDialogs: FC = () => {
   const { activeDialog, dialogOptions, closeDialog } = useSettingsDialog()
   const [adminTab, setAdminTab] = useState('llm_calls')
   const [adminProviderId, setAdminProviderId] = useState<string | undefined>()
-  const [accountTab, setAccountTab] = useState('general')
   const [projectSettingsTab, setProjectSettingsTab] = useState('general')
 
   // When opening the admin dialog with a specific tab, set it
@@ -97,7 +95,6 @@ const SettingsDialogs: FC = () => {
     if (!activeDialog) {
       setAdminTab('llm_calls')
       setAdminProviderId(undefined)
-      setAccountTab('general')
       setProjectSettingsTab('general')
     }
   }, [activeDialog])
@@ -128,6 +125,13 @@ const SettingsDialogs: FC = () => {
       url.searchParams.delete('dialog_provider_from')
       url.searchParams.delete('dialog_provider_to')
     }
+    window.history.replaceState({}, '', url.toString())
+  }, [])
+
+  // Sync the account tab to URL so refresh and deep links preserve the section
+  const handleAccountTabChange = React.useCallback((tab: string) => {
+    const url = new URL(window.location.href)
+    url.searchParams.set('dialog_tab', tab)
     window.history.replaceState({}, '', url.toString())
   }, [])
 
@@ -174,61 +178,12 @@ const SettingsDialogs: FC = () => {
           <OAuthConnections />
         </Box>
       </FullScreenDialog>
-      <DarkDialog
+      <AccountDialog
         open={activeDialog === 'account'}
         onClose={closeDialog}
-        maxWidth="xl"
-        fullWidth
-        PaperProps={{
-          sx: {
-            height: '90vh',
-            maxHeight: '90vh',
-          },
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            px: 3,
-            py: 1.5,
-            flexShrink: 0,
-          }}
-        >
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
-            Account
-          </Typography>
-          <IconButton
-            onClick={closeDialog}
-            sx={{
-              color: '#A0AEC0',
-              '&:hover': {
-                color: '#F1F1F1',
-                backgroundColor: 'rgba(255, 255, 255, 0.08)',
-              },
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </Box>
-        <DialogContent sx={{ p: 0, display: 'flex', overflow: 'hidden' }}>
-          <Box sx={{ display: 'flex', height: '100%', width: '100%' }}>
-            <Box sx={{
-              width: 240,
-              flexShrink: 0,
-              borderRight: '1px solid rgba(255, 255, 255, 0.1)',
-              overflowY: 'auto',
-              pr: 1,
-            }}>
-              <AccountSidebar activeTab={accountTab} onTabChange={setAccountTab} />
-            </Box>
-            <Box sx={{ flex: 1, overflow: 'auto' }}>
-              <Account tab={accountTab} />
-            </Box>
-          </Box>
-        </DialogContent>
-      </DarkDialog>
+        initialTab={activeDialog === 'account' ? dialogOptions.tab : undefined}
+        onTabChange={handleAccountTabChange}
+      />
       {/* Project Settings Dialog */}
       <DarkDialog
         open={activeDialog === 'project-settings'}


### PR DESCRIPTION
## The bug

`?dialog=account` on a phone rendered a floating card with the fixed 240px sidebar still next to the settings pane. On a 390px viewport that left ~90px for the content, so every section was an unreadable sliver spilling out of the card.

## The fix

**Navigation.** Phones get the master/detail pattern every mobile settings app uses: a full-screen sheet listing the four sections, pushing to one section at a time with a back arrow in the header (`< API Keys ✕`). Wide viewports keep the sidebar split unchanged. Landscape phones (short viewports) keep the split but go full-screen so no height is wasted on dialog margin.

The sheet is opaque. The theme's translucent glass `MuiDialog-paper` reads well as a floating card, but once it covers the screen the page shows through the settings forms. It also pads for the notch and the home indicator (`env(safe-area-inset-*)`; the app already ships `viewport-fit=cover`).

**Structure.** The dialog moves out of `Layout.tsx` into `components/account/AccountDialog.tsx`, and the section list lives in `accountSections.tsx` shared with the desktop sidebar so the two can't drift. Selecting a section syncs to `dialog_tab`, matching the admin and project-settings dialogs, so a reload keeps its place — and a deep link opens straight into that section.

**Panels.** Each settings card was a `Grid container spacing={2}` carrying the panel background. MUI implements spacing as a negative margin on the container, so the background painted 16px outside its own box — on a phone the panels bled off the left edge while leaving a gap on the right (this is what the `AccountSubscriptions` comment about "the card looked indented" was working around). A shared `SettingsPanel` owns the background; any grid goes inside it. Multi-column areas use CSS grid, which has no negative margins.

Also within the sections:
- Label/field and text/button rows (Full Name, Update Password, Claude connect, PR footer buttons) stack below `sm` instead of squeezing prose into a four-word column.
- The CLI snippets use the canonical `MarkdownCodeBlock` instead of a bespoke `SyntaxHighlighter` with a labelled copy button — the old one clipped the API key off-screen with no way to scroll to it. This is what `CLAUDE.md` asks for anyway.

## Verification

Driven with a real browser (Playwright against the dev stack) at 320 / 390 / 768 / 1440px, portrait and landscape, light and dark:

- No element overflows the dialog horizontally in any section, at any of those widths (measured via `getBoundingClientRect`, not by eye).
- Every section reached, scrolled to the bottom, and screenshotted.
- Nested dialogs still fit and scroll: Claude connect (taller than the viewport — confirmed scrollable to the Connect button), update password, regenerate API key.
- Deep link + reload + back: `dialog_tab=git_config` survives a reload and opens on Git Config; back returns to the list.
- Desktop layout visually unchanged.

`yarn tsc`, `yarn build`, and `yarn test` (159 files, 887 tests) all pass. 6 new tests cover the mobile push/back navigation, the deep link, and that wide screens keep the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)