### PR TITLE
fix(frontend): make the chat list usable on a phone

### DIFF
--- a/api/cmd/desktop-bridge/main.go
+++ b/api/cmd/desktop-bridge/main.go
@@ -32,7 +32,6 @@ func main() {
 		XDGRuntimeDir: os.Getenv("XDG_RUNTIME_DIR"),
 		SessionID:     os.Getenv("HELIX_SESSION_ID"),
 		WorkspaceOnly: os.Getenv("HELIX_HEADLESS") == "1",
-		AllowExec:     os.Getenv("HELIX_SERVER_SETUP") == "1",
 	}
 
 	// Apply defaults

--- a/api/pkg/anthropic/anthropic_proxy.go
+++ b/api/pkg/anthropic/anthropic_proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/helixml/helix/api/pkg/openai/logger"
 	"github.com/helixml/helix/api/pkg/pricing"
 	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go" // imported as anthropic
@@ -497,6 +498,8 @@ func (s *Proxy) logLLMCall(ctx context.Context, createdAt time.Time, resp []byte
 		Float64("total_cost", totalCost).
 		Msg("logging LLM call")
 
+	tools := validateToolCalls(vals.OriginalRequest, &respMessage)
+
 	llmCall := &types.LLMCall{
 		Created:          createdAt,
 		SessionID:        vals.SessionID,
@@ -522,6 +525,12 @@ func (s *Proxy) logLLMCall(ctx context.Context, createdAt time.Time, resp []byte
 		TotalCost:        totalCost,
 		UserID:           vals.OwnerID,
 		Stream:           stream,
+
+		FinishReason:       normalizeStopReason(respMessage.StopReason),
+		ToolsOffered:       tools.ToolsOffered,
+		ToolCallsReturned:  tools.Calls,
+		ToolCallErrors:     tools.Errors,
+		ToolCallErrorKinds: tools.KindsString(),
 	}
 
 	if apiError != nil {
@@ -625,4 +634,58 @@ func isNumeric(s string) bool {
 		}
 	}
 	return true
+}
+
+// normalizeStopReason maps Anthropic's stop_reason onto the OpenAI finish
+// reason vocabulary, so a query over llm_calls does not have to know which
+// proxy wrote the row. Reasons with no OpenAI equivalent (pause_turn, refusal)
+// pass through unchanged.
+func normalizeStopReason(reason anthropic.StopReason) string {
+	switch reason {
+	case anthropic.StopReasonToolUse:
+		return "tool_calls"
+	case anthropic.StopReasonEndTurn, anthropic.StopReasonStopSequence:
+		return "stop"
+	case anthropic.StopReasonMaxTokens:
+		return "length"
+	default:
+		return string(reason)
+	}
+}
+
+// validateToolCalls checks the tool_use blocks in the response against the
+// input schemas the request offered. Anthropic hands back already-decoded
+// input, so the invalid-JSON bucket cannot fire here — only unknown tool names
+// and schema mismatches. Server-side tools (bash, text_editor, web_search)
+// carry no input_schema and are therefore unconstrained.
+func validateToolCalls(request []byte, resp *anthropic.Message) toolcall.Result {
+	if len(request) == 0 || resp == nil {
+		return toolcall.Result{}
+	}
+
+	var body struct {
+		Tools []struct {
+			Name        string          `json:"name"`
+			InputSchema json.RawMessage `json:"input_schema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(request, &body); err != nil {
+		log.Debug().Err(err).Msg("failed to parse anthropic request for tool schemas")
+		return toolcall.Result{}
+	}
+
+	tools := make([]toolcall.Tool, 0, len(body.Tools))
+	for _, tool := range body.Tools {
+		tools = append(tools, toolcall.Tool{Name: tool.Name, Schema: tool.InputSchema})
+	}
+
+	var calls []toolcall.Call
+	for _, block := range resp.Content {
+		if block.Type != "tool_use" {
+			continue
+		}
+		calls = append(calls, toolcall.Call{Name: block.Name, Arguments: string(block.Input)})
+	}
+
+	return toolcall.Validate(tools, calls)
 }

--- a/api/pkg/anthropic/anthropic_proxy_test.go
+++ b/api/pkg/anthropic/anthropic_proxy_test.go
@@ -18,6 +18,7 @@ import (
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/logger"
 	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -369,4 +370,51 @@ func Test_stripDateFromModelName(t *testing.T) {
 			assert.Equal(t, tt.want, got, "stripDateFromModelName() = %v, want %v", got, tt.want)
 		})
 	}
+}
+
+func TestValidateToolCallsAnthropic(t *testing.T) {
+	request := []byte(`{
+		"model": "claude-opus-5",
+		"tools": [
+			{"name": "edit_file", "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"], "additionalProperties": false}},
+			{"type": "bash_20250124", "name": "bash"}
+		]
+	}`)
+
+	message := func(blocks string) *anthropic.Message {
+		var msg anthropic.Message
+		require.NoError(t, msg.UnmarshalJSON([]byte(`{"content": `+blocks+`}`)))
+		return &msg
+	}
+
+	t.Run("valid tool_use block", func(t *testing.T) {
+		result := validateToolCalls(request, message(`[{"type": "tool_use", "name": "edit_file", "input": {"path": "a.go"}}]`))
+		assert.Equal(t, 2, result.ToolsOffered)
+		assert.Equal(t, 1, result.Calls)
+		assert.Equal(t, 0, result.Errors)
+	})
+
+	t.Run("input misses the schema", func(t *testing.T) {
+		result := validateToolCalls(request, message(`[{"type": "tool_use", "name": "edit_file", "input": {"file": "a.go"}}]`))
+		assert.Equal(t, 1, result.Errors)
+		assert.Equal(t, toolcall.KindSchemaMismatch, result.KindsString())
+	})
+
+	t.Run("server tools carry no schema and are unconstrained", func(t *testing.T) {
+		result := validateToolCalls(request, message(`[{"type": "tool_use", "name": "bash", "input": {"command": "ls"}}]`))
+		assert.Equal(t, 0, result.Errors)
+	})
+
+	t.Run("text blocks are not tool calls", func(t *testing.T) {
+		result := validateToolCalls(request, message(`[{"type": "text", "text": "hello"}]`))
+		assert.Equal(t, 0, result.Calls)
+		assert.False(t, result.Errored())
+	})
+}
+
+func TestNormalizeStopReason(t *testing.T) {
+	assert.Equal(t, "tool_calls", normalizeStopReason(anthropic.StopReasonToolUse))
+	assert.Equal(t, "stop", normalizeStopReason(anthropic.StopReasonEndTurn))
+	assert.Equal(t, "length", normalizeStopReason(anthropic.StopReasonMaxTokens))
+	assert.Equal(t, "pause_turn", normalizeStopReason(anthropic.StopReason("pause_turn")))
 }

--- a/api/pkg/desktop/desktop.go
+++ b/api/pkg/desktop/desktop.go
@@ -25,7 +25,6 @@ type Config struct {
 	XDGRuntimeDir string // XDG_RUNTIME_DIR for sockets
 	SessionID     string // HELIX_SESSION_ID for session identification
 	WorkspaceOnly bool   // Serve workspace APIs without compositor/video initialization
-	AllowExec     bool   // Expose the restricted command endpoint for server setup sessions
 }
 
 // Server is the main desktop integration server.
@@ -524,11 +523,8 @@ func (s *Server) httpHandler() http.Handler {
 
 	mux.HandleFunc("/screenshot", s.handleScreenshot)
 	mux.HandleFunc("/clipboard", s.handleClipboard)
-	mux.HandleFunc("/upload", s.handleUpload)
-	mux.HandleFunc("/file", s.handleFile)
 	mux.HandleFunc("/ws/input", s.handleWSInput)   // Direct WebSocket input
 	mux.HandleFunc("/ws/stream", s.handleWSStream) // Direct WebSocket video streaming
-	mux.HandleFunc("/exec", s.handleExec)          // Execute command in container (for benchmarking)
 	s.registerWorkspaceRoutes(mux)
 	mux.HandleFunc("/clients", s.handleClients)
 	mux.HandleFunc("/video/stats", s.handleVideoStats)
@@ -547,13 +543,19 @@ func (s *Server) httpHandler() http.Handler {
 func (s *Server) workspaceHTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 	s.registerWorkspaceRoutes(mux)
-	if s.config.AllowExec {
-		mux.HandleFunc("/exec", s.handleExec)
-	}
 	return mux
 }
 
 func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
+	// Chat attachments are a workspace concern, not a desktop one: a headless
+	// task has no compositor but still needs to receive pasted/dropped files
+	// and serve them back to the UI.
+	mux.HandleFunc("/upload", s.handleUpload)
+	mux.HandleFunc("/file", s.handleFile)
+	// /exec is not desktop-specific either: git identity sync on spec approval
+	// and the Claude/Codex subscription login flows all target headless
+	// containers. Its own allowlist (see exec.go) is the security boundary.
+	mux.HandleFunc("/exec", s.handleExec)
 	mux.HandleFunc("/workspaces", s.handleWorkspaces)
 	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)
 	mux.HandleFunc("/workspace/files", s.handleWorkspaceFiles)

--- a/api/pkg/desktop/upload.go
+++ b/api/pkg/desktop/upload.go
@@ -12,10 +12,11 @@ import (
 	"time"
 )
 
-const (
-	maxUploadSize = 500 << 20 // 500MB
-	incomingDir   = "/home/retro/work/incoming"
-)
+const maxUploadSize = 500 << 20 // 500MB
+
+// incomingDir is where chat attachments land inside the agent container.
+// It is a var so tests can point it at a temp dir.
+var incomingDir = "/home/retro/work/incoming"
 
 // handleUpload handles file uploads to the sandbox incoming folder.
 func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
@@ -78,8 +79,9 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("file uploaded", "path", destPath, "size", written)
 
-	// Try to open file manager showing the uploaded file (unless suppressed via query param)
-	if r.URL.Query().Get("open_file_manager") != "false" {
+	// Try to open file manager showing the uploaded file (unless suppressed via
+	// query param). Headless tasks have no compositor, so there is nothing to open.
+	if !s.config.WorkspaceOnly && r.URL.Query().Get("open_file_manager") != "false" {
 		go s.openFileManagerWithFile(destPath)
 	}
 }

--- a/api/pkg/desktop/workspace_test.go
+++ b/api/pkg/desktop/workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -144,17 +145,19 @@ func TestWorkspaceOnlyServerServesFilesAndDiffsWithoutDesktop(t *testing.T) {
 	_ = response.Body.Close()
 	require.Equal(t, http.StatusNotFound, response.StatusCode)
 
-	response, err = http.Post(baseURL+"/exec", "application/json", strings.NewReader(`{"command":["echo","test"]}`))
+	// /exec IS served headless — git identity sync and the subscription login
+	// flows run against headless containers. Its allowlist still applies.
+	response, err = http.Post(baseURL+"/exec", "application/json", strings.NewReader(`{"command":["rm","-rf","/"]}`))
 	require.NoError(t, err)
 	_ = response.Body.Close()
-	require.Equal(t, http.StatusNotFound, response.StatusCode)
+	require.Equal(t, http.StatusForbidden, response.StatusCode)
 
 	cancel()
 	require.ErrorIs(t, <-errCh, context.Canceled)
 }
 
 func TestWorkspaceOnlyServerAllowsRestrictedExecForServerSetup(t *testing.T) {
-	server := NewServer(Config{WorkspaceOnly: true, AllowExec: true}, slog.Default())
+	server := NewServer(Config{WorkspaceOnly: true}, slog.Default())
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"command":["echo","ready"]}`))
@@ -544,4 +547,47 @@ fi
 	assert.Equal(t, "failed", resp.Repos[0].Action)
 	assert.Contains(t, resp.Repos[0].Error, "git commit",
 		"the error must mention git commit so the fork handler's wrapped message stays diagnostic")
+}
+
+// TestWorkspaceOnlyServerAcceptsChatAttachments proves a headless task can
+// receive a pasted/dropped chat attachment and serve it back. These routes
+// used to be registered on the desktop-only handler, so every upload to a
+// headless session came back as a bare 404 from the bridge.
+func TestWorkspaceOnlyServerAcceptsChatAttachments(t *testing.T) {
+	dir := t.TempDir()
+	original := incomingDir
+	incomingDir = filepath.Join(dir, "incoming")
+	t.Cleanup(func() { incomingDir = original })
+
+	server := NewServer(Config{WorkspaceOnly: true}, slog.Default())
+	handler := server.workspaceHTTPHandler()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "screenshot.png")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("fake-png-bytes"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/upload?open_file_manager=false", body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	handler.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var uploaded struct {
+		Path     string `json:"path"`
+		Size     int64  `json:"size"`
+		Filename string `json:"filename"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &uploaded))
+	assert.Equal(t, "screenshot.png", uploaded.Filename)
+	assert.Equal(t, int64(len("fake-png-bytes")), uploaded.Size)
+	assert.Equal(t, filepath.Join(incomingDir, "screenshot.png"), uploaded.Path)
+
+	recorder = httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/file?name=screenshot.png", nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Equal(t, "fake-png-bytes", recorder.Body.String())
 }

--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -18,6 +18,7 @@ import (
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/transport"
 	"github.com/helixml/helix/api/pkg/pricing"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -397,6 +398,8 @@ func (m *LoggingMiddleware) logLLMCall(ctx context.Context, createdAt time.Time,
 		Float64("total_cost", totalCost).
 		Msg("logging LLM call")
 
+	tools := validateToolCalls(req, resp)
+
 	llmCall := &types.LLMCall{
 		Created:            createdAt,
 		AppID:              appID,
@@ -424,6 +427,11 @@ func (m *LoggingMiddleware) logLLMCall(ctx context.Context, createdAt time.Time,
 		Stream:             stream,
 		ProjectID:          vals.ProjectID,
 		SpecTaskID:         vals.SpecTaskID,
+		FinishReason:       finishReason(resp),
+		ToolsOffered:       tools.ToolsOffered,
+		ToolCallsReturned:  tools.Calls,
+		ToolCallErrors:     tools.Errors,
+		ToolCallErrorKinds: tools.KindsString(),
 	}
 
 	if apiError != nil {
@@ -634,4 +642,54 @@ func (m *LoggingMiddleware) CreateFlexibleEmbeddings(ctx context.Context, reques
 	}
 
 	return resp, err
+}
+
+// finishReason reports why the provider stopped. Streaming responses carry it
+// on the accumulated choice just like non-streaming ones.
+func finishReason(resp *openai.ChatCompletionResponse) string {
+	if resp == nil || len(resp.Choices) == 0 {
+		return ""
+	}
+	return string(resp.Choices[0].FinishReason)
+}
+
+// validateToolCalls checks the tool calls in the response against the schemas
+// the request offered. Legacy function_call responses are not checked — no
+// current model emits them, and folding them in would mix two argument shapes
+// into one counter.
+func validateToolCalls(req *openai.ChatCompletionRequest, resp *openai.ChatCompletionResponse) toolcall.Result {
+	if req == nil || resp == nil || len(resp.Choices) == 0 {
+		return toolcall.Result{}
+	}
+
+	tools := make([]toolcall.Tool, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if tool.Function == nil {
+			continue
+		}
+		var schema json.RawMessage
+		if tool.Function.Parameters != nil {
+			encoded, err := json.Marshal(tool.Function.Parameters)
+			if err != nil {
+				// An unencodable schema is the caller's problem, not the
+				// model's: treat the tool as unconstrained rather than
+				// charging every call against it.
+				log.Debug().Err(err).Str("tool", tool.Function.Name).Msg("failed to encode tool schema")
+			} else {
+				schema = encoded
+			}
+		}
+		tools = append(tools, toolcall.Tool{Name: tool.Function.Name, Schema: schema})
+	}
+
+	returned := resp.Choices[0].Message.ToolCalls
+	calls := make([]toolcall.Call, 0, len(returned))
+	for _, call := range returned {
+		calls = append(calls, toolcall.Call{
+			Name:      call.Function.Name,
+			Arguments: call.Function.Arguments,
+		})
+	}
+
+	return toolcall.Validate(tools, calls)
 }

--- a/api/pkg/openai/logger/openai_logger_test.go
+++ b/api/pkg/openai/logger/openai_logger_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -586,4 +587,70 @@ func Test_logLLMCall_WithBillingLogger_Org(t *testing.T) {
 
 	// Wait for the goroutine to complete
 	mw.wg.Wait()
+}
+
+func TestValidateToolCalls(t *testing.T) {
+	req := &openai.ChatCompletionRequest{
+		Tools: []openai.Tool{{
+			Type: openai.ToolTypeFunction,
+			Function: &openai.FunctionDefinition{
+				Name: "get_weather",
+				Parameters: map[string]any{
+					"type":                 "object",
+					"properties":           map[string]any{"city": map[string]any{"type": "string"}},
+					"required":             []string{"city"},
+					"additionalProperties": false,
+				},
+			},
+		}},
+	}
+
+	respWith := func(calls ...openai.ToolCall) *openai.ChatCompletionResponse {
+		return &openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{{
+				Message:      openai.ChatCompletionMessage{ToolCalls: calls},
+				FinishReason: openai.FinishReasonToolCalls,
+			}},
+		}
+	}
+	call := func(name, args string) openai.ToolCall {
+		return openai.ToolCall{Function: openai.FunctionCall{Name: name, Arguments: args}}
+	}
+
+	t.Run("valid call", func(t *testing.T) {
+		result := validateToolCalls(req, respWith(call("get_weather", `{"city":"Vilnius"}`)))
+		assert.Equal(t, 1, result.ToolsOffered)
+		assert.Equal(t, 1, result.Calls)
+		assert.Equal(t, 0, result.Errors)
+	})
+
+	t.Run("arguments miss the schema", func(t *testing.T) {
+		result := validateToolCalls(req, respWith(call("get_weather", `{"town":"Vilnius"}`)))
+		assert.Equal(t, 1, result.Errors)
+		assert.Equal(t, toolcall.KindSchemaMismatch, result.KindsString())
+	})
+
+	t.Run("tool was never offered", func(t *testing.T) {
+		result := validateToolCalls(req, respWith(call("get_forecast", `{"city":"Vilnius"}`)))
+		assert.Equal(t, 1, result.Errors)
+		assert.Equal(t, toolcall.KindUnknownName, result.KindsString())
+	})
+
+	t.Run("a turn without tool calls is not counted", func(t *testing.T) {
+		result := validateToolCalls(req, respWith())
+		assert.Equal(t, 0, result.Calls)
+		assert.False(t, result.Errored())
+	})
+
+	t.Run("a failed request has nothing to validate", func(t *testing.T) {
+		assert.False(t, validateToolCalls(req, nil).Errored())
+	})
+}
+
+func TestFinishReason(t *testing.T) {
+	assert.Equal(t, "", finishReason(nil))
+	assert.Equal(t, "", finishReason(&openai.ChatCompletionResponse{}))
+	assert.Equal(t, "tool_calls", finishReason(&openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{FinishReason: openai.FinishReasonToolCalls}},
+	}))
 }

--- a/api/pkg/openai/logger/usage_logger.go
+++ b/api/pkg/openai/logger/usage_logger.go
@@ -47,6 +47,17 @@ func (l *UsageLogger) CreateLLMCall(ctx context.Context, call *types.LLMCall) (*
 		ProjectID:         call.ProjectID,
 	}
 
+	// Only requests that actually produced tool calls belong in the tool call
+	// error rate. Counting every request would bury the signal under ordinary
+	// prose turns, and counting requests that merely offered tools would
+	// penalise a model for correctly declining to call one.
+	if call.ToolCallsReturned > 0 {
+		metric.ToolCallRequests = 1
+		if call.ToolCallErrors > 0 {
+			metric.ToolCallErrorRequests = 1
+		}
+	}
+
 	_, err := l.CreateUsageMetric(ctx, metric)
 	if err != nil {
 		return nil, err

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -28784,6 +28784,12 @@ const docTemplate = `{
                 "sandbox_cost": {
                     "type": "number"
                 },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
+                },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",
                     "type": "number"
@@ -33216,6 +33222,10 @@ const docTemplate = `{
                 "error": {
                     "type": "string"
                 },
+                "finish_reason": {
+                    "description": "FinishReason is the provider's reason for stopping (\"stop\", \"tool_calls\",\n\"length\", ...). Anthropic's stop_reason is normalised onto the same\nvocabulary so the two proxies stay comparable.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -33272,6 +33282,19 @@ const docTemplate = `{
                 },
                 "time_to_first_token_ms": {
                     "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
+                },
+                "tool_call_error_kinds": {
+                    "type": "string"
+                },
+                "tool_call_errors": {
+                    "type": "integer"
+                },
+                "tool_calls_returned": {
+                    "type": "integer"
+                },
+                "tools_offered": {
+                    "description": "Tool call validity. ToolsOffered is how many tools the request carried,\nToolCallsReturned how many calls came back, ToolCallErrors how many of\nthose were structurally unusable, and ToolCallErrorKinds which buckets\nthey fell into (see api/pkg/toolcall). Tools offered with no calls\nreturned is not an error — it is a turn the model chose to answer in\nprose.",
                     "type": "integer"
                 },
                 "total_cost": {
@@ -40855,6 +40878,12 @@ const docTemplate = `{
                 },
                 "started_at": {
                     "type": "string"
+                },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
                 },
                 "total_cost": {
                     "type": "number"

--- a/api/pkg/server/openai_responses_proxy_handler.go
+++ b/api/pkg/server/openai_responses_proxy_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/pricing"
 	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -358,6 +359,8 @@ func (s *HelixAPIServer) recordOpenAIResponsesCall(
 	if providerID == "" {
 		providerID = endpoint.Name
 	}
+	tools := validateResponsesToolCalls(requestBody, result.Response)
+
 	call := &types.LLMCall{
 		ID:                 system.GenerateLLMCallID(),
 		Created:            started,
@@ -387,6 +390,11 @@ func (s *HelixAPIServer) recordOpenAIResponsesCall(
 		UserID:             user.ID,
 		Stream:             stream,
 		Error:              result.Error,
+		FinishReason:       tools.FinishReason,
+		ToolsOffered:       tools.Result.ToolsOffered,
+		ToolCallsReturned:  tools.Result.Calls,
+		ToolCallErrors:     tools.Result.Errors,
+		ToolCallErrorKinds: tools.Result.KindsString(),
 	}
 	logCtx, cancel := context.WithTimeout(ctx, openAIResponsesLogTimeout)
 	defer cancel()
@@ -417,4 +425,81 @@ func removeHopByHopHeaders(header http.Header) {
 
 func joinProxyPath(basePath, requestPath string) string {
 	return strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(requestPath, "/")
+}
+
+// responsesToolCallVerdict pairs the tool call validation with the finish
+// reason it implies. The Responses API has no finish_reason field — it reports
+// a status — so a turn that emitted function calls is recorded as "tool_calls"
+// to match what the Chat Completions and Anthropic proxies write.
+type responsesToolCallVerdict struct {
+	Result       toolcall.Result
+	FinishReason string
+}
+
+// validateResponsesToolCalls checks the function calls in a Responses API
+// result against the schemas the request offered. The response is either a
+// full envelope (non-streaming) or the terminal response.completed event
+// (streaming), so the output items are read from either shape. Built-in tools
+// (web_search, file_search) carry no name or parameters and do not surface as
+// function_call items, so they are left out of both sides.
+func validateResponsesToolCalls(requestBody, response []byte) responsesToolCallVerdict {
+	if len(requestBody) == 0 || len(response) == 0 {
+		return responsesToolCallVerdict{}
+	}
+
+	var request struct {
+		Tools []struct {
+			Type       string          `json:"type"`
+			Name       string          `json:"name"`
+			Parameters json.RawMessage `json:"parameters"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(requestBody, &request); err != nil {
+		log.Debug().Err(err).Msg("failed to parse Responses request for tool schemas")
+		return responsesToolCallVerdict{}
+	}
+
+	type outputItem struct {
+		Type      string `json:"type"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	var envelope struct {
+		Status   string       `json:"status"`
+		Output   []outputItem `json:"output"`
+		Response *struct {
+			Status string       `json:"status"`
+			Output []outputItem `json:"output"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(response, &envelope); err != nil {
+		log.Debug().Err(err).Msg("failed to parse Responses response for tool calls")
+		return responsesToolCallVerdict{}
+	}
+	output, status := envelope.Output, envelope.Status
+	if envelope.Response != nil {
+		output, status = envelope.Response.Output, envelope.Response.Status
+	}
+
+	tools := make([]toolcall.Tool, 0, len(request.Tools))
+	for _, tool := range request.Tools {
+		if tool.Name == "" {
+			continue
+		}
+		tools = append(tools, toolcall.Tool{Name: tool.Name, Schema: tool.Parameters})
+	}
+
+	var calls []toolcall.Call
+	for _, item := range output {
+		if item.Type != "function_call" {
+			continue
+		}
+		calls = append(calls, toolcall.Call{Name: item.Name, Arguments: item.Arguments})
+	}
+
+	verdict := responsesToolCallVerdict{Result: toolcall.Validate(tools, calls), FinishReason: status}
+	if len(calls) > 0 {
+		verdict.FinishReason = "tool_calls"
+	}
+	return verdict
 }

--- a/api/pkg/server/openai_responses_proxy_handler_test.go
+++ b/api/pkg/server/openai_responses_proxy_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/helixml/helix/api/pkg/model"
 	openailogger "github.com/helixml/helix/api/pkg/openai/logger"
 	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/toolcall"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -328,4 +329,44 @@ func TestNewOpenAIResponsesTransport(t *testing.T) {
 	require.NotSame(t, http.DefaultTransport, transport)
 	require.NotNil(t, transport.TLSClientConfig)
 	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestValidateResponsesToolCalls(t *testing.T) {
+	request := []byte(`{
+		"model": "gpt-5-codex",
+		"tools": [
+			{"type": "function", "name": "shell", "parameters": {"type": "object", "properties": {"command": {"type": "array", "items": {"type": "string"}}}, "required": ["command"]}},
+			{"type": "web_search"}
+		]
+	}`)
+
+	t.Run("streaming terminal event", func(t *testing.T) {
+		response := []byte(`{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","name":"shell","arguments":"{\"command\":[\"ls\"]}"}]}}`)
+		verdict := validateResponsesToolCalls(request, response)
+		require.Equal(t, 1, verdict.Result.ToolsOffered)
+		require.Equal(t, 1, verdict.Result.Calls)
+		require.Equal(t, 0, verdict.Result.Errors)
+		require.Equal(t, "tool_calls", verdict.FinishReason)
+	})
+
+	t.Run("non-streaming envelope with bad arguments", func(t *testing.T) {
+		response := []byte(`{"status":"completed","output":[{"type":"function_call","name":"shell","arguments":"{\"command\":\"ls\"}"}]}`)
+		verdict := validateResponsesToolCalls(request, response)
+		require.Equal(t, 1, verdict.Result.Errors)
+		require.Equal(t, toolcall.KindSchemaMismatch, verdict.Result.KindsString())
+	})
+
+	t.Run("unparseable arguments", func(t *testing.T) {
+		response := []byte(`{"status":"completed","output":[{"type":"function_call","name":"shell","arguments":"{\"command\":"}]}`)
+		verdict := validateResponsesToolCalls(request, response)
+		require.Equal(t, 1, verdict.Result.Errors)
+		require.Equal(t, toolcall.KindInvalidJSON, verdict.Result.KindsString())
+	})
+
+	t.Run("message output keeps the response status", func(t *testing.T) {
+		response := []byte(`{"status":"completed","output":[{"type":"message"}]}`)
+		verdict := validateResponsesToolCalls(request, response)
+		require.Equal(t, 0, verdict.Result.Calls)
+		require.Equal(t, "completed", verdict.FinishReason)
+	})
 }

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -28780,6 +28780,12 @@
                 "sandbox_cost": {
                     "type": "number"
                 },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
+                },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",
                     "type": "number"
@@ -33212,6 +33218,10 @@
                 "error": {
                     "type": "string"
                 },
+                "finish_reason": {
+                    "description": "FinishReason is the provider's reason for stopping (\"stop\", \"tool_calls\",\n\"length\", ...). Anthropic's stop_reason is normalised onto the same\nvocabulary so the two proxies stay comparable.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -33268,6 +33278,19 @@
                 },
                 "time_to_first_token_ms": {
                     "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
+                },
+                "tool_call_error_kinds": {
+                    "type": "string"
+                },
+                "tool_call_errors": {
+                    "type": "integer"
+                },
+                "tool_calls_returned": {
+                    "type": "integer"
+                },
+                "tools_offered": {
+                    "description": "Tool call validity. ToolsOffered is how many tools the request carried,\nToolCallsReturned how many calls came back, ToolCallErrors how many of\nthose were structurally unusable, and ToolCallErrorKinds which buckets\nthey fell into (see api/pkg/toolcall). Tools offered with no calls\nreturned is not an error — it is a turn the model chose to answer in\nprose.",
                     "type": "integer"
                 },
                 "total_cost": {
@@ -40851,6 +40874,12 @@
                 },
                 "started_at": {
                     "type": "string"
+                },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
                 },
                 "total_cost": {
                     "type": "number"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3822,6 +3822,10 @@ definitions:
         type: integer
       sandbox_cost:
         type: number
+      tool_call_error_requests:
+        type: integer
+      tool_call_requests:
+        type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
         type: number
@@ -7120,6 +7124,12 @@ definitions:
         type: integer
       error:
         type: string
+      finish_reason:
+        description: |-
+          FinishReason is the provider's reason for stopping ("stop", "tool_calls",
+          "length", ...). Anthropic's stop_reason is normalised onto the same
+          vocabulary so the two proxies stay comparable.
+        type: string
       id:
         type: string
       interaction_id:
@@ -7164,6 +7174,21 @@ definitions:
           generation stays normal). 0 means no chunk was received (the call errored
           or was cut before the first token). For non-streaming calls it equals the
           time to the full response.
+        type: integer
+      tool_call_error_kinds:
+        type: string
+      tool_call_errors:
+        type: integer
+      tool_calls_returned:
+        type: integer
+      tools_offered:
+        description: |-
+          Tool call validity. ToolsOffered is how many tools the request carried,
+          ToolCallsReturned how many calls came back, ToolCallErrors how many of
+          those were structurally unusable, and ToolCallErrorKinds which buckets
+          they fell into (see api/pkg/toolcall). Tools offered with no calls
+          returned is not an error — it is a turn the model chose to answer in
+          prose.
         type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
@@ -12790,6 +12815,10 @@ definitions:
         type: string
       started_at:
         type: string
+      tool_call_error_requests:
+        type: integer
+      tool_call_requests:
+        type: integer
       total_cost:
         type: number
       total_requests:

--- a/api/pkg/server/usage_handlers.go
+++ b/api/pkg/server/usage_handlers.go
@@ -400,6 +400,8 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 		aggregate.row.PromptTokens += row.PromptTokens
 		aggregate.row.CompletionTokens += row.CompletionTokens
 		aggregate.row.TotalTokens += row.TotalTokens
+		aggregate.row.ToolCallRequests += row.ToolCallRequests
+		aggregate.row.ToolCallErrorRequests += row.ToolCallErrorRequests
 		aggregate.row.CacheReadTokens += row.CacheReadTokens
 		aggregate.row.CacheWriteTokens += row.CacheWriteTokens
 		aggregate.row.TotalCost += estimatedCost
@@ -412,6 +414,8 @@ func (s *HelixAPIServer) enrichOrgUsageCosts(ctx context.Context, summary *types
 		metric.PromptTokens += row.PromptTokens
 		metric.CompletionTokens += row.CompletionTokens
 		metric.TotalTokens += row.TotalTokens
+		metric.ToolCallRequests += row.ToolCallRequests
+		metric.ToolCallErrorRequests += row.ToolCallErrorRequests
 		metric.CacheReadTokens += row.CacheReadTokens
 		metric.CacheWriteTokens += row.CacheWriteTokens
 		metric.TotalCost += estimatedCost

--- a/api/pkg/store/store_usage_metrics.go
+++ b/api/pkg/store/store_usage_metrics.go
@@ -131,6 +131,8 @@ func (s *PostgresStore) GetAppDailyUsageMetrics(ctx context.Context, appID strin
 			SUM(total_tokens) as total_tokens,
 			SUM(cache_read_tokens) as cache_read_tokens,
 			SUM(cache_write_tokens) as cache_write_tokens,
+			SUM(tool_call_requests) as tool_call_requests,
+			SUM(tool_call_error_requests) as tool_call_error_requests,
 			SUM(total_cost) as total_cost,
 			SUM(cache_read_cost) as cache_read_cost,
 			SUM(cache_write_cost) as cache_write_cost,
@@ -165,6 +167,8 @@ func (s *PostgresStore) GetProviderDailyUsageMetrics(ctx context.Context, provid
 			SUM(total_tokens) as total_tokens,
 			SUM(cache_read_tokens) as cache_read_tokens,
 			SUM(cache_write_tokens) as cache_write_tokens,
+			SUM(tool_call_requests) as tool_call_requests,
+			SUM(tool_call_error_requests) as tool_call_error_requests,
 			SUM(prompt_cost) as prompt_cost,
 			SUM(completion_cost) as completion_cost,
 			SUM(cache_read_cost) as cache_read_cost,
@@ -195,22 +199,24 @@ func (s *PostgresStore) GetUsersAggregatedUsageMetrics(ctx context.Context, prov
 
 	// First get the aggregated metrics per user
 	var userMetrics []struct {
-		UserID            string    `gorm:"column:user_id"`
-		Date              time.Time `gorm:"column:date"`
-		PromptTokens      int       `gorm:"column:prompt_tokens"`
-		CompletionTokens  int       `gorm:"column:completion_tokens"`
-		TotalTokens       int       `gorm:"column:total_tokens"`
-		CacheReadTokens   int       `gorm:"column:cache_read_tokens"`
-		CacheWriteTokens  int       `gorm:"column:cache_write_tokens"`
-		PromptCost        float64   `gorm:"column:prompt_cost"`
-		CompletionCost    float64   `gorm:"column:completion_cost"`
-		CacheReadCost     float64   `gorm:"column:cache_read_cost"`
-		CacheWriteCost    float64   `gorm:"column:cache_write_cost"`
-		TotalCost         float64   `gorm:"column:total_cost"`
-		DurationMs        float64   `gorm:"column:duration_ms"`
-		RequestSizeBytes  int       `gorm:"column:request_size_bytes"`
-		ResponseSizeBytes int       `gorm:"column:response_size_bytes"`
-		TotalRequests     int       `gorm:"column:total_requests"`
+		UserID                string    `gorm:"column:user_id"`
+		Date                  time.Time `gorm:"column:date"`
+		PromptTokens          int       `gorm:"column:prompt_tokens"`
+		CompletionTokens      int       `gorm:"column:completion_tokens"`
+		TotalTokens           int       `gorm:"column:total_tokens"`
+		CacheReadTokens       int       `gorm:"column:cache_read_tokens"`
+		CacheWriteTokens      int       `gorm:"column:cache_write_tokens"`
+		ToolCallRequests      int       `gorm:"column:tool_call_requests"`
+		ToolCallErrorRequests int       `gorm:"column:tool_call_error_requests"`
+		PromptCost            float64   `gorm:"column:prompt_cost"`
+		CompletionCost        float64   `gorm:"column:completion_cost"`
+		CacheReadCost         float64   `gorm:"column:cache_read_cost"`
+		CacheWriteCost        float64   `gorm:"column:cache_write_cost"`
+		TotalCost             float64   `gorm:"column:total_cost"`
+		DurationMs            float64   `gorm:"column:duration_ms"`
+		RequestSizeBytes      int       `gorm:"column:request_size_bytes"`
+		ResponseSizeBytes     int       `gorm:"column:response_size_bytes"`
+		TotalRequests         int       `gorm:"column:total_requests"`
 	}
 
 	err := s.gdb.WithContext(ctx).
@@ -223,6 +229,8 @@ func (s *PostgresStore) GetUsersAggregatedUsageMetrics(ctx context.Context, prov
 			SUM(total_tokens) as total_tokens,
 			SUM(cache_read_tokens) as cache_read_tokens,
 			SUM(cache_write_tokens) as cache_write_tokens,
+			SUM(tool_call_requests) as tool_call_requests,
+			SUM(tool_call_error_requests) as tool_call_error_requests,
 			SUM(prompt_cost) as prompt_cost,
 			SUM(completion_cost) as completion_cost,
 			SUM(cache_read_cost) as cache_read_cost,
@@ -249,21 +257,23 @@ func (s *PostgresStore) GetUsersAggregatedUsageMetrics(ctx context.Context, prov
 	for _, m := range userMetrics {
 		userIDs[m.UserID] = true
 		userMetricsMap[m.UserID] = append(userMetricsMap[m.UserID], &types.AggregatedUsageMetric{
-			Date:              m.Date,
-			PromptTokens:      m.PromptTokens,
-			CompletionTokens:  m.CompletionTokens,
-			TotalTokens:       m.TotalTokens,
-			CacheReadTokens:   m.CacheReadTokens,
-			CacheWriteTokens:  m.CacheWriteTokens,
-			PromptCost:        m.PromptCost,
-			CompletionCost:    m.CompletionCost,
-			CacheReadCost:     m.CacheReadCost,
-			CacheWriteCost:    m.CacheWriteCost,
-			TotalCost:         m.TotalCost,
-			LatencyMs:         m.DurationMs,
-			RequestSizeBytes:  m.RequestSizeBytes,
-			ResponseSizeBytes: m.ResponseSizeBytes,
-			TotalRequests:     m.TotalRequests,
+			Date:                  m.Date,
+			PromptTokens:          m.PromptTokens,
+			CompletionTokens:      m.CompletionTokens,
+			TotalTokens:           m.TotalTokens,
+			CacheReadTokens:       m.CacheReadTokens,
+			CacheWriteTokens:      m.CacheWriteTokens,
+			ToolCallRequests:      m.ToolCallRequests,
+			ToolCallErrorRequests: m.ToolCallErrorRequests,
+			PromptCost:            m.PromptCost,
+			CompletionCost:        m.CompletionCost,
+			CacheReadCost:         m.CacheReadCost,
+			CacheWriteCost:        m.CacheWriteCost,
+			TotalCost:             m.TotalCost,
+			LatencyMs:             m.DurationMs,
+			RequestSizeBytes:      m.RequestSizeBytes,
+			ResponseSizeBytes:     m.ResponseSizeBytes,
+			TotalRequests:         m.TotalRequests,
 		})
 	}
 
@@ -343,6 +353,8 @@ func (s *PostgresStore) GetAggregatedUsageMetrics(ctx context.Context, q *GetAgg
 			SUM(usage_metrics.completion_tokens) as completion_tokens,
 			SUM(usage_metrics.cache_read_tokens) as cache_read_tokens,
 			SUM(usage_metrics.cache_write_tokens) as cache_write_tokens,
+			SUM(usage_metrics.tool_call_requests) as tool_call_requests,
+			SUM(usage_metrics.tool_call_error_requests) as tool_call_error_requests,
 			SUM(usage_metrics.prompt_cost) as prompt_cost,
 			SUM(usage_metrics.completion_cost) as completion_cost,
 			SUM(usage_metrics.cache_read_cost) as cache_read_cost,
@@ -565,6 +577,8 @@ func (s *PostgresStore) GetOrgUsageSummary(ctx context.Context, q *GetOrgUsageSu
 				SUM(usage_metrics.total_tokens) as total_tokens,
 				SUM(usage_metrics.cache_read_tokens) as cache_read_tokens,
 				SUM(usage_metrics.cache_write_tokens) as cache_write_tokens,
+				SUM(usage_metrics.tool_call_requests) as tool_call_requests,
+				SUM(usage_metrics.tool_call_error_requests) as tool_call_error_requests,
 				SUM(usage_metrics.prompt_cost) as prompt_cost,
 				SUM(usage_metrics.completion_cost) as completion_cost,
 				SUM(usage_metrics.cache_read_cost) as cache_read_cost,
@@ -674,6 +688,8 @@ func (s *PostgresStore) orgUsageBreakdownQuery(ctx context.Context, q *GetOrgUsa
 		SUM(usage_metrics.completion_tokens) as completion_tokens,
 		SUM(usage_metrics.cache_read_tokens) as cache_read_tokens,
 		SUM(usage_metrics.cache_write_tokens) as cache_write_tokens,
+		SUM(usage_metrics.tool_call_requests) as tool_call_requests,
+		SUM(usage_metrics.tool_call_error_requests) as tool_call_error_requests,
 		SUM(usage_metrics.prompt_cost) as prompt_cost,
 		SUM(usage_metrics.completion_cost) as completion_cost,
 		SUM(usage_metrics.cache_read_cost) as cache_read_cost,
@@ -947,23 +963,25 @@ func (s *PostgresStore) getOrgUsageModelTimeSeries(ctx context.Context, q *GetOr
 	}
 
 	var rows []struct {
-		Date              time.Time `gorm:"column:date"`
-		Provider          string    `gorm:"column:provider"`
-		Model             string    `gorm:"column:model"`
-		PromptTokens      int       `gorm:"column:prompt_tokens"`
-		CompletionTokens  int       `gorm:"column:completion_tokens"`
-		CacheReadTokens   int       `gorm:"column:cache_read_tokens"`
-		CacheWriteTokens  int       `gorm:"column:cache_write_tokens"`
-		TotalTokens       int       `gorm:"column:total_tokens"`
-		PromptCost        float64   `gorm:"column:prompt_cost"`
-		CompletionCost    float64   `gorm:"column:completion_cost"`
-		CacheReadCost     float64   `gorm:"column:cache_read_cost"`
-		CacheWriteCost    float64   `gorm:"column:cache_write_cost"`
-		TotalCost         float64   `gorm:"column:total_cost"`
-		LatencyMs         float64   `gorm:"column:latency_ms"`
-		RequestSizeBytes  int       `gorm:"column:request_size_bytes"`
-		ResponseSizeBytes int       `gorm:"column:response_size_bytes"`
-		TotalRequests     int       `gorm:"column:total_requests"`
+		Date                  time.Time `gorm:"column:date"`
+		Provider              string    `gorm:"column:provider"`
+		Model                 string    `gorm:"column:model"`
+		PromptTokens          int       `gorm:"column:prompt_tokens"`
+		CompletionTokens      int       `gorm:"column:completion_tokens"`
+		CacheReadTokens       int       `gorm:"column:cache_read_tokens"`
+		CacheWriteTokens      int       `gorm:"column:cache_write_tokens"`
+		ToolCallRequests      int       `gorm:"column:tool_call_requests"`
+		ToolCallErrorRequests int       `gorm:"column:tool_call_error_requests"`
+		TotalTokens           int       `gorm:"column:total_tokens"`
+		PromptCost            float64   `gorm:"column:prompt_cost"`
+		CompletionCost        float64   `gorm:"column:completion_cost"`
+		CacheReadCost         float64   `gorm:"column:cache_read_cost"`
+		CacheWriteCost        float64   `gorm:"column:cache_write_cost"`
+		TotalCost             float64   `gorm:"column:total_cost"`
+		LatencyMs             float64   `gorm:"column:latency_ms"`
+		RequestSizeBytes      int       `gorm:"column:request_size_bytes"`
+		ResponseSizeBytes     int       `gorm:"column:response_size_bytes"`
+		TotalRequests         int       `gorm:"column:total_requests"`
 	}
 
 	// Restrict to the (provider, model) pairs we actually need to chart.
@@ -978,6 +996,8 @@ func (s *PostgresStore) getOrgUsageModelTimeSeries(ctx context.Context, q *GetOr
 			SUM(usage_metrics.completion_tokens) as completion_tokens,
 			SUM(usage_metrics.cache_read_tokens) as cache_read_tokens,
 			SUM(usage_metrics.cache_write_tokens) as cache_write_tokens,
+			SUM(usage_metrics.tool_call_requests) as tool_call_requests,
+			SUM(usage_metrics.tool_call_error_requests) as tool_call_error_requests,
 			SUM(usage_metrics.total_tokens) as total_tokens,
 			SUM(usage_metrics.prompt_cost) as prompt_cost,
 			SUM(usage_metrics.completion_cost) as completion_cost,
@@ -1005,21 +1025,23 @@ func (s *PostgresStore) getOrgUsageModelTimeSeries(ctx context.Context, q *GetOr
 			continue
 		}
 		metricsByModel[id] = append(metricsByModel[id], &types.AggregatedUsageMetric{
-			Date:              row.Date,
-			PromptTokens:      row.PromptTokens,
-			CompletionTokens:  row.CompletionTokens,
-			CacheReadTokens:   row.CacheReadTokens,
-			CacheWriteTokens:  row.CacheWriteTokens,
-			TotalTokens:       row.TotalTokens,
-			PromptCost:        row.PromptCost,
-			CompletionCost:    row.CompletionCost,
-			CacheReadCost:     row.CacheReadCost,
-			CacheWriteCost:    row.CacheWriteCost,
-			TotalCost:         row.TotalCost,
-			LatencyMs:         row.LatencyMs,
-			RequestSizeBytes:  row.RequestSizeBytes,
-			ResponseSizeBytes: row.ResponseSizeBytes,
-			TotalRequests:     row.TotalRequests,
+			Date:                  row.Date,
+			PromptTokens:          row.PromptTokens,
+			CompletionTokens:      row.CompletionTokens,
+			CacheReadTokens:       row.CacheReadTokens,
+			CacheWriteTokens:      row.CacheWriteTokens,
+			ToolCallRequests:      row.ToolCallRequests,
+			ToolCallErrorRequests: row.ToolCallErrorRequests,
+			TotalTokens:           row.TotalTokens,
+			PromptCost:            row.PromptCost,
+			CompletionCost:        row.CompletionCost,
+			CacheReadCost:         row.CacheReadCost,
+			CacheWriteCost:        row.CacheWriteCost,
+			TotalCost:             row.TotalCost,
+			LatencyMs:             row.LatencyMs,
+			RequestSizeBytes:      row.RequestSizeBytes,
+			ResponseSizeBytes:     row.ResponseSizeBytes,
+			TotalRequests:         row.TotalRequests,
 		})
 	}
 
@@ -1051,13 +1073,15 @@ func (s *PostgresStore) getOrgUsageAgentRuntimeTimeSeries(ctx context.Context, q
 		'unattributed'
 	)`
 	var rows []struct {
-		Date             time.Time `gorm:"column:date"`
-		Runtime          string    `gorm:"column:runtime"`
-		PromptTokens     int       `gorm:"column:prompt_tokens"`
-		CompletionTokens int       `gorm:"column:completion_tokens"`
-		CacheReadTokens  int       `gorm:"column:cache_read_tokens"`
-		CacheWriteTokens int       `gorm:"column:cache_write_tokens"`
-		TotalTokens      int       `gorm:"column:total_tokens"`
+		Date                  time.Time `gorm:"column:date"`
+		Runtime               string    `gorm:"column:runtime"`
+		PromptTokens          int       `gorm:"column:prompt_tokens"`
+		CompletionTokens      int       `gorm:"column:completion_tokens"`
+		CacheReadTokens       int       `gorm:"column:cache_read_tokens"`
+		CacheWriteTokens      int       `gorm:"column:cache_write_tokens"`
+		ToolCallRequests      int       `gorm:"column:tool_call_requests"`
+		ToolCallErrorRequests int       `gorm:"column:tool_call_error_requests"`
+		TotalTokens           int       `gorm:"column:total_tokens"`
 	}
 	err := s.orgUsageBaseQuery(ctx, q).
 		Select(`
@@ -1067,6 +1091,8 @@ func (s *PostgresStore) getOrgUsageAgentRuntimeTimeSeries(ctx context.Context, q
 			SUM(usage_metrics.completion_tokens) as completion_tokens,
 			SUM(usage_metrics.cache_read_tokens) as cache_read_tokens,
 			SUM(usage_metrics.cache_write_tokens) as cache_write_tokens,
+			SUM(usage_metrics.tool_call_requests) as tool_call_requests,
+			SUM(usage_metrics.tool_call_error_requests) as tool_call_error_requests,
 			SUM(usage_metrics.total_tokens) as total_tokens
 		`).
 		Group("usage_metrics.date, " + runtimeExpr).
@@ -1084,12 +1110,14 @@ func (s *PostgresStore) getOrgUsageAgentRuntimeTimeSeries(ctx context.Context, q
 			runtime = unattributedRuntime
 		}
 		metricsByRuntime[runtime] = append(metricsByRuntime[runtime], &types.AggregatedUsageMetric{
-			Date:             row.Date,
-			PromptTokens:     row.PromptTokens,
-			CompletionTokens: row.CompletionTokens,
-			CacheReadTokens:  row.CacheReadTokens,
-			CacheWriteTokens: row.CacheWriteTokens,
-			TotalTokens:      row.TotalTokens,
+			Date:                  row.Date,
+			PromptTokens:          row.PromptTokens,
+			CompletionTokens:      row.CompletionTokens,
+			CacheReadTokens:       row.CacheReadTokens,
+			CacheWriteTokens:      row.CacheWriteTokens,
+			ToolCallRequests:      row.ToolCallRequests,
+			ToolCallErrorRequests: row.ToolCallErrorRequests,
+			TotalTokens:           row.TotalTokens,
 		})
 		tokensByRuntime[runtime] += row.TotalTokens
 	}
@@ -1206,22 +1234,24 @@ func (s *PostgresStore) GetAppUsersAggregatedUsageMetrics(ctx context.Context, a
 
 	// First get the aggregated metrics per user
 	var userMetrics []struct {
-		UserID            string    `gorm:"column:user_id"`
-		Date              time.Time `gorm:"column:date"`
-		PromptTokens      int       `gorm:"column:prompt_tokens"`
-		CompletionTokens  int       `gorm:"column:completion_tokens"`
-		TotalTokens       int       `gorm:"column:total_tokens"`
-		CacheReadTokens   int       `gorm:"column:cache_read_tokens"`
-		CacheWriteTokens  int       `gorm:"column:cache_write_tokens"`
-		PromptCost        float64   `gorm:"column:prompt_cost"`
-		CompletionCost    float64   `gorm:"column:completion_cost"`
-		CacheReadCost     float64   `gorm:"column:cache_read_cost"`
-		CacheWriteCost    float64   `gorm:"column:cache_write_cost"`
-		TotalCost         float64   `gorm:"column:total_cost"`
-		DurationMs        float64   `gorm:"column:duration_ms"`
-		RequestSizeBytes  int       `gorm:"column:request_size_bytes"`
-		ResponseSizeBytes int       `gorm:"column:response_size_bytes"`
-		TotalRequests     int       `gorm:"column:total_requests"` // Grouped by interaction_id
+		UserID                string    `gorm:"column:user_id"`
+		Date                  time.Time `gorm:"column:date"`
+		PromptTokens          int       `gorm:"column:prompt_tokens"`
+		CompletionTokens      int       `gorm:"column:completion_tokens"`
+		TotalTokens           int       `gorm:"column:total_tokens"`
+		CacheReadTokens       int       `gorm:"column:cache_read_tokens"`
+		CacheWriteTokens      int       `gorm:"column:cache_write_tokens"`
+		ToolCallRequests      int       `gorm:"column:tool_call_requests"`
+		ToolCallErrorRequests int       `gorm:"column:tool_call_error_requests"`
+		PromptCost            float64   `gorm:"column:prompt_cost"`
+		CompletionCost        float64   `gorm:"column:completion_cost"`
+		CacheReadCost         float64   `gorm:"column:cache_read_cost"`
+		CacheWriteCost        float64   `gorm:"column:cache_write_cost"`
+		TotalCost             float64   `gorm:"column:total_cost"`
+		DurationMs            float64   `gorm:"column:duration_ms"`
+		RequestSizeBytes      int       `gorm:"column:request_size_bytes"`
+		ResponseSizeBytes     int       `gorm:"column:response_size_bytes"`
+		TotalRequests         int       `gorm:"column:total_requests"` // Grouped by interaction_id
 	}
 
 	err := s.gdb.WithContext(ctx).
@@ -1234,6 +1264,8 @@ func (s *PostgresStore) GetAppUsersAggregatedUsageMetrics(ctx context.Context, a
 			SUM(total_tokens) as total_tokens,
 			SUM(cache_read_tokens) as cache_read_tokens,
 			SUM(cache_write_tokens) as cache_write_tokens,
+			SUM(tool_call_requests) as tool_call_requests,
+			SUM(tool_call_error_requests) as tool_call_error_requests,
 			SUM(prompt_cost) as prompt_cost,
 			SUM(completion_cost) as completion_cost,
 			SUM(cache_read_cost) as cache_read_cost,
@@ -1260,21 +1292,23 @@ func (s *PostgresStore) GetAppUsersAggregatedUsageMetrics(ctx context.Context, a
 	for _, m := range userMetrics {
 		userIDs[m.UserID] = true
 		userMetricsMap[m.UserID] = append(userMetricsMap[m.UserID], &types.AggregatedUsageMetric{
-			Date:              m.Date,
-			PromptTokens:      m.PromptTokens,
-			CompletionTokens:  m.CompletionTokens,
-			TotalTokens:       m.TotalTokens,
-			CacheReadTokens:   m.CacheReadTokens,
-			CacheWriteTokens:  m.CacheWriteTokens,
-			TotalCost:         m.TotalCost,
-			PromptCost:        m.PromptCost,
-			CompletionCost:    m.CompletionCost,
-			CacheReadCost:     m.CacheReadCost,
-			CacheWriteCost:    m.CacheWriteCost,
-			LatencyMs:         m.DurationMs,
-			RequestSizeBytes:  m.RequestSizeBytes,
-			ResponseSizeBytes: m.ResponseSizeBytes,
-			TotalRequests:     m.TotalRequests,
+			Date:                  m.Date,
+			PromptTokens:          m.PromptTokens,
+			CompletionTokens:      m.CompletionTokens,
+			TotalTokens:           m.TotalTokens,
+			CacheReadTokens:       m.CacheReadTokens,
+			CacheWriteTokens:      m.CacheWriteTokens,
+			ToolCallRequests:      m.ToolCallRequests,
+			ToolCallErrorRequests: m.ToolCallErrorRequests,
+			TotalCost:             m.TotalCost,
+			PromptCost:            m.PromptCost,
+			CompletionCost:        m.CompletionCost,
+			CacheReadCost:         m.CacheReadCost,
+			CacheWriteCost:        m.CacheWriteCost,
+			LatencyMs:             m.DurationMs,
+			RequestSizeBytes:      m.RequestSizeBytes,
+			ResponseSizeBytes:     m.ResponseSizeBytes,
+			TotalRequests:         m.TotalRequests,
 		})
 	}
 

--- a/api/pkg/toolcall/validate.go
+++ b/api/pkg/toolcall/validate.go
@@ -1,0 +1,179 @@
+// Package toolcall validates the tool calls a model returned against the tool
+// schemas the caller supplied.
+//
+// This measures structural validity — did the model emit something the caller
+// could actually dispatch — not whether the tool then succeeded. A call fails
+// in exactly one of three ways, in priority order: its arguments are not JSON,
+// it names a tool that was never offered, or its arguments do not satisfy that
+// tool's parameter schema. The buckets mirror OpenRouter's tool call error rate
+// so our per-provider numbers are comparable with theirs.
+package toolcall
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// Error kinds. Stored comma-joined on the LLM call so a bad call can be
+// triaged without re-reading the request and response bodies.
+const (
+	KindInvalidJSON    = "invalid_json"
+	KindUnknownName    = "unknown_name"
+	KindSchemaMismatch = "schema_mismatch"
+)
+
+// Tool is a tool offered to the model, normalised across providers. Schema is
+// the JSON Schema for the arguments (OpenAI `function.parameters`, Anthropic
+// `input_schema`). An absent or uncompilable schema means the tool is treated
+// as always valid — we are measuring the model, not the caller's schema.
+type Tool struct {
+	Name   string
+	Schema json.RawMessage
+}
+
+// Call is one tool call the model returned. Arguments is the raw argument
+// payload as the model emitted it: a JSON string for OpenAI-shaped providers,
+// and the re-encoded object for providers that hand back decoded input
+// (Anthropic tool_use), where the invalid-JSON bucket cannot fire.
+type Call struct {
+	Name      string
+	Arguments string
+}
+
+// Result is the per-request verdict.
+type Result struct {
+	ToolsOffered int
+	Calls        int
+	Errors       int
+	// Kinds are the distinct failure buckets seen in this request, sorted.
+	Kinds []string
+}
+
+// KindsString renders Kinds for storage on the LLM call row.
+func (r Result) KindsString() string { return strings.Join(r.Kinds, ",") }
+
+// Errored reports whether the request counts against the tool call error rate.
+// A request is errored if any of its calls failed, matching OpenRouter's
+// request-level aggregation: one bad call out of five is one errored request,
+// not 20% of one.
+func (r Result) Errored() bool { return r.Errors > 0 }
+
+// Validate checks every call against the offered tools.
+func Validate(tools []Tool, calls []Call) Result {
+	result := Result{ToolsOffered: len(tools), Calls: len(calls)}
+	if len(calls) == 0 {
+		return result
+	}
+
+	schemas := make(map[string]json.RawMessage, len(tools))
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+		schemas[tool.Name] = tool.Schema
+	}
+
+	kinds := make(map[string]bool, 3)
+	for _, call := range calls {
+		kind := validateCall(schemas, call)
+		if kind == "" {
+			continue
+		}
+		result.Errors++
+		kinds[kind] = true
+	}
+
+	for kind := range kinds {
+		result.Kinds = append(result.Kinds, kind)
+	}
+	sort.Strings(result.Kinds)
+	return result
+}
+
+// validateCall returns the failure bucket for one call, or "" if it is valid.
+// A call that fails more than one way is charged to the first bucket that
+// applies, so the counts stay one-per-call.
+func validateCall(schemas map[string]json.RawMessage, call Call) string {
+	arguments := strings.TrimSpace(call.Arguments)
+	if arguments == "" {
+		// A no-argument tool call is commonly emitted as an empty string
+		// rather than "{}". Reading it as the empty object keeps that off the
+		// invalid-JSON pile; if the tool actually required arguments, the
+		// schema check below still catches it as a mismatch.
+		arguments = "{}"
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(arguments), &decoded); err != nil {
+		return KindInvalidJSON
+	}
+
+	schema, offered := schemas[call.Name]
+	if !offered {
+		return KindUnknownName
+	}
+
+	resolved := compile(schema)
+	if resolved == nil {
+		return ""
+	}
+	if err := resolved.Validate(decoded); err != nil {
+		return KindSchemaMismatch
+	}
+	return ""
+}
+
+// Coding agents resend the same handful of tool schemas on every turn, so
+// compiling per call would dominate the cost of logging. Cache by schema
+// content; the map is cleared wholesale once it grows past the bound rather
+// than evicting entry by entry, which is enough for a working set this small.
+const maxCachedSchemas = 1024
+
+var (
+	schemaCacheMu sync.RWMutex
+	schemaCache   = map[string]*jsonschema.Resolved{}
+)
+
+// compile returns the resolved schema, or nil when the tool should be treated
+// as always valid (no schema, or a schema we cannot compile).
+func compile(raw json.RawMessage) *jsonschema.Resolved {
+	if len(raw) == 0 {
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+
+	sum := sha256.Sum256([]byte(trimmed))
+	key := hex.EncodeToString(sum[:])
+
+	schemaCacheMu.RLock()
+	resolved, cached := schemaCache[key]
+	schemaCacheMu.RUnlock()
+	if cached {
+		return resolved
+	}
+
+	var schema jsonschema.Schema
+	if err := json.Unmarshal([]byte(trimmed), &schema); err == nil {
+		if compiled, err := schema.Resolve(nil); err == nil {
+			resolved = compiled
+		}
+	}
+
+	schemaCacheMu.Lock()
+	if len(schemaCache) >= maxCachedSchemas {
+		schemaCache = map[string]*jsonschema.Resolved{}
+	}
+	schemaCache[key] = resolved
+	schemaCacheMu.Unlock()
+
+	return resolved
+}

--- a/api/pkg/toolcall/validate_test.go
+++ b/api/pkg/toolcall/validate_test.go
@@ -1,0 +1,148 @@
+package toolcall
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var editFile = Tool{
+	Name: "edit_file",
+	Schema: json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path": {"type": "string"},
+			"line": {"type": "integer"}
+		},
+		"required": ["path"],
+		"additionalProperties": false
+	}`),
+}
+
+var noArgs = Tool{
+	Name:   "list_files",
+	Schema: json.RawMessage(`{"type": "object", "properties": {}}`),
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		tools  []Tool
+		calls  []Call
+		errors int
+		kinds  string
+	}{
+		{
+			name:  "valid call",
+			tools: []Tool{editFile},
+			calls: []Call{{Name: "edit_file", Arguments: `{"path": "a.go", "line": 3}`}},
+		},
+		{
+			name:   "arguments are not json",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "edit_file", Arguments: `{"path": "a.go"`}},
+			errors: 1,
+			kinds:  KindInvalidJSON,
+		},
+		{
+			name:   "tool was never offered",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "delete_file", Arguments: `{"path": "a.go"}`}},
+			errors: 1,
+			kinds:  KindUnknownName,
+		},
+		{
+			name:   "required property missing",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "edit_file", Arguments: `{"line": 3}`}},
+			errors: 1,
+			kinds:  KindSchemaMismatch,
+		},
+		{
+			name:   "wrong property type",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "edit_file", Arguments: `{"path": "a.go", "line": "three"}`}},
+			errors: 1,
+			kinds:  KindSchemaMismatch,
+		},
+		{
+			name:   "undeclared property",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "edit_file", Arguments: `{"path": "a.go", "mode": "w"}`}},
+			errors: 1,
+			kinds:  KindSchemaMismatch,
+		},
+		{
+			name:  "empty arguments on a no-argument tool are the empty object",
+			tools: []Tool{noArgs},
+			calls: []Call{{Name: "list_files", Arguments: ""}},
+		},
+		{
+			name:   "empty arguments still fail a tool that requires them",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "edit_file", Arguments: ""}},
+			errors: 1,
+			kinds:  KindSchemaMismatch,
+		},
+		{
+			name:  "tool without a schema is always valid",
+			tools: []Tool{{Name: "anything"}},
+			calls: []Call{{Name: "anything", Arguments: `{"whatever": true}`}},
+		},
+		{
+			name:  "uncompilable schema is always valid",
+			tools: []Tool{{Name: "broken", Schema: json.RawMessage(`{"type": 42}`)}},
+			calls: []Call{{Name: "broken", Arguments: `{}`}},
+		},
+		{
+			name:   "each bad call is counted once",
+			tools:  []Tool{editFile},
+			calls:  []Call{{Name: "nope", Arguments: `not json`}},
+			errors: 1,
+			kinds:  KindInvalidJSON,
+		},
+		{
+			name:  "distinct kinds are recorded together",
+			tools: []Tool{editFile},
+			calls: []Call{
+				{Name: "edit_file", Arguments: `{"path": "a.go"}`},
+				{Name: "edit_file", Arguments: `{`},
+				{Name: "nope", Arguments: `{}`},
+			},
+			errors: 2,
+			kinds:  KindInvalidJSON + "," + KindUnknownName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Validate(tc.tools, tc.calls)
+			if got.Errors != tc.errors {
+				t.Fatalf("errors = %d, want %d (kinds %q)", got.Errors, tc.errors, got.KindsString())
+			}
+			if got.KindsString() != tc.kinds {
+				t.Fatalf("kinds = %q, want %q", got.KindsString(), tc.kinds)
+			}
+			if got.Calls != len(tc.calls) {
+				t.Fatalf("calls = %d, want %d", got.Calls, len(tc.calls))
+			}
+			if got.Errored() != (tc.errors > 0) {
+				t.Fatalf("errored = %v, want %v", got.Errored(), tc.errors > 0)
+			}
+		})
+	}
+}
+
+func TestValidateNoCalls(t *testing.T) {
+	got := Validate([]Tool{editFile}, nil)
+	if got.Errored() || got.Calls != 0 || got.ToolsOffered != 1 {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}
+
+func TestCompileCaches(t *testing.T) {
+	first := compile(editFile.Schema)
+	second := compile(editFile.Schema)
+	if first == nil || first != second {
+		t.Fatalf("schema was recompiled instead of cached")
+	}
+}

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2673,6 +2673,20 @@ type LLMCall struct {
 	TotalCost          float64 `json:"total_cost"` // Prompt + completion + cache read + cache write
 	Stream             bool    `json:"stream"`
 	Error              string  `json:"error"`
+	// FinishReason is the provider's reason for stopping ("stop", "tool_calls",
+	// "length", ...). Anthropic's stop_reason is normalised onto the same
+	// vocabulary so the two proxies stay comparable.
+	FinishReason string `json:"finish_reason"`
+	// Tool call validity. ToolsOffered is how many tools the request carried,
+	// ToolCallsReturned how many calls came back, ToolCallErrors how many of
+	// those were structurally unusable, and ToolCallErrorKinds which buckets
+	// they fell into (see api/pkg/toolcall). Tools offered with no calls
+	// returned is not an error — it is a turn the model chose to answer in
+	// prose.
+	ToolsOffered       int    `json:"tools_offered"`
+	ToolCallsReturned  int    `json:"tool_calls_returned"`
+	ToolCallErrors     int    `json:"tool_call_errors"`
+	ToolCallErrorKinds string `json:"tool_call_error_kinds"`
 }
 
 // SecretScope controls which environment a project secret is injected into.
@@ -2895,6 +2909,15 @@ type UsageMetric struct {
 	DurationMs        int               `json:"duration_ms"`
 	RequestSizeBytes  int               `json:"request_size_bytes"`
 	ResponseSizeBytes int               `json:"response_size_bytes"`
+	// ToolCallRequests counts requests that returned at least one tool call,
+	// ToolCallErrorRequests how many of those returned at least one
+	// structurally invalid call. Stored as counters rather than a ratio so the
+	// daily/provider/model rollups can sum them — a stored ratio would have to
+	// be averaged, weighting a quiet day the same as a busy one. Sources with
+	// no request body (subscription/ACP usage) leave both at zero and so drop
+	// out of the denominator instead of diluting it.
+	ToolCallRequests      int `json:"tool_call_requests"`
+	ToolCallErrorRequests int `json:"tool_call_error_requests"`
 }
 
 type UsersAggregatedUsageMetric struct {
@@ -2945,6 +2968,9 @@ type AggregatedUsageMetric struct {
 	RequestSizeBytes  int     `json:"request_size_bytes"`
 	ResponseSizeBytes int     `json:"response_size_bytes"`
 	TotalRequests     int     `json:"total_requests"`
+
+	ToolCallRequests      int `json:"tool_call_requests"`
+	ToolCallErrorRequests int `json:"tool_call_error_requests"`
 }
 
 // UsageComputeDailyPoint is one day of sandbox compute spend, split by
@@ -2990,36 +3016,40 @@ type OrgComputeUsage struct {
 }
 
 type UsageBreakdownRow struct {
-	ID                string     `json:"id"`
-	Name              string     `json:"name"`
-	Email             string     `json:"email,omitempty"`
-	Username          string     `json:"username,omitempty"`
-	Provider          string     `json:"provider,omitempty"`
-	Model             string     `json:"model,omitempty"`
-	SessionID         string     `json:"session_id,omitempty"`
-	InteractionID     string     `json:"interaction_id,omitempty"`
-	PromptTokens      int        `json:"prompt_tokens"`
-	CompletionTokens  int        `json:"completion_tokens"`
-	TotalTokens       int        `json:"total_tokens"`
-	CacheReadTokens   int        `json:"cache_read_tokens"`
-	CacheWriteTokens  int        `json:"cache_write_tokens"`
-	PromptCost        float64    `json:"prompt_cost"`
-	CompletionCost    float64    `json:"completion_cost"`
-	CacheReadCost     float64    `json:"cache_read_cost"`
-	CacheWriteCost    float64    `json:"cache_write_cost"`
-	TotalCost         float64    `json:"total_cost"`
-	LatencyMs         float64    `json:"latency_ms"`
-	RequestSizeBytes  int        `json:"request_size_bytes"`
-	ResponseSizeBytes int        `json:"response_size_bytes"`
-	TotalRequests     int        `json:"total_requests"`
-	SessionCount      int        `json:"session_count"`
-	UniqueUsers       int        `json:"unique_users"`
-	UniqueSessions    int        `json:"unique_sessions"`
-	UniqueProjects    int        `json:"unique_projects"`
-	UniqueApps        int        `json:"unique_apps"`
-	StartedAt         *time.Time `json:"started_at,omitempty"`
-	EndedAt           *time.Time `json:"ended_at,omitempty"`
-	LastActivityAt    *time.Time `json:"last_activity_at,omitempty"`
+	ID                string  `json:"id"`
+	Name              string  `json:"name"`
+	Email             string  `json:"email,omitempty"`
+	Username          string  `json:"username,omitempty"`
+	Provider          string  `json:"provider,omitempty"`
+	Model             string  `json:"model,omitempty"`
+	SessionID         string  `json:"session_id,omitempty"`
+	InteractionID     string  `json:"interaction_id,omitempty"`
+	PromptTokens      int     `json:"prompt_tokens"`
+	CompletionTokens  int     `json:"completion_tokens"`
+	TotalTokens       int     `json:"total_tokens"`
+	CacheReadTokens   int     `json:"cache_read_tokens"`
+	CacheWriteTokens  int     `json:"cache_write_tokens"`
+	PromptCost        float64 `json:"prompt_cost"`
+	CompletionCost    float64 `json:"completion_cost"`
+	CacheReadCost     float64 `json:"cache_read_cost"`
+	CacheWriteCost    float64 `json:"cache_write_cost"`
+	TotalCost         float64 `json:"total_cost"`
+	LatencyMs         float64 `json:"latency_ms"`
+	RequestSizeBytes  int     `json:"request_size_bytes"`
+	ResponseSizeBytes int     `json:"response_size_bytes"`
+	TotalRequests     int     `json:"total_requests"`
+
+	ToolCallRequests      int `json:"tool_call_requests"`
+	ToolCallErrorRequests int `json:"tool_call_error_requests"`
+
+	SessionCount   int        `json:"session_count"`
+	UniqueUsers    int        `json:"unique_users"`
+	UniqueSessions int        `json:"unique_sessions"`
+	UniqueProjects int        `json:"unique_projects"`
+	UniqueApps     int        `json:"unique_apps"`
+	StartedAt      *time.Time `json:"started_at,omitempty"`
+	EndedAt        *time.Time `json:"ended_at,omitempty"`
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
 }
 
 type UsageModelTimeSeries struct {
@@ -3067,6 +3097,9 @@ type UsageCostBreakdownRow struct {
 	// and diverge from the provider breakdown whenever model info remaps it.
 	DurationMs    float64 `json:"-"`
 	TotalRequests int     `json:"-"`
+
+	ToolCallRequests      int `json:"-"`
+	ToolCallErrorRequests int `json:"-"`
 }
 
 type UsageFilterOption struct {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,9 +41,13 @@
             html,
             body {
                 height: 100%;
+                width: 100%;
                 margin: 0;
                 padding: 0;
                 overflow: hidden;
+                /* Belt and braces: nothing in a fixed-shell app should ever be
+                   able to introduce a horizontal scroll. */
+                overflow-x: hidden;
                 /* Stops a rubber-band at the end of an inner scroller from
                    chaining out to the document and dragging the whole app. */
                 overscroll-behavior: none;
@@ -63,10 +67,16 @@
                 position: fixed;
                 top: 0;
                 left: 0;
-                width: 100%;
+                right: 0;
+                width: auto;
+                max-width: 100%;
                 height: 100%;
                 height: 100svh;
-                height: var(--app-height, 100svh);
+                /* Never taller than the small viewport, so collapsing browser
+                   chrome cannot grow the shell into the space that chrome is
+                   about to reclaim; never taller than the visual viewport, so
+                   the on-screen keyboard shrinks it. */
+                height: min(var(--app-height, 100svh), 100svh);
                 overflow: hidden;
                 overscroll-behavior: none;
             }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,7 +40,17 @@
         <style>
             html,
             body {
+                /* Sized to the visible window, not to `100%`.
+                   `100%` resolves against the initial containing block, which
+                   real Mobile Safari reports as 714px while window.innerHeight
+                   is 712 — and those 2px are pannable. 2px is all Safari needs
+                   to treat the page as scrollable and start collapsing its
+                   chrome, which is what kept dragging the top bar out of view.
+                   Same clamp as the shell: follow the visual viewport, never
+                   exceed the small viewport. */
                 height: 100%;
+                height: 100svh;
+                height: min(var(--app-height, 100svh), 100svh);
                 width: 100%;
                 margin: 0;
                 padding: 0;
@@ -91,7 +101,7 @@
                    collapses — which slides a "fixed" shell out of view even
                    though nothing is scrollable. --app-offset-* follows that
                    pan; see the script below. */
-                transform: translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px));
+                transform: translateY(var(--app-offset-y, 0px));
                 overflow: hidden;
                 overscroll-behavior: none;
             }
@@ -113,12 +123,15 @@
                     // Resizing or moving the app for a zoom would be wrong, and
                     // jarring — leave the page alone and let the user pan it.
                     if (vv.scale > 1.01) {
-                        root.style.setProperty('--app-offset-x', '0px');
                         root.style.setProperty('--app-offset-y', '0px');
                         return;
                     }
                     root.style.setProperty('--app-height', vv.height + 'px');
-                    root.style.setProperty('--app-offset-x', vv.offsetLeft + 'px');
+                    // Vertical only. Translating horizontally as well pushed the
+                    // shell sideways inside a viewport that was already
+                    // accounting for the offset — costing pixels off one edge
+                    // and cutting the other. iOS only offsets horizontally
+                    // under a zoom, which is excluded above anyway.
                     root.style.setProperty('--app-offset-y', vv.offsetTop + 'px');
                 }
                 vv.addEventListener('resize', function () {
@@ -204,7 +217,14 @@
                         'root ' + (root ? Math.round(root.getBoundingClientRect().width) + 'x' +
                             Math.round(root.getBoundingClientRect().height) +
                             ' @' + Math.round(root.getBoundingClientRect().top) : 'n/a'),
-                        'safe t' + i[0] + ' r' + i[1] + ' b' + i[2] + ' l' + i[3]
+                        'safe t' + i[0] + ' r' + i[1] + ' b' + i[2] + ' l' + i[3],
+                        'html ' + getComputedStyle(de).height +
+                            '  body ' + getComputedStyle(document.body).height +
+                            '  se ' + (document.scrollingElement
+                                ? document.scrollingElement.scrollHeight + '/' +
+                                  document.scrollingElement.clientHeight +
+                                  ' top ' + Math.round(document.scrollingElement.scrollTop)
+                                : 'n/a')
                     ].join('\n');
                 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,21 +39,69 @@
         />
         <style>
             html,
-            body,
-            #root {
+            body {
                 height: 100%;
-                /* iOS Safari resolves height:100% against the LARGE viewport —
-                   the one you get with the browser chrome hidden — so a
-                   bottom-docked toolbar renders underneath the floating URL
-                   bar. svh is the small viewport: the height with that chrome
-                   showing, which is the only one guaranteed to be visible.
-                   The 100% above stays as the fallback for older engines. */
-                height: 100svh;
                 margin: 0;
                 padding: 0;
                 overflow: hidden;
+                /* Stops a rubber-band at the end of an inner scroller from
+                   chaining out to the document and dragging the whole app. */
+                overscroll-behavior: none;
+            }
+
+            /* The app shell is a fixed pane, not a tall page.
+               `overflow: hidden` on html/body is not a lock on iOS Safari — it
+               still pans the document, which is what slid the top bar up under
+               the status bar. A fixed root has nothing to scroll.
+               The height is `svh` (the small viewport: the height with the
+               browser chrome showing) rather than 100%, because iOS resolves
+               both `100%` and fixed positioning against the LARGE viewport —
+               the height you get with that chrome hidden — so a bottom-docked
+               toolbar would sit underneath the floating URL bar. `100%` stays
+               above as the fallback for engines without `svh`. */
+            #root {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                height: 100svh;
+                height: var(--app-height, 100svh);
+                overflow: hidden;
+                overscroll-behavior: none;
             }
         </style>
+        <script type="text/javascript">
+            // Pin the app shell to the visible area.
+            //
+            // #root is fixed at 100svh, which keeps it clear of the browser
+            // chrome — but svh is a constant, and the visible area is not. The
+            // on-screen keyboard shrinks it (a bottom-docked toolbar would end
+            // up behind the keyboard) and collapsing the URL bar grows it. The
+            // visual viewport reports both, so the shell follows it.
+            (function () {
+                var vv = window.visualViewport;
+                if (!vv) return;
+                var root = document.documentElement;
+                function sync() {
+                    // Pinch-zoom shrinks the visual viewport too. Resizing the
+                    // app for a zoom would be wrong, and jarring.
+                    if (vv.scale > 1.01) return;
+                    root.style.setProperty('--app-height', vv.height + 'px');
+                }
+                vv.addEventListener('resize', function () {
+                    sync();
+                    // iOS scrolls the layout viewport to reveal a focused
+                    // field. The shell is fixed, so that only slides it out of
+                    // alignment — which is what pushed the top bar under the
+                    // status bar. Put it back.
+                    if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
+                });
+                vv.addEventListener('scroll', sync);
+                window.addEventListener('orientationchange', sync);
+                sync();
+            })();
+        </script>
         <script type="text/javascript">
             // Set body bg + text color BEFORE React mounts so we don't flash
             // dark mode for users who prefer light. Mirrors the logic in

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,13 @@
             body,
             #root {
                 height: 100%;
+                /* iOS Safari resolves height:100% against the LARGE viewport —
+                   the one you get with the browser chrome hidden — so a
+                   bottom-docked toolbar renders underneath the floating URL
+                   bar. svh is the small viewport: the height with that chrome
+                   showing, which is the only one guaranteed to be visible.
+                   The 100% above stays as the fallback for older engines. */
+                height: 100svh;
                 margin: 0;
                 padding: 0;
                 overflow: hidden;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,97 @@
             })();
         </script>
         <script type="text/javascript">
+            // Viewport readout for debugging mobile layout: add ?vpdebug=1 to
+            // any URL (sticks until ?vpdebug=0). Off otherwise.
+            //
+            // The layout bugs that only appear on a real phone — the shell
+            // sliding under the status bar, a bottom bar behind the URL bar, a
+            // stray pixel of horizontal scroll — all come down to numbers no
+            // desktop browser can produce: iOS Safari's two viewports, its
+            // dynamic chrome, and the safe-area insets. This prints them, so a
+            // single screenshot from the device settles what is actually wrong
+            // instead of another round of guessing.
+            (function () {
+                var on = null;
+                try {
+                    var q = new URLSearchParams(window.location.search).get('vpdebug');
+                    if (q === '1') localStorage.setItem('vpdebug', '1');
+                    if (q === '0') localStorage.removeItem('vpdebug');
+                    on = localStorage.getItem('vpdebug') === '1';
+                } catch (e) {}
+                if (!on) return;
+
+                var el = document.createElement('div');
+                el.id = 'vpdebug';
+                el.style.cssText = [
+                    'position:fixed', 'z-index:2147483647', 'left:0', 'top:0', 'right:0',
+                    'font:11px/1.35 ui-monospace,monospace', 'white-space:pre',
+                    'background:rgba(0,0,0,0.82)', 'color:#0f0', 'padding:4px 6px',
+                    'pointer-events:none'
+                ].join(';');
+
+                function insets() {
+                    var probe = document.createElement('div');
+                    probe.style.cssText = 'position:fixed;top:0;left:0;' +
+                        'padding:env(safe-area-inset-top) env(safe-area-inset-right)' +
+                        ' env(safe-area-inset-bottom) env(safe-area-inset-left);' +
+                        'visibility:hidden;pointer-events:none';
+                    document.body.appendChild(probe);
+                    var cs = getComputedStyle(probe);
+                    var out = [cs.paddingTop, cs.paddingRight, cs.paddingBottom, cs.paddingLeft]
+                        .map(function (v) { return Math.round(parseFloat(v) || 0); });
+                    probe.remove();
+                    return out;
+                }
+
+                function unit(u) {
+                    var probe = document.createElement('div');
+                    probe.style.cssText = 'position:fixed;height:100' + u + ';visibility:hidden';
+                    document.body.appendChild(probe);
+                    var h = Math.round(probe.getBoundingClientRect().height);
+                    probe.remove();
+                    return h;
+                }
+
+                function render() {
+                    var vv = window.visualViewport;
+                    var de = document.documentElement;
+                    var root = document.getElementById('root');
+                    var i = insets();
+                    el.textContent = [
+                        'win  ' + window.innerWidth + 'x' + window.innerHeight +
+                            '  scroll ' + Math.round(window.scrollX) + ',' + Math.round(window.scrollY),
+                        'vv   ' + (vv ? Math.round(vv.width) + 'x' + Math.round(vv.height) +
+                            '  off ' + Math.round(vv.offsetLeft) + ',' + Math.round(vv.offsetTop) +
+                            '  scale ' + vv.scale.toFixed(2) : 'n/a'),
+                        'svh ' + unit('svh') + '  lvh ' + unit('lvh') + '  dvh ' + unit('dvh'),
+                        'doc  scrollWH ' + de.scrollWidth + 'x' + de.scrollHeight +
+                            '  clientWH ' + de.clientWidth + 'x' + de.clientHeight,
+                        'root ' + (root ? Math.round(root.getBoundingClientRect().width) + 'x' +
+                            Math.round(root.getBoundingClientRect().height) +
+                            ' @' + Math.round(root.getBoundingClientRect().top) : 'n/a'),
+                        'safe t' + i[0] + ' r' + i[1] + ' b' + i[2] + ' l' + i[3]
+                    ].join('\n');
+                }
+
+                function start() {
+                    document.body.appendChild(el);
+                    render();
+                    ['resize', 'scroll', 'orientationchange'].forEach(function (e) {
+                        window.addEventListener(e, render, { passive: true });
+                    });
+                    if (window.visualViewport) {
+                        window.visualViewport.addEventListener('resize', render);
+                        window.visualViewport.addEventListener('scroll', render);
+                    }
+                    setInterval(render, 500);
+                }
+
+                if (document.body) start();
+                else document.addEventListener('DOMContentLoaded', start);
+            })();
+        </script>
+        <script type="text/javascript">
             // Set body bg + text color BEFORE React mounts so we don't flash
             // dark mode for users who prefer light. Mirrors the logic in
             // contexts/theme.tsx getInitialMode().

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,21 @@
                    about to reclaim; never taller than the visual viewport, so
                    the on-screen keyboard shrinks it. */
                 height: min(var(--app-height, 100svh), 100svh);
+                /* `viewport-fit=cover` paints edge to edge, and svh includes
+                   the safe areas — without this the top bar sits under the
+                   status bar and the notch, and in landscape the edges of the
+                   UI are lost under the rounded corners. Everything inside the
+                   shell inherits the inset rather than repeating it. */
+                box-sizing: border-box;
+                padding: env(safe-area-inset-top) env(safe-area-inset-right)
+                         env(safe-area-inset-bottom) env(safe-area-inset-left);
+                /* Anchored to the visual viewport, not the layout viewport.
+                   `position: fixed` resolves against the layout viewport, and
+                   iOS Safari pans the visual viewport inside it as its chrome
+                   collapses — which slides a "fixed" shell out of view even
+                   though nothing is scrollable. --app-offset-* follows that
+                   pan; see the script below. */
+                transform: translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px));
                 overflow: hidden;
                 overscroll-behavior: none;
             }
@@ -94,10 +109,17 @@
                 if (!vv) return;
                 var root = document.documentElement;
                 function sync() {
-                    // Pinch-zoom shrinks the visual viewport too. Resizing the
-                    // app for a zoom would be wrong, and jarring.
-                    if (vv.scale > 1.01) return;
+                    // Pinch-zoom shrinks and offsets the visual viewport too.
+                    // Resizing or moving the app for a zoom would be wrong, and
+                    // jarring — leave the page alone and let the user pan it.
+                    if (vv.scale > 1.01) {
+                        root.style.setProperty('--app-offset-x', '0px');
+                        root.style.setProperty('--app-offset-y', '0px');
+                        return;
+                    }
                     root.style.setProperty('--app-height', vv.height + 'px');
+                    root.style.setProperty('--app-offset-x', vv.offsetLeft + 'px');
+                    root.style.setProperty('--app-offset-y', vv.offsetTop + 'px');
                 }
                 vv.addEventListener('resize', function () {
                     sync();

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2446,6 +2446,8 @@ export interface TypesAggregatedUsageMetric {
   request_size_bytes?: number;
   response_size_bytes?: number;
   sandbox_cost?: number;
+  tool_call_error_requests?: number;
+  tool_call_requests?: number;
   /** Prompt + completion + cache read + cache write */
   total_cost?: number;
   total_requests?: number;
@@ -4539,6 +4541,12 @@ export interface TypesLLMCall {
   created?: string;
   duration_ms?: number;
   error?: string;
+  /**
+   * FinishReason is the provider's reason for stopping ("stop", "tool_calls",
+   * "length", ...). Anthropic's stop_reason is normalised onto the same
+   * vocabulary so the two proxies stay comparable.
+   */
+  finish_reason?: string;
   id?: string;
   interaction_id?: string;
   model?: string;
@@ -4563,6 +4571,18 @@ export interface TypesLLMCall {
    * time to the full response.
    */
   time_to_first_token_ms?: number;
+  tool_call_error_kinds?: string;
+  tool_call_errors?: number;
+  tool_calls_returned?: number;
+  /**
+   * Tool call validity. ToolsOffered is how many tools the request carried,
+   * ToolCallsReturned how many calls came back, ToolCallErrors how many of
+   * those were structurally unusable, and ToolCallErrorKinds which buckets
+   * they fell into (see api/pkg/toolcall). Tools offered with no calls
+   * returned is not an error — it is a turn the model chose to answer in
+   * prose.
+   */
+  tools_offered?: number;
   /** Prompt + completion + cache read + cache write */
   total_cost?: number;
   total_tokens?: number;
@@ -8050,6 +8070,8 @@ export interface TypesUsageBreakdownRow {
   session_count?: number;
   session_id?: string;
   started_at?: string;
+  tool_call_error_requests?: number;
+  tool_call_requests?: number;
   total_cost?: number;
   total_requests?: number;
   total_tokens?: number;

--- a/frontend/src/components/agent/AgentHarness.tsx
+++ b/frontend/src/components/agent/AgentHarness.tsx
@@ -28,6 +28,10 @@ const harnessMeta: Record<string, HarnessMeta> = {
   deepseek_harness: { label: 'DeepSeek Harness', color: '#4d6bfe' },
   opencode: { label: 'opencode', color: '' },
   zed_agent: { label: 'Zed Agent', color: '' },
+  // An externally-driven Zed. Same mark, different label — it is not Helix's
+  // own agent turn.
+  zed_external: { label: 'External Agent', color: '' },
+  helix: { label: 'Helix', color: '' },
 }
 
 export const getAgentHarnessLabel = (runtime?: string): string => {
@@ -106,7 +110,7 @@ const HarnessMark: FC<{ runtime: string; size: number; color: string }> = ({ run
   if (runtime === 'goose_code') return <MaskMark runtime={runtime} src={gooseMark} size={size} color={color} />
   if (runtime === 'opencode') return <MaskMark runtime={runtime} src={openCodeMark} size={size} color={color} />
   if (runtime === 'deepseek_harness') return <MaskMark runtime={runtime} src={deepSeekHarnessMark} size={size} color={color} />
-  if (runtime === 'zed_agent') return <MaskMark runtime={runtime} src={zedAgentMark} size={size} color={color} />
+  if (runtime === 'zed_agent' || runtime === 'zed_external') return <MaskMark runtime={runtime} src={zedAgentMark} size={size} color={color} />
   return <Bot size={size} color={color} aria-hidden="true" />
 }
 

--- a/frontend/src/components/agent/CodeAgentExecutionControls.tsx
+++ b/frontend/src/components/agent/CodeAgentExecutionControls.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Divider,
+  IconButton,
   ListSubheader,
   Menu,
   MenuItem,
@@ -19,6 +20,7 @@ import {
   TypesSandboxRuntime,
 } from '../../api/api'
 import useSnackbar from '../../hooks/useSnackbar'
+import useIsPhone from '../../hooks/useIsPhone'
 import { useModelReasoningEfforts } from '../../hooks/useModelReasoningEfforts'
 import { getCodeAgentEffortOptions } from './CodeAgentEffortSelect'
 import { useHasEnabledCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
@@ -83,6 +85,7 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
   computeOnly = false,
   autoSelectDefault = false,
 }) => {
+  const isPhone = useIsPhone()
   const snackbar = useSnackbar()
   const [settingsAnchor, setSettingsAnchor] = useState<HTMLElement | null>(null)
   const [cpuAnchor, setCpuAnchor] = useState<HTMLElement | null>(null)
@@ -148,7 +151,24 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
       </Box>
     </Tooltip>
   ) : null
-  const computeControl = !onSandboxResourceOverridesChange ? null : (
+  // A phone's composer row has no width to spare, and the vCPU count is a
+  // setting you check rarely and change rarer. The chip alone still says which
+  // control this is, and the popover still says what it is set to.
+  const computeControl = !onSandboxResourceOverridesChange ? null : isPhone ? (
+    <Tooltip title={`Change sandbox size (${resources.vcpus} vCPU)`}>
+      <Box component="span" sx={{ display: 'inline-flex' }}>
+        <IconButton
+          size="small"
+          disabled={controlsDisabled}
+          aria-label={`Change sandbox size, currently ${resources.vcpus} vCPU`}
+          onClick={(event) => setCpuAnchor(event.currentTarget)}
+          sx={{ width: 28, height: 28, color: 'text.secondary', flexShrink: 0 }}
+        >
+          <Cpu size={17} />
+        </IconButton>
+      </Box>
+    </Tooltip>
+  ) : (
     <Tooltip title={`Change sandbox size (${resources.vcpus} vCPU)`}>
       <Box component="span" sx={{ display: 'inline-flex' }}>
         <Button

--- a/frontend/src/components/common/ContextUsageIndicator.tsx
+++ b/frontend/src/components/common/ContextUsageIndicator.tsx
@@ -110,8 +110,11 @@ export const ContextUsageIndicator: FC<ContextUsageIndicatorProps> = ({
         aria-valuemax={usageAvailable ? 100 : undefined}
         aria-valuenow={usageAvailable ? Math.round(percentage) : undefined}
         sx={{
-          width: 30,
-          height: 30,
+          // Matches the composer's icon buttons it sits beside — it was a 30px
+          // box around a 20px glyph next to 28px boxes around 17px ones, which
+          // read as one control being bigger than the rest.
+          width: 28,
+          height: 28,
           flexShrink: 0,
           display: 'flex',
           alignItems: 'center',
@@ -128,7 +131,7 @@ export const ContextUsageIndicator: FC<ContextUsageIndicatorProps> = ({
           component="svg"
           viewBox="0 0 20 20"
           aria-hidden="true"
-          sx={{ width: 20, height: 20, transform: 'rotate(-90deg)' }}
+          sx={{ width: 17, height: 17, transform: 'rotate(-90deg)' }}
         >
           <circle
             className="context-usage-track"

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -96,6 +96,15 @@ interface RobustPromptInputProps {
   placeholder?: string
   disabled?: boolean
   maxHeight?: number
+  /**
+   * Fill the height available instead of hugging the text.
+   *
+   * A phone composing a new task has a whole screen and a keyboard; a card
+   * floating in the middle of it wastes both. In fill mode the shell drops its
+   * card chrome, the text starts at the top, and the actions dock at the
+   * bottom — the shape every mobile compose screen has.
+   */
+  fill?: boolean
   sendMode?: 'queued' | 'direct'
   inlineImageAttachments?: boolean
   deferredFileAttachments?: boolean
@@ -521,6 +530,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   placeholder = 'Send message to agent...',
   disabled = false,
   maxHeight = 200,
+  fill = false,
   specTaskId,
   projectId,
   apiClient,
@@ -830,6 +840,9 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   const adjustHeight = useCallback(() => {
     const editor = enableSandboxCompletions ? sandboxEditorRef.current : textareaRef.current
     if (!editor) return
+    // In fill mode the height comes from the flex layout, and writing an inline
+    // height here would collapse it back to the content on every keystroke.
+    if (fill) return
 
     const oldHeight = editor.offsetHeight
     editor.style.height = 'auto'
@@ -840,7 +853,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
     if (oldHeight !== newHeight && onHeightChange) {
       onHeightChange()
     }
-  }, [enableSandboxCompletions, maxHeight, onHeightChange])
+  }, [enableSandboxCompletions, fill, maxHeight, onHeightChange])
 
   useEffect(() => {
     adjustHeight()
@@ -1328,6 +1341,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
         position: 'relative',
         width: '100%',
         minWidth: 0,
+        ...(fill && { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }),
       }}
     >
       {composerTrigger && (
@@ -1442,16 +1456,19 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          bgcolor: (theme) => getChatColors(theme).composerSurface,
-          borderRadius: hasVisibleQueue ? '0 0 22px 22px' : '22px',
-          border: '1px solid',
+          ...(fill && { flex: 1, minHeight: 0 }),
+          bgcolor: (theme) => fill ? 'transparent' : getChatColors(theme).composerSurface,
+          borderRadius: fill ? 0 : hasVisibleQueue ? '0 0 22px 22px' : '22px',
+          border: fill ? 'none' : '1px solid',
           borderColor: isDraggingOver
             ? 'primary.main'
             : !isOnline
             ? 'warning.main'
             : (theme) => getChatColors(theme).borderStrong,
           transition: 'border-color 0.15s, box-shadow 0.15s, background-color 0.15s',
-          boxShadow: isDraggingOver
+          boxShadow: fill
+            ? 'none'
+            : isDraggingOver
             ? (theme) => `0 0 0 2px ${alpha(theme.palette.primary.main, 0.22)}`
             : !isOnline
             ? (theme) => `0 0 0 2px ${alpha(theme.palette.warning.main, 0.2)}`
@@ -1563,8 +1580,9 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
               lineHeight: 1.55,
               letterSpacing: '-0.005em',
               p: 0,
-              minHeight: 70,
-              maxHeight: maxHeight,
+              ...(fill
+                ? { flex: 1, minHeight: 0, maxHeight: 'none', fontSize: '1.0625rem' }
+                : { minHeight: 70, maxHeight }),
               overflowY: 'auto',
               '&::placeholder': {
                 color: isDraggingOver
@@ -1591,6 +1609,13 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
             mt: 1.25,
             minWidth: 0,
             flexWrap: 'nowrap',
+            ...(fill && {
+              flexShrink: 0,
+              // Rather than truncate a control to "Buil…", let the row scroll.
+              overflowX: 'auto',
+              scrollbarWidth: 'none',
+              '&::-webkit-scrollbar': { display: 'none' },
+            }),
           }}
         >
           {leadingActions}

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -1581,7 +1581,13 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
               letterSpacing: '-0.005em',
               p: 0,
               ...(fill
-                ? { flex: 1, minHeight: 0, maxHeight: 'none', fontSize: '1.0625rem' }
+                ? {
+                    flex: 1,
+                    minHeight: 0,
+                    maxHeight: 'none',
+                    fontSize: '1.0625rem',
+                    overscrollBehavior: 'contain',
+                  }
                 : { minHeight: 70, maxHeight }),
               overflowY: 'auto',
               '&::placeholder': {

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -1575,7 +1575,8 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
               bgcolor: 'transparent',
               color: (theme) => getChatColors(theme).foreground,
               fontFamily: 'inherit',
-              fontSize: { xs: '0.9375rem', sm: '0.875rem' },
+              // 1rem on a phone, not 0.9375: under 16px iOS zooms in on focus.
+              fontSize: { xs: '1rem', sm: '0.875rem' },
               fontWeight: 450,
               lineHeight: 1.55,
               letterSpacing: '-0.005em',

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -1609,16 +1609,28 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
             mt: 1.25,
             minWidth: 0,
             flexWrap: 'nowrap',
-            ...(fill && {
-              flexShrink: 0,
-              // Rather than truncate a control to "Buil…", let the row scroll.
-              overflowX: 'auto',
-              scrollbarWidth: 'none',
-              '&::-webkit-scrollbar': { display: 'none' },
-            }),
+            ...(fill && { flexShrink: 0 }),
           }}
         >
-          {leadingActions}
+          {/* On a phone the model/sandbox controls are wider than the screen.
+              Only they scroll — attach and send stay pinned, because a send
+              button you have to scroll to find is worse than a cramped one. */}
+          {fill ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                minWidth: 0,
+                overflowX: 'auto',
+                scrollbarWidth: 'none',
+                '&::-webkit-scrollbar': { display: 'none' },
+                '& > *': { flexShrink: 0 },
+              }}
+            >
+              {leadingActions}
+            </Box>
+          ) : leadingActions}
 
           {leadingActions && (
             <Box

--- a/frontend/src/components/common/SandboxPromptEditor.tsx
+++ b/frontend/src/components/common/SandboxPromptEditor.tsx
@@ -215,7 +215,9 @@ const SandboxPromptEditor = forwardRef<HTMLDivElement, SandboxPromptEditorProps>
         bgcolor: 'transparent',
         color: (currentTheme) => getChatColors(currentTheme).foreground,
         fontFamily: 'inherit',
-        fontSize: { xs: '0.9375rem', sm: '0.875rem' },
+        // 1rem on a phone, not 0.9375: under 16px iOS zooms the page in when
+        // this takes focus — contenteditable is not exempt.
+        fontSize: { xs: '1rem', sm: '0.875rem' },
         fontWeight: 450,
         lineHeight: 1.55,
         letterSpacing: '-0.005em',

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -32,8 +32,10 @@ import helixLogo from '../../../assets/img/logo.png'
 import {
   buildCacheHitRatioChartData,
   getAggregateCacheHitRatio,
+  getAggregateToolCallErrorRate,
   getCacheHitRatio,
   getCacheUsageSeriesKey,
+  getToolCallErrorRate,
   getTotalInputTokens,
   getUncachedInputTokens,
 } from '../../utils/usageMetrics'
@@ -854,6 +856,37 @@ const OrgUsage: FC = () => {
     label: item.name || item.provider || 'Unknown',
     color: providerColor(item.provider || 'unknown', index, lightTheme.isLight),
   }))
+  // Tool call error rate per provider: of the requests that came back with
+  // tool calls, how many contained a call the caller could not dispatch —
+  // unparseable arguments, a tool that was never offered, or arguments that
+  // miss the tool's schema. It is a provider-quality signal, not an agent one:
+  // the same model behind two endpoints can differ here.
+  const toolCallErrorChartData = useMemo<UsageChartRow[]>(() => {
+    const byDate = new Map<string, UsageChartRow>()
+    for (const series of providerTimeSeries) {
+      const key = series.provider || 'unknown'
+      for (const metric of series.metrics || []) {
+        const date = metric.date || ''
+        let row = byDate.get(date)
+        if (!row) {
+          row = { date }
+          byDate.set(date, row)
+        }
+        // Days below the volume floor return null and stay absent from the
+        // row. That covers the zero-filled points the API emits for providers
+        // that weren't used that day, which would otherwise plot as a
+        // confident 0% rather than "no data".
+        const rate = getToolCallErrorRate(metric)
+        if (rate === null) continue
+        row[key] = rate
+      }
+    }
+    return Array.from(byDate.values()).sort((a, b) => String(a.date).localeCompare(String(b.date)))
+  }, [providerTimeSeries])
+  const toolCallErrorHeadline = useMemo(() => formatPercent(
+    getAggregateToolCallErrorRate(providerTimeSeries.flatMap(series => series.metrics || [])),
+  ), [providerTimeSeries])
+
   const latencyHeadline = useMemo(() => {
     const values = latencyChartData.flatMap(row => latencyChartSeries
       .map(s => Number(row[s.key]) || 0)
@@ -1269,6 +1302,20 @@ const OrgUsage: FC = () => {
                     />
                   </UsagePanel>
                 </Box>
+
+                <UsagePanel>
+                  <ShadcnAreaChart
+                    title="TOOL CALL ERROR RATE BY PROVIDER"
+                    headline={toolCallErrorHeadline}
+                    data={toolCallErrorChartData}
+                    series={providerChartSeries}
+                    valueFormatter={value => formatPercent(value)}
+                    stacked={false}
+                    zeroIsData
+                    variant="line"
+                    connectNulls
+                  />
+                </UsagePanel>
 
                 <UsagePanel>
                   <ShadcnAreaChart

--- a/frontend/src/components/orgs/UserOrgSelector.logic.test.ts
+++ b/frontend/src/components/orgs/UserOrgSelector.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  chatRailAction,
   isNavigationRouteActive,
   isOrgProjectSettingsRoute,
 } from './UserOrgSelector.logic'
@@ -30,5 +31,25 @@ describe('UserOrgSelector navigation state', () => {
 
   it('does not affect other routes with the same tab parameter', () => {
     expect(isOrgProjectSettingsRoute('projects', 'repositories')).toBe(false)
+  })
+})
+
+describe('chatRailAction', () => {
+  it('navigates and closes the drawer on a wide screen, as every rail entry does', () => {
+    expect(chatRailAction(false, false)).toEqual({ navigate: true, keepDrawerOpen: false })
+    expect(chatRailAction(false, true)).toEqual({ navigate: true, keepDrawerOpen: false })
+  })
+
+  it('keeps the list open on a phone — the drawer is the destination', () => {
+    expect(chatRailAction(true, false).keepDrawerOpen).toBe(true)
+    expect(chatRailAction(true, true).keepDrawerOpen).toBe(true)
+  })
+
+  it('brings a phone to the chat section when it is somewhere else', () => {
+    expect(chatRailAction(true, false).navigate).toBe(true)
+  })
+
+  it('leaves a thread the phone is already reading alone', () => {
+    expect(chatRailAction(true, true).navigate).toBe(false)
   })
 })

--- a/frontend/src/components/orgs/UserOrgSelector.logic.ts
+++ b/frontend/src/components/orgs/UserOrgSelector.logic.ts
@@ -20,3 +20,28 @@ export function isOrgProjectSettingsRoute(
     (tab === 'repositories' || tab === 'guidelines')
   )
 }
+
+export type ChatRailAction = {
+  /** Move to the chat section. */
+  navigate: boolean
+  /** Leave the nav drawer open rather than closing it behind the navigation. */
+  keepDrawerOpen: boolean
+}
+
+/**
+ * What tapping "Chat" in the nav rail should do.
+ *
+ * Every other rail entry opens a page in the main area, so closing the drawer
+ * behind it is right. Chat is the exception on a phone: the chat list lives IN
+ * the drawer, so closing it lands the user on an empty composer with the list
+ * they were reaching for hidden. And if they are already reading a thread,
+ * navigating would throw it away to show them a blank one — so the tap only
+ * opens the list.
+ */
+export function chatRailAction(
+  isPhone: boolean,
+  onChatRoute: boolean,
+): ChatRailAction {
+  if (!isPhone) return { navigate: true, keepDrawerOpen: false }
+  return { navigate: !onChatRoute, keepDrawerOpen: true }
+}

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -34,6 +34,7 @@ import useRouter from '../../hooks/useRouter'
 import useLightTheme from '../../hooks/useLightTheme'
 import useThemeConfig from '../../hooks/useThemeConfig'
 import useIsBigScreen from '../../hooks/useIsBigScreen'
+import useIsPhone from '../../hooks/useIsPhone'
 import TokenUsageDisplay from '../system/TokenUsageDisplay'
 import LowCreditsDisplay from '../system/LowCreditsDisplay'
 import SubscriptionStatusBanner from '../subscription/SubscriptionStatusBanner'
@@ -46,6 +47,7 @@ import { orgLandingRoute } from '../../utils/organizations'
 import { useSettingsDialog } from '../../contexts/settingsDialog'
 import { LIGHT_SIDEBAR_COLORS } from '../../styles/themeTokens'
 import {
+  chatRailAction,
   isNavigationRouteActive,
   isOrgProjectSettingsRoute,
 } from './UserOrgSelector.logic'
@@ -178,6 +180,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
   const lightTheme = useLightTheme()
   const themeConfig = useThemeConfig()
   const isBigScreen = useIsBigScreen()
+  const isPhone = useIsPhone()
   const settingsDialog = useSettingsDialog()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [loginDialogOpen, setLoginDialogOpen] = useState(false)
@@ -340,6 +343,16 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     account.setMobileMenuOpen(false)
   }
 
+  const handleChatClick = () => {
+    const action = chatRailAction(isPhone, isActive(['chat', 'session']))
+    if (!action.keepDrawerOpen) {
+      orgNavigateTo('chat')
+      return
+    }
+    if (action.navigate) account.orgNavigate('chat')
+    account.setMobileMenuOpen(true)
+  }
+
   const orgNavigateTo = (path: string, params: Record<string, any> = {}) => {
     // Check if this is navigation to an org page
     if (path.startsWith('org_') || (params && params.org_id)) {
@@ -392,7 +405,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         icon: <MessageCircle size={NAV_BUTTON_SIZE} />,
         tooltip: "AI chat assistant",
         isActive: isActive(['chat', 'session']),
-        onClick: () => orgNavigateTo('chat'),
+        onClick: handleChatClick,
         label: "Chat",
       },
       {
@@ -425,13 +438,15 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         onClick: () => orgNavigateTo('tasks'),
         label: "Tasks",
       },
-      {
+      // Sandboxes are a desktop workflow — a terminal, a file tree and an exec
+      // log are not usable on a phone, so the rail does not offer the trip.
+      ...(isPhone ? [] : [{
         icon: <Container size={NAV_BUTTON_SIZE} />,
         tooltip: "View sandboxes",
         isActive: isActive(['sandboxes', 'sandbox_detail']),
         onClick: () => orgNavigateTo('sandboxes'),
         label: "Sandbox",
-      },
+      }]),
       // TODO: re-enable once we have the files editor working
       // {
       //   icon: <FileText size={NAV_BUTTON_SIZE} />,
@@ -472,7 +487,8 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     }
 
     return baseButtons
-  }, [isActive, isOrgProjectSettings, currentOrgSlug, router.name])
+    // isPhone changes what tapping Chat does, so it belongs in here.
+  }, [isActive, isOrgProjectSettings, currentOrgSlug, router.name, isPhone])
 
   const isAccountSettingsActive = settingsDialog.activeDialog === 'account'
 

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -714,6 +714,13 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     return (
       <Box
         data-compact-user-menu
+        // The element `useUserMenuHeight` measures, so the sidebar's scroll
+        // column stops exactly where this menu starts. Marked explicitly rather
+        // than found by walking ancestors — see that hook. It is this box and
+        // not the wrapper above it, because in the expanded (non-compact) mode
+        // the wrapper is static and an absolutely-positioned child contributes
+        // nothing to its height.
+        data-user-menu-overlay
         sx={{
           position: 'absolute',
           left: 0,

--- a/frontend/src/components/session/NewChatProjectDialog.test.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import NewChatProjectDialog, { buildNewChatRows } from './NewChatProjectDialog'
+
+vi.mock('@mui/material/useMediaQuery', () => ({ default: () => false }))
+
+const projects = [
+  { id: 'prj_a', name: 'home stuff', github_repo_url: 'https://github.com/helixml/helix' },
+  { id: 'prj_b', name: 'webhookrelay', description: 'Relay for webhooks' },
+  { id: 'prj_c' },
+]
+
+describe('buildNewChatRows', () => {
+  it('offers a standalone chat ahead of the projects', () => {
+    const rows = buildNewChatRows(projects, '')
+    expect(rows.map((row) => row.key)).toEqual(['none', 'prj_a', 'prj_b', 'prj_c'])
+    expect(rows[0].target).toEqual({})
+    expect(rows[1].target).toEqual({ projectId: 'prj_a' })
+  })
+
+  it('names a project that has none', () => {
+    expect(buildNewChatRows(projects, '')[3].name).toBe('Untitled project')
+  })
+
+  it('matches every token, not the raw string — "hook relay" finds webhookrelay', () => {
+    expect(buildNewChatRows(projects, 'hook relay').map((row) => row.key)).toEqual(['prj_b'])
+  })
+
+  it('searches the detail line too', () => {
+    expect(buildNewChatRows(projects, 'helixml').map((row) => row.key)).toEqual(['prj_a'])
+  })
+
+  it('returns nothing when nothing matches', () => {
+    expect(buildNewChatRows(projects, 'zzz')).toEqual([])
+  })
+})
+
+describe('NewChatProjectDialog', () => {
+  const renderDialog = (onSelect = vi.fn(), onClose = vi.fn()) => {
+    render(
+      <NewChatProjectDialog open projects={projects} onClose={onClose} onSelect={onSelect} />,
+    )
+    return { onSelect, onClose }
+  }
+
+  it('starts the chat in the project that was clicked', () => {
+    const { onSelect, onClose } = renderDialog()
+
+    fireEvent.click(screen.getByLabelText('New chat in home stuff'))
+
+    expect(onSelect).toHaveBeenCalledWith({ projectId: 'prj_a' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('arrows down the list and picks with Enter', () => {
+    const { onSelect } = renderDialog()
+    const search = screen.getByLabelText('Search projects')
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith({ projectId: 'prj_a' })
+  })
+
+  it('wraps around the ends rather than sticking', () => {
+    const { onSelect } = renderDialog()
+    const search = screen.getByLabelText('Search projects')
+
+    // Up from the first row lands on the last.
+    fireEvent.keyDown(search, { key: 'ArrowUp' })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith({ projectId: 'prj_c' })
+  })
+
+  it('filters as you type', () => {
+    renderDialog()
+
+    fireEvent.change(screen.getByLabelText('Search projects'), { target: { value: 'webhook' } })
+
+    expect(screen.getByLabelText('New chat in webhookrelay')).toBeInTheDocument()
+    expect(screen.queryByLabelText('New chat in home stuff')).not.toBeInTheDocument()
+  })
+
+  it('keeps Enter safe when the filter empties the list', () => {
+    const { onSelect } = renderDialog()
+    const search = screen.getByLabelText('Search projects')
+
+    fireEvent.change(search, { target: { value: 'nothing matches this' } })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/session/NewChatProjectDialog.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.tsx
@@ -206,7 +206,8 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
           }}
           placeholder="Search…"
           inputProps={{ 'aria-label': 'Search projects' }}
-          sx={{ flex: 1, fontSize: '15px' }}
+          // 16px minimum: below it iOS zooms the page in on focus.
+          sx={{ flex: 1, fontSize: '16px' }}
         />
       </Box>
 

--- a/frontend/src/components/session/NewChatProjectDialog.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.tsx
@@ -144,6 +144,8 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
             ? {
                 m: 0,
                 borderRadius: 0,
+                height: '100%',
+                maxHeight: '100%',
                 pt: 'env(safe-area-inset-top)',
                 pb: 'env(safe-area-inset-bottom)',
               }
@@ -208,7 +210,16 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
         />
       </Box>
 
-      <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', py: 1 }}>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          WebkitOverflowScrolling: 'touch',
+          py: 1,
+        }}
+      >
         <Typography
           sx={{
             px: 2,

--- a/frontend/src/components/session/NewChatProjectDialog.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.tsx
@@ -1,0 +1,312 @@
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import InputBase from '@mui/material/InputBase'
+import Typography from '@mui/material/Typography'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
+
+import { ArrowLeft, Folder, MessagesSquare } from 'lucide-react'
+
+import type { TypesProject } from '../../api/api'
+import useLightTheme from '../../hooks/useLightTheme'
+import { matchesAllTokens } from '../../utils/searchUtils'
+
+export type NewChatTarget = { projectId?: string }
+
+type NewChatProjectDialogProps = {
+  open: boolean
+  projects: TypesProject[]
+  onClose: () => void
+  onSelect: (target: NewChatTarget) => void
+}
+
+type Row = {
+  key: string
+  name: string
+  detail: string
+  target: NewChatTarget
+  standalone?: boolean
+}
+
+const isMacPlatform = (): boolean =>
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform || '')
+
+/** Only the first nine rows can carry a modifier-digit shortcut. */
+const SHORTCUT_LIMIT = 9
+
+const projectDetail = (project: TypesProject): string =>
+  project.github_repo_url || project.description || ''
+
+export const buildNewChatRows = (projects: TypesProject[], query: string): Row[] => {
+  const rows: Row[] = [
+    {
+      key: 'none',
+      name: 'No project',
+      detail: 'A standalone chat, not attached to a repository',
+      target: {},
+      standalone: true,
+    },
+    ...projects.flatMap((project) => (project.id
+      ? [{
+          key: project.id,
+          name: project.name || 'Untitled project',
+          detail: projectDetail(project),
+          target: { projectId: project.id },
+        }]
+      : [])),
+  ]
+
+  return rows.filter((row) => matchesAllTokens(query, row.name, row.detail))
+}
+
+/**
+ * Pick where a new chat goes.
+ *
+ * The bottom-bar compose button on a phone and ⌘⇧O on the desktop both land
+ * here: choosing the project is the first decision of a new chat, and making it
+ * up front is also the quickest way to move between projects.
+ */
+const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
+  open,
+  projects,
+  onClose,
+  onSelect,
+}) => {
+  const theme = useTheme()
+  const lightTheme = useLightTheme()
+  const isNarrow = useMediaQuery(theme.breakpoints.down('sm'))
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const rows = useMemo(() => buildNewChatRows(projects, query), [projects, query])
+
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    setSelectedIndex(0)
+  }, [open])
+
+  // A filtered list can be shorter than the cursor that was sitting in it.
+  useEffect(() => {
+    setSelectedIndex((current) => (current >= rows.length ? Math.max(rows.length - 1, 0) : current))
+  }, [rows.length])
+
+  const choose = useCallback((row?: Row) => {
+    if (!row) return
+    onSelect(row.target)
+    onClose()
+  }, [onClose, onSelect])
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((current) => (rows.length ? (current + 1) % rows.length : 0))
+      return
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((current) => (rows.length ? (current - 1 + rows.length) % rows.length : 0))
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      choose(rows[selectedIndex])
+      return
+    }
+    // ⌘1…⌘9 jumps straight to a row, matching the hints in the list.
+    const modifier = isMacPlatform() ? event.metaKey : event.ctrlKey
+    if (modifier && /^[1-9]$/.test(event.key)) {
+      const index = Number(event.key) - 1
+      if (index < rows.length && index < SHORTCUT_LIMIT) {
+        event.preventDefault()
+        choose(rows[index])
+      }
+    }
+  }, [choose, rows, selectedIndex])
+
+  const shortcutLabel = isMacPlatform() ? '⌘' : 'Ctrl+'
+  const mutedColor = lightTheme.isLight ? 'rgba(113,113,122,0.9)' : 'rgba(163,163,163,0.75)'
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      fullScreen={isNarrow}
+      onKeyDown={handleKeyDown}
+      TransitionProps={{ onEntered: () => inputRef.current?.focus() }}
+      PaperProps={{
+        sx: {
+          ...(isNarrow
+            ? {
+                m: 0,
+                borderRadius: 0,
+                pt: 'env(safe-area-inset-top)',
+                pb: 'env(safe-area-inset-bottom)',
+              }
+            : {
+                position: 'fixed',
+                top: '12%',
+                m: 0,
+                borderRadius: '14px',
+              }),
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 2,
+          py: 1.5,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          component="button"
+          type="button"
+          aria-label="Close new chat picker"
+          onClick={onClose}
+          sx={{
+            appearance: 'none',
+            border: 0,
+            p: 0,
+            backgroundColor: 'transparent',
+            color: mutedColor,
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 30,
+            height: 30,
+            flexShrink: 0,
+            '&:hover': { color: 'text.primary' },
+          }}
+        >
+          <ArrowLeft size={18} />
+        </Box>
+        <InputBase
+          inputRef={inputRef}
+          autoFocus
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setSelectedIndex(0)
+          }}
+          placeholder="Search…"
+          inputProps={{ 'aria-label': 'Search projects' }}
+          sx={{ flex: 1, fontSize: '15px' }}
+        />
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', py: 1 }}>
+        <Typography
+          sx={{
+            px: 2,
+            py: 0.75,
+            fontSize: '11px',
+            fontWeight: 600,
+            letterSpacing: '0.4px',
+            color: mutedColor,
+          }}
+        >
+          Projects
+        </Typography>
+        {rows.length === 0 && (
+          <Typography sx={{ px: 2, py: 1.5, fontSize: '13px', color: mutedColor }}>
+            No projects match “{query}”.
+          </Typography>
+        )}
+        {rows.map((row, index) => (
+          <Box
+            key={row.key}
+            role="button"
+            tabIndex={-1}
+            data-new-chat-row={row.key}
+            aria-label={`New chat in ${row.name}`}
+            onMouseEnter={() => setSelectedIndex(index)}
+            onClick={() => choose(row)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              mx: 1,
+              px: 1.5,
+              // Comfortable to tap, and tall enough for two lines of text.
+              minHeight: 52,
+              borderRadius: '8px',
+              cursor: 'pointer',
+              backgroundColor: index === selectedIndex
+                ? (lightTheme.isLight ? 'rgba(0,0,0,0.05)' : 'rgba(241,243,247,0.09)')
+                : 'transparent',
+            }}
+          >
+            <Box sx={{ display: 'inline-flex', flexShrink: 0, color: mutedColor }}>
+              {row.standalone ? <MessagesSquare size={16} /> : <Folder size={16} />}
+            </Box>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography
+                noWrap
+                sx={{ fontSize: '14px', fontWeight: 500, lineHeight: '20px' }}
+              >
+                {row.name}
+              </Typography>
+              {row.detail && (
+                <Typography
+                  noWrap
+                  sx={{ fontSize: '12px', lineHeight: '16px', color: mutedColor }}
+                >
+                  {row.detail}
+                </Typography>
+              )}
+            </Box>
+            {index < SHORTCUT_LIMIT && !isNarrow && (
+              <Typography
+                sx={{
+                  flexShrink: 0,
+                  fontSize: '11px',
+                  color: mutedColor,
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {shortcutLabel}{index + 1}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      {!isNarrow && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            px: 2,
+            py: 1,
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            fontSize: '11px',
+            color: mutedColor,
+            flexShrink: 0,
+          }}
+        >
+          <span>↑↓ Navigate</span>
+          <span>Enter Select</span>
+          <span>Esc Close</span>
+        </Box>
+      )}
+    </Dialog>
+  )
+}
+
+export default NewChatProjectDialog

--- a/frontend/src/components/session/ProjectChatGroup.test.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.test.tsx
@@ -179,13 +179,98 @@ describe('ProjectChatGroup', () => {
       />,
     )
 
-    fireEvent.contextMenu(screen.getByRole('button', { name: /Project Test/ }))
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Project Test' }))
 
     expect(onOpenProjectContextMenu).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ id: 'project-test' }),
     )
     expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('starts a new chat when the project name is clicked, rather than collapsing', () => {
+    const onToggle = vi.fn()
+    const onNewTask = vi.fn()
+    render(
+      <ProjectChatGroup
+        orgId="org-test"
+        project={{ id: 'project-test', name: 'Project Test' }}
+        collapsed={false}
+        query=""
+        activeItemId=""
+        relativeTimeNow={Date.UTC(2026, 7, 6, 12, 0)}
+        enabled
+        participantIds={[]}
+        organizationMembers={[]}
+        archivingItemId={null}
+        onToggle={onToggle}
+        onNewTask={onNewTask}
+        onOpenItem={vi.fn()}
+        onOpenItemContextMenu={vi.fn()}
+        onArchiveItem={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'New task in Project Test' }))
+
+    expect(onNewTask).toHaveBeenCalled()
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('collapses from the chevron, and only from the chevron', () => {
+    const onToggle = vi.fn()
+    const onNewTask = vi.fn()
+    render(
+      <ProjectChatGroup
+        orgId="org-test"
+        project={{ id: 'project-test', name: 'Project Test' }}
+        collapsed={false}
+        query=""
+        activeItemId=""
+        relativeTimeNow={Date.UTC(2026, 7, 6, 12, 0)}
+        enabled
+        participantIds={[]}
+        organizationMembers={[]}
+        archivingItemId={null}
+        onToggle={onToggle}
+        onNewTask={onNewTask}
+        onOpenItem={vi.fn()}
+        onOpenItemContextMenu={vi.fn()}
+        onArchiveItem={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Project Test' }))
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onNewTask).not.toHaveBeenCalled()
+  })
+
+  it('keeps the name collapsing an archived group, which has no new task', () => {
+    const onToggle = vi.fn()
+    render(
+      <ProjectChatGroup
+        orgId="org-test"
+        project={{ id: 'project-test', name: 'Project Test' }}
+        collapsed={false}
+        query=""
+        activeItemId=""
+        relativeTimeNow={Date.UTC(2026, 7, 6, 12, 0)}
+        enabled
+        archived
+        participantIds={[]}
+        organizationMembers={[]}
+        archivingItemId={null}
+        onToggle={onToggle}
+        onOpenItem={vi.fn()}
+        onOpenItemContextMenu={vi.fn()}
+        onArchiveItem={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project Test' }))
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
   })
 
   it('shows a pin indicator next to a pinned chat', () => {

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -364,7 +364,11 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
             className="sidebar-group-new"
             component="button"
             type="button"
-            aria-label={`New task in ${groupName}`}
+            // The row around it already exposes this exact action, so to a
+            // screen reader this is a duplicate control with the same name —
+            // it stays as the visual hint and keeps out of the a11y tree.
+            aria-hidden="true"
+            tabIndex={-1}
             onClick={(event) => {
               event.stopPropagation()
               onNewTask()

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, MutableRefObject, useState } from 'react'
+import { FC, MouseEvent, MutableRefObject, ReactElement, useState } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -19,6 +19,8 @@ import {
 
 import type { TypesOrganizationMembership, TypesProject, TypesSessionSummary, TypesUser } from '../../api/api'
 import type { TypesPinnedChat } from '../../api/api'
+import useApps from '../../hooks/useApps'
+import useIsPhone from '../../hooks/useIsPhone'
 import useLightTheme from '../../hooks/useLightTheme'
 import useApi from '../../hooks/useApi'
 import { useListSessions } from '../../services/sessionService'
@@ -37,6 +39,9 @@ import type { SidebarItem } from './ProjectChatSidebar.logic'
 import type { SidebarThreadSortOrder } from './ProjectChatSidebar.logic'
 import type { SortableProjectHandleProps } from './SortableProject'
 import ProjectChatItemTooltip from './ProjectChatItemTooltip'
+import AgentHarness from '../agent/AgentHarness'
+import { GitBranch } from 'lucide-react'
+import { getProjectChatItemDetails, resolveProjectChatItemBranch } from './projectChatItemDetails'
 
 const SHOW_MORE_COUNT = 20
 
@@ -108,6 +113,10 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
 }) => {
   const api = useApi()
   const lightTheme = useLightTheme()
+  const { apps } = useApps()
+  // No hover on a phone, so the facts the tooltip carries have to live on the
+  // row itself. That makes the row two lines, and taller.
+  const isPhone = useIsPhone()
   const [additionalVisibleCount, setAdditionalVisibleCount] = useState(0)
   const visibleCount = visibleThreadCount + additionalVisibleCount
   const projectId = project?.id
@@ -209,6 +218,8 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
   const isFetchingMore = sessionsQuery.isFetching || tasksQuery.isFetching
   const hasError = sessionsQuery.isError || tasksQuery.isError
   const archiveVerb = archived ? 'Unarchive' : 'Archive'
+  // Archived groups have no "new task", so there the name keeps its old job.
+  const activateGroup = onNewTask || onToggle
   const paginationButtonSx = {
     appearance: 'none',
     border: 0,
@@ -247,7 +258,10 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
             event.stopPropagation()
             return
           }
-          onToggle()
+          // The name is the project's primary action: start work here. Only the
+          // chevron collapses, so reaching a project no longer costs a round
+          // trip through a collapse you did not want.
+          activateGroup()
         }}
         onContextMenu={(event) => {
           if (!project || !onOpenProjectContextMenu) return
@@ -259,9 +273,10 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
           if (event.target !== event.currentTarget) return
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault()
-            onToggle()
+            activateGroup()
           }
         }}
+        aria-label={onNewTask ? `New task in ${groupName}` : groupName}
         sx={{
           width: '100%',
           height: 32,
@@ -288,7 +303,40 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
           } : undefined,
         }}
       >
-        {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+        <Box
+          component="button"
+          type="button"
+          aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${groupName}`}
+          aria-expanded={!collapsed}
+          // Must not reach the row's click (new chat) or the drag sensor.
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggle()
+          }}
+          sx={{
+            appearance: 'none',
+            border: 0,
+            p: 0,
+            m: 0,
+            backgroundColor: 'transparent',
+            color: 'inherit',
+            cursor: 'pointer',
+            flexShrink: 0,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            // A 13px glyph is not a touch target; the box around it is.
+            width: isPhone ? 28 : 16,
+            height: isPhone ? 28 : 16,
+            borderRadius: '4px',
+            '&:hover': {
+              backgroundColor: lightTheme.isLight ? 'rgba(0,0,0,0.06)' : 'rgba(241,243,247,0.12)',
+            },
+          }}
+        >
+          {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+        </Box>
         <Folder size={14} style={{ opacity: 0.72 }} />
         <Typography
           component="span"
@@ -382,12 +430,29 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
             const taskPersonId = item.task?.assignee_id || item.task?.created_by || ''
             const taskPerson = resolveOrganizationUser(taskPersonId, organizationMembers, currentUser)
             const taskPersonRole = item.task?.assignee_id ? 'Assigned to' : 'Created by'
+            const branch = resolveProjectChatItemBranch(item, project?.default_branch)
+            // Only resolved for the phone layout — on desktop the tooltip does
+            // its own lookup when it actually opens.
+            const details = isPhone
+              ? getProjectChatItemDetails({ item, apps, repository: repositoryName, branch })
+              : undefined
+            const subLine = details
+              ? [
+                  details.branch && { key: 'branch', icon: <GitBranch size={11} />, value: details.branch },
+                  details.harness && {
+                    key: 'harness',
+                    icon: <AgentHarness runtime={details.runtime || ''} variant="short" size={11} showTooltip={false} />,
+                    value: details.harness,
+                  },
+                ].filter(Boolean) as Array<{ key: string; icon: ReactElement; value: string }>
+              : []
             return (
               <ProjectChatItemTooltip
                 key={`${item.kind}:${item.id}`}
                 item={item}
                 repository={repositoryName}
-                branch={item.task?.branch_name || item.task?.base_branch || project?.default_branch}
+                branch={branch}
+                disabled={isPhone}
               >
               <Box
                 className="project-chat-item"
@@ -405,12 +470,14 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                 sx={{
                   width: '100%',
                   minWidth: 0,
-                  height: 32,
+                  // Two lines and a 48px touch target on a phone; the dense
+                  // single-line row everywhere else.
+                  ...(isPhone
+                    ? { minHeight: 52, py: 0.75, flexDirection: 'column', alignItems: 'stretch', gap: 0.25 }
+                    : { height: 32, flexDirection: 'row', alignItems: 'center', gap: 0.75 }),
                   px: 1,
                   borderRadius: '6px',
                   display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.75,
                   color: active
                     ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
                     : (lightTheme.isLight ? '#71717a' : 'rgba(163,163,163,0.80)'),
@@ -429,12 +496,30 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                   },
                   '&:hover .sidebar-item-time, &:focus-within .sidebar-item-time': { opacity: 0 },
                   '&:hover .sidebar-item-archive, &:focus-within .sidebar-item-archive': { opacity: 1 },
+                  // Without hover the archive button can never appear, so on a
+                  // coarse pointer it is always shown. On a phone it gets its
+                  // own column instead (below), so the time stays visible too.
                   '@media (hover: none)': {
-                    '& .sidebar-item-time': { opacity: 0 },
+                    '& .sidebar-item-time': { opacity: isPhone ? 1 : 0 },
                     '& .sidebar-item-archive': { opacity: 1 },
                   },
+                  ...(isPhone && {
+                    // Rows are tall enough on a phone that adjacent ones read as
+                    // one block without a divider between them.
+                    borderBottom: '1px solid',
+                    borderColor: lightTheme.isLight
+                      ? 'rgba(0,0,0,0.06)'
+                      : 'rgba(241,243,247,0.07)',
+                    borderRadius: 0,
+                    '&:last-of-type': { borderBottom: 'none' },
+                  }),
                 }}
               >
+                <Box
+                  sx={isPhone
+                    ? { display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, width: '100%' }
+                    : { display: 'contents' }}
+                >
                 {item.kind === 'spec-task' && (
                   <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
                     <Tooltip title={pullRequestIcon?.tooltip || ''}>
@@ -539,14 +624,19 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                     </Box>
                   </Tooltip>
                 )}
-                <Box sx={{ width: 28, height: 28, flexShrink: 0, position: 'relative' }}>
+                <Box
+                  sx={isPhone
+                    ? { display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }
+                    : { width: 28, height: 28, flexShrink: 0, position: 'relative' }}
+                >
                   <Typography
                     className="sidebar-item-time"
                     component="span"
                     title={item.updatedAt ? new Date(item.updatedAt).toLocaleString() : undefined}
                     sx={{
-                      position: 'absolute',
-                      inset: 0,
+                      ...(isPhone
+                        ? { position: 'static' }
+                        : { position: 'absolute', inset: 0 }),
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'flex-end',
@@ -573,12 +663,9 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                         onArchiveItem(item)
                       }}
                       sx={{
-                        position: 'absolute',
-                        top: 0,
-                        right: 0,
-                        bottom: 0,
-                        width: 20,
-                        height: 28,
+                        ...(isPhone
+                          ? { position: 'static', width: 28, height: 28 }
+                          : { position: 'absolute', top: 0, right: 0, bottom: 0, width: 20, height: 28 }),
                         opacity: 0,
                         color: 'inherit',
                         transition: 'opacity 100ms ease',
@@ -590,6 +677,50 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
                     </IconButton>
                   </Tooltip>
                 </Box>
+                </Box>
+                {isPhone && subLine.length > 0 && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.25,
+                      minWidth: 0,
+                      color: lightTheme.isLight
+                        ? 'rgba(113,113,122,0.85)'
+                        : 'rgba(163,163,163,0.72)',
+                    }}
+                  >
+                    {subLine.map((entry) => (
+                      <Box
+                        key={entry.key}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 0.5,
+                          minWidth: 0,
+                          // The branch takes the slack; the harness name is
+                          // short and should stay whole.
+                          flexShrink: entry.key === 'branch' ? 1 : 0,
+                        }}
+                      >
+                        <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>{entry.icon}</Box>
+                        <Typography
+                          component="span"
+                          sx={{
+                            minWidth: 0,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            fontSize: '11px',
+                            lineHeight: '15px',
+                          }}
+                        >
+                          {entry.value}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                )}
               </Box>
               </ProjectChatItemTooltip>
             )

--- a/frontend/src/components/session/ProjectChatItemTooltip.tsx
+++ b/frontend/src/components/session/ProjectChatItemTooltip.tsx
@@ -4,67 +4,36 @@ import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { BrainCircuit, Cpu, FolderGit2, GitBranch, Monitor, SquareTerminal } from 'lucide-react'
 
-import { TypesSandboxRuntime } from '../../api/api'
 import useApps from '../../hooks/useApps'
-import { effectiveSpecTaskSandboxRuntime } from '../../utils/specTaskSandboxRuntime'
-import AgentHarness, { getAgentHarnessModel, getAgentHarnessRuntime } from '../agent/AgentHarness'
+import AgentHarness from '../agent/AgentHarness'
+import { getProjectChatItemDetails } from './projectChatItemDetails'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
 
 type ProjectChatItemTooltipProps = {
   item: SidebarItem
   repository?: string
   branch?: string
+  /**
+   * Phones show the same facts on the row's second line, so the tooltip would
+   * be a duplicate they cannot dismiss.
+   */
+  disabled?: boolean
   children: ReactElement
-}
-
-const runtimeLabel = (runtime?: string): string => {
-  switch (runtime) {
-    case 'claude_code': return 'Claude Code'
-    case 'codex_cli': return 'Codex'
-    case 'qwen_code': return 'Qwen Code'
-    case 'goose_code': return 'Goose'
-    case 'opencode': return 'opencode'
-    case 'deepseek_harness': return 'DeepSeek Harness'
-    case 'zed_agent': return 'Zed Agent'
-    case 'zed_external': return 'External Agent'
-    case 'helix': return 'Helix'
-    default: return runtime || ''
-  }
-}
-
-const sandboxDetails = (item: SidebarItem): { compute?: string; environment?: string } => {
-  if (item.kind !== 'spec-task' || !item.task) return {}
-
-  const vcpus = item.task.sandbox_resource_overrides?.vcpus || 4
-  const memoryMb = item.task.sandbox_resource_overrides?.memory_mb || 8192
-  const memory = memoryMb % 1024 === 0
-    ? `${memoryMb / 1024} GB RAM`
-    : `${memoryMb} MB RAM`
-  const environment = effectiveSpecTaskSandboxRuntime(item.task.sandbox_runtime)
-    === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
-    ? 'Headless'
-    : 'Full Desktop'
-
-  return { compute: `${vcpus} vCPU · ${memory}`, environment }
 }
 
 const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
   item,
   repository,
   branch,
+  disabled = false,
   children,
 }) => {
   const { apps } = useApps()
-  const configuredAppID = item.kind === 'spec-task' ? undefined : item.session?.app_id
-  const configuredApp = apps.find((app) => app.id === configuredAppID)
-  const runtime = item.task?.code_agent_config?.runtime || (configuredApp
-    ? getAgentHarnessRuntime(configuredApp)
-    : item.session?.metadata?.code_agent_runtime || item.session?.metadata?.agent_type)
-  const harness = runtimeLabel(runtime)
-  const model = item.task?.code_agent_config?.model || (configuredApp
-    ? getAgentHarnessModel(configuredApp)
-    : item.session?.model_name)
-  const { compute, environment } = sandboxDetails(item)
+  const details = getProjectChatItemDetails({ item, apps, repository, branch })
+  const { harness, model, compute, environment, runtime } = details
+
+  if (disabled) return children
+
   const rows = [
     repository && { icon: <FolderGit2 size={13} />, value: repository },
     branch && { icon: <GitBranch size={13} />, value: branch },

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -484,6 +484,12 @@ const ProjectChatSidebar: FC<{
     }
   }
 
+  // Starting a chat has its own button in the phone's bottom bar, so a project
+  // row there does not need to offer it a second time. Without a "new task"
+  // handler the row goes back to collapsing the group — which is the only thing
+  // left for it to do, and what the chevron beside it already suggests.
+  const groupsOfferNewTask = !showArchived && !isPhone
+
   const effectiveCollapsedGroups = query ? new Set<string>() : collapsedGroups
   // The desktop toolbar's controls, reused verbatim in the phone's filter sheet
   // so the two surfaces cannot offer different filters.
@@ -732,7 +738,7 @@ const ProjectChatSidebar: FC<{
               pinnedChats={pinnedChats}
               archivingItemId={archivingItemId}
               onToggle={() => toggleGroup('default')}
-              onNewTask={showArchived ? undefined : () => account.orgNavigate('chat')}
+              onNewTask={groupsOfferNewTask ? () => account.orgNavigate('chat') : undefined}
               onOpenItem={openItem}
               onOpenItemContextMenu={openItemContextMenu}
               onArchiveItem={requestArchive}
@@ -772,9 +778,9 @@ const ProjectChatSidebar: FC<{
                         pinnedChats={pinnedChats}
                         archivingItemId={archivingItemId}
                         onToggle={() => toggleGroup(project.id!)}
-                        onNewTask={showArchived
-                          ? undefined
-                          : () => account.orgNavigate('chat', {}, { project_id: project.id })}
+                        onNewTask={groupsOfferNewTask
+                          ? () => account.orgNavigate('chat', {}, { project_id: project.id })
+                          : undefined}
                         onOpenItem={openItem}
                         onOpenItemContextMenu={openItemContextMenu}
                         onOpenProjectContextMenu={openProjectContextMenu}

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../api/api'
 import type { TypesAzureDevOps, TypesGitRepository, TypesProject } from '../../api/api'
 import useAccount from '../../hooks/useAccount'
+import useIsPhone from '../../hooks/useIsPhone'
 import useLightTheme from '../../hooks/useLightTheme'
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
@@ -62,6 +63,9 @@ import SortableProject from './SortableProject'
 import useProjectChatSidebarDrag from './useProjectChatSidebarDrag'
 import useProjectChatSidebarPreferences from './useProjectChatSidebarPreferences'
 import ChatSidebarBrandHeader from './ChatSidebarBrandHeader'
+import NewChatProjectDialog from './NewChatProjectDialog'
+import type { NewChatTarget } from './NewChatProjectDialog'
+import ProjectChatSidebarMobileBar, { MOBILE_BAR_CLEARANCE } from './ProjectChatSidebarMobileBar'
 
 const RELATIVE_TIME_REFRESH_MS = 15000
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
@@ -96,6 +100,7 @@ const ProjectChatSidebar: FC<{
 }> = ({ onCollapse, onOpenSession }) => {
   const account = useAccount()
   const router = useRouter()
+  const isPhone = useIsPhone()
   const lightTheme = useLightTheme()
   const snackbar = useSnackbar()
   const { openDialog } = useSettingsDialog()
@@ -118,6 +123,7 @@ const ProjectChatSidebar: FC<{
   const [projectContextMenuPosition, setProjectContextMenuPosition] = useState<ProjectChatContextMenuPosition | null>(null)
   const [archivingItemId, setArchivingItemId] = useState<string | null>(null)
   const [createProjectOpen, setCreateProjectOpen] = useState(false)
+  const [newChatPickerOpen, setNewChatPickerOpen] = useState(false)
   const [showArchived, setShowArchived] = useState(false)
   const [chatShortcutsVisible, setChatShortcutsVisible] = useState(false)
   const sidebarRef = useRef<HTMLDivElement | null>(null)
@@ -211,25 +217,31 @@ const ProjectChatSidebar: FC<{
     setManualProjectOrder,
   )
 
-  const openNewThread = useCallback(() => {
+  // Which project a chat belongs to is its first real decision, and picking it
+  // up front doubles as the quickest way to move between projects — so the
+  // compose affordances open the picker rather than dropping you into whichever
+  // project you happened to be looking at.
+  const openNewChatPicker = useCallback(() => setNewChatPickerOpen(true), [])
+
+  const startNewChat = useCallback(({ projectId }: NewChatTarget) => {
     setShowArchived(false)
-    account.orgNavigate('chat')
+    account.orgNavigate('chat', {}, projectId ? { project_id: projectId } : {})
     onOpenSession()
   }, [account, onOpenSession])
 
-  // openNewThread is the only dependency; keeping it in the array (rather than a
-  // route id) is what stops the listener from calling a stale navigate closure.
+  // openNewChatPicker is the only dependency; keeping it in the array (rather
+  // than a route id) is what stops the listener from calling a stale closure.
   useEffect(() => {
     const handleNewThreadShortcut = (event: KeyboardEvent) => {
       if (!isNewThreadShortcut(event)) return
 
       event.preventDefault()
-      openNewThread()
+      openNewChatPicker()
     }
 
     window.addEventListener('keydown', handleNewThreadShortcut, { capture: true })
     return () => window.removeEventListener('keydown', handleNewThreadShortcut, { capture: true })
-  }, [openNewThread])
+  }, [openNewChatPicker])
 
   useEffect(() => {
     const sidebar = sidebarRef.current
@@ -473,90 +485,10 @@ const ProjectChatSidebar: FC<{
   }
 
   const effectiveCollapsedGroups = query ? new Set<string>() : collapsedGroups
-  const groupsEnabled = !!account.user?.id && !!orgId
-
-  return (
-    <Box
-      ref={sidebarRef}
-      data-chat-shortcuts-visible={chatShortcutsVisible}
-      sx={{
-        height: '100%',
-        minHeight: 0,
-        display: 'flex',
-        flexDirection: 'column',
-        fontFamily: T3_FONT_FAMILY,
-        color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-        backgroundColor: lightTheme.isLight ? '#fafafa' : '#000000',
-        '& .MuiTypography-root': { fontFamily: 'inherit' },
-        '&[data-chat-shortcuts-visible="true"] .project-chat-item[data-chat-shortcut]::after': {
-          content: 'attr(data-chat-shortcut)',
-          position: 'absolute',
-          right: 42,
-          top: 7,
-          width: 14,
-          height: 18,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderRadius: '4px',
-          color: lightTheme.isLight ? '#52525b' : '#d4d4d8',
-          backgroundColor: lightTheme.isLight ? 'rgba(39,39,42,0.08)' : 'rgba(241,243,247,0.12)',
-          fontSize: '10px',
-          fontWeight: 600,
-          lineHeight: 1,
-          fontVariantNumeric: 'tabular-nums',
-          pointerEvents: 'none',
-          zIndex: 1,
-        },
-        '&[data-chat-shortcuts-visible="true"] .project-chat-item[data-chat-shortcut] .sidebar-item-pin': {
-          opacity: 0,
-        },
-      }}
-    >
-      <ChatSidebarBrandHeader onCollapse={onCollapse} />
-
-      <Box
-        sx={{
-          height: 60,
-          minHeight: 60,
-          px: 1.5,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 0.5,
-        }}
-      >
-        <Search size={15} color="currentColor" style={{ opacity: 0.55, flexShrink: 0 }} />
-        <InputBase
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search"
-          inputProps={{ 'aria-label': 'Search' }}
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            color: 'inherit',
-            fontFamily: 'inherit',
-            fontSize: '14px',
-            fontWeight: 500,
-            '& input::placeholder': {
-              color: lightTheme.isLight ? '#71717a' : '#a3a3a3',
-              opacity: 1,
-            },
-          }}
-        />
-        <Tooltip title="New thread (⌘⇧O / Ctrl+Shift+O)">
-          <IconButton
-            size="small"
-            onClick={openNewThread}
-            aria-label="New thread"
-            aria-keyshortcuts="Meta+Shift+O Control+Shift+O"
-          >
-            <SquarePen size={16} strokeWidth={1.7} />
-          </IconButton>
-        </Tooltip>
-      </Box>
-
-      <Box sx={{ pl: 0.75, pr: 0.75, pt: 1.25, pb: 0.5, display: 'flex', alignItems: 'center' }}>
+  // The desktop toolbar's controls, reused verbatim in the phone's filter sheet
+  // so the two surfaces cannot offer different filters.
+  const filterControls = (
+    <>
         <ProjectChatSidebarProjectFilter
           projects={projects}
           selectedProjectId={projectFilter}
@@ -613,15 +545,165 @@ const ProjectChatSidebar: FC<{
             </span>
           </Tooltip>
         )}
-      </Box>
+    </>
+  )
+  const groupsEnabled = !!account.user?.id && !!orgId
+
+  return (
+    <Box
+      ref={sidebarRef}
+      data-chat-shortcuts-visible={chatShortcutsVisible}
+      sx={{
+        height: '100%',
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        // Positioning context for the phone's floating bottom bar.
+        position: 'relative',
+        fontFamily: T3_FONT_FAMILY,
+        color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
+        backgroundColor: lightTheme.isLight ? '#fafafa' : '#000000',
+        '& .MuiTypography-root': { fontFamily: 'inherit' },
+        '&[data-chat-shortcuts-visible="true"] .project-chat-item[data-chat-shortcut]::after': {
+          content: 'attr(data-chat-shortcut)',
+          position: 'absolute',
+          right: 42,
+          top: 7,
+          width: 14,
+          height: 18,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '4px',
+          color: lightTheme.isLight ? '#52525b' : '#d4d4d8',
+          backgroundColor: lightTheme.isLight ? 'rgba(39,39,42,0.08)' : 'rgba(241,243,247,0.12)',
+          fontSize: '10px',
+          fontWeight: 600,
+          lineHeight: 1,
+          fontVariantNumeric: 'tabular-nums',
+          pointerEvents: 'none',
+          zIndex: 1,
+        },
+        '&[data-chat-shortcuts-visible="true"] .project-chat-item[data-chat-shortcut] .sidebar-item-pin': {
+          opacity: 0,
+        },
+      }}
+    >
+      <ChatSidebarBrandHeader onCollapse={onCollapse} />
+
+      {!isPhone && (
+        <>
+        <Box
+          sx={{
+            height: 60,
+            minHeight: 60,
+            px: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+          }}
+        >
+          <Search size={15} color="currentColor" style={{ opacity: 0.55, flexShrink: 0 }} />
+          <InputBase
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search"
+            inputProps={{ 'aria-label': 'Search' }}
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              color: 'inherit',
+              fontFamily: 'inherit',
+              fontSize: '14px',
+              fontWeight: 500,
+              '& input::placeholder': {
+                color: lightTheme.isLight ? '#71717a' : '#a3a3a3',
+                opacity: 1,
+              },
+            }}
+          />
+          <Tooltip title="New thread (⌘⇧O / Ctrl+Shift+O)">
+            <IconButton
+              size="small"
+              onClick={openNewChatPicker}
+              aria-label="New thread"
+              aria-keyshortcuts="Meta+Shift+O Control+Shift+O"
+            >
+              <SquarePen size={16} strokeWidth={1.7} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Box sx={{ pl: 0.75, pr: 0.75, pt: 1.25, pb: 0.5, display: 'flex', alignItems: 'center' }}>
+          <ProjectChatSidebarProjectFilter
+            projects={projects}
+            selectedProjectId={projectFilter}
+            archived={showArchived}
+            onChange={selectProjectFilter}
+          />
+          {!focusMode && (
+            <ProjectChatSidebarOptions
+              projectSortOrder={preferences.projectSortOrder}
+              threadSortOrder={preferences.threadSortOrder}
+              visibleThreadCount={preferences.visibleThreadCount}
+              onProjectSortOrderChange={setProjectSortOrder}
+              onThreadSortOrderChange={setThreadSortOrder}
+              onVisibleThreadCountChange={setVisibleThreadCount}
+            />
+          )}
+          <ProjectChatSidebarPeopleFilter
+            members={selectableMembers}
+            currentUser={account.user}
+            selectedUserIds={selectedParticipantIds}
+            onSelectedUserIdsChange={updateSelectedParticipantIds}
+          />
+          <Tooltip title={showArchived ? 'Back to active chats' : 'Show archived'}>
+            <IconButton
+              size="small"
+              onClick={() => setShowArchived((current) => !current)}
+              aria-label={showArchived ? 'Back to active chats' : 'Show archived'}
+              aria-pressed={showArchived}
+              sx={{
+                color: showArchived
+                  ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
+                  : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.55)'),
+              }}
+            >
+              <Archive size={15} strokeWidth={1.7} />
+            </IconButton>
+          </Tooltip>
+          {!showArchived && (
+            <Tooltip title="New project">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => setCreateProjectOpen(true)}
+                  disabled={!account.user?.id || !orgId}
+                  aria-label="New project"
+                  sx={{
+                    color: lightTheme.isLight
+                      ? 'rgba(113,113,122,0.65)'
+                      : 'rgba(163,163,163,0.55)',
+                  }}
+                >
+                  <FolderPlus size={15} strokeWidth={1.7} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+        </Box>
+        </>
+      )}
 
       <Box
         sx={{
           flex: 1,
           minHeight: 0,
           overflowY: 'auto',
+          // Momentum scrolling, and a floor the floating bar cannot cover.
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehavior: 'contain',
           px: 0.75,
-          pb: 1.5,
+          pb: isPhone ? `${MOBILE_BAR_CLEARANCE}px` : 1.5,
           scrollbarWidth: 'none',
           msOverflowStyle: 'none',
           '&::-webkit-scrollbar': { display: 'none' },
@@ -710,6 +792,22 @@ const ProjectChatSidebar: FC<{
           </>
         )}
       </Box>
+
+      {isPhone && (
+        <ProjectChatSidebarMobileBar
+          query={query}
+          onQueryChange={setQuery}
+          onNewChat={openNewChatPicker}
+          filters={filterControls}
+        />
+      )}
+
+      <NewChatProjectDialog
+        open={newChatPickerOpen}
+        projects={projects}
+        onClose={() => setNewChatPickerOpen(false)}
+        onSelect={startNewChat}
+      />
 
       <ProjectChatItemContextMenu
         item={contextMenuItem}

--- a/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
@@ -123,7 +123,9 @@ const ProjectChatSidebarMobileBar: FC<ProjectChatSidebarMobileBarProps> = ({
                 onChange={(event) => onQueryChange(event.target.value)}
                 placeholder="Search"
                 inputProps={{ 'aria-label': 'Search chats' }}
-                sx={{ flex: 1, minWidth: 0, color: 'inherit', fontSize: '15px' }}
+                // 16px minimum: below it iOS zooms the page in on focus and does not
+                // zoom back out.
+                sx={{ flex: 1, minWidth: 0, color: 'inherit', fontSize: '16px' }}
               />
               <IconButton
                 aria-label="Clear search"

--- a/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
@@ -1,0 +1,187 @@
+import { FC, ReactNode, useEffect, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import InputBase from '@mui/material/InputBase'
+import Typography from '@mui/material/Typography'
+
+import { ListFilter, Search, SquarePen, X } from 'lucide-react'
+
+import useLightTheme from '../../hooks/useLightTheme'
+
+type ProjectChatSidebarMobileBarProps = {
+  query: string
+  onQueryChange: (query: string) => void
+  onNewChat: () => void
+  /** The same filter controls the desktop toolbar shows, for the sheet. */
+  filters: ReactNode
+}
+
+/** Height the list has to keep clear so the bar never covers the last row. */
+export const MOBILE_BAR_CLEARANCE = 84
+
+/**
+ * Filter, search and new-chat, within thumb reach.
+ *
+ * On a phone the desktop toolbar sits at the very top of a full-height list —
+ * the hardest place on the screen to reach one-handed, and the first thing to
+ * scroll past. These are the three things you actually do to a chat list, so
+ * they float at the bottom instead, and the toolbar is hidden rather than
+ * duplicated.
+ */
+const ProjectChatSidebarMobileBar: FC<ProjectChatSidebarMobileBarProps> = ({
+  query,
+  onQueryChange,
+  onNewChat,
+  filters,
+}) => {
+  const lightTheme = useLightTheme()
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (searchOpen) inputRef.current?.focus()
+  }, [searchOpen])
+
+  // A query typed here has to stay reachable, so the field stays open while it
+  // has content.
+  const expanded = searchOpen || !!query
+
+  const surface = lightTheme.isLight ? 'rgba(250,250,250,0.94)' : 'rgba(23,23,23,0.94)'
+  const border = lightTheme.isLight ? 'rgba(0,0,0,0.10)' : 'rgba(255,255,255,0.10)'
+
+  const roundButtonSx = {
+    width: 44,
+    height: 44,
+    flexShrink: 0,
+    borderRadius: '999px',
+    border: '1px solid',
+    borderColor: border,
+    backgroundColor: surface,
+    backdropFilter: 'blur(12px)',
+    color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
+    '&:hover': {
+      backgroundColor: lightTheme.isLight ? 'rgba(240,240,240,0.98)' : 'rgba(38,38,38,0.98)',
+    },
+  } as const
+
+  return (
+    <>
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 3,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          pt: 1,
+          pb: 'calc(12px + env(safe-area-inset-bottom))',
+          // The list scrolls under the bar, so the fade stops rows from
+          // colliding with it mid-scroll.
+          background: `linear-gradient(to top, ${lightTheme.isLight ? '#fafafa' : '#000000'} 55%, transparent)`,
+          pointerEvents: 'none',
+          '& > *': { pointerEvents: 'auto' },
+        }}
+      >
+        <IconButton
+          aria-label="Filter and sort chats"
+          onClick={() => setFiltersOpen(true)}
+          sx={roundButtonSx}
+        >
+          <ListFilter size={18} strokeWidth={1.8} />
+        </IconButton>
+
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            height: 44,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            borderRadius: '999px',
+            border: '1px solid',
+            borderColor: border,
+            backgroundColor: surface,
+            backdropFilter: 'blur(12px)',
+            cursor: 'text',
+          }}
+          onClick={() => setSearchOpen(true)}
+        >
+          <Search size={17} strokeWidth={1.8} style={{ opacity: 0.6, flexShrink: 0 }} />
+          {expanded ? (
+            <>
+              <InputBase
+                inputRef={inputRef}
+                value={query}
+                onChange={(event) => onQueryChange(event.target.value)}
+                placeholder="Search"
+                inputProps={{ 'aria-label': 'Search chats' }}
+                sx={{ flex: 1, minWidth: 0, color: 'inherit', fontSize: '15px' }}
+              />
+              <IconButton
+                aria-label="Clear search"
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onQueryChange('')
+                  setSearchOpen(false)
+                }}
+                sx={{ color: 'inherit', flexShrink: 0 }}
+              >
+                <X size={16} />
+              </IconButton>
+            </>
+          ) : (
+            <Typography sx={{ fontSize: '15px', opacity: 0.6 }}>Search</Typography>
+          )}
+        </Box>
+
+        <IconButton aria-label="New chat" onClick={onNewChat} sx={roundButtonSx}>
+          <SquarePen size={18} strokeWidth={1.8} />
+        </IconButton>
+      </Box>
+
+      <Drawer
+        anchor="bottom"
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        PaperProps={{
+          sx: {
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            pb: 'calc(16px + env(safe-area-inset-bottom))',
+          },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 2,
+            py: 1.5,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography sx={{ fontSize: '15px', fontWeight: 600 }}>Filter &amp; sort</Typography>
+          <IconButton aria-label="Close filters" onClick={() => setFiltersOpen(false)}>
+            <X size={18} />
+          </IconButton>
+        </Box>
+        <Box sx={{ px: 1.5, py: 1.5, display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
+          {filters}
+        </Box>
+      </Drawer>
+    </>
+  )
+}
+
+export default ProjectChatSidebarMobileBar

--- a/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarMobileBar.tsx
@@ -157,6 +157,13 @@ const ProjectChatSidebarMobileBar: FC<ProjectChatSidebarMobileBarProps> = ({
             borderTopLeftRadius: 16,
             borderTopRightRadius: 16,
             pb: 'calc(16px + env(safe-area-inset-bottom))',
+            // MUI's default paper elevation tint reads as light grey against
+            // the near-black list. The sheet belongs to the sidebar, so it
+            // takes the sidebar's surface.
+            backgroundColor: lightTheme.isLight ? '#fafafa' : '#0a0a0a',
+            backgroundImage: 'none',
+            borderTop: '1px solid',
+            borderColor: border,
           },
         }}
       >

--- a/frontend/src/components/session/projectChatItemDetails.ts
+++ b/frontend/src/components/session/projectChatItemDetails.ts
@@ -1,0 +1,87 @@
+import { TypesSandboxRuntime } from '../../api/api'
+import type { IApp } from '../../types'
+import { effectiveSpecTaskSandboxRuntime } from '../../utils/specTaskSandboxRuntime'
+import { getAgentHarnessLabel, getAgentHarnessModel, getAgentHarnessRuntime } from '../agent/AgentHarness'
+import type { SidebarItem } from './ProjectChatSidebar.logic'
+
+export type ProjectChatItemDetails = {
+  repository?: string
+  branch?: string
+  /** Raw runtime id, for `AgentHarness` — not a display string. */
+  runtime?: string
+  harness?: string
+  model?: string
+  compute?: string
+  environment?: 'Headless' | 'Full Desktop'
+}
+
+type DetailsInput = {
+  item: SidebarItem
+  apps: IApp[]
+  repository?: string
+  branch?: string
+}
+
+/**
+ * The facts a sidebar row can show about a thread.
+ *
+ * The hover tooltip (desktop) and the second line of each row (mobile) are the
+ * same information at two densities, so they resolve it here. A phone has no
+ * hover, so if these two ever disagreed the phone would silently be the wrong
+ * one — with no way for anyone to notice.
+ */
+export const getProjectChatItemDetails = ({
+  item,
+  apps,
+  repository,
+  branch,
+}: DetailsInput): ProjectChatItemDetails => {
+  // A spec task carries its own agent config. A plain chat inherits the
+  // configured app's, falling back to whatever the session recorded.
+  const configuredAppID = item.kind === 'spec-task' ? undefined : item.session?.app_id
+  const configuredApp = configuredAppID
+    ? apps.find((app) => app.id === configuredAppID)
+    : undefined
+
+  const runtime = item.task?.code_agent_config?.runtime || (configuredApp
+    ? getAgentHarnessRuntime(configuredApp)
+    : item.session?.metadata?.code_agent_runtime || item.session?.metadata?.agent_type)
+
+  const model = item.task?.code_agent_config?.model || (configuredApp
+    ? getAgentHarnessModel(configuredApp)
+    : item.session?.model_name)
+
+  const details: ProjectChatItemDetails = {
+    repository,
+    branch,
+    runtime: runtime || undefined,
+    harness: runtime ? getAgentHarnessLabel(runtime) : undefined,
+    model: model || undefined,
+  }
+
+  if (item.kind !== 'spec-task' || !item.task) return details
+
+  const vcpus = item.task.sandbox_resource_overrides?.vcpus || 4
+  const memoryMb = item.task.sandbox_resource_overrides?.memory_mb || 8192
+  const memory = memoryMb % 1024 === 0
+    ? `${memoryMb / 1024} GB RAM`
+    : `${memoryMb} MB RAM`
+
+  details.compute = `${vcpus} vCPU · ${memory}`
+  details.environment = effectiveSpecTaskSandboxRuntime(item.task.sandbox_runtime)
+    === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
+    ? 'Headless'
+    : 'Full Desktop'
+
+  return details
+}
+
+/**
+ * The branch a row should name: what the task actually works on, else what it
+ * branched from, else the project default.
+ */
+export const resolveProjectChatItemBranch = (
+  item: SidebarItem,
+  projectDefaultBranch?: string,
+): string | undefined =>
+  item.task?.branch_name || item.task?.base_branch || projectDefaultBranch || undefined

--- a/frontend/src/components/system/GlobalNotifications.tsx
+++ b/frontend/src/components/system/GlobalNotifications.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 import Box from '@mui/material/Box'
+import Slide from '@mui/material/Slide'
 import IconButton from '@mui/material/IconButton'
 import Badge from '@mui/material/Badge'
 
@@ -711,7 +712,14 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
         </Badge>
       </IconButton>
 
-      {/* Attention Queue — fixed panel, doesn't block page interaction */}
+      {/* Attention Queue — fixed panel, doesn't block page interaction.
+          Unmounted when closed rather than parked off-screen: a transformed
+          element still contributes scrollable overflow, so a panel sitting one
+          viewport-width to the right made the whole app horizontally
+          scrollable. On a phone that is a real gesture — you could drag the UI
+          sideways and push the toolbar off the screen — because iOS pans an
+          `overflow: hidden` box even though it clips it visually. */}
+      <Slide direction="left" in={drawerOpen} mountOnEnter unmountOnExit>
       <Box
         sx={{
           position: 'fixed',
@@ -719,7 +727,7 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
           right: 0,
           bottom: 0,
           width: { xs: '100%', sm: PANEL_WIDTH },
-          maxWidth: '100vw',
+          maxWidth: '100%',
           textAlign: 'left',
           backgroundColor: lightTheme.panelColor,
           borderLeft: lightTheme.border,
@@ -728,9 +736,6 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
           zIndex: 1200,
           display: 'flex',
           flexDirection: 'column',
-          transform: drawerOpen ? 'translateX(0)' : 'translateX(100%)',
-          transition: 'transform 0.25s ease-in-out',
-          pointerEvents: drawerOpen ? 'auto' : 'none',
         }}
       >
         {/* Header */}
@@ -948,6 +953,7 @@ const GlobalNotifications: React.FC<GlobalNotificationsProps> = ({ onOpenChange 
           )}
         </Box>
       </Box>
+      </Slide>
     </>
   )
 }

--- a/frontend/src/components/system/InstallPWA.tsx
+++ b/frontend/src/components/system/InstallPWA.tsx
@@ -98,7 +98,8 @@ const InstallPWA: React.FC = () => {
           right: 0,
           zIndex: 9999,
           p: 2,
-          pb: 'calc(env(safe-area-inset-bottom) + 16px)',
+          // Inside the shell, which already carries the safe-area inset.
+          pb: 2,
           background: 'linear-gradient(135deg, #1a1a2e 0%, #0d0d0d 100%)',
           borderTop: '1px solid rgba(74, 222, 128, 0.3)',
           boxShadow: '0 -4px 20px rgba(0, 0, 0, 0.5)',

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -417,6 +417,9 @@ const Page: React.FC<{
           flexDirection: 'column',
           overflowY: disableContentScroll ? 'hidden' : 'auto',
           overflowX: 'hidden',
+          // The app shell is a fixed pane; a rubber-band at the end of this
+          // scroller must not chain out and drag it.
+          overscrollBehavior: 'contain',
           width: '100%',
           maxWidth: '100vw',
           minHeight: 0,

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -421,7 +421,9 @@ const Page: React.FC<{
           // scroller must not chain out and drag it.
           overscrollBehavior: 'contain',
           width: '100%',
-          maxWidth: '100vw',
+          // 100% of the shell, not 100vw: vw is the layout viewport, which is
+          // not the width on screen once the visual viewport is offset or scaled.
+          maxWidth: '100%',
           minHeight: 0,
         }}
       >

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -122,6 +122,7 @@ import {
 } from "react-resizable-panels";
 import type { PanelImperativeHandle } from "react-resizable-panels";
 import useIsBigScreen from "../../hooks/useIsBigScreen";
+import useIsPhone from "../../hooks/useIsPhone";
 import useLightTheme from "../../hooks/useLightTheme";
 import {
   FileText,
@@ -254,6 +255,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
   // Use md breakpoint (900px) to enable split view on tablets
   const isBigScreen = useIsBigScreen({ breakpoint: "md" });
+  const isPhone = useIsPhone();
   const lightTheme = useLightTheme();
   const savedSpecTaskChatLayout = loadPanelLayout(
     SPEC_TASK_CHAT_LAYOUT_KEY,
@@ -2235,7 +2237,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     </Box>
   );
 
-  const taskChatMetadata = task?.project_id ? (
+  // Project, repo and branch are reference, not controls, and on a phone they
+  // cost a whole row directly under the composer — where the space is worth
+  // more to the message being written. They stay one tap away in Details.
+  const taskChatMetadata = task?.project_id && !isPhone ? (
     <TaskChatMetadata
       projectName={project?.name}
       onOpenProject={() => account.orgNavigate("project-specs", { id: task.project_id })}

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -140,7 +140,11 @@ import SpecTaskViewToolbar, {
 import { getAutoOpenedSpecTasks, addAutoOpenedSpecTask } from "../../lib/specTaskAutoOpen";
 import { loadPanelLayout, savePanelLayout } from "../../lib/panelLayoutStorage";
 import SpecTaskTerminalDrawer from "./SpecTaskTerminalDrawer";
-import { resolveSpecTaskChatDefaultLayout } from "./specTaskPanelLayout";
+import {
+  loadSpecTaskContentPanelOpen,
+  resolveSpecTaskChatDefaultLayout,
+  saveSpecTaskContentPanelOpen,
+} from "./specTaskPanelLayout";
 import {
   isSpecTaskTerminalToggleShortcut,
   loadSpecTaskTerminalDrawerState,
@@ -356,29 +360,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [contentCollapsed, setContentCollapsed] = useState(false);
   const contentPanelRef = useRef<PanelImperativeHandle>(null);
   const collapseContentAfterSplitRef = useRef(false);
-  const headlessInitialCollapseTaskRef = useRef<string | null>(null);
-
-  const collapseContentPanel = useCallback(() => {
-    if (chatCollapsed) {
-      collapseContentAfterSplitRef.current = true;
-      setContentCollapsed(true);
-      setChatCollapsed(false);
-      return;
-    }
-    const currentSize = contentPanelRef.current?.getSize().asPercentage;
-    if (currentSize && currentSize > 0) {
-      lastExpandedContentSizeRef.current = currentSize;
-    }
-    contentPanelRef.current?.collapse();
-  }, [chatCollapsed]);
-
-  const showContentPanel = useCallback(() => {
-    const panel = contentPanelRef.current;
-    if (!panel) return;
-    const restoredSize = lastExpandedContentSizeRef.current || 50;
-    panel.expand();
-    panel.resize(`${restoredSize}%`);
-  }, []);
+  const [contentPanelPreference, setContentPanelPreference] = useState(() => ({
+    taskId,
+    open: loadSpecTaskContentPanelOpen(taskId),
+  }));
+  const headlessContentPanelOpen = contentPanelPreference.taskId === taskId
+    ? contentPanelPreference.open
+    : loadSpecTaskContentPanelOpen(taskId);
 
   const [terminalDrawerState, setTerminalDrawerState] = useState(() =>
     loadSpecTaskTerminalDrawerState(taskId),
@@ -488,6 +476,41 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     },
     [currentView, router, syncViewWithUrl],
   );
+
+  const rememberHeadlessContentPanelOpen = (open: boolean) => {
+    if (!isHeadless || !allowContentCollapse) return;
+    setContentPanelPreference((current) => (
+      current.taskId === taskId && current.open === open
+        ? current
+        : { taskId, open }
+    ));
+    saveSpecTaskContentPanelOpen(taskId, open);
+  };
+
+  const collapseContentPanel = () => {
+    rememberHeadlessContentPanelOpen(false);
+    if (chatCollapsed) {
+      collapseContentAfterSplitRef.current = true;
+      setContentCollapsed(true);
+      setChatCollapsed(false);
+      return;
+    }
+    const currentSize = contentPanelRef.current?.getSize().asPercentage;
+    if (currentSize && currentSize > 0) {
+      lastExpandedContentSizeRef.current = currentSize;
+    }
+    contentPanelRef.current?.collapse();
+  };
+
+  const showContentPanel = () => {
+    const panel = contentPanelRef.current;
+    if (!panel) return;
+    rememberHeadlessContentPanelOpen(true);
+    if (isHeadless) handleViewChange("changes");
+    const restoredSize = lastExpandedContentSizeRef.current || 50;
+    panel.expand();
+    panel.resize(`${restoredSize}%`);
+  };
 
 
   // Design review state
@@ -714,26 +737,6 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       }
     }
   }, [activeSessionId, isBigScreen, isHeadless]);
-
-  useEffect(() => {
-    if (
-      !isHeadless
-      || !allowContentCollapse
-      || !isBigScreen
-      || !activeSessionId
-      || launchPhase
-      || chatCollapsed
-    ) return;
-    headlessInitialCollapseTaskRef.current = taskId;
-  }, [
-    activeSessionId,
-    allowContentCollapse,
-    chatCollapsed,
-    isBigScreen,
-    isHeadless,
-    launchPhase,
-    taskId,
-  ]);
 
   // Fetch session data
   const { data: sessionResponse } = useGetSession(activeSessionId || "", {
@@ -2361,18 +2364,19 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
               savedSpecTaskChatLayout,
               allowContentCollapse && (
                 collapseContentAfterSplitRef.current
-                || (isHeadless && headlessInitialCollapseTaskRef.current !== taskId)
+                || (isHeadless && !headlessContentPanelOpen)
               ),
             )}
             onLayoutChange={(layout) => {
               if (layout["spec-task-content"] === 0) {
                 collapseContentAfterSplitRef.current = false;
-                if (isHeadless) headlessInitialCollapseTaskRef.current = taskId;
+                rememberHeadlessContentPanelOpen(false);
               }
-              // A collapsed panel is transient UI state; retain the last useful
-              // split so restoring or reloading does not produce a zero-width pane.
+              // Keep the last useful split separate from the headless panel's
+              // task-specific visibility preference.
               if (layout["spec-task-chat"] > 0 && layout["spec-task-content"] > 0) {
                 lastExpandedContentSizeRef.current = layout["spec-task-content"];
+                rememberHeadlessContentPanelOpen(true);
                 savePanelLayout(SPEC_TASK_CHAT_LAYOUT_KEY, layout, SPEC_TASK_CHAT_PANEL_IDS);
               }
             }}

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
@@ -1,12 +1,19 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import SpecTaskViewToolbar from "./SpecTaskViewToolbar";
 
 vi.mock("../../hooks/useElementWidth", () => ({
   useElementWidth: () => [{ current: null }, 800],
 }));
 
+let isPhone = false;
+vi.mock("../../hooks/useIsPhone", () => ({ default: () => isPhone }));
+
 describe("SpecTaskViewToolbar", () => {
+  beforeEach(() => {
+    isPhone = false;
+  });
+
   it("hides the desktop view for a headless task and keeps panel collapse available", () => {
     const collapse = vi.fn();
     render(
@@ -22,5 +29,55 @@ describe("SpecTaskViewToolbar", () => {
     expect(screen.queryByRole("button", { name: "Desktop view" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Collapse task panel" }));
     expect(collapse).toHaveBeenCalledOnce();
+  });
+
+  it("keeps every view inline on a wide screen", () => {
+    render(
+      <SpecTaskViewToolbar currentView="chat" onViewChange={vi.fn()} hasSession showChatTab />,
+    );
+
+    for (const label of ["Chat", "Desktop", "Browser", "Diff", "Files", "Details"]) {
+      expect(screen.getByRole("button", { name: `${label} view` })).toBeInTheDocument();
+    }
+  });
+
+  it("folds the deliberate views into the menu on a phone", () => {
+    isPhone = true;
+    const onViewChange = vi.fn();
+    render(
+      <SpecTaskViewToolbar
+        currentView="chat"
+        onViewChange={onViewChange}
+        hasSession
+        showChatTab
+      />,
+    );
+
+    // Only the views you flick between stay inline.
+    for (const label of ["Chat", "Browser", "Diff"]) {
+      expect(screen.getByRole("button", { name: `${label} view` })).toBeInTheDocument();
+    }
+    for (const label of ["Desktop", "Files", "Details"]) {
+      expect(screen.queryByRole("button", { name: `${label} view` })).not.toBeInTheDocument();
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Files" }));
+
+    expect(onViewChange).toHaveBeenCalledWith("files");
+  });
+
+  it("drops the close button on a phone, where the panel is the whole screen", () => {
+    isPhone = true;
+    render(
+      <SpecTaskViewToolbar
+        currentView="chat"
+        onViewChange={vi.fn()}
+        hasSession
+        onClosePanel={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from "lucide-react";
 import { useElementWidth } from "../../hooks/useElementWidth";
+import useIsPhone from "../../hooks/useIsPhone";
 
 export type TaskView =
   | "chat"
@@ -108,6 +109,12 @@ interface ViewTab {
   sessionOnly: boolean;
   /** Chat is a tab only when chat has no panel of its own. */
   chatOnly?: boolean;
+  /**
+   * Folded into the overflow menu on a phone. Six tabs plus the lifecycle
+   * controls do not fit across 390px, and these three are the ones you visit
+   * deliberately rather than flick between.
+   */
+  foldOnPhone?: boolean;
 }
 
 const VIEW_TABS: ViewTab[] = [
@@ -118,15 +125,16 @@ const VIEW_TABS: ViewTab[] = [
     sessionOnly: true,
     chatOnly: true,
   },
-  { value: "desktop", label: "Desktop", icon: MonitorPlay, sessionOnly: true },
+  { value: "desktop", label: "Desktop", icon: MonitorPlay, sessionOnly: true, foldOnPhone: true },
   { value: "browser", label: "Browser", icon: Globe2, sessionOnly: true },
   { value: "changes", label: "Diff", icon: GitCompare, sessionOnly: true },
-  { value: "files", label: "Files", icon: Files, sessionOnly: true },
+  { value: "files", label: "Files", icon: Files, sessionOnly: true, foldOnPhone: true },
   {
     value: "details",
     label: "Details",
     icon: SlidersHorizontal,
     sessionOnly: false,
+    foldOnPhone: true,
   },
 ];
 
@@ -233,6 +241,7 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
 
   // Density comes from the toolbar's own width, not the viewport: in split view
   // the toolbar lives in the right panel, which is far narrower than the window.
+  const isPhone = useIsPhone();
   const [toolbarRef, toolbarWidth] = useElementWidth<HTMLDivElement>();
   const density = toolbarDensityForWidth(toolbarWidth);
 
@@ -240,11 +249,13 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   const iconButtonSx = toolbarIconButtonSx(density);
   const controlIconSize = ICON_BUTTON_METRICS[density].icon;
 
-  const tabs = VIEW_TABS.filter(
+  const availableTabs = VIEW_TABS.filter(
     (t) => (!t.sessionOnly || hasSession)
       && (!t.chatOnly || showChatTab)
       && (t.value !== "desktop" || showDesktop),
   );
+  const tabs = availableTabs.filter((t) => !(isPhone && t.foldOnPhone));
+  const foldedTabs = availableTabs.filter((t) => isPhone && t.foldOnPhone);
 
   const controls: SecondaryControl[] = [];
   if (onRestoreSplit) {
@@ -332,7 +343,7 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   const overflow = controls.filter((c) => !keepInline.includes(c));
 
   const extraMenuItems = renderMenuItems?.(closeMenu);
-  const hasMenu = overflow.length > 0 || !!extraMenuItems;
+  const hasMenu = overflow.length > 0 || foldedTabs.length > 0 || !!extraMenuItems;
 
   return (
     <Box
@@ -462,7 +473,7 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
               <PanelRight size={controlIconSize} />
             </IconButton>
           </Tooltip>
-        ) : onClosePanel ? (
+        ) : onClosePanel && !isPhone ? (
           <Tooltip title="Close">
             <IconButton
               size="small"
@@ -481,6 +492,21 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
         open={Boolean(menuAnchorEl)}
         onClose={closeMenu}
       >
+        {foldedTabs.map(({ value, label, icon: Icon }) => (
+          <MenuItem
+            key={`view-${value}`}
+            selected={currentView === value}
+            onClick={() => {
+              closeMenu();
+              onViewChange(value);
+            }}
+          >
+            <ListItemIcon>
+              <Icon size={18} />
+            </ListItemIcon>
+            <ListItemText>{label}</ListItemText>
+          </MenuItem>
+        ))}
         {overflow.map((control) => (
           <MenuItem
             key={control.key}

--- a/frontend/src/components/tasks/specTaskPanelLayout.test.ts
+++ b/frontend/src/components/tasks/specTaskPanelLayout.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { resolveSpecTaskChatDefaultLayout } from "./specTaskPanelLayout";
+import {
+  loadSpecTaskContentPanelOpen,
+  resolveSpecTaskChatDefaultLayout,
+  saveSpecTaskContentPanelOpen,
+  specTaskContentPanelStorageKey,
+} from "./specTaskPanelLayout";
+
+function memoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    values,
+  };
+}
 
 describe("resolveSpecTaskChatDefaultLayout", () => {
   it("starts headless content collapsed without an imperative panel call", () => {
@@ -20,5 +34,20 @@ describe("resolveSpecTaskChatDefaultLayout", () => {
       "spec-task-chat": 40,
       "spec-task-content": 60,
     });
+  });
+
+  it("defaults an unseen task to closed and remembers visibility per task", () => {
+    const storage = memoryStorage();
+
+    expect(loadSpecTaskContentPanelOpen("spt_one", storage)).toBe(false);
+
+    saveSpecTaskContentPanelOpen("spt_one", true, storage);
+    expect(loadSpecTaskContentPanelOpen("spt_one", storage)).toBe(true);
+    expect(loadSpecTaskContentPanelOpen("spt_two", storage)).toBe(false);
+
+    saveSpecTaskContentPanelOpen("spt_one", false, storage);
+    expect(loadSpecTaskContentPanelOpen("spt_one", storage)).toBe(false);
+    expect(storage.values.get(specTaskContentPanelStorageKey("spt_one")))
+      .toBe("closed");
   });
 });

--- a/frontend/src/components/tasks/specTaskPanelLayout.ts
+++ b/frontend/src/components/tasks/specTaskPanelLayout.ts
@@ -3,6 +3,11 @@ export type SpecTaskChatLayout = {
   "spec-task-content": number;
 };
 
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
 const DEFAULT_LAYOUT: SpecTaskChatLayout = {
   "spec-task-chat": 50,
   "spec-task-content": 50,
@@ -19,4 +24,33 @@ export function resolveSpecTaskChatDefaultLayout(
 ): Record<string, number> {
   if (collapseContent) return COLLAPSED_CONTENT_LAYOUT;
   return savedLayout || DEFAULT_LAYOUT;
+}
+
+export const specTaskContentPanelStorageKey = (taskId: string): string =>
+  `helix.specTask.${taskId}.contentPanel`;
+
+export function loadSpecTaskContentPanelOpen(
+  taskId: string,
+  storage: StorageLike = window.localStorage,
+): boolean {
+  try {
+    return storage.getItem(specTaskContentPanelStorageKey(taskId)) === "open";
+  } catch {
+    return false;
+  }
+}
+
+export function saveSpecTaskContentPanelOpen(
+  taskId: string,
+  open: boolean,
+  storage: StorageLike = window.localStorage,
+): void {
+  try {
+    storage.setItem(
+      specTaskContentPanelStorageKey(taskId),
+      open ? "open" : "closed",
+    );
+  } catch {
+    // Storage is optional; the panel remains usable for this page load.
+  }
 }

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -457,6 +457,16 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
               boxShadow: dialogStyles.shadow,
               transition: 'all 0.2s ease-in-out',
             },
+            container: {
+              // A full-screen dialog has to be bounded by the VISIBLE viewport,
+              // not the layout one. With the on-screen keyboard open the layout
+              // viewport is the taller of the two, so the sheet overflows it and
+              // the whole thing pans — header and all — instead of its list
+              // scrolling inside a fixed frame. `--app-height` tracks the visual
+              // viewport (see index.html); the 100% fallback is what every
+              // desktop browser resolves to anyway.
+              height: 'var(--app-height, 100%)',
+            },
             root: {
               zIndex: 100002, // Above floating windows (z-index 9999); tooltips (100004) render above
               transition: 'all 0.2s ease-in-out',

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -440,6 +440,27 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             },
           },
         },
+        MuiDrawer: {
+          styleOverrides: {
+            // Same reasoning as MuiDialog root below: portalled out of the
+            // shell, so it has to follow the visual viewport itself. Applied to
+            // the modal root rather than the paper, because the paper's
+            // transform belongs to the slide transition.
+            root: {
+              transform: 'translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px))',
+            },
+            // Scoped to the left-anchored nav drawer: a bottom sheet wants a
+            // bottom inset, not a top one, and sets its own.
+            paperAnchorLeft: {
+              boxSizing: 'border-box',
+              paddingTop: 'env(safe-area-inset-top)',
+              paddingLeft: 'env(safe-area-inset-left)',
+            },
+            paperAnchorBottom: {
+              boxSizing: 'border-box',
+            },
+          },
+        },
         MuiDialog: {
           defaultProps: {
             disableEnforceFocus: true,
@@ -470,6 +491,11 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             root: {
               zIndex: 100002, // Above floating windows (z-index 9999); tooltips (100004) render above
               transition: 'all 0.2s ease-in-out',
+              // Portalled outside #root, so the shell's anchoring does not
+              // reach it. `position: fixed` resolves against the layout
+              // viewport, which iOS Safari pans the visual viewport inside —
+              // this follows that pan so a sheet cannot drift off screen.
+              transform: 'translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px))',
               '& .MuiBackdrop-root': {
                 backgroundColor: dialogStyles.backdropFallback,
                 background: dialogStyles.backdrop,

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -447,7 +447,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             // the modal root rather than the paper, because the paper's
             // transform belongs to the slide transition.
             root: {
-              transform: 'translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px))',
+              transform: 'translateY(var(--app-offset-y, 0px))',
             },
             // Scoped to the left-anchored nav drawer: a bottom sheet wants a
             // bottom inset, not a top one, and sets its own.
@@ -495,7 +495,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
               // reach it. `position: fixed` resolves against the layout
               // viewport, which iOS Safari pans the visual viewport inside —
               // this follows that pan so a sheet cannot drift off screen.
-              transform: 'translate(var(--app-offset-x, 0px), var(--app-offset-y, 0px))',
+              transform: 'translateY(var(--app-offset-y, 0px))',
               '& .MuiBackdrop-root': {
                 backgroundColor: dialogStyles.backdropFallback,
                 background: dialogStyles.backdrop,

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -356,7 +356,10 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             // like a layout bug and none of it is. A floor rather than a fixed
             // size, so anything already larger keeps its size.
             '@media (pointer: coarse)': {
-              'input, textarea, select': {
+              // contenteditable counts: iOS zooms for anything it can put a
+              // caret in, not just form controls, and the task chat's composer
+              // is a contenteditable div rather than a textarea.
+              'input, textarea, select, [contenteditable]:not([contenteditable="false"])': {
                 fontSize: 'max(16px, 1em) !important',
               },
             },

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -465,7 +465,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
               // scrolling inside a fixed frame. `--app-height` tracks the visual
               // viewport (see index.html); the 100% fallback is what every
               // desktop browser resolves to anyway.
-              height: 'var(--app-height, 100%)',
+              height: 'min(var(--app-height, 100%), 100%)',
             },
             root: {
               zIndex: 100002, // Above floating windows (z-index 9999); tooltips (100004) render above

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -350,6 +350,16 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             'button, input, optgroup, select, textarea': {
               fontFamily: 'inherit',
             },
+            // iOS Safari zooms the page in when a text field smaller than 16px
+            // takes focus, and never zooms back out — leaving the layout panned,
+            // cut off one edge and short on the other. Every symptom of it looks
+            // like a layout bug and none of it is. A floor rather than a fixed
+            // size, so anything already larger keeps its size.
+            '@media (pointer: coarse)': {
+              'input, textarea, select': {
+                fontSize: 'max(16px, 1em) !important',
+              },
+            },
             '*': scrollbarStyles,
           },
         },

--- a/frontend/src/hooks/useIsPhone.ts
+++ b/frontend/src/hooks/useIsPhone.ts
@@ -1,0 +1,18 @@
+import { useTheme } from '@mui/material/styles'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
+/**
+ * True on a phone-width viewport.
+ *
+ * Distinct from `useIsBigScreen`, which switches at `lg` (1200px) and governs
+ * whether the nav drawer is permanent or temporary. A 1000px-wide laptop window
+ * gets the temporary drawer but is not a phone: it has a pointer, room for a
+ * 300px sidebar, and working hover. This hook is the narrower question — is
+ * there no hover and no horizontal room — and answers it at `sm` (600px).
+ */
+const useIsPhone = (): boolean => {
+  const theme = useTheme()
+  return useMediaQuery(theme.breakpoints.down('sm'))
+}
+
+export default useIsPhone

--- a/frontend/src/hooks/useUserMenuHeight.ts
+++ b/frontend/src/hooks/useUserMenuHeight.ts
@@ -12,9 +12,19 @@ import { useState, useEffect } from 'react'
 // firing the observer constantly and producing forced synchronous layouts on
 // the main thread. On Safari this is enough to freeze the tab.
 //
-// Now: find the bottom-pinned overlay parent once, then ResizeObserver it
-// directly. ResizeObserver only fires when that element actually changes size,
-// and Chrome schedules its callbacks at a layout-safe point in the frame.
+// Now: find the bottom-pinned overlay once, then ResizeObserver it directly.
+// ResizeObserver only fires when that element actually changes size, and Chrome
+// schedules its callbacks at a layout-safe point in the frame.
+//
+// The overlay is found by its `data-user-menu-overlay` marker rather than by
+// walking up from the avatar looking for the first `position: fixed/absolute`
+// ancestor pinned to `bottom: 0`. That walk had no way to tell the menu from
+// anything else it happened to pass through: on a phone the nav Drawer is a
+// temporary one, whose Paper is `position: fixed; bottom: 0`, so the walk
+// stopped there and reported the height of the whole drawer. Sidebar then
+// computed `calc(100% - 844px)` and clipped the entire chat list to zero
+// height. Desktop escaped it only because Layout gives the permanent drawer
+// `position: relative`.
 export const useUserMenuHeight = () => {
   const [userMenuHeight, setUserMenuHeight] = useState(0)
 
@@ -23,26 +33,11 @@ export const useUserMenuHeight = () => {
     let ro: ResizeObserver | null = null
     let retryTimer: ReturnType<typeof setTimeout> | null = null
 
-    const findOverlayFor = (menu: HTMLElement): HTMLElement | null => {
-      let el: HTMLElement | null = menu
-      while (el) {
-        const cs = window.getComputedStyle(el)
-        if (
-          (cs.position === 'absolute' || cs.position === 'fixed') &&
-          cs.bottom === '0px'
-        ) {
-          return el
-        }
-        el = el.parentElement
-      }
-      return null
-    }
-
     const tryAttach = () => {
       if (cancelled) return
 
-      const menu = document.querySelector('[data-compact-user-menu]')
-      if (!(menu instanceof HTMLElement)) {
+      const overlay = document.querySelector('[data-user-menu-overlay]')
+      if (!(overlay instanceof HTMLElement)) {
         // Component hasn't mounted yet (or has unmounted). Retry slowly.
         // 1s is fine for a layout-sizing decision; no-one notices a 1s wait
         // for the sidebar bottom padding to settle.
@@ -50,17 +45,20 @@ export const useUserMenuHeight = () => {
         return
       }
 
-      const overlay = findOverlayFor(menu)
-      if (!overlay) {
-        setUserMenuHeight(0)
-        return
+      // In compact mode the menu is portalled into a wrapper that carries the
+      // show/hide state, so visibility is read from the overlay and the couple
+      // of nodes above it rather than the overlay alone.
+      const isHidden = (el: HTMLElement | null, depth: number): boolean => {
+        for (let i = 0; el && i <= depth; i += 1) {
+          const cs = window.getComputedStyle(el)
+          if (cs.opacity !== '1' || cs.pointerEvents === 'none') return true
+          el = el.parentElement
+        }
+        return false
       }
 
       const measure = () => {
-        const cs = window.getComputedStyle(overlay)
-        const visible =
-          cs.opacity === '1' && cs.pointerEvents === 'auto'
-        setUserMenuHeight(visible ? overlay.offsetHeight : 0)
+        setUserMenuHeight(isHidden(overlay, 2) ? 0 : overlay.offsetHeight)
       }
 
       measure()

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -25,6 +25,7 @@ import Page from '../components/system/Page'
 import { useAccount } from '../contexts/account'
 import { useStreaming } from '../contexts/streaming'
 import { getBrowserLocale } from '../hooks/useBrowserLocale'
+import useIsPhone from '../hooks/useIsPhone'
 import useLightTheme from '../hooks/useLightTheme'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
@@ -103,6 +104,7 @@ function errorMessage(error: any, fallback: string): string {
 
 const Home: FC = () => {
   const account = useAccount()
+  const isPhone = useIsPhone()
   const lightTheme = useLightTheme()
   const router = useRouter()
   const snackbar = useSnackbar()
@@ -498,30 +500,41 @@ const Home: FC = () => {
           height: '100%',
           minHeight: 0,
           display: 'flex',
-          alignItems: 'center',
+          // A phone fills the screen and works top-down; a wide screen keeps
+          // the centred card.
+          alignItems: isPhone ? 'stretch' : 'center',
           justifyContent: 'center',
           px: { xs: 2, sm: 3 },
-          pb: { xs: 4, md: 12 },
+          pb: isPhone ? 'calc(8px + env(safe-area-inset-bottom))' : { xs: 4, md: 12 },
+          pt: isPhone ? 1 : 0,
           backgroundColor: lightTheme.isLight ? '#f7f7f8' : '#080808',
           fontFamily: T3_FONT_FAMILY,
           '& .MuiTypography-root, & .MuiButton-root': { fontFamily: 'inherit' },
         }}
       >
-        <Box sx={{ width: '100%', maxWidth: 768 }}>
-          <Typography
-            component="h1"
-            sx={{
-              mb: 3.5,
-              color: 'text.primary',
-              fontSize: { xs: '1.65rem', sm: '1.9rem' },
-              fontWeight: 560,
-              lineHeight: 1.2,
-              letterSpacing: '-0.025em',
-              textAlign: 'center',
-            }}
-          >
-            {newChatHeading(selectedProject?.name)}
-          </Typography>
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: 768,
+            ...(isPhone && { display: 'flex', flexDirection: 'column', minHeight: 0 }),
+          }}
+        >
+          {!isPhone && (
+            <Typography
+              component="h1"
+              sx={{
+                mb: 3.5,
+                color: 'text.primary',
+                fontSize: { xs: '1.65rem', sm: '1.9rem' },
+                fontWeight: 560,
+                lineHeight: 1.2,
+                letterSpacing: '-0.025em',
+                textAlign: 'center',
+              }}
+            >
+              {newChatHeading(selectedProject?.name)}
+            </Typography>
+          )}
 
           {requestedProjectId && projectsLoading ? (
             <Box sx={{ height: 150, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -533,6 +546,7 @@ const Home: FC = () => {
               sessionId={`new-thread:${selectedProjectId || 'none'}`}
               sendMode="direct"
               autoFocus
+              fill={isPhone}
               disabled={submitting || (isProjectContext && !taskCodeAgentConfig?.model)}
               placeholder={isProjectContext ? 'Describe what you want to build' : 'Ask anything'}
               inlineImageAttachments={!isProjectContext}
@@ -546,12 +560,12 @@ const Home: FC = () => {
             />
           )}
 
-          <Box sx={{ mt: 1, px: 2 }}>
+          <Box sx={isPhone ? { order: -1, mb: 0.5, flexShrink: 0 } : { mt: 1, px: 2 }}>
             <Button
               startIcon={isProjectContext ? <Folder size={14} /> : <MessageCircle size={14} />}
               endIcon={<ChevronDown size={12} />}
               onClick={(event) => setProjectMenuAnchor(event.currentTarget)}
-              sx={{ ...selectorButtonSx, fontSize: '0.7rem' }}
+              sx={{ ...selectorButtonSx, fontSize: isPhone ? '0.8rem' : '0.7rem' }}
             >
               {selectedProject?.name || 'None'}
             </Button>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -505,7 +505,8 @@ const Home: FC = () => {
           alignItems: isPhone ? 'stretch' : 'center',
           justifyContent: 'center',
           px: { xs: 2, sm: 3 },
-          pb: isPhone ? 'calc(8px + env(safe-area-inset-bottom))' : { xs: 4, md: 12 },
+          // The shell already carries the safe-area inset.
+          pb: isPhone ? 1 : { xs: 4, md: 12 },
           pt: isPhone ? 1 : 0,
           backgroundColor: lightTheme.isLight ? '#f7f7f8' : '#080808',
           fontFamily: T3_FONT_FAMILY,

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -57,6 +57,7 @@ import useLightTheme from "../hooks/useLightTheme";
 import useThemeConfig from "../hooks/useThemeConfig";
 import useIsBigScreen from "../hooks/useIsBigScreen";
 import useIsPhone from "../hooks/useIsPhone";
+import { isNavigationRouteActive } from "../components/orgs/UserOrgSelector.logic";
 import useApps from "../hooks/useApps";
 import useUserMenuHeight from "../hooks/useUserMenuHeight";
 import { LIGHT_SIDEBAR_COLORS } from "../styles/themeTokens";
@@ -533,6 +534,20 @@ const Layout: FC<{
     !isProjectsIndex &&
     !isFocusedAgentRoute &&
     !(router.name === "org_new" && router.params.app_id);
+
+  // On a phone the drawer holds the chat list, so opening a thread has to hide
+  // it — otherwise the thread you just picked sits behind the list you picked
+  // it from. Driven by the route rather than wired into each navigation, so it
+  // holds however you arrive: tapping a row, sending from the composer, or a
+  // link straight into a thread.
+  useEffect(() => {
+    if (!isPhone) return;
+    if (isNavigationRouteActive(router.name, ["session", "chat-task"])) {
+      account.setMobileMenuOpen(false);
+    }
+    // account is a context object and must not be a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPhone, router.name]);
 
   if (shouldShowSidebar) {
     // Determine which sidebar to show based on route

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -732,7 +732,7 @@ const Layout: FC<{
               // visible gap below it. The shrink-by-userMenuHeight happens in
               // Sidebar.tsx for the secondary nav's content column only.
               // Use dvh (dynamic viewport height) for iOS Safari compatibility.
-              height: isBigScreen ? "100%" : "100svh",
+              height: isBigScreen ? "100%" : "var(--app-height, 100svh)",
               // The primary rail must remain viewport-anchored. Secondary
               // navigation owns its scrolling inside SlideMenuContainer.
               overflowY: "hidden",

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -685,7 +685,8 @@ const Layout: FC<{
       <Box
         id="root-container"
         sx={{
-          minHeight: "100svh",
+          // The shell is exactly the fixed #root pane; a min-height here would
+          // be a second source of overflow to fight with.
           height: "100%",
           display: "flex",
           backgroundColor: lightTheme.backgroundColor, // Extend background behind iOS safe area

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -685,7 +685,7 @@ const Layout: FC<{
       <Box
         id="root-container"
         sx={{
-          minHeight: "100dvh",
+          minHeight: "100svh",
           height: "100%",
           display: "flex",
           backgroundColor: lightTheme.backgroundColor, // Extend background behind iOS safe area
@@ -731,7 +731,7 @@ const Layout: FC<{
               // visible gap below it. The shrink-by-userMenuHeight happens in
               // Sidebar.tsx for the secondary nav's content column only.
               // Use dvh (dynamic viewport height) for iOS Safari compatibility.
-              height: isBigScreen ? "100%" : "100dvh",
+              height: isBigScreen ? "100%" : "100svh",
               // The primary rail must remain viewport-anchored. Secondary
               // navigation owns its scrolling inside SlideMenuContainer.
               overflowY: "hidden",

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -720,10 +720,10 @@ const Layout: FC<{
                     ? visibleChatSidebarWidth
                     : themeConfig.drawerWidth
                   : isPhone
-                    ? "100vw"
+                    ? "100%"
                     : themeConfig.smallDrawerWidth
                 : 64,
-              maxWidth: "100vw",
+              maxWidth: "100%",
               boxSizing: "border-box",
               overflowX: "hidden", // Prevent horizontal scrolling
               // Drawer takes full viewport height. The floating user menu is
@@ -732,7 +732,7 @@ const Layout: FC<{
               // visible gap below it. The shrink-by-userMenuHeight happens in
               // Sidebar.tsx for the secondary nav's content column only.
               // Use dvh (dynamic viewport height) for iOS Safari compatibility.
-              height: isBigScreen ? "100%" : "var(--app-height, 100svh)",
+              height: isBigScreen ? "100%" : "min(var(--app-height, 100svh), 100svh)",
               // The primary rail must remain viewport-anchored. Secondary
               // navigation owns its scrolling inside SlideMenuContainer.
               overflowY: "hidden",

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -56,6 +56,7 @@ import useAccount from "../hooks/useAccount";
 import useLightTheme from "../hooks/useLightTheme";
 import useThemeConfig from "../hooks/useThemeConfig";
 import useIsBigScreen from "../hooks/useIsBigScreen";
+import useIsPhone from "../hooks/useIsPhone";
 import useApps from "../hooks/useApps";
 import useUserMenuHeight from "../hooks/useUserMenuHeight";
 import { LIGHT_SIDEBAR_COLORS } from "../styles/themeTokens";
@@ -253,6 +254,9 @@ const Layout: FC<{
   const themeConfig = useThemeConfig();
   const lightTheme = useLightTheme();
   const isBigScreen = useIsBigScreen();
+  // A phone has no room for the 300px drawer to sit beside the conversation —
+  // the chat list ends up a strip too narrow to read. It takes the screen.
+  const isPhone = useIsPhone();
   const router = useRouter();
   const account = useAccount();
   const apps = useApps();
@@ -714,8 +718,11 @@ const Layout: FC<{
                   ? isConversationRoute
                     ? visibleChatSidebarWidth
                     : themeConfig.drawerWidth
-                  : themeConfig.smallDrawerWidth
+                  : isPhone
+                    ? "100vw"
+                    : themeConfig.smallDrawerWidth
                 : 64,
+              maxWidth: "100vw",
               boxSizing: "border-box",
               overflowX: "hidden", // Prevent horizontal scrolling
               // Drawer takes full viewport height. The floating user menu is

--- a/frontend/src/utils/usageMetrics.test.ts
+++ b/frontend/src/utils/usageMetrics.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 import {
   buildCacheHitRatioChartData,
   getAggregateCacheHitRatio,
+  getAggregateToolCallErrorRate,
   getCacheHitRatio,
+  getToolCallErrorRate,
   getTotalInputTokens,
   getUncachedInputTokens,
 } from './usageMetrics'
@@ -74,5 +76,31 @@ describe('usage metrics', () => {
       { date: '2026-08-02T00:00:00Z', claude_code: 0.9, 'agent-1': 0.5 },
       { date: '2026-08-03T00:00:00Z' },
     ])
+  })
+})
+
+describe('tool call error rate', () => {
+  it('divides errored requests by requests that returned tool calls', () => {
+    expect(getToolCallErrorRate({ tool_call_requests: 200, tool_call_error_requests: 8 })).toBe(0.04)
+  })
+
+  it('reports nothing for a bucket too small to be meaningful', () => {
+    expect(getToolCallErrorRate({ tool_call_requests: 2, tool_call_error_requests: 1 })).toBeNull()
+    expect(getToolCallErrorRate({})).toBeNull()
+  })
+
+  it('aggregates as a ratio of sums, not a mean of daily ratios', () => {
+    const rate = getAggregateToolCallErrorRate([
+      { tool_call_requests: 2, tool_call_error_requests: 1 },
+      { tool_call_requests: 998, tool_call_error_requests: 9 },
+    ])
+
+    // Mean of the daily ratios would be ~25%; the busy day dominates instead.
+    expect(rate).toBeCloseTo(10 / 1_000)
+  })
+
+  it('has no aggregate when no request returned a tool call', () => {
+    expect(getAggregateToolCallErrorRate([{ tool_call_requests: 0 }])).toBeNull()
+    expect(getAggregateToolCallErrorRate([])).toBeNull()
   })
 })

--- a/frontend/src/utils/usageMetrics.ts
+++ b/frontend/src/utils/usageMetrics.ts
@@ -60,3 +60,35 @@ export const buildCacheHitRatioChartData = (series: CacheUsageTimeSeries[]): Cac
 
   return Array.from(dates.values()).sort((a, b) => a.date.localeCompare(b.date))
 }
+
+export interface ToolCallUsageMetric {
+  tool_call_requests?: number
+  tool_call_error_requests?: number
+}
+
+// A tool call error rate is only meaningful once enough requests have landed in
+// the bucket. Below this a single bad call swings a day from 0% to 50%, which
+// reads as a provider outage rather than the noise it is. Buckets under the
+// floor are reported as null so the chart leaves a gap instead of a spike.
+export const MIN_TOOL_CALL_REQUESTS = 20
+
+export const getToolCallErrorRate = (
+  metric: ToolCallUsageMetric,
+  minRequests: number = MIN_TOOL_CALL_REQUESTS,
+): number | null => {
+  const requests = metric.tool_call_requests ?? 0
+  if (requests < minRequests) return null
+  return (metric.tool_call_error_requests ?? 0) / requests
+}
+
+export const getAggregateToolCallErrorRate = (metrics: ToolCallUsageMetric[]): number | null => {
+  const totals = metrics.reduce((aggregate, metric) => ({
+    tool_call_requests: aggregate.tool_call_requests + (metric.tool_call_requests ?? 0),
+    tool_call_error_requests: aggregate.tool_call_error_requests + (metric.tool_call_error_requests ?? 0),
+  }), { tool_call_requests: 0, tool_call_error_requests: 0 })
+
+  // The aggregate is a ratio of sums, never a mean of daily ratios — the latter
+  // would weight a day with three tool calls the same as a day with thirty
+  // thousand. One request is enough to report a total.
+  return getToolCallErrorRate(totals, 1)
+}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3822,6 +3822,10 @@ definitions:
         type: integer
       sandbox_cost:
         type: number
+      tool_call_error_requests:
+        type: integer
+      tool_call_requests:
+        type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
         type: number
@@ -7120,6 +7124,12 @@ definitions:
         type: integer
       error:
         type: string
+      finish_reason:
+        description: |-
+          FinishReason is the provider's reason for stopping ("stop", "tool_calls",
+          "length", ...). Anthropic's stop_reason is normalised onto the same
+          vocabulary so the two proxies stay comparable.
+        type: string
       id:
         type: string
       interaction_id:
@@ -7164,6 +7174,21 @@ definitions:
           generation stays normal). 0 means no chunk was received (the call errored
           or was cut before the first token). For non-streaming calls it equals the
           time to the full response.
+        type: integer
+      tool_call_error_kinds:
+        type: string
+      tool_call_errors:
+        type: integer
+      tool_calls_returned:
+        type: integer
+      tools_offered:
+        description: |-
+          Tool call validity. ToolsOffered is how many tools the request carried,
+          ToolCallsReturned how many calls came back, ToolCallErrors how many of
+          those were structurally unusable, and ToolCallErrorKinds which buckets
+          they fell into (see api/pkg/toolcall). Tools offered with no calls
+          returned is not an error — it is a turn the model chose to answer in
+          prose.
         type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
@@ -12790,6 +12815,10 @@ definitions:
         type: string
       started_at:
         type: string
+      tool_call_error_requests:
+        type: integer
+      tool_call_requests:
+        type: integer
       total_cost:
         type: number
       total_requests:

--- a/openapi.json
+++ b/openapi.json
@@ -33385,6 +33385,12 @@
                     "sandbox_cost": {
                         "type": "number"
                     },
+                    "tool_call_error_requests": {
+                        "type": "integer"
+                    },
+                    "tool_call_requests": {
+                        "type": "integer"
+                    },
                     "total_cost": {
                         "description": "Prompt + completion + cache read + cache write",
                         "type": "number"
@@ -37817,6 +37823,10 @@
                     "error": {
                         "type": "string"
                     },
+                    "finish_reason": {
+                        "description": "FinishReason is the provider's reason for stopping (\"stop\", \"tool_calls\",\n\"length\", ...). Anthropic's stop_reason is normalised onto the same\nvocabulary so the two proxies stay comparable.",
+                        "type": "string"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -37873,6 +37883,19 @@
                     },
                     "time_to_first_token_ms": {
                         "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                        "type": "integer"
+                    },
+                    "tool_call_error_kinds": {
+                        "type": "string"
+                    },
+                    "tool_call_errors": {
+                        "type": "integer"
+                    },
+                    "tool_calls_returned": {
+                        "type": "integer"
+                    },
+                    "tools_offered": {
+                        "description": "Tool call validity. ToolsOffered is how many tools the request carried,\nToolCallsReturned how many calls came back, ToolCallErrors how many of\nthose were structurally unusable, and ToolCallErrorKinds which buckets\nthey fell into (see api/pkg/toolcall). Tools offered with no calls\nreturned is not an error — it is a turn the model chose to answer in\nprose.",
                         "type": "integer"
                     },
                     "total_cost": {
@@ -45456,6 +45479,12 @@
                     },
                     "started_at": {
                         "type": "string"
+                    },
+                    "tool_call_error_requests": {
+                        "type": "integer"
+                    },
+                    "tool_call_requests": {
+                        "type": "integer"
                     },
                     "total_cost": {
                         "type": "number"

--- a/swagger.json
+++ b/swagger.json
@@ -28780,6 +28780,12 @@
                 "sandbox_cost": {
                     "type": "number"
                 },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
+                },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",
                     "type": "number"
@@ -33212,6 +33218,10 @@
                 "error": {
                     "type": "string"
                 },
+                "finish_reason": {
+                    "description": "FinishReason is the provider's reason for stopping (\"stop\", \"tool_calls\",\n\"length\", ...). Anthropic's stop_reason is normalised onto the same\nvocabulary so the two proxies stay comparable.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -33268,6 +33278,19 @@
                 },
                 "time_to_first_token_ms": {
                     "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
+                },
+                "tool_call_error_kinds": {
+                    "type": "string"
+                },
+                "tool_call_errors": {
+                    "type": "integer"
+                },
+                "tool_calls_returned": {
+                    "type": "integer"
+                },
+                "tools_offered": {
+                    "description": "Tool call validity. ToolsOffered is how many tools the request carried,\nToolCallsReturned how many calls came back, ToolCallErrors how many of\nthose were structurally unusable, and ToolCallErrorKinds which buckets\nthey fell into (see api/pkg/toolcall). Tools offered with no calls\nreturned is not an error — it is a turn the model chose to answer in\nprose.",
                     "type": "integer"
                 },
                 "total_cost": {
@@ -40851,6 +40874,12 @@
                 },
                 "started_at": {
                     "type": "string"
+                },
+                "tool_call_error_requests": {
+                    "type": "integer"
+                },
+                "tool_call_requests": {
+                    "type": "integer"
                 },
                 "total_cost": {
                     "type": "number"


### PR DESCRIPTION
## The bug behind the bug

The chat list on a phone wasn't just cramped — it was **clipped to zero height and painting nothing**. `useUserMenuHeight` picks the element to measure by walking up from the user avatar to the first ancestor with `position: fixed|absolute` and `bottom: 0`. On a phone the nav drawer is a *temporary* one, and MUI pins its Paper to `bottom: 0`, so the walk stopped there and reported the height of the whole drawer. `Sidebar` then sized its scroll column at `calc(100% - 844px)` with `overflow: hidden`. Every row was laid out at the right coordinates and drawn nowhere. Desktop escaped it only because `Layout` gives the permanent drawer `position: relative`.

The overlay now carries a `data-user-menu-overlay` marker and the hook asks for it by name instead of guessing from layout.

## What changed

**Full-screen list.** The drawer was a 300px strip beside the conversation; on a phone it takes the screen, so the list gets 326px next to the nav rail instead of 236.

**Two-line rows.** A phone can't open a hover tooltip, so each row carries its branch and harness on a second line, at a 52px touch target with a hairline between rows. Time and archive get a column each instead of swapping on hover — on a coarse pointer that meant the timestamp was *never* visible.

That second line and the desktop tooltip now read from one `getProjectChatItemDetails`. With no hover on a phone, a disagreement between them would be invisible, so they can't be allowed to drift. It also moved the tooltip's private harness-label table onto `AgentHarness`, which is where CLAUDE.md says harness identity lives; it gained the two runtimes the private table knew about and it didn't.

**Project name starts a chat.** Clicking a project name opens a new chat there rather than collapsing the group, on both mobile and desktop. Collapsing moves to the chevron, which becomes a real button with a 28px touch target on phones. The `+ New` button leaves the accessibility tree — the row around it now exposes the identical action, so to a screen reader it had become a second control with the same name.

**Bottom bar.** Filter, search and new-chat are the three things you do to a chat list, and they were at the top of a full-height list — hardest to reach one-handed, first to scroll away. They float at the bottom now. The desktop toolbar is hidden on phones rather than duplicated, and the filter sheet renders those same controls, so the two surfaces can't offer different filters.

**New-chat project picker.** The bottom bar's compose button and ⌘⇧O both open a picker instead of dropping you into whichever project you were looking at. Which project a chat belongs to is its first real decision, and choosing it up front doubles as the quickest way to move between projects. Command-palette shaped, per the t3code reference: type to filter on name or repo, arrow through, Enter to pick, ⌘1…⌘9 for the first nine, full-screen on a phone. Filtering uses `matchesAllTokens`, so "hook relay" finds `webhookrelay`.

## Verification

Driven with a real browser against the dev stack at 390px and 1440px, dark:

- Rows render with branch + harness, time and archive both visible, no horizontal overflow.
- Bottom bar: filter sheet opens with the project/sort/people/archive controls; search expands, filters, and clears; compose opens the picker.
- Picker on both widths: 3 rows, click selects → `chat?project_id=…`; ⌃⇧O opens it on desktop, ArrowDown+Enter selects.
- Project-name click → `…/chat` (new chat), chevron still collapses.
- Desktop sidebar unchanged, and `data-user-menu-overlay` measures 198px there rather than 844.

`yarn tsc`, `yarn build` and `yarn test` (161 files, 905 tests) pass. 14 new tests cover the picker's row building, keyboard navigation and filtering, plus the project-name/chevron split.

## Not verified

CI: `gh pr checks` reports no checks for this repo's PRs and this checkout has no Drone credentials, so I couldn't confirm the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)