### PR TITLE
fix(org): back off failed agent activations

### DIFF
--- a/api/pkg/org/infrastructure/agentdelivery/queue.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue.go
@@ -18,6 +18,7 @@ import (
 const (
 	streamName    = "HELIX_ORG_AGENT_ACTIVATIONS"
 	subjectPrefix = "helix-org.agent-activations"
+	maxRetryDelay = 30 * time.Minute
 )
 
 type envelope struct {
@@ -171,7 +172,7 @@ func (q *Queue) handle(msg *pubsub.Message) {
 	var delivery envelope
 	if err := json.Unmarshal(msg.Data, &delivery); err != nil {
 		q.logger.Error("agent delivery: decode", "err", err)
-		_ = msg.NakWithDelay(time.Second)
+		_ = msg.NakWithDelay(retryDelay(msg.NumDelivered))
 		return
 	}
 	done := make(chan struct{})
@@ -191,12 +192,23 @@ func (q *Queue) handle(msg *pubsub.Message) {
 	close(done)
 	if err != nil {
 		q.logger.Warn("agent delivery: activation failed", "agent", delivery.AgentID, "err", err)
-		_ = msg.NakWithDelay(time.Second)
+		_ = msg.NakWithDelay(retryDelay(msg.NumDelivered))
 		return
 	}
 	if err := msg.Ack(); err != nil {
 		q.logger.Error("agent delivery: ack", "agent", delivery.AgentID, "err", err)
 	}
+}
+
+func retryDelay(numDelivered uint64) time.Duration {
+	delay := time.Second
+	for delivered := uint64(1); delivered < numDelivered && delay < maxRetryDelay; delivered++ {
+		delay *= 2
+	}
+	if delay > maxRetryDelay {
+		return maxRetryDelay
+	}
+	return delay
 }
 
 func subjectFor(orgID string, agentID orgchart.NodeID) string {

--- a/api/pkg/org/infrastructure/agentdelivery/queue_test.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue_test.go
@@ -46,6 +46,13 @@ func TestQueueRetriesFailedActivation(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestRetryDelay(t *testing.T) {
+	require.Equal(t, time.Second, retryDelay(1))
+	require.Equal(t, 2*time.Second, retryDelay(2))
+	require.Equal(t, 30*time.Minute, retryDelay(12))
+	require.Equal(t, 30*time.Minute, retryDelay(^uint64(0)))
+}
+
 func TestQueueFansOutPerAgent(t *testing.T) {
 	n, err := pubsub.NewInMemoryNats()
 	require.NoError(t, err)

--- a/api/pkg/pubsub/durable.go
+++ b/api/pkg/pubsub/durable.go
@@ -71,7 +71,11 @@ func (n *Nats) ConsumeDurable(ctx context.Context, streamName, consumerName, sub
 				}
 				return
 			}
-			if err := handler(&Message{Data: msg.Data(), Header: msg.Headers(), msg: msg}); err != nil {
+			numDelivered := uint64(1)
+			if metadata, err := msg.Metadata(); err == nil {
+				numDelivered = metadata.NumDelivered
+			}
+			if err := handler(&Message{Data: msg.Data(), Header: msg.Headers(), NumDelivered: numDelivered, msg: msg}); err != nil {
 				log.Error().Err(err).Str("consumer", consumerName).Msg("durable consumer handler failed")
 			}
 		}

--- a/api/pkg/pubsub/durable_test.go
+++ b/api/pkg/pubsub/durable_test.go
@@ -17,11 +17,11 @@ func TestDurableConsumerRedeliversNak(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, n.EnsurePersistentStream(ctx, "DURABLE_REDELIVERY", []string{"durable.redelivery.*"}))
-	deliveries := make(chan []byte, 2)
+	deliveries := make(chan *Message, 2)
 	attempts := 0
 	sub, err := n.ConsumeDurable(ctx, "DURABLE_REDELIVERY", "worker-one", "durable.redelivery.one", time.Second, func(msg *Message) error {
 		attempts++
-		deliveries <- msg.Data
+		deliveries <- msg
 		if attempts == 1 {
 			return msg.Nak()
 		}
@@ -31,8 +31,12 @@ func TestDurableConsumerRedeliversNak(t *testing.T) {
 	defer sub.Unsubscribe()
 	require.NoError(t, n.PublishDurable(ctx, "DURABLE_REDELIVERY", "durable.redelivery.one", []byte("hello")))
 
-	require.Equal(t, []byte("hello"), <-deliveries)
-	require.Equal(t, []byte("hello"), <-deliveries)
+	first := <-deliveries
+	require.Equal(t, []byte("hello"), first.Data)
+	require.Equal(t, uint64(1), first.NumDelivered)
+	second := <-deliveries
+	require.Equal(t, []byte("hello"), second.Data)
+	require.Equal(t, uint64(2), second.NumDelivered)
 
 	stream, err := n.js.Stream(ctx, "DURABLE_REDELIVERY")
 	require.NoError(t, err)

--- a/api/pkg/pubsub/pubsub.go
+++ b/api/pkg/pubsub/pubsub.go
@@ -42,10 +42,11 @@ type DurableConsumer struct {
 }
 
 type Message struct {
-	Type   string
-	Reply  string
-	Data   []byte
-	Header nats.Header
+	Type         string
+	Reply        string
+	Data         []byte
+	Header       nats.Header
+	NumDelivered uint64
 
 	msg acker
 }


### PR DESCRIPTION
## Summary
- expose the durable JetStream delivery count to activation handlers
- exponentially back off failed activation delivery from 1 second to a 30 minute cap
- preserve per-agent FIFO, durable retry, AckWait, and heartbeat behavior

## Root cause
Every persistent activation failure was NAKed after one second. On Meta, a stale worker session produced 1,877 retries in 33 minutes before the queue could progress.

## Tests
- go test ./pkg/pubsub ./pkg/org/infrastructure/agentdelivery -count=1
- go test -race ./pkg/pubsub -run ^TestDurableConsumer -count=1
- go test -race ./pkg/org/infrastructure/agentdelivery -count=1
- git diff --check origin/main...HEAD