### PR TITLE
fix(usage): skip non-message Anthropic responses

### DIFF
--- a/api/pkg/anthropic/anthropic_proxy.go
+++ b/api/pkg/anthropic/anthropic_proxy.go
@@ -438,6 +438,9 @@ func (s *Proxy) logLLMCall(ctx context.Context, createdAt time.Time, resp []byte
 
 	usage := respMessage.Usage
 	modelName := string(respMessage.Model)
+	if modelName == "" {
+		return
+	}
 
 	vals, ok := oai.GetContextValues(ctx)
 	if !ok {

--- a/api/pkg/anthropic/anthropic_proxy_test.go
+++ b/api/pkg/anthropic/anthropic_proxy_test.go
@@ -221,6 +221,30 @@ func TestStreamingProxyLogsCumulativeUsageSnapshot(t *testing.T) {
 	assert.EqualValues(t, 20, call.CacheWriteTokens)
 }
 
+func TestLogLLMCallSkipsVertexErrorResponse(t *testing.T) {
+	modelInfoProvider, err := model.NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	logStore := &captureAnthropicLogStore{calls: make(chan *types.LLMCall, 1)}
+	proxy := New(&config.ServerConfig{}, nil, modelInfoProvider, logStore)
+
+	req, err := http.NewRequest(http.MethodPost, "https://localhost/v1/messages", nil)
+	require.NoError(t, err)
+	req = SetRequestProviderEndpoint(req, &types.ProviderEndpoint{
+		ID:      "vertex-endpoint",
+		Name:    "anthropic",
+		BaseURL: "https://us-east5-aiplatform.googleapis.com",
+	})
+
+	proxy.logLLMCall(req.Context(), time.Now(), []byte(`[{"error":{"code":403,"message":"Vertex AI API is disabled","status":"PERMISSION_DENIED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"SERVICE_DISABLED","domain":"googleapis.com"}]}}]`), nil, false, 0)
+
+	select {
+	case <-logStore.calls:
+		t.Fatal("Vertex error response was logged as an LLM call")
+	default:
+	}
+}
+
 func Test_stripDateFromModelName(t *testing.T) {
 	tests := []struct {
 		name      string // description of this test case


### PR DESCRIPTION
## Summary
- skip Anthropic proxy logging and billing when a response has no model
- cover the observed Vertex 403 SERVICE_DISABLED response

## Root cause
The Anthropic SDK accepted the Vertex error array as a zero-value message. Helix then persisted it as a blank-model, zero-token LLM call. Meta accumulated 137,393 of these rows.

## Tests
- go test ./pkg/anthropic ./pkg/openai/logger -count=1
- git diff --check origin/main...HEAD