### PR TITLE
feat(sandbox): capacity-aware dispatch for mixed GPU/CPU-only fleets

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -121,11 +121,12 @@ type ServerConfig struct {
 	// as demand pressure, so this value is what determines when scale-up
 	// fires under load.
 	//
-	// NOTE: this value only affects the autoscaler signal today; the
-	// dispatcher (FindAvailableSandboxInstance) does NOT enforce a hard
-	// rejection at the ceiling - new dev containers can still be placed
-	// on a "full" Runner (sorted ASC by active_sandboxes). Hard
-	// dispatcher rejection is tracked separately as a follow-up.
+	// The ceiling is also enforced at dispatch: the dispatcher
+	// (FindAvailableSandboxInstance and the custom-image host picker)
+	// skips Runners at max_sandboxes, so new dev containers are never
+	// placed on a "full" Runner. With every Runner at its ceiling,
+	// placement fails with a no-capacity error until the autoscaler
+	// adds a host or a container exits.
 	//
 	// Default 20. Raise for hosts with more headroom, lower to make
 	// the autoscaler trigger sooner on smaller hosts. Range is not

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -300,36 +300,9 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	containerType := h.parseContainerType(agent.DesktopType)
 
 	// Determine sandbox ID - use agent's preference or find an available one
-	sandboxID := agent.SandboxID
-	if sandboxID == "" {
-		// Headless agents use the helix-ubuntu toolchain image, so placement must
-		// select a host advertising that image even though the created container
-		// itself has no compositor or display devices.
-		placementImage := containerType
-		requiresDisplay := true
-		if containerType == "headless" {
-			placementImage = "ubuntu"
-			// No compositor, no encoder — a CPU-only host is fine, it just
-			// has to advertise the toolchain image.
-			requiresDisplay = false
-		}
-		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find available sandbox: %w", err)
-		}
-		if sandbox != nil {
-			sandboxID = sandbox.ID
-			log.Info().
-				Str("sandbox_id", sandboxID).
-				Str("container_type", containerType).
-				Msg("Auto-selected available sandbox")
-		} else {
-			// Fallback to "local" if no sandbox found (for backwards compatibility)
-			sandboxID = "local"
-			log.Warn().
-				Str("container_type", containerType).
-				Msg("No available sandbox found, falling back to 'local'")
-		}
+	sandboxID, err := h.resolveSandboxID(ctx, agent, containerType)
+	if err != nil {
+		return nil, err
 	}
 	hydraRunnerID := fmt.Sprintf("hydra-%s", sandboxID)
 	hydraClient := hydra.NewRevDialClient(h.connman, hydraRunnerID)
@@ -1303,6 +1276,61 @@ func (h *HydraExecutor) setExternalAgentStatus(ctx context.Context, sessionID, s
 	if _, err := h.store.UpdateSession(ctx, *dbSession); err != nil {
 		log.Debug().Err(err).Str("session_id", sessionID).Msg("Failed to update external agent status")
 	}
+}
+
+// resolveSandboxID returns the sandbox host to place this session's dev
+// container on: the agent's explicit preference if set, otherwise the best
+// available registered host. When hosts are registered but none is eligible
+// it fails with a no-capacity error rather than guessing — dialing a wrong
+// device key would just hang for the RevDial grace period and surface a
+// confusing connection error. The legacy "local" device key is used only
+// when the registry is empty (single-node install with no heartbeat
+// configured, where hydra listens as "hydra-local").
+func (h *HydraExecutor) resolveSandboxID(ctx context.Context, agent *types.DesktopAgent, containerType string) (string, error) {
+	if agent.SandboxID != "" {
+		return agent.SandboxID, nil
+	}
+
+	// Headless agents use the helix-ubuntu toolchain image, so placement must
+	// select a host advertising that image even though the created container
+	// itself has no compositor or display devices.
+	placementImage := containerType
+	requiresDisplay := true
+	if containerType == "headless" {
+		placementImage = "ubuntu"
+		// No compositor, no encoder — a CPU-only host is fine, it just
+		// has to advertise the toolchain image.
+		requiresDisplay = false
+	}
+	sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
+	if err != nil {
+		return "", fmt.Errorf("failed to find available sandbox: %w", err)
+	}
+	if sandbox != nil {
+		log.Info().
+			Str("sandbox_id", sandbox.ID).
+			Str("container_type", containerType).
+			Msg("Auto-selected available sandbox")
+		return sandbox.ID, nil
+	}
+
+	registered, err := h.store.ListSandboxInstances(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list sandbox instances: %w", err)
+	}
+	if len(registered) > 0 {
+		requirements := fmt.Sprintf("online with a fresh heartbeat, under its max_sandboxes ceiling, advertising the %q image", placementImage)
+		if requiresDisplay {
+			requirements += ", and display-capable"
+		}
+		return "", fmt.Errorf("no sandbox host has capacity for a %q container: none of the %d registered host(s) is %s",
+			containerType, len(registered), requirements)
+	}
+
+	log.Warn().
+		Str("container_type", containerType).
+		Msg("No sandbox instances registered, falling back to legacy 'local' device key")
+	return "local", nil
 }
 
 // parseContainerType converts desktop type string to container type

--- a/api/pkg/external-agent/hydra_executor_placement_test.go
+++ b/api/pkg/external-agent/hydra_executor_placement_test.go
@@ -1,0 +1,77 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestResolveSandboxIDHonoursExplicitPin(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{SandboxID: "omen"}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "omen", id)
+}
+
+func TestResolveSandboxIDAutoSelectsAvailableHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(&types.SandboxInstance{ID: "host-1"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "host-1", id)
+}
+
+func TestResolveSandboxIDHeadlessPlacesOnUbuntuImageWithoutDisplay(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	// Headless containers use the helix-ubuntu toolchain image but need no
+	// display-capable host.
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", false).
+		Return(&types.SandboxInstance{ID: "nas"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "headless")
+	require.NoError(t, err)
+	assert.Equal(t, "nas", id)
+}
+
+func TestResolveSandboxIDErrorsWhenFleetHasNoCapacity(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{{ID: "full-host"}}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	_, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no sandbox host has capacity")
+}
+
+func TestResolveSandboxIDFallsBackToLocalOnEmptyRegistry(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return(nil, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "local", id)
+}

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -485,7 +485,7 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		}
 		readyByID[r.ID] = r
 		readyCount++
-		if isReadyAndOnline(r) && r.CanHostDesktop() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+		if isReadyAndOnline(r) && r.CanHostDesktop() && r.AtMaxCapacity() {
 			fleetAtCap = true
 		}
 	}

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -457,13 +457,25 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 	if err != nil {
 		return nil, fmt.Errorf("list hosts: %w", err)
 	}
+	// Headless containers run no compositor and no encoder, so any online
+	// host under its ceiling will do - including CPU-only and inference
+	// accelerator hosts that cannot stream a desktop. Prefer those, so
+	// render-capable hosts keep their slots free for desktop work.
+	var renderCapable *types.SandboxInstance
 	for _, h := range hosts {
-		// Headless containers run no compositor and no encoder, so any
-		// online host will do - including CPU-only and inference
-		// accelerator hosts that cannot stream a desktop.
-		if h.Status == "online" {
-			return h, nil
+		if h.Status != "online" || h.AtMaxCapacity() {
+			continue
 		}
+		if h.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = h
+			}
+			continue
+		}
+		return h, nil
+	}
+	if renderCapable != nil {
+		return renderCapable, nil
 	}
 	return nil, errors.New("no available sandbox host with the requested runtime")
 }

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -279,8 +279,9 @@ func (s *PostgresStore) GetSandboxInstancesOlderThanHeartbeat(ctx context.Contex
 	return instances, nil
 }
 
-// FindAvailableSandboxInstance finds a sandbox host that is online, has recent heartbeat, and has the required desktop version.
-// Returns nil if no suitable sandbox host is found.
+// FindAvailableSandboxInstance finds a sandbox host that is online, has a
+// recent heartbeat, is under its max_sandboxes ceiling, and has the required
+// desktop version. Returns nil if no suitable sandbox host is found.
 //
 // requiresDisplay narrows the search to render-capable hosts. Pass true when
 // the container will run a compositor and be streamed; pass false for
@@ -305,28 +306,50 @@ func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, deskto
 	if err != nil {
 		return nil, fmt.Errorf("error finding available sandboxes: %w", err)
 	}
+	return pickSandboxInstance(instances, desktopType, requiresDisplay), nil
+}
 
-	// Find one with the required desktop version
+// pickSandboxInstance selects a dispatch target from load-ordered candidate
+// rows (least-loaded first). A candidate must be under its max_sandboxes
+// ceiling and advertise a non-empty image tag for desktopType in its
+// heartbeat blob.
+//
+// Streamed desktops (requiresDisplay) only run on render-capable hosts: a
+// neuron/inf2 host (no /dev/dri render node) would otherwise be picked on
+// load alone, then the desktop container FATALs at startup.
+//
+// Headless work runs anywhere, but prefers hosts that CANNOT stream a
+// desktop (CPU-only, software render) so render-capable hosts keep their
+// slots free for desktop sessions; a render-capable host is only used when
+// no display-incapable host qualifies.
+func pickSandboxInstance(instances []*types.SandboxInstance, desktopType string, requiresDisplay bool) *types.SandboxInstance {
+	var renderCapable *types.SandboxInstance
 	for _, instance := range instances {
-		// Streamed desktops only run on render-capable hosts. A neuron/inf2
-		// host (no /dev/dri render node) would otherwise be picked on load
-		// alone, then the desktop container FATALs at startup. Headless
-		// containers have no such constraint.
+		if instance.AtMaxCapacity() {
+			continue
+		}
 		if requiresDisplay && !instance.CanHostDesktop() {
 			continue
 		}
-		if len(instance.DesktopVersions) > 0 {
-			var versions map[string]string
-			if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
-				continue // Skip sandboxes with invalid version JSON
-			}
-			if version, ok := versions[desktopType]; ok && version != "" {
-				return instance, nil
-			}
+		if len(instance.DesktopVersions) == 0 {
+			continue
 		}
+		var versions map[string]string
+		if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
+			continue // Skip sandboxes with invalid version JSON
+		}
+		if version, ok := versions[desktopType]; !ok || version == "" {
+			continue
+		}
+		if !requiresDisplay && instance.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = instance
+			}
+			continue
+		}
+		return instance
 	}
-
-	return nil, nil // No suitable sandbox found
+	return renderCapable
 }
 
 // Disk usage history methods

--- a/api/pkg/store/store_sandbox_pick_test.go
+++ b/api/pkg/store/store_sandbox_pick_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func pickTestInstance(t *testing.T, id, gpuVendor string, active, maxSandboxes int, versions map[string]string) *types.SandboxInstance {
+	t.Helper()
+	blob, err := json.Marshal(versions)
+	if err != nil {
+		t.Fatalf("marshal versions: %v", err)
+	}
+	return &types.SandboxInstance{
+		ID:              id,
+		GPUVendor:       gpuVendor,
+		ActiveSandboxes: active,
+		MaxSandboxes:    maxSandboxes,
+		DesktopVersions: blob,
+	}
+}
+
+func TestPickSandboxInstance(t *testing.T) {
+	ubuntu := map[string]string{"ubuntu": "abc123"}
+
+	tests := []struct {
+		name            string
+		instances       []*types.SandboxInstance
+		desktopType     string
+		requiresDisplay bool
+		wantID          string // "" means nil
+	}{
+		{
+			name:   "no instances",
+			wantID: "",
+		},
+		{
+			name: "desktop picks first load-ordered render-capable host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "a", "nvidia", 1, 20, ubuntu),
+				pickTestInstance(t, "b", "nvidia", 2, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "a",
+		},
+		{
+			name: "desktop skips cpu-only host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, ubuntu),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "gpu",
+		},
+		{
+			name: "headless prefers cpu-only host over less loaded gpu host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "gpu", "nvidia", 0, 20, ubuntu),
+				pickTestInstance(t, "nas", "none", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "nas",
+		},
+		{
+			name: "headless falls back to gpu host when no cpu-only host qualifies",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "gpu",
+		},
+		{
+			name: "host at max_sandboxes ceiling is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+				pickTestInstance(t, "free", "nvidia", 21, 40, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "free",
+		},
+		{
+			name: "all hosts at ceiling yields nil",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "zero max_sandboxes means no ceiling",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "legacy", "nvidia", 50, 0, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "legacy",
+		},
+		{
+			name: "host missing the requested image is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "sway-only", "nvidia", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "ubuntu-host", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "ubuntu-host",
+		},
+		{
+			name: "host with empty version string is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "empty", "nvidia", 0, 20, map[string]string{"ubuntu": ""}),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "invalid version JSON is skipped",
+			instances: []*types.SandboxInstance{
+				{ID: "bad", GPUVendor: "nvidia", MaxSandboxes: 20, DesktopVersions: []byte("{not json")},
+				pickTestInstance(t, "good", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "good",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickSandboxInstance(tc.instances, tc.desktopType, tc.requiresDisplay)
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
+			}
+			if gotID != tc.wantID {
+				t.Errorf("pickSandboxInstance() = %q, want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3663,6 +3663,13 @@ func (s *SandboxInstance) CanHostDesktop() bool {
 	return s.RenderNode != "SOFTWARE"
 }
 
+// AtMaxCapacity reports whether this host has reached its configured dev
+// container ceiling (SandboxMaxDevContainers at registration time).
+// MaxSandboxes 0 means no ceiling was recorded and never binds.
+func (s *SandboxInstance) AtMaxCapacity() bool {
+	return s.MaxSandboxes > 0 && s.ActiveSandboxes >= s.MaxSandboxes
+}
+
 // SandboxHeartbeatRequest is sent by sandbox-heartbeat daemon every 30 seconds
 type SandboxHeartbeatRequest struct {
 	// Desktop image versions (content-addressable Docker image hashes)

--- a/api/pkg/types/types_test.go
+++ b/api/pkg/types/types_test.go
@@ -30,6 +30,26 @@ func TestSandboxInstanceCanHostDesktop(t *testing.T) {
 	}
 }
 
+func TestSandboxInstanceAtMaxCapacity(t *testing.T) {
+	cases := []struct {
+		name   string
+		active int
+		max    int
+		want   bool
+	}{
+		{"under ceiling", 3, 20, false},
+		{"at ceiling", 20, 20, true},
+		{"over ceiling", 21, 20, true},
+		{"no ceiling recorded", 100, 0, false},
+	}
+	for _, tc := range cases {
+		s := &SandboxInstance{ActiveSandboxes: tc.active, MaxSandboxes: tc.max}
+		if got := s.AtMaxCapacity(); got != tc.want {
+			t.Errorf("%s: AtMaxCapacity()=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func Test_SessionChatRequest_PlainString(t *testing.T) {
 	request := &SessionChatRequest{
 		Messages: []*Message{

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -1,0 +1,110 @@
+# Multi-node scheduling for GPU-less hosts + headless agent sessions
+
+**Date:** 2026-08-21
+**Status:** Partially landed upstream; remainder in `feature/capability-aware-sandbox-scheduling` + follow-ups
+**Author:** Waqas Ahmad
+
+## Motivation
+
+A common Helix topology is one GPU workstation plus one or more cheap CPU-only
+machines (a NAS, spare servers, ordinary cloud VMs), all reachable over a
+private network such as Tailscale. We want:
+
+1. CPU-only hosts to join the cluster and receive the workloads they can
+   actually run.
+2. The user (or Helix) to decide per-session where it runs and whether it
+   needs a watchable desktop at all.
+3. Headless agent sessions — agent + toolchain without a compositor or
+   encoder — to land on the cheap hosts, keeping GPU capacity free for
+   streamed desktops.
+
+Concrete driving setup: `omen` (NVIDIA, runs the control plane + desktop
+sessions) and a GPU-less Ubuntu NAS on the same tailnet (runs headless
+sessions and headless Sandboxes-API containers).
+
+## Already shipped upstream (no work needed)
+
+- **Cluster join**: `sandbox_instances` registry, outbound-only RevDial
+  attach (`api/cmd/hydra/main.go`), auto-registration on connect
+  (`api/pkg/server/server.go` `ensureSandboxRegistered`), 30s heartbeat with
+  `desktop_versions`/`gpu_vendor`/`render_node`, admin Runners page.
+  Adding a node: `./install.sh --sandbox --api-host <url> --runner-token
+  <tok>`. Works over Tailscale — no inbound ports on the node.
+- **Capability-aware placement**: `SandboxInstance.CanHostDesktop()`
+  (`api/pkg/types/types.go`) gates only *streamed desktop* placement;
+  `FindAvailableSandboxInstance(ctx, desktopType, requiresDisplay)` places
+  headless work on any online host including CPU-only ones.
+  `RuntimeSpec.RequiresDisplay` does the same for the Sandboxes API
+  (`api/pkg/sandbox/runtimes.go`, `controller_provision.go`).
+- **Headless spec-task runtime**: `SandboxRuntimeHeadlessUbuntu` /
+  `desktop_type: headless` runs the helix-ubuntu toolchain image with no
+  compositor, display devices, or encoder (`hydra_executor.go` — display
+  env skipped, placement with `requiresDisplay=false`). Chat rides the
+  Zed↔Helix `external_websocket_sync` WebSocket, independent of video.
+- **Sticky placement + data safety**: sessions pin to `session.SandboxID`;
+  persistent Sandboxes-API sandboxes refuse to move off their bound host
+  (workspaces are host-local disk) — `controller_provision.go`
+  `pickHostForSandbox`.
+
+## This PR: `feature/capability-aware-sandbox-scheduling`
+
+Closes the remaining dispatch gaps for mixed GPU / CPU-only fleets:
+
+1. **Prefer CPU-only hosts for headless work.** The picker
+   (`pickSandboxInstance`, `api/pkg/store/store_sandbox.go`) now places
+   `requiresDisplay=false` work on a display-*incapable* host when one
+   qualifies, falling back to render-capable hosts otherwise — so headless
+   sessions drain to the NAS and GPU slots stay free for desktops. Same
+   preference in the custom-image host loop
+   (`controller_provision.go` `pickHostForSandbox`).
+2. **`max_sandboxes` enforced at dispatch** (was autoscaler-signal only,
+   flagged as a follow-up in `config.go`): hosts at their ceiling are
+   skipped; a fleet fully at ceiling yields a no-capacity error instead of
+   overloading the least-loaded host. `MaxSandboxes == 0` (pre-field rows)
+   means no ceiling. Shared predicate: `SandboxInstance.AtMaxCapacity()`.
+3. **No more silent `"local"` fallback** (`hydra_executor.go`
+   `resolveSandboxID`): when hosts are registered but none is eligible,
+   placement fails with an error naming the container type, image key, and
+   requirements — instead of dialing the `hydra-local` device key and
+   hanging out the RevDial grace period. The `"local"` key remains only for
+   the legacy single-node install with an empty registry.
+4. **Dev compose**: `SANDBOX_INSTANCE_ID` is overridable
+   (`${SANDBOX_INSTANCE_ID:-local}`) so a second dev node doesn't collide
+   with the hardcoded `local` row.
+
+Tests: `TestPickSandboxInstance` (store), `TestResolveSandboxID*`
+(external-agent, gomock store), `TestSandboxInstanceAtMaxCapacity` (types).
+
+## Follow-up: per-session host selection (user picks the node)
+
+`DesktopAgent.SandboxID` already pins placement (used by golden builds and
+honoured first in `resolveSandboxID`), but is not exposed to users:
+
+- API: accept optional `sandbox_id` on session / spec-task creation and
+  `CreateSandboxRequest`; validate the host is online and satisfies the
+  workload's display requirement — reject, never silently reschedule a pin.
+- Frontend: host dropdown at session creation (default **Auto**), populated
+  from the sandbox-instances listing; show hostname, GPU vendor, load.
+
+## Mode switching (headless ↔ desktop), for reference
+
+- *Same host*: stop the container, start with the other desktop type for the
+  same session — chat history (Postgres) and workspace
+  (`/data/workspaces/<sid>` on the host) survive; an in-flight agent turn is
+  interrupted (same as any resume).
+- *Cross host* (NAS headless → GPU desktop): blocked — workspaces are
+  host-local (same rationale as the persistent-sandbox refusal). Workflow:
+  agent pushes its branch, reopen on the target host. Cross-host workspace
+  sync is out of scope.
+
+## Multi-node operational notes
+
+- A remote node cannot use the dev `registry:5000` image path — it pulls
+  from ghcr.io (prod path) or a tailnet-reachable registry via
+  `HELIX_SANDBOX_REGISTRY`.
+- Upgrades touch the control plane *and* each node (re-run
+  `install.sh --sandbox` / bump `SANDBOX_TAG`). A stale node degrades
+  gracefully: it stops receiving new sessions once its advertised
+  `desktop_versions` no longer match, but keeps serving running ones.
+- `MAX_SANDBOXES` on each node is the operator throttle, now enforced at
+  dispatch (this PR).

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -238,7 +238,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -334,7 +334,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -428,7 +428,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -518,7 +518,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}


### PR DESCRIPTION
# PR 1 — feat(sandbox): capacity-aware dispatch for mixed GPU/CPU-only fleets

**Branch:** `feature/capability-aware-sandbox-scheduling` (based on `helixml/helix` main)
**Target:** `helixml/helix` `main`

## What

Closes the remaining dispatch gaps for clusters that mix a GPU host with cheap CPU-only sandbox nodes (e.g. one NVIDIA workstation + a GPU-less NAS attached via `install.sh --sandbox`):

1. **Prefer display-incapable hosts for headless placement.** `FindAvailableSandboxInstance` (and the custom-image host loop in `pickHostForSandbox`) now places `requiresDisplay=false` work on a CPU-only / software-render host when one qualifies, falling back to render-capable hosts otherwise. Headless sessions drain to the cheap nodes; GPU slots stay free for streamed desktops.
2. **Enforce `max_sandboxes` at dispatch.** Previously the ceiling only fed the autoscaler signal (flagged as a follow-up in `config.go`); the dispatcher would keep loading a "full" runner. Hosts at their ceiling are now skipped, via a shared `SandboxInstance.AtMaxCapacity()` predicate (also reused in `compute/manager.go`). `MaxSandboxes == 0` (rows predating the field) never binds.
3. **Fail loudly instead of dialing `hydra-local`.** When sandbox hosts are registered but none is eligible, `StartDesktop` placement (extracted to `resolveSandboxID`) returns a no-capacity error naming the container type, image key, and unmet requirements — instead of silently falling back to the `local` device key and hanging for the RevDial grace period with a confusing connection error. The `local` fallback remains only for legacy single-node installs with an empty registry.
4. **Dev compose:** `SANDBOX_INSTANCE_ID` is overridable (`${SANDBOX_INSTANCE_ID:-local}`) so a second dev node doesn't collide with the hardcoded `local` row.

Design doc with the full multi-node context and follow-ups (user-selectable host at session creation): `design/2026-08-21-multi-node-scheduling-and-headless-sessions.md`.

## Behavior changes

- A runner at `max_sandboxes` no longer receives new dev containers; a fleet fully at ceiling yields a no-capacity error until the autoscaler adds a host or a container exits.
- Headless work now prefers CPU-only hosts when both are eligible (was: pure least-loaded / first-online-match).
- Fleet-with-no-eligible-host is now an immediate typed error (was: silent `local` fallback).

## Tests

- `TestPickSandboxInstance` (store): display gating, version matching, ceiling skip, CPU-first preference, load-order fallback — pure function, no Postgres needed.
- `TestResolveSandboxID*` (external-agent, gomock store): explicit pin honoured, headless placed with `("ubuntu", requiresDisplay=false)`, no-capacity error with registered hosts, `local` fallback only on empty registry.
- `TestSandboxInstanceAtMaxCapacity` (types).

All of `./api/pkg/sandbox/... ./api/pkg/external-agent/ ./api/pkg/types/` pass locally (go 1.25). NOT tested: live multi-node dispatch against a second physical host — single-node dev-stack behavior is unchanged by design (registry non-empty → same picker path; the `local` fallback only triggers with an empty registry).