### PR TITLE
feat(sandbox): user-selectable sandbox host for spec tasks and sessions

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -121,11 +121,12 @@ type ServerConfig struct {
 	// as demand pressure, so this value is what determines when scale-up
 	// fires under load.
 	//
-	// NOTE: this value only affects the autoscaler signal today; the
-	// dispatcher (FindAvailableSandboxInstance) does NOT enforce a hard
-	// rejection at the ceiling - new dev containers can still be placed
-	// on a "full" Runner (sorted ASC by active_sandboxes). Hard
-	// dispatcher rejection is tracked separately as a follow-up.
+	// The ceiling is also enforced at dispatch: the dispatcher
+	// (FindAvailableSandboxInstance and the custom-image host picker)
+	// skips Runners at max_sandboxes, so new dev containers are never
+	// placed on a "full" Runner. With every Runner at its ceiling,
+	// placement fails with a no-capacity error until the autoscaler
+	// adds a host or a container exits.
 	//
 	// Default 20. Raise for hosts with more headroom, lower to make
 	// the autoscaler trigger sooner on smaller hosts. Range is not

--- a/api/pkg/external-agent/host_pin.go
+++ b/api/pkg/external-agent/host_pin.go
@@ -1,0 +1,42 @@
+package external_agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/store"
+)
+
+// DesktopTypeRequiresDisplay reports whether a desktop type needs a
+// display-capable sandbox host. Only "headless" runs without a compositor
+// and encoder; every other type is a streamed desktop.
+func DesktopTypeRequiresDisplay(desktopType string) bool {
+	return !strings.EqualFold(desktopType, "headless")
+}
+
+// ValidateSandboxHostPin checks that an explicitly requested sandbox host
+// exists, is online, and satisfies the workload's display requirement.
+// Pinned placement bypasses the dispatcher's eligibility filters, so this is
+// the only gate between a user's host choice and a container that would FATAL
+// on a display-incapable host or dial a dead RevDial key. Capacity is
+// deliberately not checked — it is transient, and a user pinning a host is
+// asking for that host, full or not.
+//
+// An empty hostID means "dispatcher chooses" and always validates.
+func ValidateSandboxHostPin(ctx context.Context, s store.Store, hostID string, requiresDisplay bool) error {
+	if hostID == "" {
+		return nil
+	}
+	host, err := s.GetSandboxInstance(ctx, hostID)
+	if err != nil {
+		return fmt.Errorf("sandbox host %q not found: %w", hostID, err)
+	}
+	if host.Status != "online" {
+		return fmt.Errorf("sandbox host %q is %s, not online", hostID, host.Status)
+	}
+	if requiresDisplay && !host.CanHostDesktop() {
+		return fmt.Errorf("sandbox host %q cannot run a streamed desktop (gpu_vendor=%q, render_node=%q); pick a display-capable host or use the headless runtime", hostID, host.GPUVendor, host.RenderNode)
+	}
+	return nil
+}

--- a/api/pkg/external-agent/host_pin_test.go
+++ b/api/pkg/external-agent/host_pin_test.go
@@ -1,0 +1,71 @@
+package external_agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDesktopTypeRequiresDisplay(t *testing.T) {
+	assert.False(t, DesktopTypeRequiresDisplay("headless"))
+	assert.False(t, DesktopTypeRequiresDisplay("Headless"))
+	assert.True(t, DesktopTypeRequiresDisplay("ubuntu"))
+	assert.True(t, DesktopTypeRequiresDisplay("sway"))
+	assert.True(t, DesktopTypeRequiresDisplay("")) // default desktop
+}
+
+func TestValidateSandboxHostPinEmptyIsNoop(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "", true))
+}
+
+func TestValidateSandboxHostPinUnknownHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "ghost").Return(nil, errors.New("record not found"))
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "ghost", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestValidateSandboxHostPinOfflineHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "offline"}, nil)
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "nas", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not online")
+}
+
+func TestValidateSandboxHostPinDesktopOnCPUOnlyHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "online", GPUVendor: "none"}, nil)
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "nas", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot run a streamed desktop")
+}
+
+func TestValidateSandboxHostPinHeadlessOnCPUOnlyHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "online", GPUVendor: "none"}, nil)
+
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "nas", false))
+}
+
+func TestValidateSandboxHostPinDesktopOnGPUHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "omen").
+		Return(&types.SandboxInstance{ID: "omen", Status: "online", GPUVendor: "nvidia"}, nil)
+
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "omen", true))
+}

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -300,36 +300,9 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	containerType := h.parseContainerType(agent.DesktopType)
 
 	// Determine sandbox ID - use agent's preference or find an available one
-	sandboxID := agent.SandboxID
-	if sandboxID == "" {
-		// Headless agents use the helix-ubuntu toolchain image, so placement must
-		// select a host advertising that image even though the created container
-		// itself has no compositor or display devices.
-		placementImage := containerType
-		requiresDisplay := true
-		if containerType == "headless" {
-			placementImage = "ubuntu"
-			// No compositor, no encoder — a CPU-only host is fine, it just
-			// has to advertise the toolchain image.
-			requiresDisplay = false
-		}
-		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find available sandbox: %w", err)
-		}
-		if sandbox != nil {
-			sandboxID = sandbox.ID
-			log.Info().
-				Str("sandbox_id", sandboxID).
-				Str("container_type", containerType).
-				Msg("Auto-selected available sandbox")
-		} else {
-			// Fallback to "local" if no sandbox found (for backwards compatibility)
-			sandboxID = "local"
-			log.Warn().
-				Str("container_type", containerType).
-				Msg("No available sandbox found, falling back to 'local'")
-		}
+	sandboxID, err := h.resolveSandboxID(ctx, agent, containerType)
+	if err != nil {
+		return nil, err
 	}
 	hydraRunnerID := fmt.Sprintf("hydra-%s", sandboxID)
 	hydraClient := hydra.NewRevDialClient(h.connman, hydraRunnerID)
@@ -1303,6 +1276,61 @@ func (h *HydraExecutor) setExternalAgentStatus(ctx context.Context, sessionID, s
 	if _, err := h.store.UpdateSession(ctx, *dbSession); err != nil {
 		log.Debug().Err(err).Str("session_id", sessionID).Msg("Failed to update external agent status")
 	}
+}
+
+// resolveSandboxID returns the sandbox host to place this session's dev
+// container on: the agent's explicit preference if set, otherwise the best
+// available registered host. When hosts are registered but none is eligible
+// it fails with a no-capacity error rather than guessing — dialing a wrong
+// device key would just hang for the RevDial grace period and surface a
+// confusing connection error. The legacy "local" device key is used only
+// when the registry is empty (single-node install with no heartbeat
+// configured, where hydra listens as "hydra-local").
+func (h *HydraExecutor) resolveSandboxID(ctx context.Context, agent *types.DesktopAgent, containerType string) (string, error) {
+	if agent.SandboxID != "" {
+		return agent.SandboxID, nil
+	}
+
+	// Headless agents use the helix-ubuntu toolchain image, so placement must
+	// select a host advertising that image even though the created container
+	// itself has no compositor or display devices.
+	placementImage := containerType
+	requiresDisplay := true
+	if containerType == "headless" {
+		placementImage = "ubuntu"
+		// No compositor, no encoder — a CPU-only host is fine, it just
+		// has to advertise the toolchain image.
+		requiresDisplay = false
+	}
+	sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
+	if err != nil {
+		return "", fmt.Errorf("failed to find available sandbox: %w", err)
+	}
+	if sandbox != nil {
+		log.Info().
+			Str("sandbox_id", sandbox.ID).
+			Str("container_type", containerType).
+			Msg("Auto-selected available sandbox")
+		return sandbox.ID, nil
+	}
+
+	registered, err := h.store.ListSandboxInstances(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list sandbox instances: %w", err)
+	}
+	if len(registered) > 0 {
+		requirements := fmt.Sprintf("online with a fresh heartbeat, under its max_sandboxes ceiling, advertising the %q image", placementImage)
+		if requiresDisplay {
+			requirements += ", and display-capable"
+		}
+		return "", fmt.Errorf("no sandbox host has capacity for a %q container: none of the %d registered host(s) is %s",
+			containerType, len(registered), requirements)
+	}
+
+	log.Warn().
+		Str("container_type", containerType).
+		Msg("No sandbox instances registered, falling back to legacy 'local' device key")
+	return "local", nil
 }
 
 // parseContainerType converts desktop type string to container type

--- a/api/pkg/external-agent/hydra_executor_placement_test.go
+++ b/api/pkg/external-agent/hydra_executor_placement_test.go
@@ -1,0 +1,77 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestResolveSandboxIDHonoursExplicitPin(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{SandboxID: "omen"}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "omen", id)
+}
+
+func TestResolveSandboxIDAutoSelectsAvailableHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(&types.SandboxInstance{ID: "host-1"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "host-1", id)
+}
+
+func TestResolveSandboxIDHeadlessPlacesOnUbuntuImageWithoutDisplay(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	// Headless containers use the helix-ubuntu toolchain image but need no
+	// display-capable host.
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", false).
+		Return(&types.SandboxInstance{ID: "nas"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "headless")
+	require.NoError(t, err)
+	assert.Equal(t, "nas", id)
+}
+
+func TestResolveSandboxIDErrorsWhenFleetHasNoCapacity(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{{ID: "full-host"}}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	_, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no sandbox host has capacity")
+}
+
+func TestResolveSandboxIDFallsBackToLocalOnEmptyRegistry(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return(nil, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "local", id)
+}

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -485,7 +485,7 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		}
 		readyByID[r.ID] = r
 		readyCount++
-		if isReadyAndOnline(r) && r.CanHostDesktop() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+		if isReadyAndOnline(r) && r.CanHostDesktop() && r.AtMaxCapacity() {
 			fleetAtCap = true
 		}
 	}

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -457,13 +457,25 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 	if err != nil {
 		return nil, fmt.Errorf("list hosts: %w", err)
 	}
+	// Headless containers run no compositor and no encoder, so any online
+	// host under its ceiling will do - including CPU-only and inference
+	// accelerator hosts that cannot stream a desktop. Prefer those, so
+	// render-capable hosts keep their slots free for desktop work.
+	var renderCapable *types.SandboxInstance
 	for _, h := range hosts {
-		// Headless containers run no compositor and no encoder, so any
-		// online host will do - including CPU-only and inference
-		// accelerator hosts that cannot stream a desktop.
-		if h.Status == "online" {
-			return h, nil
+		if h.Status != "online" || h.AtMaxCapacity() {
+			continue
 		}
+		if h.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = h
+			}
+			continue
+		}
+		return h, nil
+	}
+	if renderCapable != nil {
+		return renderCapable, nil
 	}
 	return nil, errors.New("no available sandbox host with the requested runtime")
 }

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/data"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/store"
@@ -1012,6 +1013,14 @@ If the user asks for information about Helix or installing Helix, refer them to 
 				}
 				if startReq.ExternalAgentConfig.DesktopType != "" {
 					zedAgent.DesktopType = startReq.ExternalAgentConfig.DesktopType
+				}
+				if startReq.ExternalAgentConfig.SandboxHostID != "" {
+					requiresDisplay := external_agent.DesktopTypeRequiresDisplay(zedAgent.DesktopType)
+					if err := external_agent.ValidateSandboxHostPin(req.Context(), s.Controller.Options.Store, startReq.ExternalAgentConfig.SandboxHostID, requiresDisplay); err != nil {
+						http.Error(rw, fmt.Sprintf("invalid sandbox host: %s", err.Error()), http.StatusBadRequest)
+						return
+					}
+					zedAgent.SandboxID = startReq.ExternalAgentConfig.SandboxHostID
 				}
 			}
 
@@ -2261,9 +2270,14 @@ func (s *HelixAPIServer) resumeSessionInternal(ctx context.Context, user *types.
 				Err(err).
 				Str("spec_task_id", specTaskID).
 				Msg("Failed to load spec task for resume, continuing without repository info")
-		} else if specTask.ProjectID != "" {
-			agent.ProjectID = specTask.ProjectID
-			agent.OrganizationID = specTask.OrganizationID
+		} else {
+			if specTask.ProjectID != "" {
+				agent.ProjectID = specTask.ProjectID
+				agent.OrganizationID = specTask.OrganizationID
+			}
+			// Honour the task's host pin on resume so the container comes
+			// back up on the host that has its workspace on disk.
+			agent.SandboxID = specTask.SandboxHostID
 		}
 	} else if session.Metadata.ProjectID != "" {
 		agent.ProjectID = session.Metadata.ProjectID

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -168,6 +168,13 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 	}
 	sandboxRuntime = types.EffectiveSpecTaskSandboxRuntime(sandboxRuntime)
 
+	if req.SandboxHostID != "" {
+		requiresDisplay := sandboxRuntime != types.SandboxRuntimeHeadlessUbuntu
+		if err := external_agent.ValidateSandboxHostPin(ctx, s.store, req.SandboxHostID, requiresDisplay); err != nil {
+			return nil, fmt.Errorf("invalid sandbox host: %w", err)
+		}
+	}
+
 	codeAgentConfig := cloneCodeAgentExecutionConfig(req.CodeAgentConfig)
 	if codeAgentConfig == nil && project != nil {
 		codeAgentConfig = cloneCodeAgentExecutionConfig(project.CodeAgentConfig)
@@ -232,6 +239,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		CodeAgentConfig:          codeAgentConfig,
 		SandboxResourceOverrides: sandboxResources,
 		SandboxRuntime:           sandboxRuntime,
+		SandboxHostID:            req.SandboxHostID,
 		JustDoItMode:             req.JustDoItMode, // Set Just Do It mode from request
 		// Credential-only override: whose Claude subscription authenticates this
 		// task's agent. Enforced at resolution time against the named user's
@@ -623,6 +631,7 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		ProjectID:      task.ProjectID, // For golden Docker cache overlay
 		ProjectPath:    "workspace",    // Use relative path
 		SpecTaskID:     task.ID,        // For task-scoped workspace
+		SandboxID:      task.SandboxHostID,
 		VCPUs:          sandboxVCPUs(task),
 		MemoryMB:       sandboxMemoryMB(task),
 		// RepositoryIDs / PrimaryRepositoryID set by SetRepoContext below.
@@ -1028,6 +1037,7 @@ Follow these guidelines when making changes:
 		ProjectID:           task.ProjectID, // For golden Docker cache overlay
 		ProjectPath:         "workspace",    // Use relative path
 		SpecTaskID:          task.ID,        // For task-scoped workspace
+		SandboxID:           task.SandboxHostID,
 		VCPUs:               sandboxVCPUs(task),
 		MemoryMB:            sandboxMemoryMB(task),
 		PrimaryRepositoryID: primaryRepoID, // Primary repo to open in Zed
@@ -2062,6 +2072,7 @@ func (s *SpecDrivenTaskService) ResumeSession(ctx context.Context, task *types.S
 		Input:               "Resuming Zed development environment after container restart",
 		ProjectPath:         "workspace",
 		SpecTaskID:          task.ID,
+		SandboxID:           task.SandboxHostID,
 		VCPUs:               sandboxVCPUs(task),
 		MemoryMB:            sandboxMemoryMB(task),
 		PrimaryRepositoryID: primaryRepoID,

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -279,8 +279,9 @@ func (s *PostgresStore) GetSandboxInstancesOlderThanHeartbeat(ctx context.Contex
 	return instances, nil
 }
 
-// FindAvailableSandboxInstance finds a sandbox host that is online, has recent heartbeat, and has the required desktop version.
-// Returns nil if no suitable sandbox host is found.
+// FindAvailableSandboxInstance finds a sandbox host that is online, has a
+// recent heartbeat, is under its max_sandboxes ceiling, and has the required
+// desktop version. Returns nil if no suitable sandbox host is found.
 //
 // requiresDisplay narrows the search to render-capable hosts. Pass true when
 // the container will run a compositor and be streamed; pass false for
@@ -305,28 +306,50 @@ func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, deskto
 	if err != nil {
 		return nil, fmt.Errorf("error finding available sandboxes: %w", err)
 	}
+	return pickSandboxInstance(instances, desktopType, requiresDisplay), nil
+}
 
-	// Find one with the required desktop version
+// pickSandboxInstance selects a dispatch target from load-ordered candidate
+// rows (least-loaded first). A candidate must be under its max_sandboxes
+// ceiling and advertise a non-empty image tag for desktopType in its
+// heartbeat blob.
+//
+// Streamed desktops (requiresDisplay) only run on render-capable hosts: a
+// neuron/inf2 host (no /dev/dri render node) would otherwise be picked on
+// load alone, then the desktop container FATALs at startup.
+//
+// Headless work runs anywhere, but prefers hosts that CANNOT stream a
+// desktop (CPU-only, software render) so render-capable hosts keep their
+// slots free for desktop sessions; a render-capable host is only used when
+// no display-incapable host qualifies.
+func pickSandboxInstance(instances []*types.SandboxInstance, desktopType string, requiresDisplay bool) *types.SandboxInstance {
+	var renderCapable *types.SandboxInstance
 	for _, instance := range instances {
-		// Streamed desktops only run on render-capable hosts. A neuron/inf2
-		// host (no /dev/dri render node) would otherwise be picked on load
-		// alone, then the desktop container FATALs at startup. Headless
-		// containers have no such constraint.
+		if instance.AtMaxCapacity() {
+			continue
+		}
 		if requiresDisplay && !instance.CanHostDesktop() {
 			continue
 		}
-		if len(instance.DesktopVersions) > 0 {
-			var versions map[string]string
-			if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
-				continue // Skip sandboxes with invalid version JSON
-			}
-			if version, ok := versions[desktopType]; ok && version != "" {
-				return instance, nil
-			}
+		if len(instance.DesktopVersions) == 0 {
+			continue
 		}
+		var versions map[string]string
+		if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
+			continue // Skip sandboxes with invalid version JSON
+		}
+		if version, ok := versions[desktopType]; !ok || version == "" {
+			continue
+		}
+		if !requiresDisplay && instance.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = instance
+			}
+			continue
+		}
+		return instance
 	}
-
-	return nil, nil // No suitable sandbox found
+	return renderCapable
 }
 
 // Disk usage history methods

--- a/api/pkg/store/store_sandbox_pick_test.go
+++ b/api/pkg/store/store_sandbox_pick_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func pickTestInstance(t *testing.T, id, gpuVendor string, active, maxSandboxes int, versions map[string]string) *types.SandboxInstance {
+	t.Helper()
+	blob, err := json.Marshal(versions)
+	if err != nil {
+		t.Fatalf("marshal versions: %v", err)
+	}
+	return &types.SandboxInstance{
+		ID:              id,
+		GPUVendor:       gpuVendor,
+		ActiveSandboxes: active,
+		MaxSandboxes:    maxSandboxes,
+		DesktopVersions: blob,
+	}
+}
+
+func TestPickSandboxInstance(t *testing.T) {
+	ubuntu := map[string]string{"ubuntu": "abc123"}
+
+	tests := []struct {
+		name            string
+		instances       []*types.SandboxInstance
+		desktopType     string
+		requiresDisplay bool
+		wantID          string // "" means nil
+	}{
+		{
+			name:   "no instances",
+			wantID: "",
+		},
+		{
+			name: "desktop picks first load-ordered render-capable host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "a", "nvidia", 1, 20, ubuntu),
+				pickTestInstance(t, "b", "nvidia", 2, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "a",
+		},
+		{
+			name: "desktop skips cpu-only host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, ubuntu),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "gpu",
+		},
+		{
+			name: "headless prefers cpu-only host over less loaded gpu host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "gpu", "nvidia", 0, 20, ubuntu),
+				pickTestInstance(t, "nas", "none", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "nas",
+		},
+		{
+			name: "headless falls back to gpu host when no cpu-only host qualifies",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "gpu",
+		},
+		{
+			name: "host at max_sandboxes ceiling is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+				pickTestInstance(t, "free", "nvidia", 21, 40, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "free",
+		},
+		{
+			name: "all hosts at ceiling yields nil",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "zero max_sandboxes means no ceiling",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "legacy", "nvidia", 50, 0, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "legacy",
+		},
+		{
+			name: "host missing the requested image is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "sway-only", "nvidia", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "ubuntu-host", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "ubuntu-host",
+		},
+		{
+			name: "host with empty version string is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "empty", "nvidia", 0, 20, map[string]string{"ubuntu": ""}),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "invalid version JSON is skipped",
+			instances: []*types.SandboxInstance{
+				{ID: "bad", GPUVendor: "nvidia", MaxSandboxes: 20, DesktopVersions: []byte("{not json")},
+				pickTestInstance(t, "good", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "good",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickSandboxInstance(tc.instances, tc.desktopType, tc.requiresDisplay)
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
+			}
+			if gotID != tc.wantID {
+				t.Errorf("pickSandboxInstance() = %q, want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -185,6 +185,10 @@ type CreateTaskRequest struct {
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty" swaggerignore:"true"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
 	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty"`
+	// SandboxHostID optionally pins the task's desktop container to a specific
+	// sandbox host (SandboxInstance.ID). The host must be online and satisfy
+	// the runtime's display requirement, or task creation fails.
+	SandboxHostID string `json:"sandbox_host_id,omitempty"`
 
 	// CredentialOwnerID optionally names the user whose Claude subscription should
 	// authenticate this task's agent, for orchestrators dispatching work on a
@@ -248,6 +252,11 @@ type SpecTask struct {
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty" gorm:"size:64"`
+	// SandboxHostID pins this task's desktop container to a specific sandbox
+	// host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+	// honoured on resume, so the task returns to the host that has its
+	// workspace on disk.
+	SandboxHostID string `json:"sandbox_host_id,omitempty" gorm:"size:255"`
 
 	// Git repository attachments: REMOVED - now inherited from parent Project
 	// Repos are managed at the project level. Access via project.DefaultRepoID and GetProjectRepositories(project_id)

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -638,6 +638,10 @@ type ExternalAgentConfig struct {
 	DesktopType string `json:"desktop_type,omitempty"` // "ubuntu" (default) or "sway"
 	ZoomLevel   int    `json:"zoom_level,omitempty"`   // GNOME zoom percentage (100 default, 200 for 4k/5k)
 
+	// SandboxHostID pins the session's dev container to a specific sandbox
+	// host (SandboxInstance.ID). Empty means the dispatcher chooses.
+	SandboxHostID string `json:"sandbox_host_id,omitempty"`
+
 	// Video capture/encoding mode
 	VideoMode string `json:"video_mode,omitempty"` // "shm" (default), "native", or "zerocopy"
 }

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3663,6 +3663,13 @@ func (s *SandboxInstance) CanHostDesktop() bool {
 	return s.RenderNode != "SOFTWARE"
 }
 
+// AtMaxCapacity reports whether this host has reached its configured dev
+// container ceiling (SandboxMaxDevContainers at registration time).
+// MaxSandboxes 0 means no ceiling was recorded and never binds.
+func (s *SandboxInstance) AtMaxCapacity() bool {
+	return s.MaxSandboxes > 0 && s.ActiveSandboxes >= s.MaxSandboxes
+}
+
 // SandboxHeartbeatRequest is sent by sandbox-heartbeat daemon every 30 seconds
 type SandboxHeartbeatRequest struct {
 	// Desktop image versions (content-addressable Docker image hashes)

--- a/api/pkg/types/types_test.go
+++ b/api/pkg/types/types_test.go
@@ -30,6 +30,26 @@ func TestSandboxInstanceCanHostDesktop(t *testing.T) {
 	}
 }
 
+func TestSandboxInstanceAtMaxCapacity(t *testing.T) {
+	cases := []struct {
+		name   string
+		active int
+		max    int
+		want   bool
+	}{
+		{"under ceiling", 3, 20, false},
+		{"at ceiling", 20, 20, true},
+		{"over ceiling", 21, 20, true},
+		{"no ceiling recorded", 100, 0, false},
+	}
+	for _, tc := range cases {
+		s := &SandboxInstance{ActiveSandboxes: tc.active, MaxSandboxes: tc.max}
+		if got := s.AtMaxCapacity(); got != tc.want {
+			t.Errorf("%s: AtMaxCapacity()=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func Test_SessionChatRequest_PlainString(t *testing.T) {
 	request := &SessionChatRequest{
 		Messages: []*Message{

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -75,16 +75,28 @@ Closes the remaining dispatch gaps for mixed GPU / CPU-only fleets:
 Tests: `TestPickSandboxInstance` (store), `TestResolveSandboxID*`
 (external-agent, gomock store), `TestSandboxInstanceAtMaxCapacity` (types).
 
-## Follow-up: per-session host selection (user picks the node)
+## PR 2: `feature/session-sandbox-host-pinning` — user picks the node (API)
 
-`DesktopAgent.SandboxID` already pins placement (used by golden builds and
-honoured first in `resolveSandboxID`), but is not exposed to users:
+`DesktopAgent.SandboxID` already pinned placement internally (golden builds;
+honoured first in `resolveSandboxID`); this exposes it to users:
 
-- API: accept optional `sandbox_id` on session / spec-task creation and
-  `CreateSandboxRequest`; validate the host is online and satisfies the
-  workload's display requirement — reject, never silently reschedule a pin.
-- Frontend: host dropdown at session creation (default **Auto**), populated
-  from the sandbox-instances listing; show hostname, GPU vendor, load.
+- `sandbox_host_id` on spec-task creation (`CreateTaskRequest` →
+  `SpecTask.SandboxHostID`, GORM AutoMigrate column) and on session start
+  (`ExternalAgentConfig.SandboxHostID`).
+- Validation at create time via `external_agent.ValidateSandboxHostPin`
+  (`api/pkg/external-agent/host_pin.go`): host must exist, be online, and be
+  display-capable unless the workload is headless
+  (`DesktopTypeRequiresDisplay`). Capacity is deliberately not checked — a
+  pin is an explicit "this host, full or not". Invalid pins are rejected,
+  never silently rescheduled.
+- The pin is honoured on every launch path: task start, just-do-it start,
+  restart-after-crash, and session resume (resume reads it off the spec
+  task, so the container returns to the host that has its workspace).
+- Host discovery for clients: the existing authenticated
+  `GET /api/v1/sandboxes` listing — no new endpoint.
+
+Follow-up (PR 3): frontend host dropdown at task/session creation (default
+**Auto**), populated from that listing; show hostname, GPU capability, load.
 
 ## Mode switching (headless ↔ desktop), for reference
 

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -1,0 +1,110 @@
+# Multi-node scheduling for GPU-less hosts + headless agent sessions
+
+**Date:** 2026-08-21
+**Status:** Partially landed upstream; remainder in `feature/capability-aware-sandbox-scheduling` + follow-ups
+**Author:** Waqas Ahmad
+
+## Motivation
+
+A common Helix topology is one GPU workstation plus one or more cheap CPU-only
+machines (a NAS, spare servers, ordinary cloud VMs), all reachable over a
+private network such as Tailscale. We want:
+
+1. CPU-only hosts to join the cluster and receive the workloads they can
+   actually run.
+2. The user (or Helix) to decide per-session where it runs and whether it
+   needs a watchable desktop at all.
+3. Headless agent sessions — agent + toolchain without a compositor or
+   encoder — to land on the cheap hosts, keeping GPU capacity free for
+   streamed desktops.
+
+Concrete driving setup: `omen` (NVIDIA, runs the control plane + desktop
+sessions) and a GPU-less Ubuntu NAS on the same tailnet (runs headless
+sessions and headless Sandboxes-API containers).
+
+## Already shipped upstream (no work needed)
+
+- **Cluster join**: `sandbox_instances` registry, outbound-only RevDial
+  attach (`api/cmd/hydra/main.go`), auto-registration on connect
+  (`api/pkg/server/server.go` `ensureSandboxRegistered`), 30s heartbeat with
+  `desktop_versions`/`gpu_vendor`/`render_node`, admin Runners page.
+  Adding a node: `./install.sh --sandbox --api-host <url> --runner-token
+  <tok>`. Works over Tailscale — no inbound ports on the node.
+- **Capability-aware placement**: `SandboxInstance.CanHostDesktop()`
+  (`api/pkg/types/types.go`) gates only *streamed desktop* placement;
+  `FindAvailableSandboxInstance(ctx, desktopType, requiresDisplay)` places
+  headless work on any online host including CPU-only ones.
+  `RuntimeSpec.RequiresDisplay` does the same for the Sandboxes API
+  (`api/pkg/sandbox/runtimes.go`, `controller_provision.go`).
+- **Headless spec-task runtime**: `SandboxRuntimeHeadlessUbuntu` /
+  `desktop_type: headless` runs the helix-ubuntu toolchain image with no
+  compositor, display devices, or encoder (`hydra_executor.go` — display
+  env skipped, placement with `requiresDisplay=false`). Chat rides the
+  Zed↔Helix `external_websocket_sync` WebSocket, independent of video.
+- **Sticky placement + data safety**: sessions pin to `session.SandboxID`;
+  persistent Sandboxes-API sandboxes refuse to move off their bound host
+  (workspaces are host-local disk) — `controller_provision.go`
+  `pickHostForSandbox`.
+
+## This PR: `feature/capability-aware-sandbox-scheduling`
+
+Closes the remaining dispatch gaps for mixed GPU / CPU-only fleets:
+
+1. **Prefer CPU-only hosts for headless work.** The picker
+   (`pickSandboxInstance`, `api/pkg/store/store_sandbox.go`) now places
+   `requiresDisplay=false` work on a display-*incapable* host when one
+   qualifies, falling back to render-capable hosts otherwise — so headless
+   sessions drain to the NAS and GPU slots stay free for desktops. Same
+   preference in the custom-image host loop
+   (`controller_provision.go` `pickHostForSandbox`).
+2. **`max_sandboxes` enforced at dispatch** (was autoscaler-signal only,
+   flagged as a follow-up in `config.go`): hosts at their ceiling are
+   skipped; a fleet fully at ceiling yields a no-capacity error instead of
+   overloading the least-loaded host. `MaxSandboxes == 0` (pre-field rows)
+   means no ceiling. Shared predicate: `SandboxInstance.AtMaxCapacity()`.
+3. **No more silent `"local"` fallback** (`hydra_executor.go`
+   `resolveSandboxID`): when hosts are registered but none is eligible,
+   placement fails with an error naming the container type, image key, and
+   requirements — instead of dialing the `hydra-local` device key and
+   hanging out the RevDial grace period. The `"local"` key remains only for
+   the legacy single-node install with an empty registry.
+4. **Dev compose**: `SANDBOX_INSTANCE_ID` is overridable
+   (`${SANDBOX_INSTANCE_ID:-local}`) so a second dev node doesn't collide
+   with the hardcoded `local` row.
+
+Tests: `TestPickSandboxInstance` (store), `TestResolveSandboxID*`
+(external-agent, gomock store), `TestSandboxInstanceAtMaxCapacity` (types).
+
+## Follow-up: per-session host selection (user picks the node)
+
+`DesktopAgent.SandboxID` already pins placement (used by golden builds and
+honoured first in `resolveSandboxID`), but is not exposed to users:
+
+- API: accept optional `sandbox_id` on session / spec-task creation and
+  `CreateSandboxRequest`; validate the host is online and satisfies the
+  workload's display requirement — reject, never silently reschedule a pin.
+- Frontend: host dropdown at session creation (default **Auto**), populated
+  from the sandbox-instances listing; show hostname, GPU vendor, load.
+
+## Mode switching (headless ↔ desktop), for reference
+
+- *Same host*: stop the container, start with the other desktop type for the
+  same session — chat history (Postgres) and workspace
+  (`/data/workspaces/<sid>` on the host) survive; an in-flight agent turn is
+  interrupted (same as any resume).
+- *Cross host* (NAS headless → GPU desktop): blocked — workspaces are
+  host-local (same rationale as the persistent-sandbox refusal). Workflow:
+  agent pushes its branch, reopen on the target host. Cross-host workspace
+  sync is out of scope.
+
+## Multi-node operational notes
+
+- A remote node cannot use the dev `registry:5000` image path — it pulls
+  from ghcr.io (prod path) or a tailnet-reachable registry via
+  `HELIX_SANDBOX_REGISTRY`.
+- Upgrades touch the control plane *and* each node (re-run
+  `install.sh --sandbox` / bump `SANDBOX_TAG`). A stale node degrades
+  gracefully: it stops receiving new sessions once its advertised
+  `desktop_versions` no longer match, but keeps serving running ones.
+- `MAX_SANDBOXES` on each node is the operator throttle, now enforced at
+  dispatch (this PR).

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -238,7 +238,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -334,7 +334,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -428,7 +428,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -518,7 +518,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}


### PR DESCRIPTION
> **Stacked PR** — builds on https://github.com/helixml/helix/pull/3089 and includes its commits. Review only the newest commit until that PR merges.

# PR 2 — feat(sandbox): user-selectable sandbox host for spec tasks and sessions

**Branch:** `feature/session-sandbox-host-pinning` (stacked on `feature/capability-aware-sandbox-scheduling`)
**Target:** `feature/capability-aware-sandbox-scheduling` (or `main` after PR 1 merges)

## What

Lets a user (or an orchestrator) choose which cluster node a spec task or external-agent session runs on — e.g. "important desktop sessions on the GPU workstation, headless tasks on the NAS". Builds on PR 1's capability-aware dispatch.

`DesktopAgent.SandboxID` already pinned placement internally (golden builds use it, and `resolveSandboxID` honours it first) — this PR exposes it through the public API with validation:

1. **Spec tasks:** new optional `sandbox_host_id` on `CreateTaskRequest`, persisted as `SpecTask.SandboxHostID` (GORM AutoMigrate column, `size:255`).
2. **Sessions:** new optional `sandbox_host_id` on `ExternalAgentConfig`, applied when starting a `zed_external` session.
3. **Validation at create time** — `external_agent.ValidateSandboxHostPin` (`api/pkg/external-agent/host_pin.go`): the host must exist, be `online`, and be display-capable (`CanHostDesktop`) unless the workload is headless (`DesktopTypeRequiresDisplay` / `SandboxRuntimeHeadlessUbuntu`). Invalid pins are **rejected with a 400/typed error, never silently rescheduled**. Capacity is deliberately not checked: a pin is an explicit "this host, full or not", and capacity is transient.
4. **Pin honoured on every launch path:** task start, just-do-it start, restart-after-container-crash, and session resume. Resume reads the pin off the spec task, so a restarted container returns to the host that has its workspace on local disk (workspaces are host-local — see the persistent-sandbox refusal rationale in `controller_provision.go`).
5. **Host discovery for clients:** the existing authenticated `GET /api/v1/sandboxes` listing (already swagger-annotated and in the generated client) — no new endpoint.

## Tests

- `TestValidateSandboxHostPin*` + `TestDesktopTypeRequiresDisplay` (external-agent, gomock store): empty pin no-op, unknown host, offline host, desktop-on-CPU-only rejected, headless-on-CPU-only allowed, desktop-on-GPU allowed.
- PR 1's `TestResolveSandboxIDHonoursExplicitPin` covers the executor side.
- Full `./api/pkg/server/` (CGo), `./api/pkg/services/`, `./api/pkg/external-agent/`, `./api/pkg/types/` suites pass (go 1.25).

NOT tested: end-to-end pin through the UI (frontend selector lands in PR 3); DB column creation happens via GORM AutoMigrate on API start.