### PR TITLE
feat(frontend): sandbox host selector for new spec tasks

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -121,11 +121,12 @@ type ServerConfig struct {
 	// as demand pressure, so this value is what determines when scale-up
 	// fires under load.
 	//
-	// NOTE: this value only affects the autoscaler signal today; the
-	// dispatcher (FindAvailableSandboxInstance) does NOT enforce a hard
-	// rejection at the ceiling - new dev containers can still be placed
-	// on a "full" Runner (sorted ASC by active_sandboxes). Hard
-	// dispatcher rejection is tracked separately as a follow-up.
+	// The ceiling is also enforced at dispatch: the dispatcher
+	// (FindAvailableSandboxInstance and the custom-image host picker)
+	// skips Runners at max_sandboxes, so new dev containers are never
+	// placed on a "full" Runner. With every Runner at its ceiling,
+	// placement fails with a no-capacity error until the autoscaler
+	// adds a host or a container exits.
 	//
 	// Default 20. Raise for hosts with more headroom, lower to make
 	// the autoscaler trigger sooner on smaller hosts. Range is not

--- a/api/pkg/external-agent/host_pin.go
+++ b/api/pkg/external-agent/host_pin.go
@@ -1,0 +1,42 @@
+package external_agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/store"
+)
+
+// DesktopTypeRequiresDisplay reports whether a desktop type needs a
+// display-capable sandbox host. Only "headless" runs without a compositor
+// and encoder; every other type is a streamed desktop.
+func DesktopTypeRequiresDisplay(desktopType string) bool {
+	return !strings.EqualFold(desktopType, "headless")
+}
+
+// ValidateSandboxHostPin checks that an explicitly requested sandbox host
+// exists, is online, and satisfies the workload's display requirement.
+// Pinned placement bypasses the dispatcher's eligibility filters, so this is
+// the only gate between a user's host choice and a container that would FATAL
+// on a display-incapable host or dial a dead RevDial key. Capacity is
+// deliberately not checked — it is transient, and a user pinning a host is
+// asking for that host, full or not.
+//
+// An empty hostID means "dispatcher chooses" and always validates.
+func ValidateSandboxHostPin(ctx context.Context, s store.Store, hostID string, requiresDisplay bool) error {
+	if hostID == "" {
+		return nil
+	}
+	host, err := s.GetSandboxInstance(ctx, hostID)
+	if err != nil {
+		return fmt.Errorf("sandbox host %q not found: %w", hostID, err)
+	}
+	if host.Status != "online" {
+		return fmt.Errorf("sandbox host %q is %s, not online", hostID, host.Status)
+	}
+	if requiresDisplay && !host.CanHostDesktop() {
+		return fmt.Errorf("sandbox host %q cannot run a streamed desktop (gpu_vendor=%q, render_node=%q); pick a display-capable host or use the headless runtime", hostID, host.GPUVendor, host.RenderNode)
+	}
+	return nil
+}

--- a/api/pkg/external-agent/host_pin_test.go
+++ b/api/pkg/external-agent/host_pin_test.go
@@ -1,0 +1,71 @@
+package external_agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDesktopTypeRequiresDisplay(t *testing.T) {
+	assert.False(t, DesktopTypeRequiresDisplay("headless"))
+	assert.False(t, DesktopTypeRequiresDisplay("Headless"))
+	assert.True(t, DesktopTypeRequiresDisplay("ubuntu"))
+	assert.True(t, DesktopTypeRequiresDisplay("sway"))
+	assert.True(t, DesktopTypeRequiresDisplay("")) // default desktop
+}
+
+func TestValidateSandboxHostPinEmptyIsNoop(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "", true))
+}
+
+func TestValidateSandboxHostPinUnknownHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "ghost").Return(nil, errors.New("record not found"))
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "ghost", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestValidateSandboxHostPinOfflineHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "offline"}, nil)
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "nas", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not online")
+}
+
+func TestValidateSandboxHostPinDesktopOnCPUOnlyHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "online", GPUVendor: "none"}, nil)
+
+	err := ValidateSandboxHostPin(context.Background(), mockStore, "nas", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot run a streamed desktop")
+}
+
+func TestValidateSandboxHostPinHeadlessOnCPUOnlyHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "nas").
+		Return(&types.SandboxInstance{ID: "nas", Status: "online", GPUVendor: "none"}, nil)
+
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "nas", false))
+}
+
+func TestValidateSandboxHostPinDesktopOnGPUHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().GetSandboxInstance(gomock.Any(), "omen").
+		Return(&types.SandboxInstance{ID: "omen", Status: "online", GPUVendor: "nvidia"}, nil)
+
+	require.NoError(t, ValidateSandboxHostPin(context.Background(), mockStore, "omen", true))
+}

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -300,36 +300,9 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 	containerType := h.parseContainerType(agent.DesktopType)
 
 	// Determine sandbox ID - use agent's preference or find an available one
-	sandboxID := agent.SandboxID
-	if sandboxID == "" {
-		// Headless agents use the helix-ubuntu toolchain image, so placement must
-		// select a host advertising that image even though the created container
-		// itself has no compositor or display devices.
-		placementImage := containerType
-		requiresDisplay := true
-		if containerType == "headless" {
-			placementImage = "ubuntu"
-			// No compositor, no encoder — a CPU-only host is fine, it just
-			// has to advertise the toolchain image.
-			requiresDisplay = false
-		}
-		sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find available sandbox: %w", err)
-		}
-		if sandbox != nil {
-			sandboxID = sandbox.ID
-			log.Info().
-				Str("sandbox_id", sandboxID).
-				Str("container_type", containerType).
-				Msg("Auto-selected available sandbox")
-		} else {
-			// Fallback to "local" if no sandbox found (for backwards compatibility)
-			sandboxID = "local"
-			log.Warn().
-				Str("container_type", containerType).
-				Msg("No available sandbox found, falling back to 'local'")
-		}
+	sandboxID, err := h.resolveSandboxID(ctx, agent, containerType)
+	if err != nil {
+		return nil, err
 	}
 	hydraRunnerID := fmt.Sprintf("hydra-%s", sandboxID)
 	hydraClient := hydra.NewRevDialClient(h.connman, hydraRunnerID)
@@ -1303,6 +1276,61 @@ func (h *HydraExecutor) setExternalAgentStatus(ctx context.Context, sessionID, s
 	if _, err := h.store.UpdateSession(ctx, *dbSession); err != nil {
 		log.Debug().Err(err).Str("session_id", sessionID).Msg("Failed to update external agent status")
 	}
+}
+
+// resolveSandboxID returns the sandbox host to place this session's dev
+// container on: the agent's explicit preference if set, otherwise the best
+// available registered host. When hosts are registered but none is eligible
+// it fails with a no-capacity error rather than guessing — dialing a wrong
+// device key would just hang for the RevDial grace period and surface a
+// confusing connection error. The legacy "local" device key is used only
+// when the registry is empty (single-node install with no heartbeat
+// configured, where hydra listens as "hydra-local").
+func (h *HydraExecutor) resolveSandboxID(ctx context.Context, agent *types.DesktopAgent, containerType string) (string, error) {
+	if agent.SandboxID != "" {
+		return agent.SandboxID, nil
+	}
+
+	// Headless agents use the helix-ubuntu toolchain image, so placement must
+	// select a host advertising that image even though the created container
+	// itself has no compositor or display devices.
+	placementImage := containerType
+	requiresDisplay := true
+	if containerType == "headless" {
+		placementImage = "ubuntu"
+		// No compositor, no encoder — a CPU-only host is fine, it just
+		// has to advertise the toolchain image.
+		requiresDisplay = false
+	}
+	sandbox, err := h.store.FindAvailableSandboxInstance(ctx, placementImage, requiresDisplay)
+	if err != nil {
+		return "", fmt.Errorf("failed to find available sandbox: %w", err)
+	}
+	if sandbox != nil {
+		log.Info().
+			Str("sandbox_id", sandbox.ID).
+			Str("container_type", containerType).
+			Msg("Auto-selected available sandbox")
+		return sandbox.ID, nil
+	}
+
+	registered, err := h.store.ListSandboxInstances(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list sandbox instances: %w", err)
+	}
+	if len(registered) > 0 {
+		requirements := fmt.Sprintf("online with a fresh heartbeat, under its max_sandboxes ceiling, advertising the %q image", placementImage)
+		if requiresDisplay {
+			requirements += ", and display-capable"
+		}
+		return "", fmt.Errorf("no sandbox host has capacity for a %q container: none of the %d registered host(s) is %s",
+			containerType, len(registered), requirements)
+	}
+
+	log.Warn().
+		Str("container_type", containerType).
+		Msg("No sandbox instances registered, falling back to legacy 'local' device key")
+	return "local", nil
 }
 
 // parseContainerType converts desktop type string to container type

--- a/api/pkg/external-agent/hydra_executor_placement_test.go
+++ b/api/pkg/external-agent/hydra_executor_placement_test.go
@@ -1,0 +1,77 @@
+package external_agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestResolveSandboxIDHonoursExplicitPin(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{SandboxID: "omen"}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "omen", id)
+}
+
+func TestResolveSandboxIDAutoSelectsAvailableHost(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(&types.SandboxInstance{ID: "host-1"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "host-1", id)
+}
+
+func TestResolveSandboxIDHeadlessPlacesOnUbuntuImageWithoutDisplay(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	// Headless containers use the helix-ubuntu toolchain image but need no
+	// display-capable host.
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", false).
+		Return(&types.SandboxInstance{ID: "nas"}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "headless")
+	require.NoError(t, err)
+	assert.Equal(t, "nas", id)
+}
+
+func TestResolveSandboxIDErrorsWhenFleetHasNoCapacity(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{{ID: "full-host"}}, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	_, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no sandbox host has capacity")
+}
+
+func TestResolveSandboxIDFallsBackToLocalOnEmptyRegistry(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	mockStore.EXPECT().
+		FindAvailableSandboxInstance(gomock.Any(), "ubuntu", true).
+		Return(nil, nil)
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return(nil, nil)
+	h := &HydraExecutor{store: mockStore}
+
+	id, err := h.resolveSandboxID(context.Background(), &types.DesktopAgent{}, "ubuntu")
+	require.NoError(t, err)
+	assert.Equal(t, "local", id)
+}

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -485,7 +485,7 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		}
 		readyByID[r.ID] = r
 		readyCount++
-		if isReadyAndOnline(r) && r.CanHostDesktop() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+		if isReadyAndOnline(r) && r.CanHostDesktop() && r.AtMaxCapacity() {
 			fleetAtCap = true
 		}
 	}

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -457,13 +457,25 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 	if err != nil {
 		return nil, fmt.Errorf("list hosts: %w", err)
 	}
+	// Headless containers run no compositor and no encoder, so any online
+	// host under its ceiling will do - including CPU-only and inference
+	// accelerator hosts that cannot stream a desktop. Prefer those, so
+	// render-capable hosts keep their slots free for desktop work.
+	var renderCapable *types.SandboxInstance
 	for _, h := range hosts {
-		// Headless containers run no compositor and no encoder, so any
-		// online host will do - including CPU-only and inference
-		// accelerator hosts that cannot stream a desktop.
-		if h.Status == "online" {
-			return h, nil
+		if h.Status != "online" || h.AtMaxCapacity() {
+			continue
 		}
+		if h.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = h
+			}
+			continue
+		}
+		return h, nil
+	}
+	if renderCapable != nil {
+		return renderCapable, nil
 	}
 	return nil, errors.New("no available sandbox host with the requested runtime")
 }

--- a/api/pkg/server/agent_sandboxes_handlers.go
+++ b/api/pkg/server/agent_sandboxes_handlers.go
@@ -114,8 +114,8 @@ type SessionSandboxStateResponse struct {
 // @Produce json
 // @Param sandbox_id query string false "Sandbox instance ID to query"
 // @Success 200 {object} AgentSandboxesDebugResponse
-// @Failure 401 {object} system.HTTPError
-// @Failure 500 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 500 {object} types.APIError
 // @Security ApiKeyAuth
 // @Router /api/v1/admin/agent-sandboxes/debug [get]
 func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, req *http.Request) {
@@ -387,8 +387,8 @@ func formatDuration(d time.Duration) string {
 // @Accept json
 // @Produce text/event-stream
 // @Success 200 {string} string "event: message"
-// @Failure 401 {object} system.HTTPError
-// @Failure 501 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 501 {object} types.APIError
 // @Security ApiKeyAuth
 // @Router /api/v1/admin/agent-sandboxes/events [get]
 func (apiServer *HelixAPIServer) getAgentSandboxesEvents(rw http.ResponseWriter, req *http.Request) {
@@ -403,10 +403,10 @@ func (apiServer *HelixAPIServer) getAgentSandboxesEvents(rw http.ResponseWriter,
 // @Produce json
 // @Param id path string true "Session ID"
 // @Success 200 {object} SessionSandboxStateResponse
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 500 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 500 {object} types.APIError
 // @Security BearerAuth
 // @Router /api/v1/sessions/{id}/sandbox-state [get]
 func (apiServer *HelixAPIServer) getSessionSandboxState(rw http.ResponseWriter, req *http.Request) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -59,13 +59,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -99,13 +99,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "501": {
                         "description": "Not Implemented",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -3318,7 +3318,7 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4069,13 +4069,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4119,13 +4119,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4232,13 +4232,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4285,31 +4285,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4365,31 +4365,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4486,31 +4486,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4608,25 +4608,25 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4753,25 +4753,25 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4805,25 +4805,25 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4857,25 +4857,25 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15685,19 +15685,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15766,19 +15766,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15836,19 +15836,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -18910,25 +18910,25 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -31231,6 +31231,10 @@ const docTemplate = `{
                 "prompt": {
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID optionally pins the task's desktop container to a specific\nsandbox host (SandboxInstance.ID). The host must be online and satisfy\nthe runtime's display requirement, or task creation fails.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -31737,6 +31741,10 @@ const docTemplate = `{
                 },
                 "resolution": {
                     "description": "Display resolution - either use Resolution preset or explicit dimensions",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins the session's dev container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses.",
                     "type": "string"
                 },
                 "video_mode": {
@@ -38468,6 +38476,10 @@ const docTemplate = `{
                     "description": "User stories + EARS acceptance criteria (markdown)",
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -39313,6 +39325,10 @@ const docTemplate = `{
                 },
                 "requirements_spec": {
                     "description": "User stories + EARS acceptance criteria (markdown)",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
                     "type": "string"
                 },
                 "sandbox_resource_overrides": {

--- a/api/pkg/server/external_agent_handlers.go
+++ b/api/pkg/server/external_agent_handlers.go
@@ -376,8 +376,8 @@ func (apiServer *HelixAPIServer) getExternalAgentScreenshot(res http.ResponseWri
 // @Param sessionID path string true "Session ID"
 // @Param body body object true "Command to execute" Example({"command": ["vkcube"], "background": true})
 // @Success 200 {object} object "Execution result"
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/exec [post]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) execInSandbox(res http.ResponseWriter, req *http.Request) {
@@ -533,7 +533,7 @@ func (apiServer *HelixAPIServer) execCommandInDesktop(ctx context.Context, sessi
 // @Produce application/octet-stream
 // @Param size query int false "Size of data to return in bytes (default 524288 = 512KB, max 2MB)"
 // @Success 200 {file} binary
-// @Failure 401 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
 // @Router /api/v1/bandwidth-probe [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getBandwidthProbe(res http.ResponseWriter, req *http.Request) {
@@ -576,8 +576,8 @@ func (apiServer *HelixAPIServer) getBandwidthProbe(res http.ResponseWriter, req 
 // @Produce json
 // @Param sessionID path string true "Session ID"
 // @Success 200 {object} types.ClipboardData
-// @Failure 401 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 404 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/clipboard [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getExternalAgentClipboard(res http.ResponseWriter, req *http.Request) {
@@ -687,8 +687,8 @@ func (apiServer *HelixAPIServer) getExternalAgentClipboard(res http.ResponseWrit
 // @Param sessionID path string true "Session ID"
 // @Param clipboard body types.ClipboardData true "Clipboard data to set"
 // @Success 200
-// @Failure 401 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 404 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/clipboard [post]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) setExternalAgentClipboard(res http.ResponseWriter, req *http.Request) {
@@ -806,11 +806,11 @@ func (apiServer *HelixAPIServer) setExternalAgentClipboard(res http.ResponseWrit
 // @Param file formData file true "File to upload"
 // @Param open_file_manager query bool false "Open file manager to show uploaded file (default: true)"
 // @Success 200 {object} types.SandboxFileUploadResponse
-// @Failure 400 {object} system.HTTPError
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/upload [post]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) uploadFileToSandbox(res http.ResponseWriter, req *http.Request) {
@@ -979,11 +979,11 @@ func desktopUploadURL(rawQuery string) string {
 // @Param sessionID path string true "Session ID"
 // @Param name query string true "Uploaded attachment filename"
 // @Success 200 {file} binary
-// @Failure 400 {object} system.HTTPError
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/file [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getExternalAgentFile(res http.ResponseWriter, req *http.Request) {
@@ -1116,10 +1116,10 @@ func (apiServer *HelixAPIServer) configurePendingSession(res http.ResponseWriter
 // @Tags ExternalAgents
 // @Param sessionID path string true "Session ID"
 // @Success 101 "Switching Protocols"
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/ws/input [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) proxyInputWebSocket(res http.ResponseWriter, req *http.Request) {
@@ -1291,10 +1291,10 @@ func generateProxySessionID() string {
 // @Tags ExternalAgents
 // @Param sessionID path string true "Session ID"
 // @Success 101 "Switching Protocols"
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/ws/stream [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, req *http.Request) {
@@ -1531,10 +1531,10 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 // @Produce json
 // @Param sessionID path string true "Session ID"
 // @Success 200 {object} types.WorkspacesResponse
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/workspaces [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getExternalAgentWorkspaces(res http.ResponseWriter, req *http.Request) {

--- a/api/pkg/server/organization_role_handlers.go
+++ b/api/pkg/server/organization_role_handlers.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // listOrganizationRoles godoc
@@ -30,7 +32,8 @@ func (apiServer *HelixAPIServer) listOrganizationRoles(rw http.ResponseWriter, r
 		return
 	}
 
-	roles, err := apiServer.Store.ListRoles(r.Context(), orgID)
+	var roles []*types.Role
+	roles, err = apiServer.Store.ListRoles(r.Context(), orgID)
 	if err != nil {
 		log.Err(err).Msg("error listing roles")
 		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -998,9 +998,9 @@ func (s *HelixAPIServer) deleteProviderEndpoint(rw http.ResponseWriter, r *http.
 // @Param   from query string false "Start date"
 // @Param   to query string false "End date"
 // @Success 200 {array} types.AggregatedUsageMetric
-// @Failure 400 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 500 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 500 {object} types.APIError
 // @Router /api/v1/provider-endpoints/{id}/daily-usage [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getProviderDailyUsage(rw http.ResponseWriter, r *http.Request) {
@@ -1070,9 +1070,9 @@ func (s *HelixAPIServer) getProviderDailyUsage(rw http.ResponseWriter, r *http.R
 // @Param   to query string false "End date"
 // @Param   aggregation_level query string false "Aggregation level" Enums(30min,hourly) default(30min)
 // @Success 200 {array} types.AggregatedUsageMetric
-// @Failure 400 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 500 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 500 {object} types.APIError
 // @Router /api/v1/provider-endpoints/{id}/throughput-usage [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getProviderThroughputUsage(rw http.ResponseWriter, r *http.Request) {
@@ -1153,9 +1153,9 @@ func (s *HelixAPIServer) getProviderThroughputUsage(rw http.ResponseWriter, r *h
 // @Param   from query string false "Start date"
 // @Param   to query string false "End date"
 // @Success 200 {array} types.UsersAggregatedUsageMetric
-// @Failure 400 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 500 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 500 {object} types.APIError
 // @Router /api/v1/provider-endpoints/{id}/users-daily-usage [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getProviderUsersDailyUsage(rw http.ResponseWriter, r *http.Request) {

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/data"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/store"
@@ -1012,6 +1013,14 @@ If the user asks for information about Helix or installing Helix, refer them to 
 				}
 				if startReq.ExternalAgentConfig.DesktopType != "" {
 					zedAgent.DesktopType = startReq.ExternalAgentConfig.DesktopType
+				}
+				if startReq.ExternalAgentConfig.SandboxHostID != "" {
+					requiresDisplay := external_agent.DesktopTypeRequiresDisplay(zedAgent.DesktopType)
+					if err := external_agent.ValidateSandboxHostPin(req.Context(), s.Controller.Options.Store, startReq.ExternalAgentConfig.SandboxHostID, requiresDisplay); err != nil {
+						http.Error(rw, fmt.Sprintf("invalid sandbox host: %s", err.Error()), http.StatusBadRequest)
+						return
+					}
+					zedAgent.SandboxID = startReq.ExternalAgentConfig.SandboxHostID
 				}
 			}
 
@@ -2261,9 +2270,14 @@ func (s *HelixAPIServer) resumeSessionInternal(ctx context.Context, user *types.
 				Err(err).
 				Str("spec_task_id", specTaskID).
 				Msg("Failed to load spec task for resume, continuing without repository info")
-		} else if specTask.ProjectID != "" {
-			agent.ProjectID = specTask.ProjectID
-			agent.OrganizationID = specTask.OrganizationID
+		} else {
+			if specTask.ProjectID != "" {
+				agent.ProjectID = specTask.ProjectID
+				agent.OrganizationID = specTask.OrganizationID
+			}
+			// Honour the task's host pin on resume so the container comes
+			// back up on the host that has its workspace on disk.
+			agent.SandboxID = specTask.SandboxHostID
 		}
 	} else if session.Metadata.ProjectID != "" {
 		agent.ProjectID = session.Metadata.ProjectID

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -55,13 +55,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -95,13 +95,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "501": {
                         "description": "Not Implemented",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -3314,7 +3314,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4065,13 +4065,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4115,13 +4115,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4228,13 +4228,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4281,31 +4281,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4361,31 +4361,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4482,31 +4482,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4604,25 +4604,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4749,25 +4749,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4801,25 +4801,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4853,25 +4853,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15681,19 +15681,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15762,19 +15762,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15832,19 +15832,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -18906,25 +18906,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -31227,6 +31227,10 @@
                 "prompt": {
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID optionally pins the task's desktop container to a specific\nsandbox host (SandboxInstance.ID). The host must be online and satisfy\nthe runtime's display requirement, or task creation fails.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -31733,6 +31737,10 @@
                 },
                 "resolution": {
                     "description": "Display resolution - either use Resolution preset or explicit dimensions",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins the session's dev container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses.",
                     "type": "string"
                 },
                 "video_mode": {
@@ -38464,6 +38472,10 @@
                     "description": "User stories + EARS acceptance criteria (markdown)",
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -39309,6 +39321,10 @@
                 },
                 "requirements_spec": {
                     "description": "User stories + EARS acceptance criteria (markdown)",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
                     "type": "string"
                 },
                 "sandbox_resource_overrides": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5670,6 +5670,12 @@ definitions:
         type: string
       prompt:
         type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID optionally pins the task's desktop container to a specific
+          sandbox host (SandboxInstance.ID). The host must be online and satisfy
+          the runtime's display requirement, or task creation fails.
+        type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
       sandbox_runtime:
@@ -6042,6 +6048,11 @@ definitions:
       resolution:
         description: Display resolution - either use Resolution preset or explicit
           dimensions
+        type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins the session's dev container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses.
         type: string
       video_mode:
         description: Video capture/encoding mode
@@ -11061,6 +11072,13 @@ definitions:
       requirements_spec:
         description: User stories + EARS acceptance criteria (markdown)
         type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins this task's desktop container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+          honoured on resume, so the task returns to the host that has its
+          workspace on disk.
+        type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
       sandbox_runtime:
@@ -11715,6 +11733,13 @@ definitions:
         type: array
       requirements_spec:
         description: User stories + EARS acceptance criteria (markdown)
+        type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins this task's desktop container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+          honoured on resume, so the task returns to the host that has its
+          workspace on disk.
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
@@ -13685,11 +13710,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - ApiKeyAuth: []
       summary: Get sandbox debugging data
@@ -13710,11 +13735,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "501":
           description: Not Implemented
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - ApiKeyAuth: []
       summary: Get sandbox real-time events (SSE)
@@ -15788,7 +15813,7 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Bandwidth probe for adaptive bitrate
@@ -16263,11 +16288,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get session clipboard content
@@ -16295,11 +16320,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Set session clipboard content
@@ -16369,11 +16394,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Execute command in sandbox
@@ -16404,23 +16429,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Read an uploaded chat attachment
@@ -16457,23 +16482,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Upload file to sandbox
@@ -16536,23 +16561,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Update a workspace file
@@ -16616,19 +16641,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get workspace review sources
@@ -16712,19 +16737,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get workspaces from container
@@ -16746,19 +16771,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Direct WebSocket input for PipeWire/GNOME sessions
@@ -16780,19 +16805,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Direct WebSocket video streaming for PipeWire/GNOME sessions
@@ -23709,15 +23734,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider daily usage
@@ -23762,15 +23787,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider throughput usage
@@ -23807,15 +23832,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider daily usage per user
@@ -25798,19 +25823,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get sandbox state for a session

--- a/api/pkg/server/workspace_review_handlers.go
+++ b/api/pkg/server/workspace_review_handlers.go
@@ -55,10 +55,10 @@ func (apiServer *HelixAPIServer) callSessionDesktopJSON(ctx context.Context, ses
 // @Param base query string false "Base ref (default main)"
 // @Param ignore_whitespace query bool false "Ignore whitespace-only changes"
 // @Success 200 {object} types.WorkspaceReviewResponse
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 404 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/workspace-review [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getWorkspaceReview(w http.ResponseWriter, req *http.Request) {
@@ -150,11 +150,11 @@ func (apiServer *HelixAPIServer) downloadWorkspaceFile(w http.ResponseWriter, re
 // @Param sessionID path string true "Session ID"
 // @Param request body types.WorkspaceFileWriteRequest true "Workspace file update"
 // @Success 200 {object} types.WorkspaceFileResponse
-// @Failure 400 {object} system.HTTPError
-// @Failure 401 {object} system.HTTPError
-// @Failure 403 {object} system.HTTPError
-// @Failure 409 {object} system.HTTPError
-// @Failure 503 {object} system.HTTPError
+// @Failure 400 {object} types.APIError
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 409 {object} types.APIError
+// @Failure 503 {object} types.APIError
 // @Router /api/v1/external-agents/{sessionID}/workspace-file [put]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) putWorkspaceFile(w http.ResponseWriter, req *http.Request) {

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -168,6 +168,13 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 	}
 	sandboxRuntime = types.EffectiveSpecTaskSandboxRuntime(sandboxRuntime)
 
+	if req.SandboxHostID != "" {
+		requiresDisplay := sandboxRuntime != types.SandboxRuntimeHeadlessUbuntu
+		if err := external_agent.ValidateSandboxHostPin(ctx, s.store, req.SandboxHostID, requiresDisplay); err != nil {
+			return nil, fmt.Errorf("invalid sandbox host: %w", err)
+		}
+	}
+
 	codeAgentConfig := cloneCodeAgentExecutionConfig(req.CodeAgentConfig)
 	if codeAgentConfig == nil && project != nil {
 		codeAgentConfig = cloneCodeAgentExecutionConfig(project.CodeAgentConfig)
@@ -232,6 +239,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		CodeAgentConfig:          codeAgentConfig,
 		SandboxResourceOverrides: sandboxResources,
 		SandboxRuntime:           sandboxRuntime,
+		SandboxHostID:            req.SandboxHostID,
 		JustDoItMode:             req.JustDoItMode, // Set Just Do It mode from request
 		// Credential-only override: whose Claude subscription authenticates this
 		// task's agent. Enforced at resolution time against the named user's
@@ -623,6 +631,7 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		ProjectID:      task.ProjectID, // For golden Docker cache overlay
 		ProjectPath:    "workspace",    // Use relative path
 		SpecTaskID:     task.ID,        // For task-scoped workspace
+		SandboxID:      task.SandboxHostID,
 		VCPUs:          sandboxVCPUs(task),
 		MemoryMB:       sandboxMemoryMB(task),
 		// RepositoryIDs / PrimaryRepositoryID set by SetRepoContext below.
@@ -1028,6 +1037,7 @@ Follow these guidelines when making changes:
 		ProjectID:           task.ProjectID, // For golden Docker cache overlay
 		ProjectPath:         "workspace",    // Use relative path
 		SpecTaskID:          task.ID,        // For task-scoped workspace
+		SandboxID:           task.SandboxHostID,
 		VCPUs:               sandboxVCPUs(task),
 		MemoryMB:            sandboxMemoryMB(task),
 		PrimaryRepositoryID: primaryRepoID, // Primary repo to open in Zed
@@ -2062,6 +2072,7 @@ func (s *SpecDrivenTaskService) ResumeSession(ctx context.Context, task *types.S
 		Input:               "Resuming Zed development environment after container restart",
 		ProjectPath:         "workspace",
 		SpecTaskID:          task.ID,
+		SandboxID:           task.SandboxHostID,
 		VCPUs:               sandboxVCPUs(task),
 		MemoryMB:            sandboxMemoryMB(task),
 		PrimaryRepositoryID: primaryRepoID,

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -279,8 +279,9 @@ func (s *PostgresStore) GetSandboxInstancesOlderThanHeartbeat(ctx context.Contex
 	return instances, nil
 }
 
-// FindAvailableSandboxInstance finds a sandbox host that is online, has recent heartbeat, and has the required desktop version.
-// Returns nil if no suitable sandbox host is found.
+// FindAvailableSandboxInstance finds a sandbox host that is online, has a
+// recent heartbeat, is under its max_sandboxes ceiling, and has the required
+// desktop version. Returns nil if no suitable sandbox host is found.
 //
 // requiresDisplay narrows the search to render-capable hosts. Pass true when
 // the container will run a compositor and be streamed; pass false for
@@ -305,28 +306,50 @@ func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, deskto
 	if err != nil {
 		return nil, fmt.Errorf("error finding available sandboxes: %w", err)
 	}
+	return pickSandboxInstance(instances, desktopType, requiresDisplay), nil
+}
 
-	// Find one with the required desktop version
+// pickSandboxInstance selects a dispatch target from load-ordered candidate
+// rows (least-loaded first). A candidate must be under its max_sandboxes
+// ceiling and advertise a non-empty image tag for desktopType in its
+// heartbeat blob.
+//
+// Streamed desktops (requiresDisplay) only run on render-capable hosts: a
+// neuron/inf2 host (no /dev/dri render node) would otherwise be picked on
+// load alone, then the desktop container FATALs at startup.
+//
+// Headless work runs anywhere, but prefers hosts that CANNOT stream a
+// desktop (CPU-only, software render) so render-capable hosts keep their
+// slots free for desktop sessions; a render-capable host is only used when
+// no display-incapable host qualifies.
+func pickSandboxInstance(instances []*types.SandboxInstance, desktopType string, requiresDisplay bool) *types.SandboxInstance {
+	var renderCapable *types.SandboxInstance
 	for _, instance := range instances {
-		// Streamed desktops only run on render-capable hosts. A neuron/inf2
-		// host (no /dev/dri render node) would otherwise be picked on load
-		// alone, then the desktop container FATALs at startup. Headless
-		// containers have no such constraint.
+		if instance.AtMaxCapacity() {
+			continue
+		}
 		if requiresDisplay && !instance.CanHostDesktop() {
 			continue
 		}
-		if len(instance.DesktopVersions) > 0 {
-			var versions map[string]string
-			if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
-				continue // Skip sandboxes with invalid version JSON
-			}
-			if version, ok := versions[desktopType]; ok && version != "" {
-				return instance, nil
-			}
+		if len(instance.DesktopVersions) == 0 {
+			continue
 		}
+		var versions map[string]string
+		if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {
+			continue // Skip sandboxes with invalid version JSON
+		}
+		if version, ok := versions[desktopType]; !ok || version == "" {
+			continue
+		}
+		if !requiresDisplay && instance.CanHostDesktop() {
+			if renderCapable == nil {
+				renderCapable = instance
+			}
+			continue
+		}
+		return instance
 	}
-
-	return nil, nil // No suitable sandbox found
+	return renderCapable
 }
 
 // Disk usage history methods

--- a/api/pkg/store/store_sandbox_pick_test.go
+++ b/api/pkg/store/store_sandbox_pick_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func pickTestInstance(t *testing.T, id, gpuVendor string, active, maxSandboxes int, versions map[string]string) *types.SandboxInstance {
+	t.Helper()
+	blob, err := json.Marshal(versions)
+	if err != nil {
+		t.Fatalf("marshal versions: %v", err)
+	}
+	return &types.SandboxInstance{
+		ID:              id,
+		GPUVendor:       gpuVendor,
+		ActiveSandboxes: active,
+		MaxSandboxes:    maxSandboxes,
+		DesktopVersions: blob,
+	}
+}
+
+func TestPickSandboxInstance(t *testing.T) {
+	ubuntu := map[string]string{"ubuntu": "abc123"}
+
+	tests := []struct {
+		name            string
+		instances       []*types.SandboxInstance
+		desktopType     string
+		requiresDisplay bool
+		wantID          string // "" means nil
+	}{
+		{
+			name:   "no instances",
+			wantID: "",
+		},
+		{
+			name: "desktop picks first load-ordered render-capable host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "a", "nvidia", 1, 20, ubuntu),
+				pickTestInstance(t, "b", "nvidia", 2, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "a",
+		},
+		{
+			name: "desktop skips cpu-only host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, ubuntu),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "gpu",
+		},
+		{
+			name: "headless prefers cpu-only host over less loaded gpu host",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "gpu", "nvidia", 0, 20, ubuntu),
+				pickTestInstance(t, "nas", "none", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "nas",
+		},
+		{
+			name: "headless falls back to gpu host when no cpu-only host qualifies",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "nas", "none", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "gpu", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: false,
+			wantID:          "gpu",
+		},
+		{
+			name: "host at max_sandboxes ceiling is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+				pickTestInstance(t, "free", "nvidia", 21, 40, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "free",
+		},
+		{
+			name: "all hosts at ceiling yields nil",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "full", "nvidia", 20, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "zero max_sandboxes means no ceiling",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "legacy", "nvidia", 50, 0, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "legacy",
+		},
+		{
+			name: "host missing the requested image is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "sway-only", "nvidia", 0, 20, map[string]string{"sway": "zzz"}),
+				pickTestInstance(t, "ubuntu-host", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "ubuntu-host",
+		},
+		{
+			name: "host with empty version string is skipped",
+			instances: []*types.SandboxInstance{
+				pickTestInstance(t, "empty", "nvidia", 0, 20, map[string]string{"ubuntu": ""}),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "",
+		},
+		{
+			name: "invalid version JSON is skipped",
+			instances: []*types.SandboxInstance{
+				{ID: "bad", GPUVendor: "nvidia", MaxSandboxes: 20, DesktopVersions: []byte("{not json")},
+				pickTestInstance(t, "good", "nvidia", 5, 20, ubuntu),
+			},
+			desktopType:     "ubuntu",
+			requiresDisplay: true,
+			wantID:          "good",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickSandboxInstance(tc.instances, tc.desktopType, tc.requiresDisplay)
+			gotID := ""
+			if got != nil {
+				gotID = got.ID
+			}
+			if gotID != tc.wantID {
+				t.Errorf("pickSandboxInstance() = %q, want %q", gotID, tc.wantID)
+			}
+		})
+	}
+}

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -185,6 +185,10 @@ type CreateTaskRequest struct {
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty" swaggerignore:"true"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
 	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty"`
+	// SandboxHostID optionally pins the task's desktop container to a specific
+	// sandbox host (SandboxInstance.ID). The host must be online and satisfy
+	// the runtime's display requirement, or task creation fails.
+	SandboxHostID string `json:"sandbox_host_id,omitempty"`
 
 	// CredentialOwnerID optionally names the user whose Claude subscription should
 	// authenticate this task's agent, for orchestrators dispatching work on a
@@ -248,6 +252,11 @@ type SpecTask struct {
 	CodeAgentOverrides       *CodeAgentOverrides       `json:"code_agent_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty" gorm:"size:64"`
+	// SandboxHostID pins this task's desktop container to a specific sandbox
+	// host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+	// honoured on resume, so the task returns to the host that has its
+	// workspace on disk.
+	SandboxHostID string `json:"sandbox_host_id,omitempty" gorm:"size:255"`
 
 	// Git repository attachments: REMOVED - now inherited from parent Project
 	// Repos are managed at the project level. Access via project.DefaultRepoID and GetProjectRepositories(project_id)

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -638,6 +638,10 @@ type ExternalAgentConfig struct {
 	DesktopType string `json:"desktop_type,omitempty"` // "ubuntu" (default) or "sway"
 	ZoomLevel   int    `json:"zoom_level,omitempty"`   // GNOME zoom percentage (100 default, 200 for 4k/5k)
 
+	// SandboxHostID pins the session's dev container to a specific sandbox
+	// host (SandboxInstance.ID). Empty means the dispatcher chooses.
+	SandboxHostID string `json:"sandbox_host_id,omitempty"`
+
 	// Video capture/encoding mode
 	VideoMode string `json:"video_mode,omitempty"` // "shm" (default), "native", or "zerocopy"
 }

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3663,6 +3663,13 @@ func (s *SandboxInstance) CanHostDesktop() bool {
 	return s.RenderNode != "SOFTWARE"
 }
 
+// AtMaxCapacity reports whether this host has reached its configured dev
+// container ceiling (SandboxMaxDevContainers at registration time).
+// MaxSandboxes 0 means no ceiling was recorded and never binds.
+func (s *SandboxInstance) AtMaxCapacity() bool {
+	return s.MaxSandboxes > 0 && s.ActiveSandboxes >= s.MaxSandboxes
+}
+
 // SandboxHeartbeatRequest is sent by sandbox-heartbeat daemon every 30 seconds
 type SandboxHeartbeatRequest struct {
 	// Desktop image versions (content-addressable Docker image hashes)

--- a/api/pkg/types/types_test.go
+++ b/api/pkg/types/types_test.go
@@ -30,6 +30,26 @@ func TestSandboxInstanceCanHostDesktop(t *testing.T) {
 	}
 }
 
+func TestSandboxInstanceAtMaxCapacity(t *testing.T) {
+	cases := []struct {
+		name   string
+		active int
+		max    int
+		want   bool
+	}{
+		{"under ceiling", 3, 20, false},
+		{"at ceiling", 20, 20, true},
+		{"over ceiling", 21, 20, true},
+		{"no ceiling recorded", 100, 0, false},
+	}
+	for _, tc := range cases {
+		s := &SandboxInstance{ActiveSandboxes: tc.active, MaxSandboxes: tc.max}
+		if got := s.AtMaxCapacity(); got != tc.want {
+			t.Errorf("%s: AtMaxCapacity()=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func Test_SessionChatRequest_PlainString(t *testing.T) {
 	request := &SessionChatRequest{
 		Messages: []*Message{

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -75,16 +75,28 @@ Closes the remaining dispatch gaps for mixed GPU / CPU-only fleets:
 Tests: `TestPickSandboxInstance` (store), `TestResolveSandboxID*`
 (external-agent, gomock store), `TestSandboxInstanceAtMaxCapacity` (types).
 
-## Follow-up: per-session host selection (user picks the node)
+## PR 2: `feature/session-sandbox-host-pinning` — user picks the node (API)
 
-`DesktopAgent.SandboxID` already pins placement (used by golden builds and
-honoured first in `resolveSandboxID`), but is not exposed to users:
+`DesktopAgent.SandboxID` already pinned placement internally (golden builds;
+honoured first in `resolveSandboxID`); this exposes it to users:
 
-- API: accept optional `sandbox_id` on session / spec-task creation and
-  `CreateSandboxRequest`; validate the host is online and satisfies the
-  workload's display requirement — reject, never silently reschedule a pin.
-- Frontend: host dropdown at session creation (default **Auto**), populated
-  from the sandbox-instances listing; show hostname, GPU vendor, load.
+- `sandbox_host_id` on spec-task creation (`CreateTaskRequest` →
+  `SpecTask.SandboxHostID`, GORM AutoMigrate column) and on session start
+  (`ExternalAgentConfig.SandboxHostID`).
+- Validation at create time via `external_agent.ValidateSandboxHostPin`
+  (`api/pkg/external-agent/host_pin.go`): host must exist, be online, and be
+  display-capable unless the workload is headless
+  (`DesktopTypeRequiresDisplay`). Capacity is deliberately not checked — a
+  pin is an explicit "this host, full or not". Invalid pins are rejected,
+  never silently rescheduled.
+- The pin is honoured on every launch path: task start, just-do-it start,
+  restart-after-crash, and session resume (resume reads it off the spec
+  task, so the container returns to the host that has its workspace).
+- Host discovery for clients: the existing authenticated
+  `GET /api/v1/sandboxes` listing — no new endpoint.
+
+Follow-up (PR 3): frontend host dropdown at task/session creation (default
+**Auto**), populated from that listing; show hostname, GPU capability, load.
 
 ## Mode switching (headless ↔ desktop), for reference
 

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -95,8 +95,22 @@ honoured first in `resolveSandboxID`); this exposes it to users:
 - Host discovery for clients: the existing authenticated
   `GET /api/v1/sandboxes` listing — no new endpoint.
 
-Follow-up (PR 3): frontend host dropdown at task/session creation (default
-**Auto**), populated from that listing; show hostname, GPU capability, load.
+## PR 3: `feature/sandbox-host-selector-ui` — host selector in the task form
+
+- `SandboxHostSelect` (`frontend/src/components/tasks/SandboxHostSelect.tsx`):
+  compact dropdown in the new-task form, default **Auto (least loaded)**,
+  listing online hosts with hostname, GPU vendor (or "cpu-only"), and
+  active/max load. Renders nothing on single-node installs (fewer than two
+  online hosts) so the common case stays uncluttered. Desktop runtimes only
+  offer display-capable hosts (mirrors `CanHostDesktop`); switching runtime
+  clears a pin that became invalid.
+- `NewSpecTaskForm` sends `sandbox_host_id` on create.
+- Regenerated swagger + TS client (`./stack update_openapi` steps). Fixed
+  pre-existing generator breakage on main: five handler files annotated
+  `system.HTTPError` (or `types.Role`) without importing the package, which
+  aborted `swag init`; also note swag must run with working VCS stamping or
+  `GOFLAGS=-buildvcs=false`, else it emits fully-qualified definition names
+  and renames half the generated TS types.
 
 ## Mode switching (headless ↔ desktop), for reference
 

--- a/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
+++ b/design/2026-08-21-multi-node-scheduling-and-headless-sessions.md
@@ -1,0 +1,110 @@
+# Multi-node scheduling for GPU-less hosts + headless agent sessions
+
+**Date:** 2026-08-21
+**Status:** Partially landed upstream; remainder in `feature/capability-aware-sandbox-scheduling` + follow-ups
+**Author:** Waqas Ahmad
+
+## Motivation
+
+A common Helix topology is one GPU workstation plus one or more cheap CPU-only
+machines (a NAS, spare servers, ordinary cloud VMs), all reachable over a
+private network such as Tailscale. We want:
+
+1. CPU-only hosts to join the cluster and receive the workloads they can
+   actually run.
+2. The user (or Helix) to decide per-session where it runs and whether it
+   needs a watchable desktop at all.
+3. Headless agent sessions — agent + toolchain without a compositor or
+   encoder — to land on the cheap hosts, keeping GPU capacity free for
+   streamed desktops.
+
+Concrete driving setup: `omen` (NVIDIA, runs the control plane + desktop
+sessions) and a GPU-less Ubuntu NAS on the same tailnet (runs headless
+sessions and headless Sandboxes-API containers).
+
+## Already shipped upstream (no work needed)
+
+- **Cluster join**: `sandbox_instances` registry, outbound-only RevDial
+  attach (`api/cmd/hydra/main.go`), auto-registration on connect
+  (`api/pkg/server/server.go` `ensureSandboxRegistered`), 30s heartbeat with
+  `desktop_versions`/`gpu_vendor`/`render_node`, admin Runners page.
+  Adding a node: `./install.sh --sandbox --api-host <url> --runner-token
+  <tok>`. Works over Tailscale — no inbound ports on the node.
+- **Capability-aware placement**: `SandboxInstance.CanHostDesktop()`
+  (`api/pkg/types/types.go`) gates only *streamed desktop* placement;
+  `FindAvailableSandboxInstance(ctx, desktopType, requiresDisplay)` places
+  headless work on any online host including CPU-only ones.
+  `RuntimeSpec.RequiresDisplay` does the same for the Sandboxes API
+  (`api/pkg/sandbox/runtimes.go`, `controller_provision.go`).
+- **Headless spec-task runtime**: `SandboxRuntimeHeadlessUbuntu` /
+  `desktop_type: headless` runs the helix-ubuntu toolchain image with no
+  compositor, display devices, or encoder (`hydra_executor.go` — display
+  env skipped, placement with `requiresDisplay=false`). Chat rides the
+  Zed↔Helix `external_websocket_sync` WebSocket, independent of video.
+- **Sticky placement + data safety**: sessions pin to `session.SandboxID`;
+  persistent Sandboxes-API sandboxes refuse to move off their bound host
+  (workspaces are host-local disk) — `controller_provision.go`
+  `pickHostForSandbox`.
+
+## This PR: `feature/capability-aware-sandbox-scheduling`
+
+Closes the remaining dispatch gaps for mixed GPU / CPU-only fleets:
+
+1. **Prefer CPU-only hosts for headless work.** The picker
+   (`pickSandboxInstance`, `api/pkg/store/store_sandbox.go`) now places
+   `requiresDisplay=false` work on a display-*incapable* host when one
+   qualifies, falling back to render-capable hosts otherwise — so headless
+   sessions drain to the NAS and GPU slots stay free for desktops. Same
+   preference in the custom-image host loop
+   (`controller_provision.go` `pickHostForSandbox`).
+2. **`max_sandboxes` enforced at dispatch** (was autoscaler-signal only,
+   flagged as a follow-up in `config.go`): hosts at their ceiling are
+   skipped; a fleet fully at ceiling yields a no-capacity error instead of
+   overloading the least-loaded host. `MaxSandboxes == 0` (pre-field rows)
+   means no ceiling. Shared predicate: `SandboxInstance.AtMaxCapacity()`.
+3. **No more silent `"local"` fallback** (`hydra_executor.go`
+   `resolveSandboxID`): when hosts are registered but none is eligible,
+   placement fails with an error naming the container type, image key, and
+   requirements — instead of dialing the `hydra-local` device key and
+   hanging out the RevDial grace period. The `"local"` key remains only for
+   the legacy single-node install with an empty registry.
+4. **Dev compose**: `SANDBOX_INSTANCE_ID` is overridable
+   (`${SANDBOX_INSTANCE_ID:-local}`) so a second dev node doesn't collide
+   with the hardcoded `local` row.
+
+Tests: `TestPickSandboxInstance` (store), `TestResolveSandboxID*`
+(external-agent, gomock store), `TestSandboxInstanceAtMaxCapacity` (types).
+
+## Follow-up: per-session host selection (user picks the node)
+
+`DesktopAgent.SandboxID` already pins placement (used by golden builds and
+honoured first in `resolveSandboxID`), but is not exposed to users:
+
+- API: accept optional `sandbox_id` on session / spec-task creation and
+  `CreateSandboxRequest`; validate the host is online and satisfies the
+  workload's display requirement — reject, never silently reschedule a pin.
+- Frontend: host dropdown at session creation (default **Auto**), populated
+  from the sandbox-instances listing; show hostname, GPU vendor, load.
+
+## Mode switching (headless ↔ desktop), for reference
+
+- *Same host*: stop the container, start with the other desktop type for the
+  same session — chat history (Postgres) and workspace
+  (`/data/workspaces/<sid>` on the host) survive; an in-flight agent turn is
+  interrupted (same as any resume).
+- *Cross host* (NAS headless → GPU desktop): blocked — workspaces are
+  host-local (same rationale as the persistent-sandbox refusal). Workflow:
+  agent pushes its branch, reopen on the target host. Cross-host workspace
+  sync is out of scope.
+
+## Multi-node operational notes
+
+- A remote node cannot use the dev `registry:5000` image path — it pulls
+  from ghcr.io (prod path) or a tailnet-reachable registry via
+  `HELIX_SANDBOX_REGISTRY`.
+- Upgrades touch the control plane *and* each node (re-run
+  `install.sh --sandbox` / bump `SANDBOX_TAG`). A stale node degrades
+  gracefully: it stops receiving new sessions once its advertised
+  `desktop_versions` no longer match, but keeps serving running ones.
+- `MAX_SANDBOXES` on each node is the operator throttle, now enforced at
+  dispatch (this PR).

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -238,7 +238,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -334,7 +334,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -428,7 +428,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}
@@ -518,7 +518,7 @@ services:
       # RevDial configuration (connect sandbox to API)
       - HELIX_API_URL=http://api:8080
       - HELIX_API_BASE_URL=http://api:8080
-      - SANDBOX_INSTANCE_ID=local
+      - SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       # Hydra multi-Docker isolation (per-scope dockerd for each agent session)
       - HYDRA_ENABLED=${HYDRA_ENABLED:-true}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3631,6 +3631,12 @@ export interface TypesCreateTaskRequest {
   priority?: TypesSpecTaskPriority;
   project_id?: string;
   prompt?: string;
+  /**
+   * SandboxHostID optionally pins the task's desktop container to a specific
+   * sandbox host (SandboxInstance.ID). The host must be online and satisfy
+   * the runtime's display requirement, or task creation fails.
+   */
+  sandbox_host_id?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
   sandbox_runtime?: TypesSandboxRuntime;
   type?: string;
@@ -3863,6 +3869,11 @@ export interface TypesExternalAgentConfig {
   display_width?: number;
   /** Display resolution - either use Resolution preset or explicit dimensions */
   resolution?: string;
+  /**
+   * SandboxHostID pins the session's dev container to a specific sandbox
+   * host (SandboxInstance.ID). Empty means the dispatcher chooses.
+   */
+  sandbox_host_id?: string;
   /** Video capture/encoding mode */
   video_mode?: string;
   /** GNOME zoom percentage (100 default, 200 for 4k/5k) */
@@ -7022,6 +7033,13 @@ export interface TypesSpecTask {
   repo_pull_requests?: TypesRepoPR[];
   /** User stories + EARS acceptance criteria (markdown) */
   requirements_spec?: string;
+  /**
+   * SandboxHostID pins this task's desktop container to a specific sandbox
+   * host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+   * honoured on resume, so the task returns to the host that has its
+   * workspace on disk.
+   */
+  sandbox_host_id?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
   sandbox_runtime?: TypesSandboxRuntime;
   /** "absent", "running", "starting" — derived from session config in listTasks */
@@ -7407,6 +7425,13 @@ export interface TypesSpecTaskWithProject {
   repo_pull_requests?: TypesRepoPR[];
   /** User stories + EARS acceptance criteria (markdown) */
   requirements_spec?: string;
+  /**
+   * SandboxHostID pins this task's desktop container to a specific sandbox
+   * host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+   * honoured on resume, so the task returns to the host that has its
+   * workspace on disk.
+   */
+  sandbox_host_id?: string;
   sandbox_resource_overrides?: TypesSandboxResourceOverrides;
   sandbox_runtime?: TypesSandboxRuntime;
   /** "absent", "running", "starting" — derived from session config in listTasks */
@@ -8751,7 +8776,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<ServerAgentSandboxesDebugResponse, SystemHTTPError>({
+      this.request<ServerAgentSandboxesDebugResponse, TypesAPIError>({
         path: `/api/v1/admin/agent-sandboxes/debug`,
         method: "GET",
         query: query,
@@ -8771,7 +8796,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1AdminAgentSandboxesEventsList: (params: RequestParams = {}) =>
-      this.request<string, SystemHTTPError>({
+      this.request<string, TypesAPIError>({
         path: `/api/v1/admin/agent-sandboxes/events`,
         method: "GET",
         secure: true,
@@ -10341,7 +10366,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<File, SystemHTTPError>({
+      this.request<File, TypesAPIError>({
         path: `/api/v1/bandwidth-probe`,
         method: "GET",
         query: query,
@@ -10701,7 +10726,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsClipboardDetail: (sessionId: string, params: RequestParams = {}) =>
-      this.request<TypesClipboardData, SystemHTTPError>({
+      this.request<TypesClipboardData, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/clipboard`,
         method: "GET",
         secure: true,
@@ -10719,7 +10744,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsClipboardCreate: (sessionId: string, clipboard: TypesClipboardData, params: RequestParams = {}) =>
-      this.request<void, SystemHTTPError>({
+      this.request<void, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/clipboard`,
         method: "POST",
         body: clipboard,
@@ -10762,7 +10787,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsExecCreate: (sessionId: string, body: object, params: RequestParams = {}) =>
-      this.request<object, SystemHTTPError>({
+      this.request<object, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/exec`,
         method: "POST",
         body: body,
@@ -10789,7 +10814,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<File, SystemHTTPError>({
+      this.request<File, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/file`,
         method: "GET",
         query: query,
@@ -10818,7 +10843,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesSandboxFileUploadResponse, SystemHTTPError>({
+      this.request<TypesSandboxFileUploadResponse, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/upload`,
         method: "POST",
         query: query,
@@ -10871,7 +10896,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       request: TypesWorkspaceFileWriteRequest,
       params: RequestParams = {},
     ) =>
-      this.request<TypesWorkspaceFileResponse, SystemHTTPError>({
+      this.request<TypesWorkspaceFileResponse, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/workspace-file`,
         method: "PUT",
         body: request,
@@ -10928,7 +10953,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesWorkspaceReviewResponse, SystemHTTPError>({
+      this.request<TypesWorkspaceReviewResponse, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/workspace-review`,
         method: "GET",
         query: query,
@@ -11000,7 +11025,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsWorkspacesDetail: (sessionId: string, params: RequestParams = {}) =>
-      this.request<TypesWorkspacesResponse, SystemHTTPError>({
+      this.request<TypesWorkspacesResponse, TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/workspaces`,
         method: "GET",
         secure: true,
@@ -11018,7 +11043,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsWsInputDetail: (sessionId: string, params: RequestParams = {}) =>
-      this.request<any, void | SystemHTTPError>({
+      this.request<any, void | TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/ws/input`,
         method: "GET",
         secure: true,
@@ -11035,7 +11060,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1ExternalAgentsWsStreamDetail: (sessionId: string, params: RequestParams = {}) =>
-      this.request<any, void | SystemHTTPError>({
+      this.request<any, void | TypesAPIError>({
         path: `/api/v1/external-agents/${sessionId}/ws/stream`,
         method: "GET",
         secure: true,
@@ -16115,7 +16140,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
+      this.request<TypesAggregatedUsageMetric[], TypesAPIError>({
         path: `/api/v1/provider-endpoints/${id}/daily-usage`,
         method: "GET",
         query: query,
@@ -16149,7 +16174,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
+      this.request<TypesAggregatedUsageMetric[], TypesAPIError>({
         path: `/api/v1/provider-endpoints/${id}/throughput-usage`,
         method: "GET",
         query: query,
@@ -16178,7 +16203,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesUsersAggregatedUsageMetric[], SystemHTTPError>({
+      this.request<TypesUsersAggregatedUsageMetric[], TypesAPIError>({
         path: `/api/v1/provider-endpoints/${id}/users-daily-usage`,
         method: "GET",
         query: query,
@@ -17533,7 +17558,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1SessionsSandboxStateDetail: (id: string, params: RequestParams = {}) =>
-      this.request<ServerSessionSandboxStateResponse, SystemHTTPError>({
+      this.request<ServerSessionSandboxStateResponse, TypesAPIError>({
         path: `/api/v1/sessions/${id}/sandbox-state`,
         method: "GET",
         secure: true,

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -31,6 +31,7 @@ import { ChevronDown, X } from "lucide-react";
 import AssigneeSelector from "./AssigneeSelector";
 import OrganizationUserAvatar, { resolveOrganizationUser } from "../widgets/OrganizationUserAvatar";
 import GooseRecipeSelector from "./GooseRecipeSelector";
+import SandboxHostSelect from "./SandboxHostSelect";
 import {
   TypesCodeAgentExecutionConfig,
   TypesCreateTaskRequest,
@@ -152,6 +153,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
     preferredSpecTaskSandboxRuntime(projectId),
   );
+  // Sandbox host pin; empty string means the dispatcher chooses. Only offered
+  // on multi-node installs (SandboxHostSelect renders nothing otherwise).
+  const [sandboxHostId, setSandboxHostId] = useState("");
   // Goose recipe selection — only meaningful when the selected agent's runtime
   // is goose_code. Empty selectedRecipeName means "use vanilla goose"; the
   // backend skips baking and the agent's declared recipes are still available
@@ -410,6 +414,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     );
     setSelectedRecipeName("");
     setRecipeParams({});
+    setSandboxHostId("");
     // justDoItMode and autoStart intentionally kept — they persist to the next
     // task via localStorage (see handleJustDoItChange / handleAutoStartChange)
     setBranchMode(TypesBranchMode.BranchModeNew);
@@ -479,6 +484,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             : undefined,
         sandbox_resource_overrides: sandboxResourceOverrides,
         sandbox_runtime: sandboxRuntime,
+        sandbox_host_id: sandboxHostId || undefined,
       };
 
       const response = await api
@@ -1120,6 +1126,14 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                 onSandboxResourceOverridesChange={setSandboxResourceOverrides}
                 onSandboxRuntimeChange={handleSandboxRuntimeChange}
                 autoSelectDefault
+              />
+              <SandboxHostSelect
+                value={sandboxHostId}
+                onChange={setSandboxHostId}
+                requiresDisplay={
+                  sandboxRuntime !==
+                  TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
+                }
               />
               {selectedAgentIsGoose && (
                 <GooseRecipeSelector

--- a/frontend/src/components/tasks/SandboxHostSelect.tsx
+++ b/frontend/src/components/tasks/SandboxHostSelect.tsx
@@ -1,0 +1,113 @@
+import React, { FC, useEffect, useMemo } from "react";
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import { useQuery } from "@tanstack/react-query";
+
+import useApi from "../../hooks/useApi";
+import { TypesSandboxInstance } from "../../api/api";
+
+// Mirrors SandboxInstance.CanHostDesktop on the API side: streamed desktops
+// need display and encode hardware, headless containers run anywhere.
+const canHostDesktop = (host: TypesSandboxInstance): boolean => {
+  if (host.gpu_vendor === "none" || host.gpu_vendor === "neuron") return false;
+  return host.render_node !== "SOFTWARE";
+};
+
+interface SandboxHostSelectProps {
+  // Selected sandbox host id; empty string means "Auto" (dispatcher chooses).
+  value: string;
+  onChange: (hostID: string) => void;
+  // Whether the chosen runtime streams a desktop (false for headless).
+  requiresDisplay: boolean;
+}
+
+// Host picker for task/session placement. Renders nothing on single-node
+// installs (fewer than two online hosts) so the common case stays uncluttered.
+const SandboxHostSelect: FC<SandboxHostSelectProps> = ({
+  value,
+  onChange,
+  requiresDisplay,
+}) => {
+  const api = useApi();
+
+  const { data: hosts } = useQuery({
+    queryKey: ["sandbox-hosts"],
+    queryFn: async () => {
+      const response = await api.getApiClient().v1SandboxesList();
+      return response.data;
+    },
+    refetchInterval: 30_000,
+  });
+
+  const onlineHosts = useMemo(
+    () => (hosts || []).filter((h) => h.status === "online"),
+    [hosts],
+  );
+
+  const eligibleHosts = useMemo(
+    () => onlineHosts.filter((h) => !requiresDisplay || canHostDesktop(h)),
+    [onlineHosts, requiresDisplay],
+  );
+
+  const selectionEligible =
+    value === "" || eligibleHosts.some((h) => h.id === value);
+
+  // Clear a pin that stopped being valid (host went offline, or the runtime
+  // switched to desktop while a CPU-only host was selected) — the API would
+  // reject it at create time anyway.
+  useEffect(() => {
+    if (!selectionEligible) {
+      onChange("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectionEligible, value]);
+
+  // Single-node install (or hosts still loading): nothing to choose.
+  if (onlineHosts.length < 2) return null;
+
+  return (
+    <FormControl size="small" fullWidth>
+      <InputLabel id="sandbox-host-select-label">Sandbox host</InputLabel>
+      <Select
+        labelId="sandbox-host-select-label"
+        label="Sandbox host"
+        value={selectionEligible ? value : ""}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <MenuItem value="">
+          <Typography variant="body2">Auto (least loaded)</Typography>
+        </MenuItem>
+        {eligibleHosts.map((host) => (
+          <MenuItem key={host.id} value={host.id || ""}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 1,
+                minWidth: 0,
+              }}
+            >
+              <Typography variant="body2" noWrap>
+                {host.hostname || host.id}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" noWrap>
+                {host.gpu_vendor && host.gpu_vendor !== "none"
+                  ? host.gpu_vendor
+                  : "cpu-only"}
+                {" · "}
+                {host.active_sandboxes ?? 0}
+                {host.max_sandboxes ? `/${host.max_sandboxes}` : ""} running
+              </Typography>
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default SandboxHostSelect;

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5670,6 +5670,12 @@ definitions:
         type: string
       prompt:
         type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID optionally pins the task's desktop container to a specific
+          sandbox host (SandboxInstance.ID). The host must be online and satisfy
+          the runtime's display requirement, or task creation fails.
+        type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
       sandbox_runtime:
@@ -6042,6 +6048,11 @@ definitions:
       resolution:
         description: Display resolution - either use Resolution preset or explicit
           dimensions
+        type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins the session's dev container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses.
         type: string
       video_mode:
         description: Video capture/encoding mode
@@ -11061,6 +11072,13 @@ definitions:
       requirements_spec:
         description: User stories + EARS acceptance criteria (markdown)
         type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins this task's desktop container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+          honoured on resume, so the task returns to the host that has its
+          workspace on disk.
+        type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
       sandbox_runtime:
@@ -11715,6 +11733,13 @@ definitions:
         type: array
       requirements_spec:
         description: User stories + EARS acceptance criteria (markdown)
+        type: string
+      sandbox_host_id:
+        description: |-
+          SandboxHostID pins this task's desktop container to a specific sandbox
+          host (SandboxInstance.ID). Empty means the dispatcher chooses. Also
+          honoured on resume, so the task returns to the host that has its
+          workspace on disk.
         type: string
       sandbox_resource_overrides:
         $ref: '#/definitions/types.SandboxResourceOverrides'
@@ -13685,11 +13710,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - ApiKeyAuth: []
       summary: Get sandbox debugging data
@@ -13710,11 +13735,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "501":
           description: Not Implemented
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - ApiKeyAuth: []
       summary: Get sandbox real-time events (SSE)
@@ -15788,7 +15813,7 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Bandwidth probe for adaptive bitrate
@@ -16263,11 +16288,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get session clipboard content
@@ -16295,11 +16320,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Set session clipboard content
@@ -16369,11 +16394,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Execute command in sandbox
@@ -16404,23 +16429,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Read an uploaded chat attachment
@@ -16457,23 +16482,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Upload file to sandbox
@@ -16536,23 +16561,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Update a workspace file
@@ -16616,19 +16641,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get workspace review sources
@@ -16712,19 +16737,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get workspaces from container
@@ -16746,19 +16771,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Direct WebSocket input for PipeWire/GNOME sessions
@@ -16780,19 +16805,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Direct WebSocket video streaming for PipeWire/GNOME sessions
@@ -23709,15 +23734,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider daily usage
@@ -23762,15 +23787,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider throughput usage
@@ -23807,15 +23832,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get provider daily usage per user
@@ -25798,19 +25823,19 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/system.HTTPError'
+            $ref: '#/definitions/types.APIError'
       security:
       - BearerAuth: []
       summary: Get sandbox state for a session

--- a/openapi.json
+++ b/openapi.json
@@ -53,7 +53,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -63,7 +63,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -99,7 +99,7 @@
                         "content": {
                             "text/event-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -109,7 +109,7 @@
                         "content": {
                             "text/event-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -3910,7 +3910,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4778,7 +4778,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4788,7 +4788,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4837,7 +4837,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4847,7 +4847,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4966,7 +4966,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -4976,7 +4976,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5033,7 +5033,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5043,7 +5043,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5053,7 +5053,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5063,7 +5063,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5073,7 +5073,7 @@
                         "content": {
                             "application/octet-stream": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5148,7 +5148,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5158,7 +5158,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5168,7 +5168,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5178,7 +5178,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5188,7 +5188,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5298,7 +5298,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5308,7 +5308,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5318,7 +5318,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5328,7 +5328,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5338,7 +5338,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5454,7 +5454,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5464,7 +5464,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5474,7 +5474,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5484,7 +5484,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5630,7 +5630,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5640,7 +5640,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5650,7 +5650,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5660,7 +5660,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5700,7 +5700,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5710,7 +5710,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5720,7 +5720,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5730,7 +5730,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5770,7 +5770,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5780,7 +5780,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5790,7 +5790,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -5800,7 +5800,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18680,7 +18680,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18690,7 +18690,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18700,7 +18700,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18779,7 +18779,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18789,7 +18789,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18799,7 +18799,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18865,7 +18865,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18875,7 +18875,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -18885,7 +18885,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -22543,7 +22543,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -22553,7 +22553,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -22563,7 +22563,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -22573,7 +22573,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
+                                    "$ref": "#/components/schemas/types.APIError"
                                 }
                             }
                         }
@@ -35832,6 +35832,10 @@
                     "prompt": {
                         "type": "string"
                     },
+                    "sandbox_host_id": {
+                        "description": "SandboxHostID optionally pins the task's desktop container to a specific\nsandbox host (SandboxInstance.ID). The host must be online and satisfy\nthe runtime's display requirement, or task creation fails.",
+                        "type": "string"
+                    },
                     "sandbox_resource_overrides": {
                         "$ref": "#/components/schemas/types.SandboxResourceOverrides"
                     },
@@ -36338,6 +36342,10 @@
                     },
                     "resolution": {
                         "description": "Display resolution - either use Resolution preset or explicit dimensions",
+                        "type": "string"
+                    },
+                    "sandbox_host_id": {
+                        "description": "SandboxHostID pins the session's dev container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses.",
                         "type": "string"
                     },
                     "video_mode": {
@@ -43069,6 +43077,10 @@
                         "description": "User stories + EARS acceptance criteria (markdown)",
                         "type": "string"
                     },
+                    "sandbox_host_id": {
+                        "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
+                        "type": "string"
+                    },
                     "sandbox_resource_overrides": {
                         "$ref": "#/components/schemas/types.SandboxResourceOverrides"
                     },
@@ -43914,6 +43926,10 @@
                     },
                     "requirements_spec": {
                         "description": "User stories + EARS acceptance criteria (markdown)",
+                        "type": "string"
+                    },
+                    "sandbox_host_id": {
+                        "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
                         "type": "string"
                     },
                     "sandbox_resource_overrides": {

--- a/swagger.json
+++ b/swagger.json
@@ -55,13 +55,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -95,13 +95,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "501": {
                         "description": "Not Implemented",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -3314,7 +3314,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4065,13 +4065,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4115,13 +4115,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4228,13 +4228,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4281,31 +4281,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4361,31 +4361,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4482,31 +4482,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4604,25 +4604,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4749,25 +4749,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4801,25 +4801,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -4853,25 +4853,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15681,19 +15681,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15762,19 +15762,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -15832,19 +15832,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -18906,25 +18906,25 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
+                            "$ref": "#/definitions/types.APIError"
                         }
                     }
                 }
@@ -31227,6 +31227,10 @@
                 "prompt": {
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID optionally pins the task's desktop container to a specific\nsandbox host (SandboxInstance.ID). The host must be online and satisfy\nthe runtime's display requirement, or task creation fails.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -31733,6 +31737,10 @@
                 },
                 "resolution": {
                     "description": "Display resolution - either use Resolution preset or explicit dimensions",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins the session's dev container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses.",
                     "type": "string"
                 },
                 "video_mode": {
@@ -38464,6 +38472,10 @@
                     "description": "User stories + EARS acceptance criteria (markdown)",
                     "type": "string"
                 },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
+                    "type": "string"
+                },
                 "sandbox_resource_overrides": {
                     "$ref": "#/definitions/types.SandboxResourceOverrides"
                 },
@@ -39309,6 +39321,10 @@
                 },
                 "requirements_spec": {
                     "description": "User stories + EARS acceptance criteria (markdown)",
+                    "type": "string"
+                },
+                "sandbox_host_id": {
+                    "description": "SandboxHostID pins this task's desktop container to a specific sandbox\nhost (SandboxInstance.ID). Empty means the dispatcher chooses. Also\nhonoured on resume, so the task returns to the host that has its\nworkspace on disk.",
                     "type": "string"
                 },
                 "sandbox_resource_overrides": {


### PR DESCRIPTION
> **Stacked PR** — builds on https://github.com/helixml/helix/pull/3089 and https://github.com/helixml/helix/pull/3090 and includes their commits. Review only the newest commit until those merge.

# PR 3 — feat(frontend): sandbox host selector for new spec tasks

**Branch:** `feature/sandbox-host-selector-ui` (stacked on `feature/session-sandbox-host-pinning`)
**Target:** `feature/session-sandbox-host-pinning` (or `main` after PR 2 merges)

## What

The UI half of host pinning: lets a user choose which cluster node a new spec task runs on.

1. **`SandboxHostSelect`** (`frontend/src/components/tasks/SandboxHostSelect.tsx`), rendered in the new-task form under the execution controls:
   - Default **Auto (least loaded)** — the PR 1 dispatcher decides.
   - Lists online hosts with hostname, GPU vendor (or "cpu-only"), and active/max container load; refreshes every 30s via React Query on the generated `v1SandboxesList` client method.
   - **Renders nothing on single-node installs** (fewer than two online hosts), so the common case stays exactly as before.
   - Desktop runtimes only offer display-capable hosts (mirrors `SandboxInstance.CanHostDesktop`); headless offers every online host. A pin invalidated by switching runtime or by the host going offline is cleared back to Auto — the API would reject it at create time anyway (PR 2 validation).
2. **`NewSpecTaskForm`** sends `sandbox_host_id` in the create request and resets it with the rest of the form state.
3. **Regenerated swagger + TypeScript client** (the `./stack update_openapi` steps), picking up `sandbox_host_id` on `TypesCreateTaskRequest` / `TypesSpecTask` / `TypesExternalAgentConfig`.

## Drive-by fix: `update_openapi` was broken on main

`swag init` aborts on main with `ParseComment error … cannot find type definition: system.HTTPError`. Five handler files reference types in swagger annotations without importing the package swag needs for resolution:

- `agent_sandboxes_handlers.go`, `external_agent_handlers.go`, `provider_handlers.go`, `workspace_review_handlers.go`: annotations switched to `types.APIError` (the majority pattern — 85 uses vs 62 — and `types` is already imported in all four).
- `organization_role_handlers.go`: annotates `types.Role` with no `types` import; now imports it and types the `ListRoles` result explicitly.

Operational note for whoever runs the generator in a container: swag must run with working VCS stamping (git `safe.directory`) or `GOFLAGS=-buildvcs=false` — when `go list` fails, swag silently emits fully-qualified definition names (`github_com_helixml_helix_api_pkg_types.*`), which renames half the generated TS types and breaks the frontend build.

## Tests

- `cd frontend && yarn build` passes; `NewSpecTaskForm.test.tsx` passes.
- Generated-client diff is minimal (42 insertions / 17 deletions) after the naming fix.
- `go build ./api/pkg/server/` passes (annotation edits are comments; only `organization_role_handlers.go` has a code change).

NOT tested: live multi-node dropdown behavior in a browser — a single-node dev stack intentionally hides the selector (needs a second registered host, or a hand-inserted `sandbox_instances` row, to see it).