### PR TITLE
fix(org): sync linked project config on agent update

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/controller/knowledge"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/filestore"
 	"github.com/helixml/helix/api/pkg/oauth"
 	orgdomainstore "github.com/helixml/helix/api/pkg/org/domain/store"
@@ -1220,17 +1221,63 @@ func (s *HelixAPIServer) updateAgent(_ http.ResponseWriter, r *http.Request) (*t
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
+	restore := func(updateErr error) *system.HTTPError {
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 10*time.Second)
+		defer cancel()
+		if _, rollbackErr := s.Store.UpdateApp(rollbackCtx, existing); rollbackErr != nil {
+			return system.NewHTTPError500(fmt.Sprintf("%v; restore agent app: %v", updateErr, rollbackErr))
+		}
+		return system.NewHTTPError500(updateErr.Error())
+	}
 
 	err = s.ensureKnowledge(r.Context(), updated)
 	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
+		return nil, restore(err)
 	}
 
 	err = s.ensureTriggerConfigurations(r.Context(), updated)
 	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
+		return nil, restore(err)
+	}
+	if err := s.syncOrgAgentProjectCodeAgentConfig(r.Context(), updated); err != nil {
+		return nil, restore(err)
 	}
 	return updated, nil
+}
+
+func (s *HelixAPIServer) syncOrgAgentProjectCodeAgentConfig(ctx context.Context, app *types.App) error {
+	if app.AgentKind != types.AgentKindOrg || app.OrganizationID == "" {
+		return nil
+	}
+	projects, err := s.Store.ListProjects(ctx, &store.ListProjectsQuery{OrganizationID: app.OrganizationID})
+	if err != nil {
+		return fmt.Errorf("list linked projects: %w", err)
+	}
+	var linked *types.Project
+	for _, project := range projects {
+		if project == nil || project.OrganizationID != app.OrganizationID || project.DefaultHelixAppID != app.ID {
+			continue
+		}
+		if linked != nil {
+			return fmt.Errorf("org agent %s is linked to more than one project", app.ID)
+		}
+		linked = project
+	}
+	if linked == nil {
+		return nil
+	}
+	desired, err := external_agent.MaterializeCodeAgentConfig(app, nil)
+	if err != nil {
+		return fmt.Errorf("materialize agent project config: %w", err)
+	}
+	if linked.CodeAgentConfig != nil {
+		desired.ServiceTier = linked.CodeAgentConfig.ServiceTier
+	}
+	linked.CodeAgentConfig = desired
+	if err := s.Store.UpdateProject(ctx, linked); err != nil {
+		return fmt.Errorf("sync linked project %s: %w", linked.ID, err)
+	}
+	return nil
 }
 
 // deleteAgent godoc

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -228,6 +228,7 @@ func TestUpdateAppPreservesAgentKind(t *testing.T) {
 	})
 	helixStore.EXPECT().ListKnowledge(gomock.Any(), gomock.Any()).Return(nil, nil)
 	helixStore.EXPECT().ListTriggerConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{OrganizationID: existing.OrganizationID}).Return(nil, nil)
 
 	server := &HelixAPIServer{
 		Store: helixStore,
@@ -247,6 +248,124 @@ func TestUpdateAppPreservesAgentKind(t *testing.T) {
 	require.Nil(t, httpErr)
 	require.NotNil(t, updated)
 	assert.Equal(t, types.AgentKindOrg, updated.AgentKind)
+}
+
+func TestUpdateAppSyncsLinkedOrgProjectCodeAgentConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	user := types.User{ID: "usr-owner", Type: types.OwnerTypeUser}
+	existing := &types.App{
+		ID: "app-engineer", Owner: user.ID, OwnerType: user.Type,
+		OrganizationID: "org-test", AgentKind: types.AgentKindOrg,
+	}
+	update := *existing
+	update.Config.Helix.Assistants = []types.AssistantConfig{{
+		Name: "Software Engineer", AgentType: types.AgentTypeZedExternal,
+		CodeAgentRuntime: types.CodeAgentRuntimeZedAgent, CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+		Provider: "provider-qwen", Model: "qwen3.8-27b",
+	}}
+	linked := &types.Project{
+		ID: "project-engineer", OrganizationID: existing.OrganizationID, DefaultHelixAppID: existing.ID,
+		CodeAgentConfig: &types.CodeAgentExecutionConfig{
+			Runtime: types.CodeAgentRuntimeClaudeCode, CredentialType: types.CodeAgentCredentialTypeSubscription,
+			Model: "claude-opus-5", ServiceTier: "priority",
+		},
+	}
+	unrelated := &types.Project{ID: "project-other", OrganizationID: existing.OrganizationID, DefaultHelixAppID: "app-other"}
+
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID: user.ID, OrganizationID: existing.OrganizationID, Role: types.OrganizationRoleMember,
+	}, nil)
+	providerManager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), existing.OrganizationID, types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{{ID: "provider-qwen", Name: "qwen"}}, nil)
+	helixStore.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, app *types.App) (*types.App, error) {
+		return app, nil
+	})
+	helixStore.EXPECT().ListKnowledge(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListTriggerConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{OrganizationID: existing.OrganizationID}).
+		Return([]*types.Project{linked, unrelated}, nil)
+	helixStore.EXPECT().UpdateProject(gomock.Any(), linked).DoAndReturn(func(_ context.Context, project *types.Project) error {
+		require.Equal(t, types.CodeAgentRuntimeZedAgent, project.CodeAgentConfig.Runtime)
+		require.Equal(t, types.CodeAgentCredentialTypeAPIKey, project.CodeAgentConfig.CredentialType)
+		require.Equal(t, "provider-qwen", project.CodeAgentConfig.ProviderRef)
+		require.Equal(t, "qwen3.8-27b", project.CodeAgentConfig.Model)
+		require.Equal(t, "priority", project.CodeAgentConfig.ServiceTier)
+		return nil
+	})
+
+	body, err := json.Marshal(update)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/agents/"+existing.ID, bytes.NewReader(body))
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
+	req = req.WithContext(setRequestUser(req.Context(), user))
+	server := &HelixAPIServer{Store: helixStore, providerManager: providerManager}
+
+	updated, httpErr := server.updateAgent(nil, req)
+
+	require.Nil(t, httpErr)
+	require.NotNil(t, updated)
+	require.Nil(t, unrelated.CodeAgentConfig)
+}
+
+func TestUpdateAppRejectsMultipleLinkedOrgProjectsAndRestoresApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	user := types.User{ID: "usr-owner", Type: types.OwnerTypeUser}
+	existing := &types.App{
+		ID: "app-engineer", Owner: user.ID, OwnerType: user.Type,
+		OrganizationID: "org-test", AgentKind: types.AgentKindOrg,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			Name: "Software Engineer", AgentType: types.AgentTypeZedExternal,
+			CodeAgentRuntime: types.CodeAgentRuntimeClaudeCode, CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+			Model: "claude-opus-5",
+		}}}},
+	}
+	update := *existing
+	update.Config.Helix.Assistants = append([]types.AssistantConfig(nil), existing.Config.Helix.Assistants...)
+	update.Config.Helix.Assistants[0].CodeAgentRuntime = types.CodeAgentRuntimeZedAgent
+	update.Config.Helix.Assistants[0].CodeAgentCredentialType = types.CodeAgentCredentialTypeAPIKey
+	update.Config.Helix.Assistants[0].Provider = "provider-qwen"
+	update.Config.Helix.Assistants[0].Model = "qwen3.8-27b"
+	projects := []*types.Project{
+		{ID: "project-one", OrganizationID: existing.OrganizationID, DefaultHelixAppID: existing.ID},
+		{ID: "project-two", OrganizationID: existing.OrganizationID, DefaultHelixAppID: existing.ID},
+	}
+
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID: user.ID, OrganizationID: existing.OrganizationID, Role: types.OrganizationRoleMember,
+	}, nil)
+	providerManager.EXPECT().ListProviderEndpointsForOwner(gomock.Any(), existing.OrganizationID, types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{{ID: "provider-qwen", Name: "qwen"}}, nil)
+	gomock.InOrder(
+		helixStore.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, app *types.App) (*types.App, error) {
+			require.Equal(t, "qwen3.8-27b", app.Config.Helix.Assistants[0].Model)
+			return app, nil
+		}),
+		helixStore.EXPECT().UpdateApp(gomock.Any(), existing).Return(existing, nil),
+	)
+	helixStore.EXPECT().ListKnowledge(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListTriggerConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil)
+	helixStore.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{OrganizationID: existing.OrganizationID}).Return(projects, nil)
+
+	body, err := json.Marshal(update)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/agents/"+existing.ID, bytes.NewReader(body))
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
+	req = req.WithContext(setRequestUser(req.Context(), user))
+	server := &HelixAPIServer{Store: helixStore, providerManager: providerManager}
+
+	updated, httpErr := server.updateAgent(nil, req)
+
+	require.Nil(t, updated)
+	require.NotNil(t, httpErr)
+	require.Contains(t, httpErr.Message, "more than one project")
 }
 
 func TestIsSpecTaskSelectableAgent(t *testing.T) {

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
@@ -189,14 +188,6 @@ func (c *inProcHelixClient) UpdateAgent(ctx context.Context, appID string, patch
 	if err != nil {
 		return err
 	}
-	priorJSON, err := json.Marshal(existing)
-	if err != nil {
-		return fmt.Errorf("snapshot agent app: %w", err)
-	}
-	var prior types.App
-	if err := json.Unmarshal(priorJSON, &prior); err != nil {
-		return fmt.Errorf("snapshot agent app: %w", err)
-	}
 	if err := c.server.authorizeUserToApp(ctx, user, existing, types.ActionUpdate); err != nil {
 		return err
 	}
@@ -241,11 +232,6 @@ func (c *inProcHelixClient) UpdateAgent(ctx context.Context, appID string, patch
 		return err
 	}
 	if _, herr := c.server.updateAgent(nil, r); herr != nil {
-		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-		if _, rollbackErr := c.server.Store.UpdateApp(rollbackCtx, &prior); rollbackErr != nil {
-			return fmt.Errorf("%s; restore agent app: %w", herr.Error(), rollbackErr)
-		}
 		return errors.New(herr.Error())
 	}
 	return nil

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -400,7 +400,12 @@ func TestInProcClient_UpdateAgentRestoresAppAfterPostSaveFailure(t *testing.T) {
 			}},
 		}},
 	}
-	st.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil).Times(2)
+	handlerExisting := *existing
+	handlerExisting.Config.Helix.Assistants = append([]types.AssistantConfig(nil), existing.Config.Helix.Assistants...)
+	gomock.InOrder(
+		st.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil),
+		st.EXPECT().GetApp(gomock.Any(), existing.ID).Return(&handlerExisting, nil),
+	)
 	var savedPrompt, restoredPrompt string
 	st.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, app *types.App) (*types.App, error) {


### PR DESCRIPTION
## Summary

- sync an org Agent linked project execution config whenever the Agent runtime or model is updated
- keep project task creation on the Agent configured harness instead of a stale organization default
- preserve project service-tier overrides and reject invalid multi-project Agent links before writing
- restore the prior Agent when downstream reconciliation fails

## Root cause

Org Agent updates changed the Agent App but left the generated project `code_agent_config` unchanged. The project task composer reads that project value, so an Agent configured for OpenCode/Qwen could still show and submit Claude Code/Opus.

## Testing

- `cd api && go test ./pkg/server -count=1`
- `git diff --check`

## Operations

This prevents future drift. Existing stale Meta project rows require a separate bounded backfill after deployment; this PR does not mutate production data.