### PR TITLE
fix: require explicit org providers and collapse legacy models

### DIFF
--- a/api/pkg/server/org_code_agent_harness_handlers.go
+++ b/api/pkg/server/org_code_agent_harness_handlers.go
@@ -119,12 +119,15 @@ func (apiServer *HelixAPIServer) buildOrgCodeAgentHarnessStatuses(ctx context.Co
 		status := &types.OrgCodeAgentHarnessStatus{
 			Runtime:              runtime,
 			Enabled:              true,
+			ProviderRefs:         []string{},
 			SupportsSubscription: runtime.SupportsSubscriptionCredentials(),
 		}
 		if policy != nil {
 			status.Enabled = policy.Enabled
 			status.SubscriptionEnabled = policy.SubscriptionEnabled
-			status.ProviderRefs = policy.ProviderRefs
+			if policy.ProviderRefs != nil {
+				status.ProviderRefs = policy.ProviderRefs
+			}
 		}
 		switch runtime {
 		case types.CodeAgentRuntimeClaudeCode:
@@ -264,6 +267,7 @@ func (apiServer *HelixAPIServer) loadOrgCodeAgentHarnessPolicy(
 			OrganizationID: orgID,
 			Runtime:        runtime,
 			Enabled:        true,
+			ProviderRefs:   []string{},
 		}, nil
 	}
 	if err != nil {
@@ -271,6 +275,9 @@ func (apiServer *HelixAPIServer) loadOrgCodeAgentHarnessPolicy(
 	}
 	if harness == nil {
 		return nil, fmt.Errorf("failed to load coding-agent harness policy: store returned no policy")
+	}
+	if harness.ProviderRefs == nil {
+		harness.ProviderRefs = []string{}
 	}
 	return harness, nil
 }

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -31,7 +31,7 @@ func TestValidateOrgCodeAgentHarness(t *testing.T) {
 		providerRef    string
 		wantErr        string
 	}{
-		{name: "enabled", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1"},
+		{name: "legacy nil denies provider", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
 		{name: "provider allowed", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1"},
 		{name: "provider denied", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-2"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
 		{name: "provider denied in subscription mode", row: &types.OrgCodeAgentHarness{Enabled: true, SubscriptionEnabled: boolPointer(true), ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
@@ -39,7 +39,7 @@ func TestValidateOrgCodeAgentHarness(t *testing.T) {
 		{name: "subscription denied by legacy nil", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeSubscription, wantErr: "subscription credentials are not enabled"},
 		{name: "subscription explicitly disabled", row: &types.OrgCodeAgentHarness{Enabled: true, SubscriptionEnabled: boolPointer(false)}, credentialType: types.CodeAgentCredentialTypeSubscription, wantErr: "subscription credentials are not enabled"},
 		{name: "disabled", row: &types.OrgCodeAgentHarness{Enabled: false}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "not enabled"},
-		{name: "missing preserves legacy API access", storeErr: store.ErrNotFound, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1"},
+		{name: "missing denies API access", storeErr: store.ErrNotFound, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
 		{name: "store failure", storeErr: fmt.Errorf("database unavailable"), credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "failed to load"},
 	}
 
@@ -212,7 +212,8 @@ func TestBuildOrgCodeAgentHarnessStatuses(t *testing.T) {
 	assert.Equal(t, []string{"provider-1"}, byRuntime[types.CodeAgentRuntimeClaudeCode].ProviderRefs)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeClaudeCode].ViewerHasSubscription)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeCodexCLI].Enabled)
-	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
+	require.NotNil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
+	assert.Empty(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
 	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].SubscriptionEnabled)
 	assert.False(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ViewerHasSubscription)
 }

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dgraph-io/ristretto/v2"
 	"github.com/helixml/helix/api/pkg/config"
-	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
@@ -19,7 +18,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestGetProviderSnapshotMissingHarnessPolicyPreservesVisibleProviders(t *testing.T) {
+func TestGetProviderSnapshotMissingHarnessPolicyHidesVisibleProviders(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
 	providerManager := manager.NewMockProviderManager(ctrl)
@@ -44,7 +43,7 @@ func TestGetProviderSnapshotMissingHarnessPolicyPreservesVisibleProviders(t *tes
 	snapshot, err := server.getProviderSnapshot(context.Background(), "user_1", app)
 
 	require.NoError(t, err)
-	require.Equal(t, []external_agent.ProviderRef{{ID: "pe_anthropic", Name: "anthropic"}}, snapshot)
+	require.Empty(t, snapshot)
 }
 
 func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {

--- a/api/pkg/types/org_code_agent_harness.go
+++ b/api/pkg/types/org_code_agent_harness.go
@@ -8,9 +8,8 @@ import (
 // OrgCodeAgentHarness records whether an organization permits one coding
 // harness and which provider endpoints that harness may use. Models
 // deliberately do not live here: a task selects a model from the allowed
-// providers' current model lists when it starts. An absent row retains the
-// pre-policy behaviour: the harness and all visible API providers are enabled,
-// while subscription credentials remain opt-in.
+// providers' current model lists when it starts. API providers and subscription
+// credentials are both opt-in.
 type OrgCodeAgentHarness struct {
 	ID        string    `json:"id" gorm:"primaryKey"`
 	Created   time.Time `json:"created"`
@@ -25,10 +24,8 @@ type OrgCodeAgentHarness struct {
 	// remain in API-provider mode until an owner explicitly connects or selects
 	// a subscription.
 	SubscriptionEnabled *bool `json:"subscription_enabled"`
-	// Nil preserves the pre-allow-list behaviour where every provider visible
-	// to the organization is allowed. A non-nil empty list allows none. Once an
-	// owner changes a provider switch, the UI writes an explicit full list so
-	// newly connected providers do not become exposed automatically.
+	// Nil and an empty list allow no providers. Providers must be explicitly
+	// enabled for each harness.
 	ProviderRefs []string `json:"provider_refs" gorm:"type:jsonb;serializer:json"`
 }
 
@@ -63,7 +60,7 @@ type OrgCodeAgentHarnessStatus struct {
 }
 
 func (h *OrgCodeAgentHarness) AllowsProvider(providerRef string) bool {
-	return !h.AllowsSubscription() && (h.ProviderRefs == nil || slices.Contains(h.ProviderRefs, providerRef))
+	return !h.AllowsSubscription() && slices.Contains(h.ProviderRefs, providerRef)
 }
 
 func (h *OrgCodeAgentHarness) AllowsSubscription() bool {

--- a/frontend/src/components/agent/CodeAgentConfigPicker.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.tsx
@@ -47,6 +47,11 @@ import {
   providerSupportsCodeAgentRuntime,
   providersForCodeAgentRuntime,
 } from '../../utils/codeAgentProviders'
+import {
+  currentNativeModels,
+  isLegacyNativeModel,
+  nativeProviderForRuntime,
+} from '../../utils/nativeModels'
 
 type Runtime = TypesCodeAgentRuntime
 
@@ -64,25 +69,6 @@ interface ModelOption {
   provider?: TypesProviderEndpoint
   providerLabel: string
   credentialType: TypesCodeAgentCredentialType
-}
-
-const CURRENT_NATIVE_MODELS: Partial<Record<Runtime, string[]>> = {
-  [TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode]: [
-    'claude-opus-5',
-    'claude-fable-5',
-  ],
-  [TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI]: [
-    'gpt-5.6-sol',
-    'gpt-5.6-terra',
-    'gpt-5.6-luna',
-  ],
-}
-
-function isLegacyNativeModel(runtime: Runtime, modelID: string): boolean {
-  const current = CURRENT_NATIVE_MODELS[runtime]
-  if (!current) return false
-  const normalized = (modelID.split('/').pop() || modelID).toLowerCase()
-  return !current.some((id) => normalized === id || normalized.startsWith(`${id}-`))
 }
 
 export const SELECTABLE_CODE_AGENT_RUNTIMES: ReadonlyArray<Runtime> = [
@@ -160,7 +146,8 @@ function subscriptionModelOptions(runtime: Runtime): ModelOption[] {
 }
 
 function preferredModelOption(runtime: Runtime, options: ModelOption[]): ModelOption | undefined {
-  const preferredModels = CURRENT_NATIVE_MODELS[runtime] || []
+  const nativeProvider = nativeProviderForRuntime(runtime)
+  const preferredModels = currentNativeModels(nativeProvider)
   for (const preferred of preferredModels) {
     const option = options.find(({ id }) => {
       const normalized = (id.split('/').pop() || id).toLowerCase()
@@ -168,7 +155,7 @@ function preferredModelOption(runtime: Runtime, options: ModelOption[]): ModelOp
     })
     if (option) return option
   }
-  return options.find(({ id }) => !isLegacyNativeModel(runtime, id)) || options[0]
+  return options.find(({ id }) => !isLegacyNativeModel(id, nativeProvider)) || options[0]
 }
 
 function defaultCodeAgentConfig(
@@ -371,8 +358,11 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     model.providerLabel,
     getAgentHarnessLabel(runtime),
   ))
-  const currentModels = visibleModels.filter((model) => !isLegacyNativeModel(runtime, model.id))
-  const legacyModels = visibleModels.filter((model) => isLegacyNativeModel(runtime, model.id))
+  const nativeProvider = nativeProviderForRuntime(runtime)
+  const currentModels = visibleModels.filter((model) =>
+    !isLegacyNativeModel(model.id, nativeProvider))
+  const legacyModels = visibleModels.filter((model) =>
+    isLegacyNativeModel(model.id, nativeProvider))
   const configuredProviders = providersAllowedForHarness(
     providers,
     configuredRuntimeStatus,

--- a/frontend/src/components/create/AdvancedModelPicker.test.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AdvancedModelPicker from './AdvancedModelPicker'
+
+const providerState = vi.hoisted(() => ({ providers: [] as any[] }))
+
+vi.mock('../../services/providersService', () => ({
+  useListProviders: () => ({ data: providerState.providers, isLoading: false }),
+}))
+vi.mock('../../services/userService', () => ({
+  useGetUserTokenUsage: () => ({ data: undefined, isLoading: false }),
+}))
+vi.mock('../../services/orgService', () => ({
+  useGetOrgByName: () => ({ data: undefined, isLoading: false }),
+}))
+vi.mock('../../hooks/useRouter', () => ({
+  default: () => ({ params: {} }),
+}))
+
+describe('AdvancedModelPicker', () => {
+  beforeEach(() => {
+    providerState.providers = [
+      {
+        id: 'openai-provider',
+        name: 'OpenAI',
+        base_url: 'https://api.openai.com/v1',
+        available_models: [
+          { id: 'gpt-5.6-sol', enabled: true, type: 'chat' },
+          { id: 'gpt-4o', enabled: true, type: 'chat' },
+        ],
+      },
+      {
+        id: 'anthropic-provider',
+        name: 'Anthropic',
+        base_url: 'https://api.anthropic.com/v1',
+        available_models: [
+          { id: 'claude-opus-5', enabled: true, type: 'chat' },
+          { id: 'claude-opus-4-1', enabled: true, type: 'chat' },
+        ],
+      },
+      {
+        id: 'custom-provider',
+        name: 'Custom',
+        base_url: 'http://models.local/v1',
+        available_models: [
+          { id: 'gpt-4-custom', enabled: true, type: 'chat' },
+        ],
+      },
+    ]
+  })
+
+  it('collapses native legacy models while keeping custom models and search matches visible', () => {
+    render(
+      <AdvancedModelPicker
+        currentType="chat"
+        selectedModelId="gpt-5.6-sol"
+        selectedProvider="openai-provider"
+        onSelectModel={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-5.6-sol/i }))
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByText('gpt-5.6-sol')).toBeInTheDocument()
+    expect(dialog.getByText('claude-opus-5')).toBeInTheDocument()
+    expect(dialog.getByText('gpt-4-custom')).toBeInTheDocument()
+    expect(dialog.queryByText('gpt-4o')).not.toBeInTheDocument()
+    expect(dialog.queryByText('claude-opus-4-1')).not.toBeInTheDocument()
+    const legacyButton = dialog.getByRole('button', { name: 'Show Legacy models' })
+    expect(legacyButton).toHaveTextContent('Legacy models (2)')
+    fireEvent.click(legacyButton)
+    expect(dialog.getByText('gpt-4o')).toBeInTheDocument()
+    expect(dialog.getByText('claude-opus-4-1')).toBeInTheDocument()
+    fireEvent.click(dialog.getByRole('button', { name: 'Hide Legacy models' }))
+
+    fireEvent.change(dialog.getByPlaceholderText('Search models...'), { target: { value: 'gpt-4o' } })
+    expect(dialog.getByText('gpt-4o')).toBeInTheDocument()
+  })
+
+  it('keeps a selected legacy model outside the collapsed section', () => {
+    render(
+      <AdvancedModelPicker
+        currentType="chat"
+        selectedModelId="gpt-4o"
+        selectedProvider="openai-provider"
+        onSelectModel={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /gpt-4o/i }))
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByText('gpt-4o')).toBeInTheDocument()
+    expect(dialog.getByRole('button', { name: 'Show Legacy models' })).toHaveTextContent('Legacy models (1)')
+  })
+})

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -44,6 +44,7 @@ import useLightTheme from '../../hooks/useLightTheme';
 import { useGetOrgByName } from '../../services/orgService';
 
 import useRouter from '../../hooks/useRouter';
+import { isLegacyNativeModel, nativeProviderForEndpoint } from '../../utils/nativeModels';
 
 interface AdvancedModelPickerProps {
   selectedModelId?: string;
@@ -210,6 +211,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
   const dialogOpen = externalOpen !== undefined ? externalOpen : internalDialogOpen;
   const [searchQuery, setSearchQuery] = useState('');
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(true);
+  const [legacyModelsOpen, setLegacyModelsOpen] = useState(false);
 
   // Track the initially selected model when dialog opens (so it stays at top without jumping)
   const initialSelectedModelRef = useRef<string | undefined>(undefined);
@@ -218,6 +220,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
   useEffect(() => {
     if (externalOpen) {
       setSearchQuery('');
+      setLegacyModelsOpen(false);
       initialSelectedModelRef.current = selectedModelId;
     }
   }, [externalOpen]);
@@ -376,8 +379,19 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
     return models;
   }, [searchQuery, allModels, currentType, showOnlyEnabled, recommendedModels, dialogOpen]);
 
+  const currentModels = filteredModels.filter((model) =>
+    model.id === selectedModelId
+    || !isLegacyNativeModel(model.id || '', nativeProviderForEndpoint(model.provider)))
+  const legacyModels = filteredModels.filter((model) =>
+    model.id !== selectedModelId
+    && isLegacyNativeModel(model.id || '', nativeProviderForEndpoint(model.provider)))
+  const displayedModels: Array<ModelWithProvider | null> = searchQuery || legacyModels.length === 0
+    ? [...currentModels, ...legacyModels]
+    : [...currentModels, null, ...(legacyModelsOpen ? legacyModels : [])]
+
   const handleOpenDialog = () => {
     setSearchQuery('');
+    setLegacyModelsOpen(false);
     // Capture the initially selected model so we can pin it to the top without jumping
     initialSelectedModelRef.current = selectedModelId;
     setInternalDialogOpen(true);
@@ -554,7 +568,26 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
                  <CircularProgress />
                </Box>
             )}
-            {!isLoading && filteredModels.map((model) => {
+            {!isLoading && displayedModels.map((model) => {
+              if (!model) {
+                return (
+                  <Button
+                    key="legacy-models"
+                    fullWidth
+                    aria-expanded={legacyModelsOpen}
+                    aria-label={`${legacyModelsOpen ? 'Hide' : 'Show'} Legacy models`}
+                    onClick={() => setLegacyModelsOpen((open) => !open)}
+                    endIcon={(
+                      <ArrowDropDownIcon
+                        sx={{ transform: legacyModelsOpen ? 'rotate(180deg)' : undefined }}
+                      />
+                    )}
+                    sx={{ justifyContent: 'space-between', color: 'text.secondary', textTransform: 'none' }}
+                  >
+                    Legacy models ({legacyModels.length})
+                  </Button>
+                )
+              }
               const formattedContextLength = formatContextLength(model.context_length);
               const isDisabled = !model.enabled;
               const isRecommended = recommendedModels.includes(model.id || '');

--- a/frontend/src/utils/nativeModels.ts
+++ b/frontend/src/utils/nativeModels.ts
@@ -1,0 +1,32 @@
+import { TypesCodeAgentRuntime, TypesProviderEndpoint } from '../api/api'
+
+type NativeProvider = 'anthropic' | 'openai'
+
+const CURRENT_NATIVE_MODELS: Record<NativeProvider, string[]> = {
+  anthropic: ['claude-opus-5', 'claude-fable-5'],
+  openai: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'],
+}
+
+export function nativeProviderForRuntime(runtime: TypesCodeAgentRuntime): NativeProvider | undefined {
+  if (runtime === TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode) return 'anthropic'
+  if (runtime === TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI) return 'openai'
+  return undefined
+}
+
+export function nativeProviderForEndpoint(provider: TypesProviderEndpoint): NativeProvider | undefined {
+  const name = provider.name?.toLowerCase()
+  if (name === 'anthropic' || provider.base_url?.startsWith('https://api.anthropic.com/')) return 'anthropic'
+  if (name === 'openai' || provider.base_url?.startsWith('https://api.openai.com/')) return 'openai'
+  return undefined
+}
+
+export function currentNativeModels(provider: NativeProvider | undefined): string[] {
+  return provider ? CURRENT_NATIVE_MODELS[provider] : []
+}
+
+export function isLegacyNativeModel(modelID: string, provider: NativeProvider | undefined): boolean {
+  if (!provider) return false
+  const normalized = (modelID.split('/').pop() || modelID).toLowerCase()
+  return !CURRENT_NATIVE_MODELS[provider].some((id) =>
+    normalized === id || normalized.startsWith(`${id}-`))
+}


### PR DESCRIPTION
## Summary
- make missing or legacy nil organization provider allow-lists fail closed
- return explicit empty provider lists so settings and task pickers hide unenabled global providers
- reject unenabled providers through the shared server-side harness policy
- reuse native current-model classification in regular Chat and collapse older OpenAI/Anthropic models behind `Legacy models (N)`
- keep search matches, selected legacy models, and custom-provider models visible

## Testing
- `cd api && go test ./pkg/server -count=1`
- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn test src/components/agent/CodeAgentConfigPicker.test.tsx src/components/create/AdvancedModelPicker.test.tsx --run` (21 tests passed)
- `git diff --check`

## Build note
- local `yarn build` remains blocked by the pre-existing macOS case collision between `WorkspaceReviewMessage.tsx` and `workspaceReviewMessage.ts`; this PR does not touch those files

## Live evidence
A fresh Meta organization with no harness policy rows, no owned provider endpoints, and no Codex subscription could select `codex_cli` with `provider_ref=openai`. The request resolved Meta's built-in OpenAI endpoint because missing policy rows previously meant all visible providers.