### PR TITLE
fix(api): honour the providers management toggle for non-admins

### DIFF
--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -115,7 +115,7 @@ func (apiServer *HelixAPIServer) getConfig(ctx context.Context) (types.ServerCon
 	if err != nil {
 		return types.ServerConfigForFrontend{}, system.NewHTTPError500(err.Error())
 	}
-	config.ProvidersManagementEnabled = systemSettings.ProvidersManagementEnabled || apiServer.Cfg.Providers.EnableCustomUserProviders
+	config.ProvidersManagementEnabled = providersManagementEnabled(systemSettings, apiServer.Cfg)
 
 	// /config is unauthenticated (registered on insecureRouter), so we don't
 	// know which user is calling and can't ask the quota manager for their

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/pricing"
@@ -49,12 +50,20 @@ func (s *HelixAPIServer) listProviders(rw http.ResponseWriter, r *http.Request) 
 
 var blankAPIKey = "********"
 
+// providersManagementEnabled reports whether non-admin users may manage their
+// own provider endpoints. Two operator controls grant this and they mean the
+// same thing: the static ENABLE_CUSTOM_USER_PROVIDERS env var and the admin
+// UI's "Providers Management" toggle stored in system settings.
+func providersManagementEnabled(settings *types.SystemSettings, cfg *config.ServerConfig) bool {
+	return settings.ProvidersManagementEnabled || cfg.Providers.EnableCustomUserProviders
+}
+
 func (s *HelixAPIServer) isProvidersManagementEnabled(ctx context.Context) bool {
 	systemSettings, err := s.Store.GetSystemSettings(ctx)
 	if err != nil {
-		return false
+		return s.Cfg.Providers.EnableCustomUserProviders
 	}
-	return systemSettings.ProvidersManagementEnabled
+	return providersManagementEnabled(systemSettings, s.Cfg)
 }
 
 // listProviderEndpoints godoc
@@ -621,11 +630,6 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
-	if !isAdmin && !s.Cfg.Providers.EnableCustomUserProviders {
-		http.Error(rw, "Custom user providers are not enabled", http.StatusForbidden)
-		return
-	}
-
 	var endpoint types.ProviderEndpoint
 	if err := json.NewDecoder(r.Body).Decode(&endpoint); err != nil {
 		log.Err(err).Msg("error decoding request body")
@@ -732,11 +736,6 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	// Check if providers management is enabled
 	if !s.isProvidersManagementEnabled(r.Context()) && !user.Admin {
 		http.Error(rw, "Providers management is not enabled", http.StatusForbidden)
-		return
-	}
-
-	if !user.Admin && !s.Cfg.Providers.EnableCustomUserProviders {
-		http.Error(rw, "Custom user providers are not enabled", http.StatusForbidden)
 		return
 	}
 
@@ -1013,11 +1012,6 @@ func (s *HelixAPIServer) getProviderDailyUsage(rw http.ResponseWriter, r *http.R
 		return
 	}
 
-	if !user.Admin && !s.Cfg.Providers.EnableCustomUserProviders {
-		writeErrResponse(rw, errors.New("custom user providers are not enabled"), http.StatusForbidden)
-		return
-	}
-
 	from := time.Now().Add(-time.Hour * 24 * 7) // Last 7 days
 	to := time.Now()
 
@@ -1081,11 +1075,6 @@ func (s *HelixAPIServer) getProviderThroughputUsage(rw http.ResponseWriter, r *h
 
 	if !s.isProvidersManagementEnabled(r.Context()) && !user.Admin {
 		writeErrResponse(rw, errors.New("providers management is not enabled"), http.StatusForbidden)
-		return
-	}
-
-	if !user.Admin && !s.Cfg.Providers.EnableCustomUserProviders {
-		writeErrResponse(rw, errors.New("custom user providers are not enabled"), http.StatusForbidden)
 		return
 	}
 
@@ -1166,11 +1155,6 @@ func (s *HelixAPIServer) getProviderUsersDailyUsage(rw http.ResponseWriter, r *h
 	// Check if providers management is enabled
 	if !s.isProvidersManagementEnabled(ctx) && !user.Admin {
 		writeErrResponse(rw, errors.New("providers management is not enabled"), http.StatusForbidden)
-		return
-	}
-
-	if !user.Admin && !s.Cfg.Providers.EnableCustomUserProviders {
-		writeErrResponse(rw, errors.New("custom user providers are not enabled"), http.StatusForbidden)
 		return
 	}
 

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -1173,3 +1173,93 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_Headers() {
 		})
 	}
 }
+
+// Flipping the admin UI's "Providers Management" toggle must be enough for a
+// non-admin to create a provider endpoint. Before, the handler also demanded
+// ENABLE_CUSTOM_USER_PROVIDERS=true and rejected with "Custom user providers
+// are not enabled" even though /config told the frontend the feature was on.
+func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_NonAdminAllowedBySystemSetting() {
+	s.server.authMiddleware = &authMiddleware{
+		store: s.store,
+		cfg:   authMiddlewareConfig{},
+	}
+	s.server.Cfg.Providers.EnableCustomUserProviders = false
+	s.store.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&types.User{ID: "user_id"}, nil).AnyTimes()
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+
+	body, err := json.Marshal(types.ProviderEndpoint{
+		Name:         "my-openrouter",
+		BaseURL:      "https://openrouter.ai/api/v1",
+		APIKey:       "sk-secret",
+		EndpointType: types.ProviderEndpointTypeUser,
+	})
+	s.Require().NoError(err)
+
+	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().CreateProviderEndpoint(gomock.Any(), gomock.Any()).Return(&types.ProviderEndpoint{
+		ID:           "ep_openrouter",
+		Name:         "my-openrouter",
+		BaseURL:      "https://openrouter.ai/api/v1",
+		APIKey:       "sk-secret",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}, nil)
+
+	warmDone := make(chan struct{})
+	s.manager.EXPECT().GetClient(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *manager.GetClientRequest) (openai.Client, error) {
+			defer close(warmDone)
+			return s.openAiClient, nil
+		})
+	s.openAiClient.EXPECT().ListModels(gomock.Any()).Return([]types.OpenAIModel{{ID: "gpt-4o"}}, nil)
+	s.modelInfoProvider.EXPECT().GetModelInfo(gomock.Any(), gomock.Any()).Return(nil, errors.New("not found"))
+
+	req, err := http.NewRequest("POST", "/v1/provider-endpoints", bytes.NewReader(body))
+	s.Require().NoError(err)
+	req = req.WithContext(s.authCtx)
+
+	rr := httptest.NewRecorder()
+	s.server.createProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	select {
+	case <-warmDone:
+	case <-time.After(5 * time.Second):
+		s.Fail("cache warm goroutine did not complete in time")
+	}
+}
+
+// With both the system setting and the env var off, a non-admin is still denied.
+func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_NonAdminDeniedWhenDisabled() {
+	s.server.authMiddleware = &authMiddleware{
+		store: s.store,
+		cfg:   authMiddlewareConfig{},
+	}
+	s.server.Cfg.Providers.EnableCustomUserProviders = false
+	s.store.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&types.User{ID: "user_id"}, nil).AnyTimes()
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: false,
+	}, nil)
+
+	body, err := json.Marshal(types.ProviderEndpoint{
+		Name:         "my-openrouter",
+		BaseURL:      "https://openrouter.ai/api/v1",
+		EndpointType: types.ProviderEndpointTypeUser,
+	})
+	s.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", "/v1/provider-endpoints", bytes.NewReader(body))
+	s.Require().NoError(err)
+	req = req.WithContext(s.authCtx)
+
+	rr := httptest.NewRecorder()
+	s.server.createProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusForbidden, rr.Code, rr.Body.String())
+}


### PR DESCRIPTION
## Problem

Adding a provider at `/orgs/<org>/providers` failed with **`Custom user providers are not enabled`** even though the admin UI's *Providers Management* toggle was on.

The provider handlers gated on **two** flags ANDed together:

- `systemSettings.ProvidersManagementEnabled` — the admin UI toggle
- `Cfg.Providers.EnableCustomUserProviders` — the static `ENABLE_CUSTOM_USER_PROVIDERS` env var (default `false`)

`/config` already **OR**ed them (`api/pkg/server/handlers.go:118`) when telling the frontend whether the feature was available, so the frontend showed the page and the create/update/usage handlers rejected every non-admin write with 403.

## Fix

The two controls mean the same thing ("let non-admins manage their own providers"), so they are now one gate:

- `providersManagementEnabled(settings, cfg)` — single source of truth, used by both `isProvidersManagementEnabled` and `/config`, so the frontend and API gates can't drift.
- Removed the five duplicated `EnableCustomUserProviders` checks in `createProviderEndpoint`, `updateProviderEndpoint`, `getProviderDailyUsage`, `getProviderThroughputUsage`, `getProviderUsersDailyUsage`.

Admin behaviour is unchanged, and with both controls off non-admins are still denied (now with the accurate "Providers management is not enabled" message).

## Tests

Two regression tests in `provider_handlers_test.go` covering the case no existing test had (toggle on, env var off):

- `TestCreateProviderEndpoint_NonAdminAllowedBySystemSetting` — 200
- `TestCreateProviderEndpoint_NonAdminDeniedWhenDisabled` — 403

```
CGO_ENABLED=1 go test -run TestProviderHandlersSuite ./pkg/server/ -count=1
ok  	github.com/helixml/helix/api/pkg/server	0.077s
```

**NOT tested end-to-end in a browser** — verified by unit tests and the code path above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)