### PR TITLE
fix(frontend): anchor iPad Safari app shell

### DIFF
--- a/design/2026-08-22-ipad-safari-shell-scroll.md
+++ b/design/2026-08-22-ipad-safari-shell-scroll.md
@@ -1,0 +1,58 @@
+# iPad Safari shell scroll investigation
+
+## Symptom
+
+After focusing the new-chat composer, iPad Safari could scroll the document.
+The app shell then moved down with the visual viewport, leaving a blank strip
+above the sidebar header and producing visible jitter.
+
+## Cause
+
+Commit `fa13a7d15523058e4a49b62e969cf40e7e6a3326` compensated for iPhone
+Safari viewport panning by translating the full-height `#root` and MUI portal
+roots by `visualViewport.offsetTop`. The workaround was global, so it also ran
+on iPad.
+
+A transform extends scrollable overflow to include both the original and
+translated bounds. Once iPad reported a positive visual viewport offset, the
+translated full-height shell extended below the document. That created the
+page scrollbar; scrolling changed `offsetTop`, which changed the transform,
+forming the visible feedback loop.
+
+This is the vertical equivalent of the notifications-panel overflow fixed in
+`d6236cfbb7856d3a86372247aa36a1a22ac3a98b`.
+
+## Physical iPad follow-up
+
+Restricting both fixed positioning and translation to iPhone removed the
+transform overflow, but it did not fully anchor the iPad shell. A physical iPad
+then reported `scrollHeight/clientHeight=900/900` while its document was still
+at `scrollTop=71`. That is viewport panning, not ordinary content overflow. The
+static root moved with the document and took the sidebar header off screen.
+
+## Fix
+
+The root shell remains fixed on both iPhone and iPad, so WebKit panning the
+document cannot move the app. Only Apple touch devices with a phone-sized
+screen receive the `visualViewport.offsetTop` transform. iPad therefore has a
+fixed but untransformed root whose height still follows the visual viewport for
+the software keyboard. Portalled drawers and dialogs likewise resolve to
+`transform: none` outside the iPhone path.
+
+## Verification
+
+- Physical iPad screenshot before the final anchoring change: document
+  `900/900` at `scrollTop=71`, proving WebKit can pan a zero-range document.
+- iPad Pro 13-inch simulator, iOS 26.5, Safari: mode `standard`, root
+  `position: fixed` / `transform: none` at top `0`, document `900/900`, scroll
+  `0,0`.
+- iPhone 17 Pro simulator, iOS 26.5, Safari: mode `ios-phone`, root
+  `position: fixed` with the viewport transform, document `714/714`, scroll
+  `0,0`.
+- T3 browser at the iPad Pro landscape viewport (`1366x1024`): focused the
+  composer and attempted a 1200px page scroll. The document remained
+  `1024/1024` at `scrollY=0`; root remained fixed at top `0` with no transform.
+- Synthetic iPad `visualViewport.offsetTop=100`: no viewport transform was
+  installed, root top remained `0`, and document height remained `1024/1024`.
+- iPad MUI drawer and dialog portal roots both computed to `transform: none`.
+- `cd frontend && yarn build` completed successfully.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,20 +37,24 @@
             rel="stylesheet"
             href="https://fonts.googleapis.com/icon?family=Material+Icons"
         />
+        <script type="text/javascript">
+            // iOS Safari's visual-viewport translation is only needed on a
+            // phone. Applying it to iPad makes the translated, full-height app
+            // shell extend the document's scrollable overflow.
+            (function () {
+                var ua = navigator.userAgent || '';
+                var appleTouch = /iPhone|iPod/i.test(ua) ||
+                    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+                var phoneSized = Math.min(window.screen.width, window.screen.height) <= 500;
+                if (appleTouch && phoneSized) {
+                    document.documentElement.classList.add('helix-ios-phone');
+                }
+            })();
+        </script>
         <style>
             html,
             body {
-                /* Sized to the visible window, not to `100%`.
-                   `100%` resolves against the initial containing block, which
-                   real Mobile Safari reports as 714px while window.innerHeight
-                   is 712 — and those 2px are pannable. 2px is all Safari needs
-                   to treat the page as scrollable and start collapsing its
-                   chrome, which is what kept dragging the top bar out of view.
-                   Same clamp as the shell: follow the visual viewport, never
-                   exceed the small viewport. */
                 height: 100%;
-                height: 100svh;
-                height: min(var(--app-height, 100svh), 100svh);
                 width: 100%;
                 margin: 0;
                 padding: 0;
@@ -63,30 +67,19 @@
                 overscroll-behavior: none;
             }
 
-            /* The app shell is a fixed pane, not a tall page.
-               `overflow: hidden` on html/body is not a lock on iOS Safari — it
-               still pans the document, which is what slid the top bar up under
-               the status bar. A fixed root has nothing to scroll.
-               The height is `svh` (the small viewport: the height with the
-               browser chrome showing) rather than 100%, because iOS resolves
-               both `100%` and fixed positioning against the LARGE viewport —
-               the height you get with that chrome hidden — so a bottom-docked
-               toolbar would sit underneath the floating URL bar. `100%` stays
-               above as the fallback for engines without `svh`. */
             #root {
+                /* iPad Safari can pan the layout viewport even when the
+                   document has no scroll range. Keep the app shell out of that
+                   document flow; its own panes provide the intended scrolling. */
                 position: fixed;
                 top: 0;
                 left: 0;
                 right: 0;
-                width: auto;
-                max-width: 100%;
                 height: 100%;
                 height: 100svh;
-                /* Never taller than the small viewport, so collapsing browser
-                   chrome cannot grow the shell into the space that chrome is
-                   about to reclaim; never taller than the visual viewport, so
-                   the on-screen keyboard shrinks it. */
                 height: min(var(--app-height, 100svh), 100svh);
+                width: auto;
+                max-width: 100%;
                 /* `viewport-fit=cover` paints edge to edge, and svh includes
                    the safe areas — without this the top bar sits under the
                    status bar and the notch, and in landscape the edges of the
@@ -95,15 +88,22 @@
                 box-sizing: border-box;
                 padding: env(safe-area-inset-top) env(safe-area-inset-right)
                          env(safe-area-inset-bottom) env(safe-area-inset-left);
-                /* Anchored to the visual viewport, not the layout viewport.
-                   `position: fixed` resolves against the layout viewport, and
-                   iOS Safari pans the visual viewport inside it as its chrome
-                   collapses — which slides a "fixed" shell out of view even
-                   though nothing is scrollable. --app-offset-* follows that
-                   pan; see the script below. */
-                transform: translateY(var(--app-offset-y, 0px));
+                /* Only iPhone installs this variable. iPad remains fixed but
+                   untransformed, avoiding transform-generated overflow. */
+                transform: var(--app-viewport-transform, none);
                 overflow: hidden;
                 overscroll-behavior: none;
+            }
+
+            /* On iPhone, `overflow: hidden` does not prevent Safari from
+               panning the visual viewport when its chrome or keyboard moves.
+               It needs the additional offset compensation below. iPad must
+               not use that compensation: translating a full-height element
+               extends scrollable overflow and creates an offset feedback loop. */
+            html.helix-ios-phone,
+            html.helix-ios-phone body {
+                height: 100svh;
+                height: min(var(--app-height, 100svh), 100svh);
             }
         </style>
         <script type="text/javascript">
@@ -118,21 +118,22 @@
                 var vv = window.visualViewport;
                 if (!vv) return;
                 var root = document.documentElement;
+                var iosPhone = root.classList.contains('helix-ios-phone');
                 function sync() {
                     // Pinch-zoom shrinks and offsets the visual viewport too.
                     // Resizing or moving the app for a zoom would be wrong, and
                     // jarring — leave the page alone and let the user pan it.
                     if (vv.scale > 1.01) {
-                        root.style.setProperty('--app-offset-y', '0px');
+                        root.style.removeProperty('--app-viewport-transform');
                         return;
                     }
                     root.style.setProperty('--app-height', vv.height + 'px');
-                    // Vertical only. Translating horizontally as well pushed the
-                    // shell sideways inside a viewport that was already
-                    // accounting for the offset — costing pixels off one edge
-                    // and cutting the other. iOS only offsets horizontally
-                    // under a zoom, which is excluded above anyway.
-                    root.style.setProperty('--app-offset-y', vv.offsetTop + 'px');
+                    if (iosPhone) {
+                        root.style.setProperty(
+                            '--app-viewport-transform',
+                            'translateY(' + vv.offsetTop + 'px)'
+                        );
+                    }
                 }
                 vv.addEventListener('resize', function () {
                     sync();
@@ -140,7 +141,9 @@
                     // field. The shell is fixed, so that only slides it out of
                     // alignment — which is what pushed the top bar under the
                     // status bar. Put it back.
-                    if (window.scrollY !== 0 || window.scrollX !== 0) window.scrollTo(0, 0);
+                    if (iosPhone && (window.scrollY !== 0 || window.scrollX !== 0)) {
+                        window.scrollTo(0, 0);
+                    }
                 });
                 vv.addEventListener('scroll', sync);
                 window.addEventListener('orientationchange', sync);
@@ -204,6 +207,7 @@
                     var vv = window.visualViewport;
                     var de = document.documentElement;
                     var root = document.getElementById('root');
+                    var rootStyle = root ? getComputedStyle(root) : null;
                     var i = insets();
                     el.textContent = [
                         'win  ' + window.innerWidth + 'x' + window.innerHeight +
@@ -217,6 +221,9 @@
                         'root ' + (root ? Math.round(root.getBoundingClientRect().width) + 'x' +
                             Math.round(root.getBoundingClientRect().height) +
                             ' @' + Math.round(root.getBoundingClientRect().top) : 'n/a'),
+                        'mode ' + (de.classList.contains('helix-ios-phone') ? 'ios-phone' : 'standard') +
+                            '  pos ' + (rootStyle ? rootStyle.position : 'n/a') +
+                            '  tf ' + (rootStyle ? rootStyle.transform : 'n/a'),
                         'safe t' + i[0] + ' r' + i[1] + ' b' + i[2] + ' l' + i[3],
                         'html ' + getComputedStyle(de).height +
                             '  body ' + getComputedStyle(document.body).height +

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -455,12 +455,11 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
         },
         MuiDrawer: {
           styleOverrides: {
-            // Same reasoning as MuiDialog root below: portalled out of the
-            // shell, so it has to follow the visual viewport itself. Applied to
-            // the modal root rather than the paper, because the paper's
-            // transform belongs to the slide transition.
             root: {
-              transform: 'translateY(var(--app-offset-y, 0px))',
+              // Applied only on iPhone via the variable. `none` matters on
+              // iPad: a translated full-screen portal contributes scrollable
+              // overflow even when the page clips it.
+              transform: 'var(--app-viewport-transform, none)',
             },
             // Scoped to the left-anchored nav drawer: a bottom sheet wants a
             // bottom inset, not a top one, and sets its own.
@@ -504,11 +503,7 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
             root: {
               zIndex: 100002, // Above floating windows (z-index 9999); tooltips (100004) render above
               transition: 'all 0.2s ease-in-out',
-              // Portalled outside #root, so the shell's anchoring does not
-              // reach it. `position: fixed` resolves against the layout
-              // viewport, which iOS Safari pans the visual viewport inside —
-              // this follows that pan so a sheet cannot drift off screen.
-              transform: 'translateY(var(--app-offset-y, 0px))',
+              transform: 'var(--app-viewport-transform, none)',
               '& .MuiBackdrop-root': {
                 backgroundColor: dialogStyles.backdropFallback,
                 background: dialogStyles.backdrop,


### PR DESCRIPTION
## Summary
- keep the app shell fixed on iPad without applying the iPhone viewport transform
- scope visual viewport translation to phone-sized Apple touch devices
- prevent Drawer and Dialog portals from generating transformed overflow on iPad

## Verification
- tested iPad Pro and iPhone 17 Pro in the iOS 26.5 simulator
- tested focused composer and attempted document scrolling at an iPad Pro landscape viewport
- verified iPad Drawer and Dialog portal transforms resolve to none
- `cd frontend && yarn build`