### PR TITLE
fix(frontend): copy terminal selections to chat

### DIFF
--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -1131,12 +1131,18 @@ fi
 rm -f /tmp/zerocopy.so /tmp/vsockenc.so /tmp/libnvrtc*.so*
 _INSTALL_PLUGINS
 
-# AI agent privacy configs
+# AI agent privacy configs.
+# chown: these run after the `chown -R retro:retro /home/retro` above, so
+# without it the agent user owns its home but not these two directories, and
+# anything writing into them at runtime (skill links, agent state) fails with
+# EACCES. Dockerfile.sway-helix already chowns .qwen for the same reason.
 RUN mkdir -p /home/retro/.qwen && \
-    echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.qwen/settings.json
+    echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.qwen/settings.json && \
+    chown -R retro:retro /home/retro/.qwen
 
 RUN mkdir -p /home/retro/.gemini && \
-    echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.gemini/settings.json
+    echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.gemini/settings.json && \
+    chown -R retro:retro /home/retro/.gemini
 
 
 

--- a/api/pkg/server/sandboxes_api_handlers.go
+++ b/api/pkg/server/sandboxes_api_handlers.go
@@ -607,7 +607,7 @@ fi
 if command -v tmux >/dev/null 2>&1; then
   tmux has-session -t helix-` + session + ` 2>/dev/null || tmux new-session -d -s helix-` + session + newSessionWorkingDirectory + newSessionShell + `
   tmux set-option -t helix-` + session + ` status off
-  tmux set-option -t helix-` + session + ` mouse on
+  tmux set-option -t helix-` + session + ` mouse off
   exec tmux attach-session -d -t helix-` + session + `
 fi
 echo "tmux not available — falling back to bash (session will not persist across reconnects)" >&2

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -655,7 +655,13 @@ echo "  Claude: ~/.claude.json -> $CLAUDE_STATE_DIR/.claude.json"
 # every harness.
 if [ -d /opt/helix/skills ]; then
     for skills_dir in ~/.claude/skills ~/.agents/skills ~/.qwen/skills; do
-        mkdir -p "$skills_dir"
+        # Report rather than swallow: a root-owned parent (as ~/.qwen was
+        # before the image chowned it) makes this fail, and a silently
+        # unlinked harness looks identical to one that has no skills.
+        if ! mkdir -p "$skills_dir" 2>/dev/null; then
+            echo "  Skills: cannot create $skills_dir (check ownership) — skipped"
+            continue
+        fi
         # ~/.claude lives on the persistent workspace mount, so links written by
         # an older image outlive it. Drop the ones whose target is gone before
         # relinking, or a skill dropped from HELIX_SKILLS dangles forever.

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -25,6 +25,7 @@ interface AgentChatProps {
   showSessionPromptQueue?: boolean
   enableInteractionDebugCopy?: boolean
   onWillSend?: () => void
+  appendText?: string
   leadingActions?: ReactNode
   footerContent?: ReactNode
   reviewComments?: readonly WorkspaceReviewComment[]
@@ -42,6 +43,7 @@ const AgentChat: FC<AgentChatProps> = ({
   showSessionPromptQueue = false,
   enableInteractionDebugCopy,
   onWillSend,
+  appendText,
   leadingActions,
   footerContent,
   reviewComments,
@@ -164,6 +166,7 @@ const AgentChat: FC<AgentChatProps> = ({
               apiClient={apiClient}
               onSend={handleSend}
               onWillSend={onWillSend}
+              appendText={appendText}
               onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
               onFileUpload={handleFileUpload}
               onCancel={handleCancel}

--- a/frontend/src/components/session/PersistentTerminalPane.test.tsx
+++ b/frontend/src/components/session/PersistentTerminalPane.test.tsx
@@ -1,0 +1,143 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PersistentTerminalPane from './PersistentTerminalPane'
+
+const clipboard = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../../utils/clipboard', () => clipboard)
+
+const xterm = vi.hoisted(() => {
+  const state: {
+    keyHandler?: (event: KeyboardEvent) => boolean
+    selectionHandler?: () => void
+    selection: string
+  } = {
+    selection: '',
+  }
+
+  const terminal = {
+    cols: 80,
+    rows: 24,
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    focus: vi.fn(),
+    write: vi.fn(),
+    dispose: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    attachCustomKeyEventHandler: vi.fn((handler: (event: KeyboardEvent) => boolean) => {
+      state.keyHandler = handler
+    }),
+    onSelectionChange: vi.fn((handler: () => void) => {
+      state.selectionHandler = handler
+      return { dispose: vi.fn() }
+    }),
+    hasSelection: vi.fn(() => state.selection.length > 0),
+    getSelection: vi.fn(() => state.selection),
+    clearSelection: vi.fn(() => {
+      state.selection = ''
+      state.selectionHandler?.()
+    }),
+  }
+
+  return { state, terminal }
+})
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function Terminal() {
+    return xterm.terminal
+  }),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function FitAddon() {
+    return { fit: vi.fn() }
+  }),
+}))
+
+class MockWebSocket {
+  static OPEN = 1
+  readyState = MockWebSocket.OPEN
+  binaryType = ''
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+}
+
+describe('PersistentTerminalPane', () => {
+  beforeEach(() => {
+    xterm.state.selection = ''
+    xterm.state.keyHandler = undefined
+    xterm.state.selectionHandler = undefined
+    vi.clearAllMocks()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      disconnect() {}
+    })
+  })
+
+  it('copies a selection with Ctrl+C but leaves Ctrl+C to the terminal without one', () => {
+    render(<PersistentTerminalPane websocketUrl="ws://terminal" />)
+
+    xterm.state.selection = 'selected output'
+    const copyEvent = new KeyboardEvent('keydown', {
+      key: 'c',
+      ctrlKey: true,
+      cancelable: true,
+    })
+
+    expect(xterm.state.keyHandler?.(copyEvent)).toBe(false)
+    expect(clipboard.copyTextToClipboard).toHaveBeenCalledWith('selected output')
+
+    const macCopyEvent = new KeyboardEvent('keydown', {
+      key: 'c',
+      metaKey: true,
+      cancelable: true,
+    })
+
+    expect(xterm.state.keyHandler?.(macCopyEvent)).toBe(false)
+    expect(clipboard.copyTextToClipboard).toHaveBeenLastCalledWith('selected output')
+
+    xterm.state.selection = ''
+    const interruptEvent = new KeyboardEvent('keydown', {
+      key: 'c',
+      ctrlKey: true,
+      cancelable: true,
+    })
+
+    expect(xterm.state.keyHandler?.(interruptEvent)).toBe(true)
+    expect(clipboard.copyTextToClipboard).toHaveBeenCalledTimes(2)
+  })
+
+  it('offers copy and add-to-chat actions from the selection context menu', () => {
+    const onCopyToChat = vi.fn()
+    const { container } = render(
+      <PersistentTerminalPane
+        websocketUrl="ws://terminal"
+        onCopyToChat={onCopyToChat}
+      />,
+    )
+
+    act(() => {
+      xterm.state.selection = 'build failed on line 42'
+      xterm.state.selectionHandler?.()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Copy to chat' })).not.toBeInTheDocument()
+
+    fireEvent.contextMenu(container.firstElementChild!, { clientX: 120, clientY: 80 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy' }))
+    expect(clipboard.copyTextToClipboard).toHaveBeenCalledWith('build failed on line 42')
+
+    fireEvent.contextMenu(container.firstElementChild!, { clientX: 120, clientY: 80 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add to chat' }))
+    expect(onCopyToChat).toHaveBeenCalledWith('build failed on line 42')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/session/PersistentTerminalPane.tsx
+++ b/frontend/src/components/session/PersistentTerminalPane.tsx
@@ -1,7 +1,12 @@
-import { FC, useEffect, useRef } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 import Box from '@mui/material/Box'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
 import { FitAddon } from '@xterm/addon-fit'
 import { Terminal } from '@xterm/xterm'
+import { Copy, MessageSquareText } from 'lucide-react'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import '@xterm/xterm/css/xterm.css'
 
 interface Props {
@@ -10,6 +15,13 @@ interface Props {
   active?: boolean
   onActivate?: () => void
   onExit?: (exitCode: number) => void
+  onCopyToChat?: (text: string) => void
+}
+
+interface TerminalContextMenu {
+  mouseX: number
+  mouseY: number
+  text: string
 }
 
 const PersistentTerminalPane: FC<Props> = ({
@@ -18,13 +30,21 @@ const PersistentTerminalPane: FC<Props> = ({
   active = false,
   onActivate,
   onExit,
+  onCopyToChat,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const onExitRef = useRef(onExit)
+  const onCopyToChatRef = useRef(onCopyToChat)
+  const [selectedText, setSelectedText] = useState('')
+  const [contextMenu, setContextMenu] = useState<TerminalContextMenu | null>(null)
 
   useEffect(() => {
     onExitRef.current = onExit
   }, [onExit])
+
+  useEffect(() => {
+    onCopyToChatRef.current = onCopyToChat
+  }, [onCopyToChat])
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -41,6 +61,23 @@ const PersistentTerminalPane: FC<Props> = ({
     term.loadAddon(fit)
     term.open(containerRef.current)
     fit.fit()
+
+    term.attachCustomKeyEventHandler((event) => {
+      const isCopyShortcut = event.type === 'keydown'
+        && event.key.toLowerCase() === 'c'
+        && (event.metaKey || event.ctrlKey)
+        && !event.altKey
+
+      if (!isCopyShortcut || !term.hasSelection()) return true
+
+      event.preventDefault()
+      void copyTextToClipboard(term.getSelection()).catch(() => {})
+      return false
+    })
+
+    const selectionDisposable = term.onSelectionChange(() => {
+      setSelectedText(term.getSelection())
+    })
 
     const ws = new WebSocket(websocketUrl)
     ws.binaryType = 'arraybuffer'
@@ -110,6 +147,7 @@ const PersistentTerminalPane: FC<Props> = ({
       resizeObserver?.disconnect()
       if (resizeFrame !== undefined) window.cancelAnimationFrame(resizeFrame)
       dataDisposable?.dispose()
+      selectionDisposable.dispose()
       ws.close()
       term.dispose()
     }
@@ -121,6 +159,16 @@ const PersistentTerminalPane: FC<Props> = ({
   return (
     <Box
       onMouseDown={onActivate}
+      onContextMenu={(event) => {
+        if (!selectedText) return
+        event.preventDefault()
+        event.stopPropagation()
+        setContextMenu({
+          mouseX: event.clientX,
+          mouseY: event.clientY,
+          text: selectedText,
+        })
+      }}
       sx={{
         position: 'relative',
         minWidth: 0,
@@ -134,6 +182,58 @@ const PersistentTerminalPane: FC<Props> = ({
       }}
     >
       <Box ref={containerRef} sx={{ width: '100%', height: '100%' }} />
+      <Menu
+        open={contextMenu !== null}
+        onClose={() => setContextMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={contextMenu
+          ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+          : undefined}
+        MenuListProps={{
+          dense: true,
+          'aria-label': 'Terminal selection actions',
+          sx: { py: 0.5 },
+        }}
+        slotProps={{
+          paper: {
+            sx: {
+              minWidth: 150,
+              border: '1px solid',
+              borderColor: 'divider',
+              boxShadow: 4,
+            },
+          },
+        }}
+      >
+        <MenuItem
+          onClick={() => {
+            if (contextMenu) {
+              void copyTextToClipboard(contextMenu.text).catch(() => {})
+            }
+            setContextMenu(null)
+          }}
+        >
+          <ListItemIcon sx={{ minWidth: 30 }}>
+            <Copy size={16} />
+          </ListItemIcon>
+          Copy
+        </MenuItem>
+        {onCopyToChat && (
+          <MenuItem
+            onClick={() => {
+              if (contextMenu) {
+                onCopyToChatRef.current?.(contextMenu.text)
+              }
+              setContextMenu(null)
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 30 }}>
+              <MessageSquareText size={16} />
+            </ListItemIcon>
+            Add to chat
+          </MenuItem>
+        )}
+      </Menu>
     </Box>
   )
 }

--- a/frontend/src/components/session/SessionTerminal.tsx
+++ b/frontend/src/components/session/SessionTerminal.tsx
@@ -34,6 +34,7 @@ interface Props {
   running: boolean
   fillContainer?: boolean
   onRequestClose?: () => void
+  onCopyToChat?: (text: string) => void
 }
 
 const terminalSelectionStorageKey = (sessionId: string) =>
@@ -88,6 +89,7 @@ interface TerminalTreeProps {
   activePaneName: string | null
   onActivate: (sessionName: string) => void
   onExit: (sessionName: string) => void
+  onCopyToChat?: (text: string) => void
 }
 
 const TerminalTree: FC<TerminalTreeProps> = ({
@@ -96,6 +98,7 @@ const TerminalTree: FC<TerminalTreeProps> = ({
   activePaneName,
   onActivate,
   onExit,
+  onCopyToChat,
 }) => {
   if (node.type === 'pane') {
     return (
@@ -104,6 +107,7 @@ const TerminalTree: FC<TerminalTreeProps> = ({
         active={node.sessionName === activePaneName}
         onActivate={() => onActivate(node.sessionName)}
         onExit={() => onExit(node.sessionName)}
+        onCopyToChat={onCopyToChat}
       />
     )
   }
@@ -132,6 +136,7 @@ const TerminalTree: FC<TerminalTreeProps> = ({
             activePaneName={activePaneName}
             onActivate={onActivate}
             onExit={onExit}
+            onCopyToChat={onCopyToChat}
           />
         </Box>
       ))}
@@ -144,6 +149,7 @@ const SessionTerminal: FC<Props> = ({
   running,
   fillContainer = false,
   onRequestClose,
+  onCopyToChat,
 }) => {
   const [layout, setLayout] = useState<TerminalLayoutState>(() =>
     readStoredLayout(sessionId),
@@ -352,6 +358,7 @@ const SessionTerminal: FC<Props> = ({
               activePaneName: terminalSessionName,
             }))}
             onExit={removePane}
+            onCopyToChat={onCopyToChat}
           />
         ) : (
           <Box sx={{ display: 'grid', placeItems: 'center', height: '100%' }}>

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -384,9 +384,16 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const [terminalDrawerState, setTerminalDrawerState] = useState(() =>
     loadSpecTaskTerminalDrawerState(taskId),
   );
+  const terminalChatAppendSequence = useRef(0);
+  const [terminalChatAppend, setTerminalChatAppend] = useState<{
+    text: string;
+    sequence: number;
+  } | null>(null);
 
   useEffect(() => {
     setTerminalDrawerState(loadSpecTaskTerminalDrawerState(taskId));
+    terminalChatAppendSequence.current = 0;
+    setTerminalChatAppend(null);
   }, [taskId]);
 
   const toggleTerminalDrawer = useCallback(() => {
@@ -412,6 +419,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       return next;
     });
   }, [taskId]);
+
+  const copyTerminalSelectionToChat = useCallback((text: string) => {
+    terminalChatAppendSequence.current += 1;
+    setTerminalChatAppend({
+      text,
+      sequence: terminalChatAppendSequence.current,
+    });
+  }, []);
+
+  const terminalChatAppendText = terminalChatAppend
+    ? terminalChatAppend.text + "#" + terminalChatAppend.sequence
+    : undefined;
 
   const handleAgentModelChange = useCodeAgentConfigChange(updateExecutionConfig.mutateAsync);
 
@@ -2558,6 +2577,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   sessionId={activeSessionId}
                   specTaskId={task.id}
                   projectId={task.project_id}
+                  appendText={terminalChatAppendText}
                   enableInteractionDebugCopy
                   onWillSend={handleWillSend}
                   leadingActions={(
@@ -2870,6 +2890,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   sessionId={activeSessionId}
                   specTaskId={task.id}
                   projectId={task.project_id}
+                  appendText={terminalChatAppendText}
                   enableInteractionDebugCopy
                   onWillSend={handleWillSend}
                   leadingActions={(
@@ -3026,6 +3047,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
           height={terminalDrawerState.height}
           onHeightChange={setTerminalDrawerHeight}
           onClose={closeTerminalDrawer}
+          onCopyToChat={copyTerminalSelectionToChat}
         />
       )}
 

--- a/frontend/src/components/tasks/SpecTaskTerminalDrawer.tsx
+++ b/frontend/src/components/tasks/SpecTaskTerminalDrawer.tsx
@@ -13,6 +13,7 @@ interface Props {
   height: number
   onHeightChange: (height: number) => void
   onClose: () => void
+  onCopyToChat: (text: string) => void
 }
 
 const SpecTaskTerminalDrawer: FC<Props> = ({
@@ -21,6 +22,7 @@ const SpecTaskTerminalDrawer: FC<Props> = ({
   height,
   onHeightChange,
   onClose,
+  onCopyToChat,
 }) => {
   const [renderedHeight, setRenderedHeight] = useState(() =>
     clampSpecTaskTerminalHeight(height),
@@ -138,6 +140,7 @@ const SpecTaskTerminalDrawer: FC<Props> = ({
         running={running}
         fillContainer
         onRequestClose={onClose}
+        onCopyToChat={onCopyToChat}
       />
     </Box>
   )

--- a/frontend/src/components/widgets/MonacoEditorClipboard.test.ts
+++ b/frontend/src/components/widgets/MonacoEditorClipboard.test.ts
@@ -25,6 +25,9 @@ describe('MonacoEditor clipboard integration', () => {
     document.body.innerHTML = ''
   })
 
+  // Importing monaco-editor is what this test measures, so its transform and
+  // module evaluation are charged to the test's own budget. That is ~2s on a warm
+  // dev machine and well past the 5s default on a loaded CI worker.
   it('does not access navigator.clipboard after Monaco initializes on HTTP', async () => {
     const clipboardGetter = vi.fn(() => {
       throw new TypeError('navigator.clipboard is unavailable')
@@ -78,5 +81,5 @@ describe('MonacoEditor clipboard integration', () => {
     expect(clipboardGetter).not.toHaveBeenCalled()
 
     editor.dispose()
-  })
+  }, 30000)
 })

--- a/frontend/src/components/widgets/SettingRow.tsx
+++ b/frontend/src/components/widgets/SettingRow.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactNode } from 'react'
-import { Box, Typography } from '@mui/material'
-import { SxProps, Theme } from '@mui/material/styles'
+import { Box, BoxProps, Typography } from '@mui/material'
 
 interface SettingRowProps {
   /** What the setting is called. Replaces the control's own floating label. */
@@ -15,7 +14,7 @@ interface SettingRowProps {
    */
   align?: 'center' | 'start'
   /** Width of the control column. */
-  controlWidth?: SxProps<Theme>['width']
+  controlWidth?: BoxProps['width']
   /** The control, plus any adornment (a settings shortcut, a unit suffix). */
   children: ReactNode
 }

--- a/stack
+++ b/stack
@@ -926,7 +926,13 @@ function build-desktop() {
     exit 1
   fi
 
-  docker buildx build --provenance=false -f "$DOCKERFILE" \
+  # --load: with a docker-container buildx driver (any project-local builder
+  # left selected in `docker buildx use`) an unqualified build writes only to
+  # the build cache. The image hash read back below would then be the previous
+  # build's, which reports "Image unchanged (layers cached)" and skips the
+  # sandbox transfer — a green build that shipped nothing. Harmless no-op on
+  # the default docker driver.
+  docker buildx build --provenance=false --load -f "$DOCKERFILE" \
     --build-arg "GO_VERSION=${GO_VERSION}" \
     -t "${IMAGE_NAME}:latest" \
     .


### PR DESCRIPTION
## Summary

- Copy selected terminal text with Ctrl/Cmd+C while preserving interrupt behavior when nothing is selected.
- Add terminal selection context-menu actions for Copy and Add to chat.
- Append terminal selections to the task chat composer.
- Fix agent config directory ownership and ensure desktop builds load images correctly.
- Disable tmux mouse mode to preserve terminal selection behavior.

## Testing

- Added `PersistentTerminalPane` tests for keyboard copy and context-menu actions.
- Not run: full frontend build and end-to-end UI verification.