### PR TITLE
fix(authz): confine project-scoped session keys to their own project

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -248,6 +248,12 @@ steps:
       RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
       ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
       START_HELIX_TEST_SERVER: "true"
+      # Artifact creation is gated on subdomain hosting being configured:
+      # artifact_handlers.go checks vhostBaseDomain before accepting an upload,
+      # whatever the artifact's visibility. Without this the artifact endpoints
+      # 400 and no test touching them can run. SERVER_URL supplies the rest of
+      # the base domain and is set by startAPIServer in integration_test.go.
+      DEV_SUBDOMAIN: "dev"
       # Agent configuration
       REASONING_MODEL_PROVIDER: openai
       REASONING_MODEL: gpt-5.6-luna

--- a/api/pkg/server/authz.go
+++ b/api/pkg/server/authz.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/helixml/helix/api/pkg/orgstore"
@@ -151,7 +152,39 @@ func (apiServer *HelixAPIServer) authorizeUserToProjectByID(ctx context.Context,
 	return apiServer.authorizeUserToProject(ctx, user, project, action)
 }
 
+// errProjectScopedKey is returned when a project-scoped credential is used
+// against a different project.
+var errProjectScopedKey = errors.New("credential is scoped to another project")
+
+// enforceKeyProjectScope confines a project-scoped credential to its own
+// project.
+//
+// Sandbox agents authenticate with a session key minted for one spec task
+// (services.GetOrCreateSessionAPIKey). That key carries the task's project but
+// belongs to the human who created the task, so plain user RBAC answers "may
+// this user reach that project?" — true for every project they are a member
+// of. Without this check an agent can read and write artifacts, tasks and
+// other project sub-resources belonging to projects it was never dispatched
+// to.
+//
+// Only credentials that carry a project are constrained. Keycloak sessions and
+// ordinary user keys leave User.ProjectID empty and are unaffected, as are
+// session keys minted for work with no project (helix-org workers, plain chat
+// sessions), which keep their existing reach.
+func enforceKeyProjectScope(user *types.User, projectID string) error {
+	if user == nil || user.ProjectID == "" || user.ProjectID == projectID {
+		return nil
+	}
+	return fmt.Errorf("%w: key is scoped to project %s, request targets %s", errProjectScopedKey, user.ProjectID, projectID)
+}
+
 func (apiServer *HelixAPIServer) authorizeUserToProject(ctx context.Context, user *types.User, project *types.Project, action types.Action) error {
+	// Scope check first: a project-scoped key must not reach another project
+	// even when its owner would otherwise be authorized.
+	if err := enforceKeyProjectScope(user, project.ID); err != nil {
+		return err
+	}
+
 	// If the organization ID is not set and the user is not the project owner, then error
 	if project.OrganizationID == "" {
 		// This is the old style project logic, where the project is owned by a user and optionally made global

--- a/api/pkg/server/authz_project_scope_test.go
+++ b/api/pkg/server/authz_project_scope_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// A session key minted for one spec task must not reach another project, even
+// though its owner is a member of both. See enforceKeyProjectScope.
+func TestEnforceKeyProjectScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		user      *types.User
+		projectID string
+		wantErr   bool
+	}{
+		{
+			name:      "unscoped credential reaches any project",
+			user:      &types.User{ID: "usr_1"},
+			projectID: "prj_a",
+		},
+		{
+			name:      "scoped credential reaches its own project",
+			user:      &types.User{ID: "usr_1", ProjectID: "prj_a"},
+			projectID: "prj_a",
+		},
+		{
+			name:      "scoped credential is refused another project",
+			user:      &types.User{ID: "usr_1", ProjectID: "prj_a"},
+			projectID: "prj_b",
+			wantErr:   true,
+		},
+		{
+			// helix-org workers and plain chat sessions get a session key with
+			// no project; they keep their existing reach.
+			name:      "session key without a project is unconstrained",
+			user:      &types.User{ID: "usr_1", SessionID: "ses_1"},
+			projectID: "prj_b",
+		},
+		{
+			name:      "nil user is not a scope decision",
+			user:      nil,
+			projectID: "prj_a",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforceKeyProjectScope(tc.user, tc.projectID)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected scope error, got nil")
+				}
+				if !errors.Is(err, errProjectScopedKey) {
+					t.Fatalf("expected errProjectScopedKey, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// The scope check must run before any ownership or membership rule, otherwise
+// a project owner's own session key would still reach their other projects.
+func TestAuthorizeUserToProjectRejectsForeignProjectForScopedKey(t *testing.T) {
+	apiServer := &HelixAPIServer{}
+
+	owner := &types.User{ID: "usr_owner", ProjectID: "prj_a"}
+	foreign := &types.Project{ID: "prj_b", UserID: "usr_owner"}
+
+	err := apiServer.authorizeUserToProject(t.Context(), owner, foreign, types.ActionUpdate)
+	if err == nil {
+		t.Fatal("expected project owner with a scoped key to be refused another project")
+	}
+	if !errors.Is(err, errProjectScopedKey) {
+		t.Fatalf("expected errProjectScopedKey, got %v", err)
+	}
+
+	// Same key, its own project: ownership applies as before.
+	own := &types.Project{ID: "prj_a", UserID: "usr_owner"}
+	if err := apiServer.authorizeUserToProject(t.Context(), owner, own, types.ActionUpdate); err != nil {
+		t.Fatalf("expected owner to keep access to its scoped project, got %v", err)
+	}
+}

--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -1036,7 +1036,11 @@ func (apiServer *HelixAPIServer) completeClaudeOAuthLogin(_ http.ResponseWriter,
 		AccessToken:  tokens.AccessToken,
 		RefreshToken: tokens.RefreshToken,
 		ExpiresAt:    tokens.ExpiresAt,
-		Scopes:       tokens.Scopes,
+		// Carry the login deadline through. Dropping it left every
+		// browser-connected subscription with no recorded expiry until a
+		// background refresh happened to supply one.
+		RefreshTokenExpiresAt: tokens.RefreshExpiresAt,
+		Scopes:                tokens.Scopes,
 	}
 	return apiServer.createClaudeSubscriptionFrom(req.Context(), user, createReq)
 }

--- a/api/pkg/types/claude_subscription.go
+++ b/api/pkg/types/claude_subscription.go
@@ -21,12 +21,14 @@ type ClaudeSubscription struct {
 	SubscriptionType     string         `json:"subscription_type"`                      // "max", "pro"
 	RateLimitTier        string         `json:"rate_limit_tier"`
 	Scopes               pq.StringArray `json:"scopes" gorm:"type:text[]"`
-	AccessTokenExpiresAt time.Time      `json:"access_token_expires_at"`
+	AccessTokenExpiresAt time.Time      `json:"access_token_expires_at,omitzero"`
 	// RefreshTokenExpiresAt is when the login itself dies and the user must
 	// re-authenticate. Refreshing keeps the 8h access token alive but does not
 	// move this, so it is the only honest basis for an expiry warning. Zero for
-	// setup tokens, which carry no refresh token.
-	RefreshTokenExpiresAt time.Time `json:"refresh_token_expires_at"`
+	// setup tokens, which carry no refresh token — omitzero so an absent
+	// deadline reaches the client as absent, not as "0001-01-01T00:00:00Z",
+	// which reads as a date 739850 days in the past.
+	RefreshTokenExpiresAt time.Time `json:"refresh_token_expires_at,omitzero"`
 	Status                string    `json:"status"` // "active", "expired", "error"
 
 	// DelegatedOrgIDs lists the organizations whose agent sessions may

--- a/design/2026-08-23-drone-webhook-loss-webhookrelay.md
+++ b/design/2026-08-23-drone-webhook-loss-webhookrelay.md
@@ -1,0 +1,238 @@
+# Silent CI: how a 10-second webhook timeout cost us builds, and how WebhookRelay fixed it
+
+Date: 2026-08-23
+Repo: helixml/helix — CI: self-hosted Drone at drone.lukemarsden.net
+
+NOTE: all tokens in this document are redacted. Do not paste real
+`sk-whrm-…` / Drone tokens into a published post.
+
+## 1. The symptom
+
+https://github.com/helixml/helix/pull/3098 had no CI checks. Not failing — absent.
+
+    gh pr view 3098 --json statusCheckRollup
+    → {"statusCheckRollup": []}
+
+    gh api repos/helixml/helix/commits/42aa22853ea572c5cba55980e053d11cba74db46/status
+    → {"state":"pending","total_count":0}
+
+The parent commit was fine:
+
+    gh api repos/helixml/helix/commits/0c9294065/status
+    → {"state":"success","total_count":1,
+       "context":"continuous-integration/drone/push",
+       "target_url":"https://drone.lukemarsden.net/helixml/helix/3856"}
+
+Drone had built the branch twice — 3855 (`a34dce12`, failure) and 3856
+(`0c929406`, success) — but had never heard of `42aa2285`, the PR head.
+GitHub attaches commit statuses per SHA, so the PR showed nothing.
+
+## 2. The red herring
+
+The webhook looked healthy:
+
+    gh api repos/helixml/helix/hooks --jq '.[] | {id,url:.config.url,active,last_response}'
+    → {"id":603552912,"url":"https://drone.lukemarsden.net/hook","active":true,
+       "last_response":{"code":200,"message":"OK","status":"active"}}
+
+`last_response` only reflects the *most recent* delivery. A hook that drops
+one delivery in fifty still reads 200/OK forever. Deliveries are where the
+truth is.
+
+## 3. The actual error
+
+    gh api "repos/helixml/helix/hooks/603552912/deliveries?per_page=60" \
+      --jq '.[] | select(.status_code==500) | "\(.delivered_at) \(.event) \(.status)"'
+
+    2026-08-21T20:52:55.855Z  push  POST https://drone.lukemarsden.net/hook giving up after 1 attempt(s): Post "https://drone.lukemarsden.net/hook": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+    2026-08-21T15:52:38.568Z  push  (same)
+    2026-08-21T15:50:43.191Z  push  (same)
+
+Keywords for search: **"giving up after 1 attempt(s)"**, **"context deadline
+exceeded"**, **"Client.Timeout exceeded while awaiting headers"**,
+**status_code 500**, **GitHub webhook not retried**.
+
+Two facts collide:
+
+- GitHub allows a webhook **10 seconds** to respond.
+- GitHub **does not retry** a failed delivery — `giving up after 1 attempt(s)`.
+
+Drone's `/hook` handler does real synchronous work: signature validation, repo
+lookup, fetching `.drone.yml` from the GitHub API, build creation. When that
+crossed 10s, the delivery was gone permanently, and with it the build.
+
+There was no alert, no failed build, no red X. Just absence — the worst CI
+failure mode, because absence looks like "not started yet".
+
+A `pull_request synchronize` hook 8 seconds earlier returned 200, but
+`.drone.yml` triggers only on `push`/`tag`, so it was inert.
+
+    trigger:
+      event:
+        - push
+        - tag
+
+(Confirmed across 125 builds of history: 124 `push`, 1 `tag`, zero `pull_request`.)
+
+Fetching an individual delivery body needs an extra scope:
+
+    gh: This API operation needs the "admin:repo_hook" scope.
+
+## 4. The fix: put a relay in front
+
+Before — Drone's latency sits on GitHub's critical path:
+
+    GitHub --(10s limit, 0 retries)--> Drone     # slow Drone = lost build
+
+After — the relay answers instantly and owns delivery:
+
+    GitHub --(~0.5s 200)--> WebhookRelay --(60s, 8 attempts, 24h queue)--> Drone
+
+The headline win is not the retries. It is **decoupling the acknowledgement
+from the delivery**. GitHub now talks to something that is always fast, so
+GitHub's 10s limit stops being a constraint on Drone at all. Even with retries
+disabled this removes the failure mode.
+
+### MCP setup
+
+    claude mcp add --transport http webhookrelay https://my.webhookrelay.com/v1/mcp \
+      --header "Authorization: Bearer sk-whrm-REDACTED"
+
+Tools used: `create_bucket`, `create_output`, `update_output`,
+`list_webhook_logs`, `get_webhook_log`, `list_buckets`, `delete_bucket`.
+
+### Bucket
+
+    create_bucket {
+      "name": "helix-drone",
+      "destination": "https://drone.lukemarsden.net/hook",
+      "internal": false
+    }
+    → endpoint_url: https://01m0nspf19eykaba8qp6crg5zd.hooks.webhookrelay.com
+
+### Output tuning — every value chosen against a specific failure
+
+    update_output {
+      "lock_path":         true,   # always POST exactly /hook, never /hook/
+      "retries":           5,      # +5 on top of the first 3 attempts = 8
+      "timeout_seconds":   60,     # default 20 could clip the same slow path
+      "tls_verification":  true,   # DEFAULT IS false — surprising, fix it
+      "durability": { "enabled": true, "schedule": "medium",
+                      "handoff_after": "15m", "deadline": "24h" }
+    }
+
+Deliberately NOT set: `response_from_output`. That makes the input reply with
+the destination's response — which would re-couple GitHub's 10s timeout to
+Drone's latency and undo the entire point. Keep the static fast 200.
+
+## 5. The part that could have broken everything: HMAC
+
+Drone validates GitHub's `X-Hub-Signature-256`, an HMAC-SHA256 over the **raw
+request body**. Any relay that re-serializes JSON — reorders keys, changes
+whitespace — silently invalidates every signature. You would trade lost builds
+for rejected builds.
+
+### Proof 1 — manual probe
+
+    request_body:  {"zen":"Keep it logically awesome.","hook_id":603552912,...}
+    Content-Length: 99
+    X-Hub-Signature-256: sha256=7ea7fb87…      ← forwarded
+    X-Github-Event: ping                        ← forwarded
+    X-Github-Delivery: probe-0001-relay-passthrough
+    → Drone responded 200 in 77ms
+
+### Proof 2 — the real one
+
+Created a throwaway GitHub webhook with a secret we control
+(`probe-secret-abc123`), fired `POST /repos/{o}/{r}/hooks/{id}/pings`, then
+recomputed the HMAC over the body **as the relay delivered it**:
+
+    sig sent    : sha256=d8acea04077b98470cc10d1823851dc5625474d999adcbd7ec16cdd5998dcafe
+    sig w/known : sha256=d8acea04077b98470cc10d1823851dc5625474d999adcbd7ec16cdd5998dcafe
+    MATCH       : True
+
+GitHub signed the *original* payload and it still validated after the hop.
+That is byte-exact passthrough, proven rather than assumed.
+
+## 6. The trap worth the whole blog post
+
+Repointing a GitHub webhook looks like a one-liner. One of the two obvious
+ways to do it **destroys the webhook secret**.
+
+### DESTRUCTIVE — `PATCH /repos/{owner}/{repo}/hooks/{id}`
+
+    gh api -X PATCH repos/helixml/helix/hooks/669228346 -f config[url]=https://new.example/hook
+
+    before: {"content_type":"json","insecure_ssl":"0","secret":"********","url":"…"}
+    after:  {"content_type":"form","insecure_ssl":"0","url":"…/patched"}
+
+`config` is replaced wholesale. Two things die:
+
+1. `secret` — gone. The next ping arrived with **no `X-Hub-Signature-256` header
+   at all**. Surviving headers were only: `X-Github-Delivery`, `X-Github-Event`,
+   `X-Github-Hook-Id`, `X-Github-Hook-Installation-Target-Id`,
+   `X-Github-Hook-Installation-Target-Type`.
+2. `content_type` — silently reverted `json` → `form`.
+
+Either alone kills CI. And it is **unrecoverable**: GitHub never returns a
+secret (`"secret": "********"`), and Drone hides `secret`/`signer` from
+non-admin users, so there is nothing to read it back from.
+
+### SAFE — `PATCH /repos/{owner}/{repo}/hooks/{id}/config`
+
+    gh api -X PATCH repos/helixml/helix/hooks/669228346/config -f url=https://new.example/hook
+
+    after: {"content_type":"json","insecure_ssl":"0","secret":"********","url":"…/patched2"}
+    → signature present, matches known secret, Content-Type: application/json
+
+Only the supplied fields change. This is the one to use.
+
+Method: never test this on production CI. Create a throwaway hook with a
+secret you control, point it at a bucket with no forwarding output, and let the
+signature tell you the truth.
+
+## 7. End-to-end verification
+
+Signed ping through the full chain:
+
+    GitHub delivery: ping 200 OK
+    relay log:       status=sent code=200 69ms
+
+Real push on a throwaway branch (`test/webhookrelay-verify`, commit `97ac01f3`):
+
+    Drone build 3873  event=push  after=97ac01f3  status=running
+    builds created for 97ac01f3: count=1     ← no duplicate delivery
+
+Drone validated the relayed signature and created the build. A ping alone would
+not have proven this — only a push exercises build creation.
+
+## 8. Honest residual risks
+
+- **Duplicate deliveries on tags.** If Drone processes a hook but answers
+  slowly, a retry creates a second build. Harmless on branches. On a tag it is a
+  second concurrent production deploy, because `deploy-prod` (`.drone.yml:2559`,
+  `scripts/deploy-prod.sh "$DRONE_TAG"`) is gated on `refs/tags/*`. The 60s relay
+  timeout makes this far less likely than GitHub's 10s, but the real fix is a
+  lock in the deploy script. Drone does not dedupe on `X-GitHub-Delivery`.
+- **Fork PRs still get nothing.** Drone repo config has `ignore_forks: true`, and
+  `.drone.yml` triggers only on push/tag. https://github.com/helixml/helix/pull/3094
+  (from `iamwaqasahmad/helix-fork`) is unaffected by any of this.
+- **The relay is now a dependency** of all CI, and sees every payload of a
+  private repo.
+- **Drone is still slow sometimes.** The relay stops that costing builds; it does
+  not fix the underlying handler latency.
+
+## 9. Rollback
+
+    gh api -X PATCH repos/helixml/helix/hooks/603552912/config \
+      -f url=https://drone.lukemarsden.net/hook
+
+## 10. Recommended belt-and-braces
+
+A reconciliation job comparing each GitHub branch head against Drone's latest
+build for that branch, triggering the missing ones:
+
+    POST /api/repos/helixml/helix/builds?branch=<branch>
+
+Catches losses from any cause, including an outage of the relay itself. When
+the failure mode is silence, you want something that actively looks for gaps.

--- a/frontend/src/components/account/claudeSubscriptionUtils.test.ts
+++ b/frontend/src/components/account/claudeSubscriptionUtils.test.ts
@@ -113,6 +113,13 @@ describe('getClaudeLoginExpiry', () => {
     expect(getClaudeLoginExpiry('not-a-date')).toBeNull()
   })
 
+  it('treats Go\'s zero time as no deadline, not a deadline in year 1', () => {
+    // Verbatim from GET /api/v1/claude-subscriptions for a setup token: an
+    // unset time.Time serialises as a real, parseable date. Reading it as a
+    // deadline told a user with a working login "Expired 739850d ago".
+    expect(getClaudeLoginExpiry('0001-01-01T00:00:00Z')).toBeNull()
+  })
+
   it('warns once the login dies within a day', () => {
     // Not a whole number of hours: inHours(5) lands microseconds under 5h and
     // floors to 4, which made this assertion flake under load.

--- a/frontend/src/components/account/claudeSubscriptionUtils.ts
+++ b/frontend/src/components/account/claudeSubscriptionUtils.ts
@@ -75,6 +75,11 @@ export function getClaudeLoginExpiry(refreshTokenExpiresAt?: string | null): Cla
   if (!refreshTokenExpiresAt) return null
   const expiresAt = new Date(refreshTokenExpiresAt)
   if (isNaN(expiresAt.getTime())) return null
+  // Go renders an unset time.Time as "0001-01-01T00:00:00Z". That parses
+  // cleanly, so a falsy check does not catch it — it just is not a deadline.
+  // Setup tokens carry no refresh token and so have none at all, and reading
+  // year 1 as one claimed "Expired 739850d ago" against a working login.
+  if (expiresAt.getTime() <= 0) return null
 
   const diffMs = expiresAt.getTime() - Date.now()
   const DAY_MS = 24 * 60 * 60 * 1000

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -47,7 +47,7 @@ import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import MoveUpIcon from "@mui/icons-material/MoveUp";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import HubIcon from "@mui/icons-material/Hub";
-import { Settings, Wrench } from "lucide-react";
+import { Settings, Trash2, Wrench } from "lucide-react";
 
 import AgentToolsPicker from "../components/tools/AgentToolsPicker";
 
@@ -1892,14 +1892,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
 
   const renderDangerTab = () => (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Box
-        sx={{
-          border: "2px solid",
-          borderColor: "error.main",
-          borderRadius: 1,
-          p: 2,
-        }}
-      >
+      <Box>
         <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
           <WarningIcon sx={{ mr: 1, color: "error.main" }} />
           <Typography variant="h6" color="error">
@@ -1957,27 +1950,30 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
             borderRadius: 1,
             border: "1px solid",
             borderColor: "error.light",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 2,
           }}
         >
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-            Delete Project
-          </Typography>
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ mb: 2 }}
-          >
-            Once you delete a project, there is no going back. This will
-            permanently delete the project, all its tasks, and associated
-            data.
-          </Typography>
+          <Box>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+              Delete Project
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Once you delete a project, there is no going back. This will
+              permanently delete the project, all its tasks, and associated
+              data.
+            </Typography>
+          </Box>
           <Button
             variant="outlined"
             color="error"
-            startIcon={<DeleteForeverIcon />}
+            startIcon={<Trash2 size={18} />}
             onClick={() => setDeleteDialogOpen(true)}
+            sx={{ flexShrink: 0 }}
           >
-            Delete This Project
+            Delete project
           </Button>
         </Box>
       </Box>

--- a/integration-test/api/artifacts_project_scope_test.go
+++ b/integration-test/api/artifacts_project_scope_test.go
@@ -185,6 +185,20 @@ func (suite *ArtifactsProjectScopeTestSuite) createArtifact(apiClient *client.He
 	})
 }
 
+// requireProjectScopeRefusal asserts the request was refused by the project
+// scope check specifically. Asserting only "an error occurred" lets these tests
+// pass for unrelated reasons: on an instance without subdomain hosting the
+// artifact endpoints return 400 for every upload, which is indistinguishable
+// from enforcement working if the assertion only checks that err != nil.
+func (suite *ArtifactsProjectScopeTestSuite) requireProjectScopeRefusal(err error, msg string) {
+	suite.T().Helper()
+
+	suite.Require().Error(err, msg)
+	suite.Require().Contains(err.Error(), "403", "%s: expected a 403, got %v", msg, err)
+	suite.Require().Contains(err.Error(), "scoped to another project",
+		"%s: expected the project scope refusal, got %v", msg, err)
+}
+
 // The agent must keep full use of the project it was dispatched to.
 func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyRetainsOwnProject() {
 	scopedClient, err := getAPIClient(suite.scopedKey)
@@ -208,10 +222,10 @@ func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyCannotReachAnotherProj
 	suite.Require().NoError(err)
 
 	_, err = scopedClient.ListArtifacts(suite.ctx, suite.projectB.ID)
-	suite.Require().Error(err, "scoped key must not list another project's artifacts")
+	suite.requireProjectScopeRefusal(err, "scoped key must not list another project's artifacts")
 
 	_, err = suite.createArtifact(scopedClient, suite.projectB.ID, "cross-project artifact")
-	suite.Require().Error(err, "scoped key must not create artifacts in another project")
+	suite.requireProjectScopeRefusal(err, "scoped key must not create artifacts in another project")
 }
 
 // Deleting is the destructive case: an artifact the agent never created, in a
@@ -229,7 +243,7 @@ func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyCannotDeleteAnotherPro
 	scopedClient, err := getAPIClient(suite.scopedKey)
 	suite.Require().NoError(err)
 
-	suite.Require().Error(scopedClient.DeleteArtifact(suite.ctx, victim.ID),
+	suite.requireProjectScopeRefusal(scopedClient.DeleteArtifact(suite.ctx, victim.ID),
 		"scoped key must not delete an artifact in another project")
 
 	// Still there, via a credential that is allowed to see it.

--- a/integration-test/api/artifacts_project_scope_test.go
+++ b/integration-test/api/artifacts_project_scope_test.go
@@ -1,0 +1,255 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/helixml/helix/api/pkg/auth"
+	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// A sandbox agent authenticates with a session key minted for one spec task.
+// That key belongs to the human who created the task, so plain user RBAC would
+// let the agent reach every project its owner is a member of. These tests pin
+// the scoping that stops it, using artifacts as the project sub-resource — the
+// agent-facing write surface where it matters most.
+func TestArtifactsProjectScopeTestSuite(t *testing.T) {
+	suite.Run(t, new(ArtifactsProjectScopeTestSuite))
+}
+
+type ArtifactsProjectScopeTestSuite struct {
+	suite.Suite
+	ctx           context.Context
+	db            *store.PostgresStore
+	authenticator auth.Authenticator
+
+	user       *types.User
+	userAPIKey string
+
+	organization *types.Organization
+	defaultApp   *types.App
+
+	projectA *types.Project // the project the agent was dispatched to
+	projectB *types.Project // another project the same user owns
+
+	// scopedKey mimics services.GetOrCreateSessionAPIKey: same owner as
+	// userAPIKey, but carrying session/project/spec-task attribution.
+	scopedKey string
+}
+
+func (suite *ArtifactsProjectScopeTestSuite) SetupTest() {
+	suite.ctx = context.Background()
+
+	db, err := getStoreClient()
+	suite.Require().NoError(err)
+	suite.db = db
+
+	authenticator, err := auth.NewHelixAuthenticator(&config.ServerConfig{}, suite.db, "test-secret", nil)
+	suite.Require().NoError(err)
+	suite.authenticator = authenticator
+
+	email := fmt.Sprintf("artifact-scope-%s@test.com", uuid.New().String())
+	user, apiKey, err := createUser(suite.T(), suite.db, suite.authenticator, email)
+	suite.Require().NoError(err)
+	suite.user = user
+	suite.userAPIKey = apiKey
+
+	ownerClient, err := getAPIClient(suite.userAPIKey)
+	suite.Require().NoError(err)
+
+	organization, err := ownerClient.CreateOrganization(suite.ctx, &types.Organization{
+		Name: "artifact-scope-" + time.Now().Format("2006-01-02-15-04-05-06"),
+	})
+	suite.Require().NoError(err)
+	suite.organization = organization
+
+	suite.T().Cleanup(func() {
+		_ = ownerClient.DeleteOrganization(suite.ctx, suite.organization.ID)
+	})
+
+	// A project needs either a code-agent config or a default Agent. An Agent
+	// keeps this suite focused on authorization rather than execution config.
+	defaultApp, err := ownerClient.CreateApp(suite.ctx, &types.App{
+		OrganizationID: suite.organization.ID,
+		Config: types.AppConfig{
+			Helix: types.AppHelixConfig{
+				Name:        "artifact-scope-agent-" + uuid.New().String(),
+				Description: "artifact project scope test agent",
+				Assistants: []types.AssistantConfig{{
+					Name:  "assistant",
+					Model: "openai/gpt-oss-20b",
+				}},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+
+	defaultApp.AgentKind = types.AgentKindOrg
+	defaultApp, err = suite.db.UpdateApp(suite.ctx, defaultApp)
+	suite.Require().NoError(err)
+	suite.defaultApp = defaultApp
+
+	suite.projectA = suite.createProject("scope-a-" + uuid.New().String())
+	suite.projectB = suite.createProject("scope-b-" + uuid.New().String())
+
+	suite.scopedKey = suite.createSessionScopedKey(suite.projectA.ID)
+}
+
+func (suite *ArtifactsProjectScopeTestSuite) createProject(name string) *types.Project {
+	suite.T().Helper()
+
+	// A project needs a primary repository; artifacts do not use it, but
+	// project creation rejects the request without one.
+	repo := suite.createTestRepository(name)
+
+	var project types.Project
+	status, body := apiJSON(suite.T(), suite.userAPIKey, http.MethodPost, "/projects", &types.ProjectCreateRequest{
+		OrganizationID:    suite.organization.Name,
+		Name:              name,
+		Description:       "artifact project scope test",
+		DefaultRepoID:     repo.ID,
+		DefaultHelixAppID: suite.defaultApp.ID,
+	}, &project)
+	suite.Require().Equal(http.StatusOK, status, body)
+	suite.Require().NotEmpty(project.ID)
+
+	return &project
+}
+
+func (suite *ArtifactsProjectScopeTestSuite) createTestRepository(namePrefix string) *types.GitRepository {
+	suite.T().Helper()
+
+	var repo types.GitRepository
+	status, body := apiJSON(suite.T(), suite.userAPIKey, http.MethodPost, "/git/repositories", &types.GitRepositoryCreateRequest{
+		Name:           namePrefix + "-repo",
+		Description:    "artifact project scope test repository",
+		RepoType:       types.GitRepositoryTypeCode,
+		OwnerID:        suite.user.ID,
+		OrganizationID: suite.organization.ID,
+		DefaultBranch:  "main",
+		InitialFiles: map[string]string{
+			"README.md": "# artifact project scope test\n",
+		},
+		Metadata: map[string]interface{}{},
+	}, &repo)
+	suite.Require().Equal(http.StatusCreated, status, body)
+	return &repo
+}
+
+// createSessionScopedKey mirrors what the spec-task service mints for a sandbox:
+// an ordinary API key owned by the task creator, tagged with the session, the
+// project and the spec task.
+func (suite *ArtifactsProjectScopeTestSuite) createSessionScopedKey(projectID string) string {
+	suite.T().Helper()
+
+	key, err := system.GenerateAPIKey()
+	suite.Require().NoError(err)
+
+	_, err = suite.db.CreateAPIKey(suite.ctx, &types.ApiKey{
+		Name:           "Session key - scope test",
+		Key:            key,
+		Owner:          suite.user.ID,
+		OwnerType:      types.OwnerTypeUser,
+		Type:           types.APIkeytypeAPI,
+		OrganizationID: suite.organization.ID,
+		SessionID:      "ses_" + strings.ReplaceAll(uuid.New().String(), "-", ""),
+		ProjectID:      projectID,
+		SpecTaskID:     "spt_" + strings.ReplaceAll(uuid.New().String(), "-", ""),
+	})
+	suite.Require().NoError(err)
+
+	return key
+}
+
+func (suite *ArtifactsProjectScopeTestSuite) createArtifact(apiClient *client.HelixClient, projectID, name string) (*types.Artifact, error) {
+	suite.T().Helper()
+
+	visibility := types.ArtifactVisibilityProject
+	return apiClient.CreateArtifact(suite.ctx, projectID, &client.ArtifactUploadRequest{
+		Name:       &name,
+		Visibility: &visibility,
+		Content: &client.ArtifactContent{
+			Filename: "index.html",
+			Reader:   strings.NewReader("<h1>scope test</h1>"),
+		},
+	})
+}
+
+// The agent must keep full use of the project it was dispatched to.
+func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyRetainsOwnProject() {
+	scopedClient, err := getAPIClient(suite.scopedKey)
+	suite.Require().NoError(err)
+
+	artifact, err := suite.createArtifact(scopedClient, suite.projectA.ID, "own-project artifact")
+	suite.Require().NoError(err, "scoped key must still write to its own project")
+	suite.Require().Equal(suite.projectA.ID, artifact.ProjectID)
+
+	artifacts, err := scopedClient.ListArtifacts(suite.ctx, suite.projectA.ID)
+	suite.Require().NoError(err, "scoped key must still read its own project")
+	suite.Require().Len(artifacts, 1)
+
+	suite.Require().NoError(scopedClient.DeleteArtifact(suite.ctx, artifact.ID),
+		"scoped key must still delete in its own project")
+}
+
+// The same key must not reach a sibling project, even though its owner may.
+func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyCannotReachAnotherProject() {
+	scopedClient, err := getAPIClient(suite.scopedKey)
+	suite.Require().NoError(err)
+
+	_, err = scopedClient.ListArtifacts(suite.ctx, suite.projectB.ID)
+	suite.Require().Error(err, "scoped key must not list another project's artifacts")
+
+	_, err = suite.createArtifact(scopedClient, suite.projectB.ID, "cross-project artifact")
+	suite.Require().Error(err, "scoped key must not create artifacts in another project")
+}
+
+// Deleting is the destructive case: an artifact the agent never created, in a
+// project it was never dispatched to.
+func (suite *ArtifactsProjectScopeTestSuite) TestScopedKeyCannotDeleteAnotherProjectsArtifact() {
+	ownerClient, err := getAPIClient(suite.userAPIKey)
+	suite.Require().NoError(err)
+
+	victim, err := suite.createArtifact(ownerClient, suite.projectB.ID, "owner artifact in B")
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		_ = ownerClient.DeleteArtifact(suite.ctx, victim.ID)
+	})
+
+	scopedClient, err := getAPIClient(suite.scopedKey)
+	suite.Require().NoError(err)
+
+	suite.Require().Error(scopedClient.DeleteArtifact(suite.ctx, victim.ID),
+		"scoped key must not delete an artifact in another project")
+
+	// Still there, via a credential that is allowed to see it.
+	remaining, err := ownerClient.ListArtifacts(suite.ctx, suite.projectB.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(remaining, 1, "artifact must survive the refused delete")
+}
+
+// The restriction comes from the key's scope, not from the user losing access:
+// the same human, on an unscoped key, still reaches both projects.
+func (suite *ArtifactsProjectScopeTestSuite) TestUnscopedKeyReachesBothProjects() {
+	ownerClient, err := getAPIClient(suite.userAPIKey)
+	suite.Require().NoError(err)
+
+	for _, projectID := range []string{suite.projectA.ID, suite.projectB.ID} {
+		_, err := ownerClient.ListArtifacts(suite.ctx, projectID)
+		suite.Require().NoError(err, "unscoped user key must reach project %s", projectID)
+	}
+
+	artifact, err := suite.createArtifact(ownerClient, suite.projectB.ID, "unscoped write")
+	suite.Require().NoError(err)
+	suite.Require().NoError(ownerClient.DeleteArtifact(suite.ctx, artifact.ID))
+}


### PR DESCRIPTION
## Problem

A sandbox agent authenticates with a session key minted for one spec task (`services.GetOrCreateSessionAPIKey`). The key records the task's project — but that field is written `// For metrics/attribution` and never reaches an authorization decision. `auth_middleware.go:228` copies it onto the user, where `user.ProjectID` is read **only** by the usage recorders (`openai_chat_handlers.go:215`, `anthropic_api_proxy_handler.go:114`).

The key belongs to the human who created the task, so project RBAC asks "may this *user* reach that project?" — true for every project they are a member of.

Verified against a live sandbox, using the agent's own `USER_API_TOKEN` for a task in `prj_01kzqwykxqps28fpys1z5cbcha`:

```
GET  /projects/<own>/artifacts    → 200
GET  /projects/<other>/artifacts  → 200   ← should not be reachable
CREATE artifact in <other>        → art_01m0nt0f8ypf9fhc713q78zbyy
DELETE that artifact              → deleted
```

Artifacts are where this surfaced, but the gap applies to every endpoint that authorizes on user identity.

## Fix

Enforce the scope the key already carries, in `authorizeUserToProject` — the chokepoint every project sub-resource goes through, rather than patching artifact handlers alone. The check runs before ownership and membership rules, because a project owner's scoped key must not reach their *other* projects either.

Credentials with no project are untouched: Keycloak sessions, ordinary user keys, and session keys minted for work with no project (helix-org workers, plain chat sessions) keep their existing reach. That last exemption is deliberate — the artifacts design has an org Worker publishing to another project it manages.

A DB survey confirms the blast radius: `project_id` is set on 260 keys, **all** of which also carry a `session_id`. No app key or plain user key carries one.

## Tests

**Unit** (`api/pkg/server/authz_project_scope_test.go`): the scope helper's table, plus a test that the check precedes ownership.

**API integration** (`integration-test/api/artifacts_project_scope_test.go`), one org, two projects, a key minted the way the spec-task service mints one:

- scoped key keeps full read/write/delete on its own project
- scoped key cannot list or create in a sibling project
- scoped key cannot delete an artifact it did not create in a sibling project, and that artifact survives
- the same user's unscoped key still reaches both — proving the restriction comes from the key's scope, not lost access

Verified the tests fail without the fix: with enforcement disabled, `TestScopedKeyCannotReachAnotherProject` and `TestScopedKeyCannotDeleteAnotherProjectsArtifact` fail; re-enabled, all four pass. `go test ./pkg/server/` and the existing `TestOrganizationsRBACTestSuite` are green.

## Follow-up not in this PR

Longer term the agent should get its own principal rather than a credential impersonating the user — `created_by` on artifacts would then name the agent, which is better provenance. This PR closes the hole with the data already on the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)