### PR TITLE
fix(org): consume retired topic rows so deleted triggers stay deleted

### DIFF
--- a/api/pkg/org/application/cutover/cutover.go
+++ b/api/pkg/org/application/cutover/cutover.go
@@ -7,6 +7,25 @@
 // the expected value is success, and a conflicting one is an error, so
 // running it on every boot converges and then does nothing.
 //
+// Repeat-safe is not the same as run-once, and the difference is the
+// user's deletes. A retired row that survives its own conversion is a
+// standing instruction to recreate that Trigger or attachment: delete
+// the Trigger, redeploy, and the next boot builds it again, because
+// "does the target exist?" cannot tell a not-yet-converted row from a
+// converted-then-deleted one. So the conversion CONSUMES what it
+// reads — each retired row is deleted once it has been handled, which
+// is the tombstone. "Handled" includes the outcomes that create
+// nothing: a Processor output Topic (skipped by design), a dangling or
+// human subscription, and a repeat run finding the target already
+// there. A skipped output Topic in particular must not be left behind,
+// because deleting its Processor removes the branch that identifies it
+// and the row would then convert into a Trigger for a stream nobody
+// owns.
+//
+// Consuming a row is destructive by design: after conversion the
+// retired tables are dead weight awaiting a DROP, and the Processor
+// input column is already cleared the same way.
+//
 // What it converts, and the invariant each conversion preserves:
 //
 //   - Every workflow Topic becomes a Trigger with the SAME id. That is
@@ -100,14 +119,17 @@ func Convert(ctx context.Context, d Deps) (Result, error) {
 		key := store.OrgScopedID{OrgID: topic.OrganizationID, ID: topic.ID}
 		if _, isBranch := branches[key]; isBranch {
 			result.Skipped++
-			continue
+		} else {
+			created, err := convertTopic(ctx, d.Store, topic)
+			if err != nil {
+				return result, err
+			}
+			if created {
+				result.Triggers++
+			}
 		}
-		created, err := convertTopic(ctx, d.Store, topic)
-		if err != nil {
-			return result, err
-		}
-		if created {
-			result.Triggers++
+		if err := d.Store.RetiredTopics.Delete(ctx, topic.OrganizationID, topic.ID); err != nil {
+			return result, fmt.Errorf("cutover: consume retired topic %q: %w", topic.ID, err)
 		}
 	}
 
@@ -118,6 +140,9 @@ func Convert(ctx context.Context, d Deps) (Result, error) {
 		}
 		if created {
 			result.Attachments++
+		}
+		if err := d.Store.RetiredSubscriptions.Delete(ctx, sub.OrganizationID, sub.NodeID, string(sub.TopicID)); err != nil {
+			return result, fmt.Errorf("cutover: consume retired subscription %q→%q: %w", sub.NodeID, sub.TopicID, err)
 		}
 	}
 

--- a/api/pkg/org/application/cutover/cutover_test.go
+++ b/api/pkg/org/application/cutover/cutover_test.go
@@ -252,3 +252,75 @@ func TestConvert_NothingToDoOnCleanInstall(t *testing.T) {
 	require.Zero(t, res.Attachments)
 	require.Zero(t, res.Inputs)
 }
+
+// TestConvert_DeletedTriggerStaysDeleted: the conversion consumes each
+// retired row, so a Trigger a user deletes after the upgrade does not
+// come back on the next boot. Without that, every deploy resurrects
+// every Trigger derived from a pre-cutover Topic.
+func TestConvert_DeletedTriggerStaysDeleted(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	memory.SeedRetired(st,
+		[]streaming.Topic{topic(t, "s-general", "general", transport.LocalTransport())}, nil, nil)
+
+	first, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Triggers)
+
+	require.NoError(t, st.Triggers.Delete(ctx, org, "s-general"))
+
+	second, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Zero(t, second.Triggers)
+	require.Empty(t, triggerIDs(t, st))
+}
+
+// TestConvert_DetachedWorkerStaysDetached: same tombstone property for
+// the subscription half — a Worker detached from a Trigger after the
+// upgrade must not be re-attached by the next boot's conversion.
+func TestConvert_DetachedWorkerStaysDetached(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	worker(t, st, "b-sam", false)
+	memory.SeedRetired(st,
+		[]streaming.Topic{topic(t, "s-general", "general", transport.LocalTransport())},
+		[]streaming.Subscription{sub(t, "b-sam", "s-general")}, nil)
+
+	first, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Attachments)
+
+	rows, err := st.WorkerAttachments.Find(ctx, store.WithOrg(org), store.WithWorkerID(orgchart.NodeID("b-sam")))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NoError(t, st.WorkerAttachments.Delete(ctx, org, rows[0].ID))
+
+	second, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Zero(t, second.Attachments)
+	require.Empty(t, attachmentSources(t, st, "b-sam"))
+}
+
+// TestConvert_OutputTopicStaysConsumedAfterProcessorDeleted: a skipped
+// Processor output Topic is handled, not deferred. Once its Processor is
+// deleted the branch index no longer recognises the row, so a retained
+// row would be converted into a live Trigger for a stream nobody owns.
+func TestConvert_OutputTopicStaysConsumedAfterProcessorDeleted(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	seedBranch(t, st, "p-truncate", "po-out", "s-truncated")
+	memory.SeedRetired(st,
+		[]streaming.Topic{topic(t, "s-truncated", "p-truncate output", transport.LocalTransport())}, nil, nil)
+
+	first, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Zero(t, first.Triggers)
+	require.Equal(t, 1, first.Skipped)
+
+	require.NoError(t, st.Processors.Delete(ctx, org, "p-truncate"))
+
+	second, err := cutover.Convert(ctx, cutover.Deps{Store: st})
+	require.NoError(t, err)
+	require.Zero(t, second.Triggers)
+	require.Empty(t, triggerIDs(t, st))
+}

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -108,14 +108,22 @@ type NodeRuntimeState interface {
 //
 // ListAll deliberately crosses tenant boundaries: the conversion runs
 // once at boot for the whole deployment, before any org is scoped.
+//
+// Delete removes one converted row. The conversion consumes what it
+// reads: a retained row is a standing instruction to recreate the
+// Trigger, so it would undo the user's next delete on the next boot.
 type RetiredTopics interface {
 	ListAll(ctx context.Context) ([]streaming.Topic, error)
+	Delete(ctx context.Context, orgID, topicID string) error
 }
 
 // RetiredSubscriptions is the read side of the pre-cutover
 // (Worker, Topic) subscription table, read only by application/cutover.
+// Delete consumes one converted row, for the same reason as
+// RetiredTopics.Delete.
 type RetiredSubscriptions interface {
 	ListAll(ctx context.Context) ([]streaming.Subscription, error)
+	Delete(ctx context.Context, orgID, workerID, topicID string) error
 }
 
 // RetiredProcessorInputs reads the pre-cutover `input_topic_id` column

--- a/api/pkg/org/infrastructure/persistence/gorm/retired.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/retired.go
@@ -14,16 +14,18 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/transport"
 )
 
-// This file is the read-only remnant of the pre-cutover Topic model.
-// Nothing at runtime writes these tables: their only reader is
+// This file is the remnant of the pre-cutover Topic model. Nothing at
+// runtime reads or writes these tables: their only user is
 // application/cutover, which converts each row into a Trigger, a
-// Processor input, or a Worker attachment exactly once. AutoMigrate no
-// longer manages the row types, so the tables are left exactly as the
-// last pre-cutover release wrote them, and they are dropped once
-// deployed data has converted.
+// Processor input, or a Worker attachment exactly once and then deletes
+// it. The delete is the point — a retained row would recreate its
+// Trigger on every subsequent boot, undoing whatever the user deleted
+// in between. AutoMigrate no longer manages the row types, so the
+// tables are otherwise left exactly as the last pre-cutover release
+// wrote them, and they are dropped once deployed data has converted.
 //
-// Every read here is deliberately cross-tenant: the conversion runs
-// once at boot for the whole deployment, before any org is scoped.
+// Every statement here is deliberately cross-tenant: the conversion
+// runs once at boot for the whole deployment, before any org is scoped.
 
 type retiredTopicRow struct {
 	ID              string
@@ -77,6 +79,21 @@ func (r *retiredReader) ListAll(ctx context.Context) ([]streaming.Topic, error) 
 	return out, nil
 }
 
+// Delete removes one converted Topic row. The conversion consumes every
+// row it reads, so a Trigger the user later deletes is not recreated by
+// the next boot.
+func (r *retiredReader) Delete(ctx context.Context, orgID, topicID string) error {
+	if !r.db.Migrator().HasTable("org_topics") {
+		return nil
+	}
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ? AND id = ?", orgID, topicID).
+		Delete(&retiredTopicRow{}).Error; err != nil {
+		return fmt.Errorf("delete retired topic %q: %w", topicID, err)
+	}
+	return nil
+}
+
 type retiredSubscriptionReader struct{ db *gorm.DB }
 
 func newRetiredSubscriptionReader(db *gorm.DB) *retiredSubscriptionReader {
@@ -101,6 +118,20 @@ func (r *retiredSubscriptionReader) ListAll(ctx context.Context) ([]streaming.Su
 		out = append(out, sub)
 	}
 	return out, nil
+}
+
+// Delete removes one converted subscription row, so a Worker the user
+// later detaches is not re-attached by the next boot.
+func (r *retiredSubscriptionReader) Delete(ctx context.Context, orgID, workerID, topicID string) error {
+	if !r.db.Migrator().HasTable("org_subscriptions") {
+		return nil
+	}
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ? AND bot_id = ? AND topic_id = ?", orgID, workerID, topicID).
+		Delete(&retiredSubscriptionRow{}).Error; err != nil {
+		return fmt.Errorf("delete retired subscription %q→%q: %w", workerID, topicID, err)
+	}
+	return nil
 }
 
 type retiredProcessorInputReader struct{ db *gorm.DB }

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -822,12 +822,40 @@ func (r *retiredRepo) ListAll(_ context.Context) ([]streaming.Topic, error) {
 	return append([]streaming.Topic(nil), r.topics...), nil
 }
 
+func (r *retiredRepo) Delete(_ context.Context, orgID, topicID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	kept := make([]streaming.Topic, 0, len(r.topics))
+	for _, t := range r.topics {
+		if t.OrganizationID == orgID && t.ID == topicID {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	r.topics = kept
+	return nil
+}
+
 type retiredSubsRepo struct{ inner *retiredRepo }
 
 func (r *retiredSubsRepo) ListAll(_ context.Context) ([]streaming.Subscription, error) {
 	r.inner.mu.RLock()
 	defer r.inner.mu.RUnlock()
 	return append([]streaming.Subscription(nil), r.inner.subscriptions...), nil
+}
+
+func (r *retiredSubsRepo) Delete(_ context.Context, orgID, workerID, topicID string) error {
+	r.inner.mu.Lock()
+	defer r.inner.mu.Unlock()
+	kept := make([]streaming.Subscription, 0, len(r.inner.subscriptions))
+	for _, sub := range r.inner.subscriptions {
+		if sub.OrganizationID == orgID && sub.NodeID == workerID && sub.TopicID == topicID {
+			continue
+		}
+		kept = append(kept, sub)
+	}
+	r.inner.subscriptions = kept
+	return nil
 }
 
 type retiredInputsRepo struct{ inner *retiredRepo }

--- a/design/2026-08-20-helix-org-triggers.md
+++ b/design/2026-08-20-helix-org-triggers.md
@@ -811,6 +811,13 @@ fallback to Topics.
      Trigger, Processor, subscription, and attachment repositories. Existing
      target rows with the expected values are success; conflicting target rows
      are errors. Add no migration-specific database schema or state machine.
+   - Consume each retired row once it has been handled: delete the Topic and
+     subscription rows, as the Processor input column is already cleared. The
+     source row is the tombstone. Without that, "does the target exist?" cannot
+     distinguish a not-yet-converted row from a converted-then-deleted one, and
+     every deploy resurrects Triggers and attachments the user deleted. Handled
+     includes the outcomes that create nothing — a Processor output Topic, a
+     dangling or human subscription, an already-converged target.
 
 2. **Make Triggers own inbound transports.**
 
@@ -880,9 +887,10 @@ fallback to Topics.
      dispatch, Processor output Topics, reconcilers that create Topics, and the
      PR 3 legacy-delivery adapter. Do not add a read/write Topic projection.
    - Old Topic persistence may remain temporarily only as the input read by the
-     repeat-safe conversion. No runtime service may create or update Topic or
-     subscription rows after the cutover. Physical table cleanup can follow
-     once deployed data has converted.
+     repeat-safe conversion, which deletes each row as it converts it. No
+     runtime service may create or update Topic or subscription rows after the
+     cutover. Physical table cleanup can follow once deployed data has
+     converted.
    - Remove or disable old Topic REST and MCP operations rather than translating
      them. PR 5 introduces the public Trigger and attachment surfaces used by
      the replacement frontend.


### PR DESCRIPTION
## Summary

Deleted legacy-derived Triggers resurrected on API restart. `convertTopic` guarded only on "does a Trigger with this id already exist" — with the retired `org_topics` row still present after conversion, that test cannot tell a not-yet-converted row from a converted-then-deleted one. `Convert` runs on every boot, so any Trigger derived from a pre-cutover Topic came back after the next deploy. `convertSubscription` had the same shape for Worker attachments.

The fix: the conversion **consumes what it reads**. Each retired Topic and subscription row is deleted once handled, and that deletion is the tombstone. "Handled" includes the outcomes that create nothing:

- a Processor output Topic (skipped by design) — this one matters most: deleting its Processor removes the branch that identifies the row, after which a retained row would convert into a live Trigger for a stream nobody owns;
- a dangling or human subscription;
- a repeat run that finds the target already there.

This mirrors what the Processor input path already did (`RetiredProcessorInputs.Clear` after conversion) and keeps `Convert` repeat-safe: on a converged deployment it reads three empty tables and returns.

`RetiredTopics` / `RetiredSubscriptions` gain a `Delete`; implemented in both the gorm and in-memory stores.

## Tests

TDD — three tests written first, each reproducing the reported bug (`go test ./pkg/org/application/cutover/`):

| Test | Failure before the fix |
|---|---|
| `TestConvert_DeletedTriggerStaysDeleted` | second `Convert` recreated the deleted Trigger (`Triggers: 1`) |
| `TestConvert_DetachedWorkerStaysDetached` | second `Convert` re-attached the detached Worker (`Attachments: 1`) |
| `TestConvert_OutputTopicStaysConsumedAfterProcessorDeleted` | after the Processor was deleted, its output Topic converted into a Trigger |

All three now pass, along with the rest of `./pkg/org/...`.

## Verified end-to-end on the dev stack

Reproduced the reporter's setup against real Postgres (the gorm `DELETE`s have no unit coverage — the org gorm suite runs on the in-memory store):

1. Inserted a synthetic `org_topics` row plus a matching `org_subscriptions` row, restarted the API →
   `cutover: converted retired topic model triggers=1 attachments=1 processor_output_topics_skipped=0`; the Trigger and attachment were created and **both legacy rows were gone**. The 5 pre-existing processor-branch-output topic rows (previously re-skipped on every boot) were consumed too.
2. Deleted the Trigger and its attachment, restarted the API again → nothing was recreated, and `Convert` returned early on three empty tables.

## Note

Consuming a row is destructive by design: after conversion the retired tables are dead weight awaiting a `DROP`, and the Processor input column was already cleared the same way. A rollback to a pre-cutover release would no longer find the converted Topic rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
