### PR TITLE
fix(secrets): stop secret deletion orphaning agent grants

### DIFF
--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -220,6 +220,10 @@ type WorkerSecretBindings interface {
 	Update(context.Context, workersecret.Binding) error
 	Get(context.Context, string, orgchart.NodeID, string) (workersecret.Binding, error)
 	List(context.Context, string, orgchart.NodeID) ([]workersecret.Binding, error)
+	// ListBySecretID finds every binding pointing at one Helix secret,
+	// across Workers and organizations, so deleting that secret can
+	// report and revoke its grants instead of orphaning them.
+	ListBySecretID(context.Context, string) ([]workersecret.Binding, error)
 	Delete(context.Context, string, orgchart.NodeID, string) error
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/worker_secret.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/worker_secret.go
@@ -82,6 +82,19 @@ func (r *workerSecretBindingsRepo) List(ctx context.Context, orgID string, worke
 	}
 	return out, nil
 }
+func (r *workerSecretBindingsRepo) ListBySecretID(ctx context.Context, secretID string) ([]workersecret.Binding, error) {
+	var rows []workerSecretBindingRow
+	if err := r.db.WithContext(ctx).
+		Where("source_kind = ? AND secret_id = ?", string(workersecret.SourceHelixSecret), secretID).
+		Order("org_id, worker_id, name").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("list worker secret bindings by secret: %w", err)
+	}
+	out := make([]workersecret.Binding, len(rows))
+	for i := range rows {
+		out[i] = bindingDomain(rows[i])
+	}
+	return out, nil
+}
 func (r *workerSecretBindingsRepo) Delete(ctx context.Context, orgID string, workerID orgchart.NodeID, name string) error {
 	res := r.db.WithContext(ctx).Where("org_id = ? AND worker_id = ? AND name = ?", orgID, workerID, name).Delete(&workerSecretBindingRow{})
 	if res.Error != nil {

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -123,6 +123,18 @@ func (r *workerSecretBindingsRepo) List(_ context.Context, orgID string, workerI
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
+func (r *workerSecretBindingsRepo) ListBySecretID(_ context.Context, secretID string) ([]workersecret.Binding, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]workersecret.Binding, 0)
+	for _, b := range r.rows {
+		if b.SourceKind == workersecret.SourceHelixSecret && b.SecretID == secretID {
+			out = append(out, b)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
 func (r *workerSecretBindingsRepo) Delete(_ context.Context, orgID string, workerID orgchart.NodeID, name string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/api/pkg/org/interfaces/server/api/worker_secrets.go
+++ b/api/pkg/org/interfaces/server/api/worker_secrets.go
@@ -21,8 +21,12 @@ type WorkerSecretBindingDTO struct {
 	SecretID          string                  `json:"secret_id,omitempty"`
 	AccountID         string                  `json:"account_id,omitempty"`
 	ExportKey         string                  `json:"export_key,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
-	UpdatedAt         time.Time               `json:"updated_at"`
+	// Available reports whether the bound source still exists. A
+	// deleted source leaves the binding in place pointing at nothing,
+	// and this is the only signal the operator gets.
+	Available bool      `json:"available"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type PutWorkerSecretRequest struct {
@@ -60,14 +64,28 @@ func (a *apiHandler) listWorkerSecrets(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 503, errWorkerSecretsUnavailable)
 		return
 	}
-	rows, err := a.deps.WorkerSecrets.List(r.Context(), orgID, orgchart.NodeID(r.PathValue("id")))
+	workerID := orgchart.NodeID(r.PathValue("id"))
+	rows, err := a.deps.WorkerSecrets.List(r.Context(), orgID, workerID)
 	if err != nil {
 		writeError(w, errStatus(err), err)
 		return
 	}
+	// Descriptors resolves each binding against the live source
+	// catalog. Without it a grant whose source was deleted is
+	// indistinguishable from a healthy one on this page.
+	descriptors, err := a.deps.WorkerSecrets.Descriptors(r.Context(), orgID, workerID)
+	if err != nil {
+		writeError(w, errStatus(err), err)
+		return
+	}
+	available := make(map[string]bool, len(descriptors))
+	for _, d := range descriptors {
+		available[d.Name] = d.Available
+	}
 	out := make([]WorkerSecretBindingDTO, len(rows))
 	for i := range rows {
 		out[i] = bindingDTO(rows[i])
+		out[i].Available = available[rows[i].Name]
 	}
 	writeJSON(w, 200, out)
 }

--- a/api/pkg/org/interfaces/server/api/worker_secrets_test.go
+++ b/api/pkg/org/interfaces/server/api/worker_secrets_test.go
@@ -1,0 +1,89 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/workersecrets"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/workersecret"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+)
+
+// liveSourceResolver accepts every binding, so availability in these
+// tests is decided purely by whether the catalog still lists the source
+// — the same thing that happens when a project secret is deleted.
+type liveSourceResolver struct{}
+
+func (liveSourceResolver) Validate(context.Context, workersecret.Binding) error { return nil }
+func (liveSourceResolver) Resolve(context.Context, workersecret.Binding) (workersecret.Resolved, error) {
+	return workersecret.Resolved{}, nil
+}
+
+// newWorkerSecretsDeps seeds one Agent holding two grants — one whose
+// source is still in the catalog, one whose source has been deleted.
+func newWorkerSecretsDeps(t *testing.T) orgapi.Deps {
+	t.Helper()
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	node, err := orgchart.NewNode("b-agent", "# Agent", nil, now, "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Nodes.Create(ctx, node); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range []workersecret.Binding{
+		{Name: "LIVE_TOKEN", SecretID: "sec-live"},
+		{Name: "DEAD_TOKEN", SecretID: "sec-deleted"},
+	} {
+		b.OrganizationID, b.WorkerID = "org-test", node.ID
+		b.SourceKind, b.CreatedAt, b.UpdatedAt = workersecret.SourceHelixSecret, now, now
+		if err := st.WorkerSecretBindings.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	catalog := func(context.Context, string, orgchart.NodeID) ([]workersecret.AvailableSource, error) {
+		return []workersecret.AvailableSource{{
+			Label: "LIVE_TOKEN", SourceKind: workersecret.SourceHelixSecret,
+			SecretID: "sec-live", ProposedName: "LIVE_TOKEN",
+		}}, nil
+	}
+	svc, err := workersecrets.New(st.WorkerSecretBindings, st.Nodes, liveSourceResolver{}, func() time.Time { return now }, nil, catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps.WorkerSecrets = svc
+	return deps
+}
+
+// A grant whose source has been deleted stays in the list and is marked
+// unavailable, so the panel showing what an Agent holds can show the
+// break instead of looking healthy.
+func TestListWorkerSecrets_MarksDeletedSourceUnavailable(t *testing.T) {
+	deps := newWorkerSecretsDeps(t)
+
+	rec := do(t, orgapi.Handler(deps), http.MethodGet, "/agents/b-agent/secrets", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body)
+	}
+	var got []orgapi.WorkerSecretBindingDTO
+	decode(t, rec, &got)
+	if len(got) != 2 {
+		t.Fatalf("got %d bindings, want 2: %+v", len(got), got)
+	}
+	byName := map[string]orgapi.WorkerSecretBindingDTO{}
+	for _, b := range got {
+		byName[b.Name] = b
+	}
+	if !byName["LIVE_TOKEN"].Available {
+		t.Error("LIVE_TOKEN should be available; its source is still in the catalog")
+	}
+	if byName["DEAD_TOKEN"].Available {
+		t.Error("DEAD_TOKEN should be unavailable; its source was deleted")
+	}
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -16996,6 +16996,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Revoke Agent grants and delete anyway",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -17003,6 +17009,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.Secret"
+                        }
+                    },
+                    "409": {
+                        "description": "Secret is granted to one or more Agents",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -24494,6 +24506,10 @@ const docTemplate = `{
                 "account_id": {
                     "type": "string"
                 },
+                "available": {
+                    "description": "Available reports whether the bound source still exists. A\ndeleted source leaves the binding in place pointing at nothing,\nand this is the only signal the operator gets.",
+                    "type": "boolean"
+                },
                 "content_type": {
                     "type": "string"
                 },
@@ -30093,7 +30109,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "refresh_token_expires_at": {
-                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token.",
+                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token — omitzero so an absent\ndeadline reaches the client as absent, not as \"0001-01-01T00:00:00Z\",\nwhich reads as a date 739850 days in the past.",
                     "type": "string"
                 },
                 "scopes": {

--- a/api/pkg/server/secret_delete_bindings_test.go
+++ b/api/pkg/server/secret_delete_bindings_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/workersecret"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// fakeSecretStore is a minimal stateful store.Store: only the two methods
+// the secret delete handler touches are real. Every other method is
+// promoted from the (nil) embedded interface and must not be called.
+type fakeSecretStore struct {
+	store.Store
+	secrets map[string]*types.Secret
+}
+
+func (f *fakeSecretStore) GetSecret(_ context.Context, id string) (*types.Secret, error) {
+	s, ok := f.secrets[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return s, nil
+}
+
+func (f *fakeSecretStore) DeleteSecret(_ context.Context, id string) error {
+	if _, ok := f.secrets[id]; !ok {
+		return store.ErrNotFound
+	}
+	delete(f.secrets, id)
+	return nil
+}
+
+// newBoundSecretServer wires a HelixAPIServer holding one project secret
+// that is granted to one Agent through a real in-memory org store.
+func newBoundSecretServer(t *testing.T) (*HelixAPIServer, *fakeSecretStore) {
+	t.Helper()
+	fake := &fakeSecretStore{secrets: map[string]*types.Secret{
+		"sec-1": {ID: "sec-1", Name: "SMOKE_TOKEN", Owner: "user-1", ProjectID: "prj-1"},
+	}}
+	orgStore := orgmemory.New()
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	if err := orgStore.WorkerSecretBindings.Create(context.Background(), workersecret.Binding{
+		OrganizationID: "org-1", WorkerID: orgchart.NodeID("w-1"), Name: "SMOKE_TOKEN",
+		SourceKind: workersecret.SourceHelixSecret, SecretID: "sec-1",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	s := &HelixAPIServer{Store: fake, helixOrg: &helixOrgHandlers{store: orgStore}}
+	return s, fake
+}
+
+func deleteSecretRequest(t *testing.T, s *HelixAPIServer, query string) (*types.Secret, int) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/secrets/sec-1"+query, nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "sec-1"})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user-1"}))
+	secret, herr := s.deleteSecret(httptest.NewRecorder(), req)
+	if herr != nil {
+		return nil, herr.StatusCode
+	}
+	return secret, http.StatusOK
+}
+
+// A secret granted to an Agent cannot be deleted by accident: the delete
+// is refused with 409 and both the secret and the binding survive.
+func TestDeleteSecret_GrantedToAgent_Refused(t *testing.T) {
+	s, fake := newBoundSecretServer(t)
+
+	_, status := deleteSecretRequest(t, s, "")
+
+	if status != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", status)
+	}
+	if _, ok := fake.secrets["sec-1"]; !ok {
+		t.Fatal("secret was deleted despite the refusal")
+	}
+	if _, err := s.helixOrg.store.WorkerSecretBindings.Get(context.Background(), "org-1", "w-1", "SMOKE_TOKEN"); err != nil {
+		t.Fatalf("binding was removed despite the refusal: %v", err)
+	}
+}
+
+// force=true is the deliberate destroy route: the secret goes and its
+// grants are revoked with it, so no binding is left pointing at a dead id.
+func TestDeleteSecret_Force_RevokesGrants(t *testing.T) {
+	s, fake := newBoundSecretServer(t)
+
+	_, status := deleteSecretRequest(t, s, "?force=true")
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if _, ok := fake.secrets["sec-1"]; ok {
+		t.Fatal("secret survived a forced delete")
+	}
+	if _, err := s.helixOrg.store.WorkerSecretBindings.Get(context.Background(), "org-1", "w-1", "SMOKE_TOKEN"); err == nil {
+		t.Fatal("binding survived a forced delete, orphaned at a dead secret id")
+	}
+}

--- a/api/pkg/server/secrets_handlers.go
+++ b/api/pkg/server/secrets_handlers.go
@@ -209,7 +209,9 @@ func (s *HelixAPIServer) updateSecret(_ http.ResponseWriter, r *http.Request) (*
 // @Description Delete a secret for the user.
 // @Tags    secrets
 // @Success 200 {object} types.Secret
+// @Failure 409 {object} system.HTTPError "Secret is granted to one or more Agents"
 // @Param id path string true "Secret ID"
+// @Param force query boolean false "Revoke Agent grants and delete anyway"
 // @Router /api/v1/secrets/{id} [delete]
 // @Security BearerAuth
 func (s *HelixAPIServer) deleteSecret(_ http.ResponseWriter, r *http.Request) (*types.Secret, *system.HTTPError) {
@@ -241,6 +243,31 @@ func (s *HelixAPIServer) deleteSecret(_ http.ResponseWriter, r *http.Request) (*
 	}
 	if !authorized {
 		return nil, system.NewHTTPError403("Access denied")
+	}
+
+	// Agents granted this secret hold a binding that points at its id.
+	// Deleting the secret without revoking them leaves the binding
+	// pointing at nothing and the failure only shows up inside the
+	// sandbox, so refuse until the caller confirms with force=true and
+	// then revoke the grants along with the secret.
+	if s.helixOrg != nil {
+		bound, err := s.helixOrg.store.WorkerSecretBindings.ListBySecretID(ctx, id)
+		if err != nil {
+			return nil, system.NewHTTPError500(err.Error())
+		}
+		if len(bound) > 0 && r.URL.Query().Get("force") != "true" {
+			return nil, system.NewHTTPError409(fmt.Sprintf(
+				"%s is granted to %d agent(s); deleting it revokes their access", existing.Name, len(bound)))
+		}
+		// Revoked before the secret is gone: a grant removed from a
+		// secret that still exists can be re-granted from the Agent's
+		// secrets panel, while the reverse leaves the orphan this
+		// guard exists to prevent.
+		for _, b := range bound {
+			if err := s.helixOrg.store.WorkerSecretBindings.Delete(ctx, b.OrganizationID, b.WorkerID, b.Name); err != nil {
+				return nil, system.NewHTTPError500(err.Error())
+			}
+		}
 	}
 
 	err = s.Store.DeleteSecret(ctx, id)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -16992,6 +16992,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Revoke Agent grants and delete anyway",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -16999,6 +17005,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.Secret"
+                        }
+                    },
+                    "409": {
+                        "description": "Secret is granted to one or more Agents",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -24490,6 +24502,10 @@
                 "account_id": {
                     "type": "string"
                 },
+                "available": {
+                    "description": "Available reports whether the bound source still exists. A\ndeleted source leaves the binding in place pointing at nothing,\nand this is the only signal the operator gets.",
+                    "type": "boolean"
+                },
                 "content_type": {
                     "type": "string"
                 },
@@ -30089,7 +30105,7 @@
                     "type": "string"
                 },
                 "refresh_token_expires_at": {
-                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token.",
+                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token — omitzero so an absent\ndeadline reaches the client as absent, not as \"0001-01-01T00:00:00Z\",\nwhich reads as a date 739850 days in the past.",
                     "type": "string"
                 },
                 "scopes": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -814,6 +814,12 @@ definitions:
     properties:
       account_id:
         type: string
+      available:
+        description: |-
+          Available reports whether the bound source still exists. A
+          deleted source leaves the binding in place pointing at nothing,
+          and this is the only signal the operator gets.
+        type: boolean
       content_type:
         type: string
       created_at:
@@ -4852,7 +4858,9 @@ definitions:
           RefreshTokenExpiresAt is when the login itself dies and the user must
           re-authenticate. Refreshing keeps the 8h access token alive but does not
           move this, so it is the only honest basis for an expiry warning. Zero for
-          setup tokens, which carry no refresh token.
+          setup tokens, which carry no refresh token — omitzero so an absent
+          deadline reaches the client as absent, not as "0001-01-01T00:00:00Z",
+          which reads as a date 739850 days in the past.
         type: string
       scopes:
         items:
@@ -24596,11 +24604,19 @@ paths:
         name: id
         required: true
         type: string
+      - description: Revoke Agent grants and delete anyway
+        in: query
+        name: force
+        type: boolean
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.Secret'
+        "409":
+          description: Secret is granted to one or more Agents
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
       summary: Delete a secret

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -538,6 +538,12 @@ export interface ApiUpsertChartPositionsRequest {
 
 export interface ApiWorkerSecretBindingDTO {
   account_id?: string;
+  /**
+   * Available reports whether the bound source still exists. A
+   * deleted source leaves the binding in place pointing at nothing,
+   * and this is the only signal the operator gets.
+   */
+  available?: boolean;
   content_type?: string;
   created_at?: string;
   description?: string;
@@ -3087,7 +3093,9 @@ export interface TypesClaudeSubscription {
    * RefreshTokenExpiresAt is when the login itself dies and the user must
    * re-authenticate. Refreshing keeps the 8h access token alive but does not
    * move this, so it is the only honest basis for an expiry warning. Zero for
-   * setup tokens, which carry no refresh token.
+   * setup tokens, which carry no refresh token — omitzero so an absent
+   * deadline reaches the client as absent, not as "0001-01-01T00:00:00Z",
+   * which reads as a date 739850 days in the past.
    */
   refresh_token_expires_at?: string;
   scopes?: string[];
@@ -16831,10 +16839,18 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request DELETE:/api/v1/secrets/{id}
      * @secure
      */
-    v1SecretsDelete: (id: string, params: RequestParams = {}) =>
-      this.request<TypesSecret, any>({
+    v1SecretsDelete: (
+      id: string,
+      query?: {
+        /** Revoke Agent grants and delete anyway */
+        force?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesSecret, SystemHTTPError>({
         path: `/api/v1/secrets/${id}`,
         method: "DELETE",
+        query: query,
         secure: true,
         ...params,
       }),

--- a/frontend/src/components/helix-org/WorkerSecretsPanel.tsx
+++ b/frontend/src/components/helix-org/WorkerSecretsPanel.tsx
@@ -95,8 +95,8 @@ const WorkerSecretsPanel: FC<{ agentID?: string; projectID?: string; readOnly?: 
       <Tooltip title={projectID ? 'Create a secret in this Agent’s project' : 'This Agent has no project'}><span><Button size="small" variant="outlined" startIcon={<Plus size={16}/>} onClick={() => setNewSecretOpen(true)} disabled={readOnly || !projectID}>New Secret</Button></span></Tooltip>
     </Box>
     <Alert severity="warning">Granting a binding authorizes this Agent to retrieve and use the credential value. Values are never shown on this page.</Alert>
-    {bindings.map((binding) => <Box key={binding.name} sx={{ display: 'flex', alignItems: 'center', gap: 1, border: 1, borderColor: 'divider', borderRadius: 1, p: 1 }}>
-      <Box sx={{ flex: 1, minWidth: 0 }}><Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontWeight: 600 }}>{binding.name}</Typography><Typography variant="caption" color="text.secondary">{binding.usage || binding.source_kind}</Typography></Box>
+    {bindings.map((binding) => <Box key={binding.name} sx={{ display: 'flex', alignItems: 'center', gap: 1, border: 1, borderColor: binding.available === false ? 'warning.main' : 'divider', borderRadius: 1, p: 1 }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}><Typography variant="body2" sx={{ fontFamily: 'var(--helix-font-mono)', fontWeight: 600 }}>{binding.name}</Typography><Typography variant="caption" color={binding.available === false ? 'warning.main' : 'text.secondary'}>{binding.available === false ? 'Source deleted — this grant no longer resolves. Remove it or grant a new source.' : (binding.usage || binding.source_kind)}</Typography></Box>
       <Tooltip title="Remove secret grant"><span><IconButton aria-label={`Remove ${binding.name}`} size="small" disabled={readOnly || del.isPending} onClick={async () => { try { await del.mutateAsync(binding.name!); snackbar.success(`Removed ${binding.name}`) } catch (error: any) { snackbar.error(error?.response?.data?.error ?? error?.message ?? 'Failed to remove secret') } }}><Trash2 size={18}/></IconButton></span></Tooltip>
     </Box>)}
     <TextField

--- a/frontend/src/hooks/useSecrets.ts
+++ b/frontend/src/hooks/useSecrets.ts
@@ -58,10 +58,11 @@ export const useSecrets = () => {
     }
   }, [api, loadData])
 
-  const deleteSecret = useCallback(async (id: string): Promise<boolean> => {
-    await api.delete(`/api/v1/secrets/${id}`, {}, {
-      snackbar: true,
-    })
+  // force skips the "granted to N agents" refusal and revokes those
+  // grants along with the secret. The generated client is used here so
+  // the 409 surfaces to the caller instead of becoming a snackbar.
+  const deleteSecret = useCallback(async (id: string, force?: boolean): Promise<boolean> => {
+    await api.getApiClient().v1SecretsDelete(id, force ? { force: true } : undefined)
     loadData()
     return true
   }, [api, loadData])

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -440,16 +440,40 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
     },
   });
 
-  // Delete secret mutation
+  // Delete secret mutation. The server refuses with 409 while the secret
+  // is granted to an agent; that refusal becomes the confirm dialog, and
+  // confirming retries with force so the grants are revoked with it.
+  const [secretDeleteConflict, setSecretDeleteConflict] = useState<{
+    secretId: string;
+    message: string;
+  } | null>(null);
   const deleteSecretMutation = useMutation({
-    mutationFn: async (secretId: string) => {
-      await api.getApiClient().v1SecretsDelete(secretId);
+    mutationFn: async ({
+      secretId,
+      force,
+    }: {
+      secretId: string;
+      force?: boolean;
+    }) => {
+      await api
+        .getApiClient()
+        .v1SecretsDelete(secretId, force ? { force: true } : undefined);
     },
     onSuccess: () => {
+      setSecretDeleteConflict(null);
       snackbar.success("Secret deleted");
       refetchSecrets();
     },
-    onError: () => {
+    onError: (error: any, variables) => {
+      if (error?.response?.status === 409) {
+        setSecretDeleteConflict({
+          secretId: variables.secretId,
+          message:
+            error.response.data ||
+            "This secret is granted to one or more agents.",
+        });
+        return;
+      }
       snackbar.error("Failed to delete secret");
     },
   });
@@ -1733,7 +1757,8 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
                     size="small"
                     color="error"
                     onClick={() =>
-                      secret.id && deleteSecretMutation.mutate(secret.id)
+                      secret.id &&
+                      deleteSecretMutation.mutate({ secretId: secret.id })
                     }
                     disabled={deleteSecretMutation.isPending}
                     startIcon={<DeleteIcon />}
@@ -2550,6 +2575,31 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
             }
           >
             {moveProjectMutation.isPending ? "Moving..." : "Move Project"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Secret delete confirmation — raised by the server's 409 */}
+      <Dialog
+        open={Boolean(secretDeleteConflict)}
+        onClose={() => setSecretDeleteConflict(null)}
+      >
+        <DialogTitle>Delete secret?</DialogTitle>
+        <DialogContent>{secretDeleteConflict?.message}</DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSecretDeleteConflict(null)}>Cancel</Button>
+          <Button
+            color="error"
+            disabled={deleteSecretMutation.isPending}
+            onClick={() =>
+              secretDeleteConflict &&
+              deleteSecretMutation.mutate({
+                secretId: secretDeleteConflict.secretId,
+                force: true,
+              })
+            }
+          >
+            Delete anyway
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/Secrets.tsx
+++ b/frontend/src/pages/Secrets.tsx
@@ -38,6 +38,7 @@ const SecretsContent: React.FC = () => {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newSecretName, setNewSecretName] = useState('');
   const [newSecretValue, setNewSecretValue] = useState('');
+  const [deleteConflict, setDeleteConflict] = useState('');
 
   useEffect(() => {
     if(!account.user) return
@@ -51,17 +52,26 @@ const SecretsContent: React.FC = () => {
   };
 
   const handleDeleteConfirm = async () => {
-    if (secretToDelete) {
-      await secrets.deleteSecret(secretToDelete);
-      setDeleteDialogOpen(false);
-      setSecretToDelete(null);
+    if (!secretToDelete) return;
+    try {
+      // The second confirm is the force: the server refuses with 409
+      // while the secret is still granted to an agent.
+      await secrets.deleteSecret(secretToDelete, Boolean(deleteConflict));
+      handleDeleteCancel();
       secrets.loadData(); // Refresh the list after deleting a secret
+    } catch (error: any) {
+      if (error?.response?.status === 409) {
+        setDeleteConflict(error.response.data || 'This secret is granted to one or more agents.');
+        return;
+      }
+      throw error;
     }
   };
 
   const handleDeleteCancel = () => {
     setDeleteDialogOpen(false);
     setSecretToDelete(null);
+    setDeleteConflict('');
   };
 
   const handleCreateClick = () => {
@@ -174,12 +184,12 @@ const SecretsContent: React.FC = () => {
       <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>
         <DialogTitle>Confirm Delete</DialogTitle>
         <DialogContent>
-          Are you sure you want to delete this secret? This action cannot be undone.
+          {deleteConflict || 'Are you sure you want to delete this secret? This action cannot be undone.'}
         </DialogContent>
         <DialogActions>
           <Button onClick={handleDeleteCancel}>Cancel</Button>
           <Button onClick={handleDeleteConfirm} color="error">
-            Delete
+            {deleteConflict ? 'Delete anyway' : 'Delete'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -814,6 +814,12 @@ definitions:
     properties:
       account_id:
         type: string
+      available:
+        description: |-
+          Available reports whether the bound source still exists. A
+          deleted source leaves the binding in place pointing at nothing,
+          and this is the only signal the operator gets.
+        type: boolean
       content_type:
         type: string
       created_at:
@@ -4852,7 +4858,9 @@ definitions:
           RefreshTokenExpiresAt is when the login itself dies and the user must
           re-authenticate. Refreshing keeps the 8h access token alive but does not
           move this, so it is the only honest basis for an expiry warning. Zero for
-          setup tokens, which carry no refresh token.
+          setup tokens, which carry no refresh token — omitzero so an absent
+          deadline reaches the client as absent, not as "0001-01-01T00:00:00Z",
+          which reads as a date 739850 days in the past.
         type: string
       scopes:
         items:
@@ -24596,11 +24604,19 @@ paths:
         name: id
         required: true
         type: string
+      - description: Revoke Agent grants and delete anyway
+        in: query
+        name: force
+        type: boolean
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.Secret'
+        "409":
+          description: Secret is granted to one or more Agents
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
       summary: Delete a secret

--- a/openapi.json
+++ b/openapi.json
@@ -20156,6 +20156,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Revoke Agent grants and delete anyway",
+                        "name": "force",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -20165,6 +20173,16 @@
                             "*/*": {
                                 "schema": {
                                     "$ref": "#/components/schemas/types.Secret"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Secret is granted to one or more Agents",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
                                 }
                             }
                         }
@@ -29050,6 +29068,10 @@
                     "account_id": {
                         "type": "string"
                     },
+                    "available": {
+                        "description": "Available reports whether the bound source still exists. A\ndeleted source leaves the binding in place pointing at nothing,\nand this is the only signal the operator gets.",
+                        "type": "boolean"
+                    },
                     "content_type": {
                         "type": "string"
                     },
@@ -34649,7 +34671,7 @@
                         "type": "string"
                     },
                     "refresh_token_expires_at": {
-                        "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token.",
+                        "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token — omitzero so an absent\ndeadline reaches the client as absent, not as \"0001-01-01T00:00:00Z\",\nwhich reads as a date 739850 days in the past.",
                         "type": "string"
                     },
                     "scopes": {

--- a/swagger.json
+++ b/swagger.json
@@ -16992,6 +16992,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Revoke Agent grants and delete anyway",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -16999,6 +17005,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.Secret"
+                        }
+                    },
+                    "409": {
+                        "description": "Secret is granted to one or more Agents",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -24490,6 +24502,10 @@
                 "account_id": {
                     "type": "string"
                 },
+                "available": {
+                    "description": "Available reports whether the bound source still exists. A\ndeleted source leaves the binding in place pointing at nothing,\nand this is the only signal the operator gets.",
+                    "type": "boolean"
+                },
                 "content_type": {
                     "type": "string"
                 },
@@ -30089,7 +30105,7 @@
                     "type": "string"
                 },
                 "refresh_token_expires_at": {
-                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token.",
+                    "description": "RefreshTokenExpiresAt is when the login itself dies and the user must\nre-authenticate. Refreshing keeps the 8h access token alive but does not\nmove this, so it is the only honest basis for an expiry warning. Zero for\nsetup tokens, which carry no refresh token — omitzero so an absent\ndeadline reaches the client as absent, not as \"0001-01-01T00:00:00Z\",\nwhich reads as a date 739850 days in the past.",
                     "type": "string"
                 },
                 "scopes": {


### PR DESCRIPTION
## The bug

Deleting a project secret while an Agent held a grant on it left the binding row pointing at a dead id. `available-secrets` is a catalogue of *live* sources, so the deleted secret vanished from it by construction — and the binding list, the surface meant to show what an Agent holds, showed nothing wrong. The failure only surfaced as a `get_secret` error inside the sandbox at runtime.

Triggers already refuse deletion while workers are attached (`ErrSourceInUse`). Secrets had no equivalent.

## The fix

**Guard the delete.** `DELETE /api/v1/secrets/{id}` now returns 409 while grants exist, and `?force=true` revokes those grants along with the secret.

A hard block like the trigger one would be wrong here: a secret is a credential, and a leaked one has to be destroyable immediately, not after editing N agents. So the refusal is a confirmation step, not a wall. Grants are revoked *before* the secret — there is no transaction spanning the two stores, and a revoked grant on a live secret can be re-granted from the panel, while the reverse is the orphan this exists to prevent.

Both frontend delete sites turn the 409 into the confirm. Note `ProjectSettings` previously deleted a project secret on a **single click with no confirmation at all** — almost certainly the flow this was hit on.

**Surface the orphan.** `GET /orgs/{org}/agents/{id}/secrets` now returns `available` per binding. The domain already computed this in `Descriptors()`, but its only caller was the MCP `list_secrets` tool — the agent could see a grant was dead, the operator could not. The panel renders an unavailable grant in warning colour.

This second part covers the orphan paths the guard does not: deleting a `ServiceConnection`, or moving/clearing an Agent's project, break grants the same way. (Source fields were deliberately *not* added to `workersecret.Descriptor` — it is marshalled straight to the agent, whose tool contract promises backend source details are never returned.)

No FK, no `ON DELETE CASCADE`, no tombstone column — the check is application code, and a revoked grant is deleted rather than left as litter, since a re-created secret gets a new id and the binding could never heal.

## Tests

Written first, watched fail, then fixed:

- `TestDeleteSecret_GrantedToAgent_Refused` — failed with `status = 200, want 409`
- `TestDeleteSecret_Force_RevokesGrants` — failed with `binding survived a forced delete, orphaned at a dead secret id` (the reported bug, reproduced)
- `TestListWorkerSecrets_MarksDeletedSourceUnavailable` — failed with `LIVE_TOKEN should be available`

## Verified live

Against the dev stack on real Postgres (so the gorm `ListBySecretID` query is exercised, not just the in-memory store):

```
--- unforced delete:
HTTP 409
SMOKE_TOKEN is granted to 1 agent(s); deleting it revokes their access
--- secret still present? 1
--- binding still present? 1

--- forced delete:
HTTP 200
--- secret rows left:  0
--- binding rows left: 0
--- unrelated slack binding survived: SLACK_BOT_TOKEN|connected_account
```

And the availability field over HTTP:

```
DEAD_TOKEN      -> available = False
SLACK_BOT_TOKEN -> available = True
```

### Frontend, verified in the browser

Driven with Playwright against the dev stack at `localhost:8080` (logged in as `test@test.com`), all three surfaces:

**Secrets page** — delete → `Confirm Delete` / "UI_SMOKE_TOKEN is granted to 1 agent(s); deleting it revokes their access" / `CANCEL` `DELETE ANYWAY`. Confirming leaves 0 secret rows and 0 binding rows, and the table row disappears.

**Project settings → Secrets** — the path that previously deleted on one click with no confirmation now raises `Delete secret?` with the same message. "Delete anyway" → `Secret deleted` snackbar, 0 rows of each.

**Agent secrets panel** — a grant whose source is gone renders with an orange border and "Source deleted — this grant no longer resolves. Remove it or grant a new source.", directly above a healthy grant rendering normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)