### PR TITLE
fix(org): reject unknown tool names on bot create and update

### DIFF
--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -226,6 +226,11 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 			return CreateResult{}, fmt.Errorf("source: %w", err)
 		}
 	}
+	// Same reason: reject an unknown tool name before the agent app is
+	// created, so a typo doesn't cost a create-then-clean-up round trip.
+	if err := s.Nodes.ValidateTools(p.Tools); err != nil {
+		return CreateResult{}, err
+	}
 
 	agentName := strings.TrimSpace(p.Name)
 	if agentName == "" {

--- a/api/pkg/org/application/nodes/nodes.go
+++ b/api/pkg/org/application/nodes/nodes.go
@@ -39,6 +39,10 @@ var ErrReportingCycle = errors.New("reporting cycle")
 // repository is not wired. Adapters map it to 501.
 var ErrReportingLinesUnavailable = errors.New("reporting lines not wired")
 
+// ErrUnknownTool is returned by any write that would persist a tool name
+// the live registry does not know. Adapters map it to 400.
+var ErrUnknownTool = errors.New("unknown tool")
+
 // Nodes owns the node-mutation use cases.
 type Nodes struct {
 	nodes          store.Nodes
@@ -134,6 +138,9 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 	// An agent gets the caller's tools unioned with the read baseline.
 	tools := p.Tools
 	if p.Kind != orgchart.NodeKindHuman {
+		if err := s.ValidateTools(p.Tools); err != nil {
+			return orgchart.Node{}, err
+		}
 		tools = MergeTools(p.Tools, s.baseTools)
 	}
 	node, err := orgchart.NewNode(id, p.Content, tools, s.now(), orgID)
@@ -183,6 +190,11 @@ type UpdateParams struct {
 // With* builders, bumps UpdatedAt, and persists. Returns
 // store.ErrNotFound (wrapped) when the (orgID, id) row is absent.
 func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p UpdateParams) (orgchart.Node, error) {
+	if p.Tools != nil {
+		if err := s.ValidateTools(*p.Tools); err != nil {
+			return orgchart.Node{}, err
+		}
+	}
 	existing, err := s.nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return orgchart.Node{}, err
@@ -242,6 +254,9 @@ func normalizeProjectIDs(projectIDs []string) []string {
 // and a call that adds nothing writes nothing. Returns store.ErrNotFound
 // (wrapped) when the (orgID, id) row is absent.
 func (s *Nodes) AttachTools(ctx context.Context, orgID string, id orgchart.NodeID, names []tool.Name) (orgchart.Node, error) {
+	if err := s.ValidateTools(names); err != nil {
+		return orgchart.Node{}, err
+	}
 	existing, err := s.nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return orgchart.Node{}, err
@@ -457,6 +472,31 @@ func (s *Nodes) convergeToolNames(existing []tool.Name) []tool.Name {
 		out = append(out, name)
 	}
 	return out
+}
+
+// ValidateTools rejects any name the live registry does not know, so a
+// typo fails the whole write instead of persisting a dead name. A stored
+// name with no tool behind it is silently ignored at invoke time, which
+// leaves the Bot advertising a capability it does not have.
+//
+// It is the single validation the MCP tools and the REST handlers share.
+// An unavailable or empty catalogue skips the check for the same reason
+// pruning does: a runtime that hasn't wired the registry must not guess
+// a name is wrong.
+func (s *Nodes) ValidateTools(names []tool.Name) error {
+	if s == nil || len(names) == 0 || s.knownTools == nil {
+		return nil
+	}
+	known := s.knownTools()
+	if len(known) == 0 {
+		return nil
+	}
+	for _, name := range names {
+		if !known[name] {
+			return fmt.Errorf("%w %q", ErrUnknownTool, name)
+		}
+	}
+	return nil
 }
 
 // RenamedTools maps a retired tool name to the name (or names) that

--- a/api/pkg/org/application/nodes/validate_tools_test.go
+++ b/api/pkg/org/application/nodes/validate_tools_test.go
@@ -1,0 +1,95 @@
+package nodes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/nodes"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// A typo in a tool name must fail the write, not persist a dead name.
+// A Node carrying a name the registry doesn't know advertises a
+// capability it does not have: the tool is silently ignored at invoke
+// time, so the operator believes the Bot can do something it cannot.
+
+func TestCreate_RejectsUnknownTool(t *testing.T) {
+	st := memory.New()
+	_, err := svc(st, nil, live).Create(context.Background(), org, nodes.CreateParams{
+		ID:      "b-typo",
+		Content: "# Typo",
+		Tools:   []tool.Name{"chat", "not_a_real_tool_abc"},
+	})
+	require.ErrorIs(t, err, nodes.ErrUnknownTool)
+	require.ErrorContains(t, err, "not_a_real_tool_abc")
+
+	_, getErr := st.Nodes.Get(context.Background(), org, "b-typo")
+	require.ErrorIs(t, getErr, store.ErrNotFound, "rejected create must leave no row")
+}
+
+func TestUpdate_RejectsUnknownTool(t *testing.T) {
+	st := memory.New()
+	seed(t, st, "b-sam", []tool.Name{"chat"})
+
+	patch := []tool.Name{"chat", "totally_fake_tool_xyz"}
+	_, err := svc(st, nil, live).Update(context.Background(), org, "b-sam", nodes.UpdateParams{Tools: &patch})
+	require.ErrorIs(t, err, nodes.ErrUnknownTool)
+	require.ErrorContains(t, err, "totally_fake_tool_xyz")
+
+	require.Equal(t, []tool.Name{"chat"}, toolsOf(t, st, "b-sam"), "rejected patch must not mutate the row")
+}
+
+func TestAttachTools_RejectsUnknownTool(t *testing.T) {
+	st := memory.New()
+	seed(t, st, "b-sam", []tool.Name{"chat"})
+
+	_, err := svc(st, nil, live).AttachTools(context.Background(), org, "b-sam", []tool.Name{"not_a_real_tool_abc"})
+	require.ErrorIs(t, err, nodes.ErrUnknownTool)
+
+	require.Equal(t, []tool.Name{"chat"}, toolsOf(t, st, "b-sam"))
+}
+
+// Known names still write. The baseline union is applied after
+// validation, so a create with only known names is unaffected.
+func TestCreate_AcceptsRegisteredTools(t *testing.T) {
+	st := memory.New()
+	node, err := svc(st, []tool.Name{"managers"}, live).Create(context.Background(), org, nodes.CreateParams{
+		ID:      "b-ok",
+		Content: "# OK",
+		Tools:   []tool.Name{"chat", "attach_worker"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []tool.Name{"chat", "attach_worker", "managers"}, node.Tools)
+}
+
+// Same rule the pruning path follows: a runtime that hasn't wired the
+// registry must not guess. With no catalogue there is nothing to check
+// against, so the write goes through rather than failing every create.
+func TestCreate_UnwiredCatalogueSkipsValidation(t *testing.T) {
+	st := memory.New()
+	_, err := svc(st, nil, nil).Create(context.Background(), org, nodes.CreateParams{
+		ID:      "b-nocat",
+		Content: "# No catalogue",
+		Tools:   []tool.Name{"whatever_tool"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []tool.Name{"whatever_tool"}, toolsOf(t, st, "b-nocat"))
+}
+
+// A human placeholder never makes an MCP request and gets no tools —
+// validation must not reject the empty list it is created with.
+func TestCreate_HumanNodeUnaffected(t *testing.T) {
+	st := memory.New()
+	node, err := svc(st, []tool.Name{"managers"}, live).Create(context.Background(), org, nodes.CreateParams{
+		ID:          "h-user",
+		Content:     "Org member.",
+		Kind:        orgchart.NodeKindHuman,
+		HelixUserID: "usr-1",
+	})
+	require.NoError(t, err)
+	require.Empty(t, node.Tools)
+}

--- a/api/pkg/org/interfaces/mcptools/attach_tool.go
+++ b/api/pkg/org/interfaces/mcptools/attach_tool.go
@@ -52,9 +52,6 @@ func (t *AttachTool) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 	if len(args.Tools) == 0 {
 		return nil, fmt.Errorf("tools must contain at least one tool name")
 	}
-	if err := validateRegisteredTools(args.Tools, t.deps.ToolNames); err != nil {
-		return nil, err
-	}
 	orgID := inv.Caller.OrganizationID()
 	if orgID == "" {
 		return nil, fmt.Errorf("attach_tool: caller has no OrgID")
@@ -64,23 +61,4 @@ func (t *AttachTool) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 		return nil, err
 	}
 	return json.Marshal(map[string]any{"id": string(updated.ID), "tools": updated.Tools})
-}
-
-// validateRegisteredTools rejects any name not in the registered
-// catalogue so a typo fails the whole call rather than silently adding a
-// dead tool. No-op when the catalogue provider isn't wired.
-func validateRegisteredTools(names []string, provider func() []tool.Name) error {
-	if provider == nil {
-		return nil
-	}
-	valid := make(map[string]struct{})
-	for _, n := range provider() {
-		valid[n] = struct{}{}
-	}
-	for _, n := range names {
-		if _, ok := valid[n]; !ok {
-			return fmt.Errorf("unknown tool %q", n)
-		}
-	}
-	return nil
 }

--- a/api/pkg/org/interfaces/mcptools/bulk_tools_test.go
+++ b/api/pkg/org/interfaces/mcptools/bulk_tools_test.go
@@ -31,6 +31,9 @@ func bulkTestEnv(t *testing.T) (*store.Store, *Registry, botCaller) {
 	}
 	injectTestPublishing(&deps)
 	reg := NewRegistry()
+	// The catalogue is read lazily, so wiring it before RegisterBuiltins
+	// is what the composition root does too.
+	deps.KnownTools = Catalogue(reg)
 	if err := RegisterBuiltins(reg, deps.Build()); err != nil {
 		t.Fatalf("register builtins: %v", err)
 	}

--- a/api/pkg/org/interfaces/mcptools/create_bot.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot.go
@@ -90,9 +90,6 @@ func (t *CreateBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMe
 	if args.Content == "" {
 		return nil, fmt.Errorf("content is required")
 	}
-	if err := validateRegisteredTools(args.Tools, t.deps.ToolNames); err != nil {
-		return nil, err
-	}
 	orgID := inv.Caller.OrganizationID()
 	if orgID == "" {
 		return nil, fmt.Errorf("create_bot: caller has no OrgID")

--- a/api/pkg/org/interfaces/mcptools/detach_tool.go
+++ b/api/pkg/org/interfaces/mcptools/detach_tool.go
@@ -14,7 +14,9 @@ import (
 // DetachTool removes one or more tools from a Bot — the counterpart to
 // attach_tool. It refuses to remove a universal read-baseline tool (the
 // service enforces this): those are mandatory and would be re-added by
-// the reconciler anyway. Owner-only.
+// the reconciler anyway. A name the registry doesn't know is rejected up
+// front — DetachTools itself treats it as a no-op, so without the check a
+// typo would look like it worked. Owner-only.
 type DetachTool struct {
 	deps Deps
 }
@@ -50,7 +52,7 @@ func (t *DetachTool) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 	if len(args.Tools) == 0 {
 		return nil, fmt.Errorf("tools must contain at least one tool name")
 	}
-	if err := validateRegisteredTools(args.Tools, t.deps.ToolNames); err != nil {
+	if err := t.deps.Nodes.ValidateTools(args.Tools); err != nil {
 		return nil, err
 	}
 	orgID := inv.Caller.OrganizationID()

--- a/api/pkg/org/interfaces/mcptools/registry.go
+++ b/api/pkg/org/interfaces/mcptools/registry.go
@@ -50,6 +50,21 @@ func (r *Registry) Get(name tool.Name) (tool.Tool, error) {
 	return tool, nil
 }
 
+// Catalogue returns a closure over the registry's live tool names — the
+// catalogue the nodes service validates writes against and prunes
+// retired names with. Read lazily, so a composition root can inject it
+// before RegisterBuiltins has populated the registry.
+func Catalogue(reg *Registry) func() map[tool.Name]bool {
+	return func() map[tool.Name]bool {
+		all := reg.List()
+		out := make(map[tool.Name]bool, len(all))
+		for _, t := range all {
+			out[t.Name()] = true
+		}
+		return out
+	}
+}
+
 // List returns every registered tool, sorted by name for stable
 // rendering. Used by the chart UI's role editor to populate the
 // "Tools" multi-select with the catalogue of available tools.

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -450,6 +450,8 @@ func errStatus(err error) int {
 		return http.StatusNotFound
 	case errors.Is(err, store.ErrConflict):
 		return http.StatusConflict
+	case errors.Is(err, nodes.ErrUnknownTool):
+		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
 	}

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -64,9 +64,14 @@ func newDepsClock(t *testing.T, clock func() time.Time, newID func() string) (or
 	reg := configregistry.New(st.Configs)
 	topo := reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Triggers: st.Triggers, Attachments: st.WorkerAttachments, Now: clock})
 
+	// The MCP registry is the authority on which tool names exist. The
+	// REST harness wires it exactly as the composition root does, so a
+	// handler test sees the same tool-name validation production does.
+	toolReg := mcpRegistry(t, st, clock, newID)
 	botsSvc := nodes.New(nodes.Deps{
 		Nodes: st.Nodes, Lines: st.ReportingLines, Reconciler: topo,
 		Now: clock, NewID: newID, BaseTools: mcptools.BaseReadTools,
+		KnownTools: mcptools.Catalogue(toolReg),
 	})
 	assetsSvc, err := assets.New(assets.Deps{
 		Assets: st.Assets, Links: st.AssetLinks, Nodes: st.Nodes,
@@ -111,6 +116,7 @@ func newDepsClock(t *testing.T, clock func() time.Time, newID func() string) (or
 		ChartLayout: chartlayout.New(chartlayout.Deps{Positions: st.ChartPositions, Now: clock}),
 		Configs:     reg,
 		Hub:         hub,
+		Tools:       toolReg,
 	}
 	return deps, st, reg
 }

--- a/api/pkg/org/interfaces/server/api/bots_rest_test.go
+++ b/api/pkg/org/interfaces/server/api/bots_rest_test.go
@@ -248,7 +248,7 @@ func TestRESTUpdateNonHumanIdentityDoesNotRequireHumanAuthorization(t *testing.T
 func TestRESTUpdateAgentRollsBackOrgProfile(t *testing.T) {
 	deps, st, _ := newDeps(t)
 	ctx := context.Background()
-	bot, err := orgchart.NewNode("b-agent", "old content", []tool.Name{"old_tool"}, time.Now().UTC(), "org-test")
+	bot, err := orgchart.NewNode("b-agent", "old content", []tool.Name{mcptools.ManagersName}, time.Now().UTC(), "org-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,7 @@ func TestRESTUpdateAgentRollsBackOrgProfile(t *testing.T) {
 	rec := do(t, orgapi.Handler(deps), http.MethodPatch, "/bots/b-agent", orgapi.UpdateBotRequest{
 		Name:            &name,
 		Content:         &content,
-		Tools:           []string{"new_tool"},
+		Tools:           []string{mcptools.ChatName},
 		ProjectIDs:      []string{"prj-new"},
 		PreserveContext: &preserve,
 		Identity:        map[string]string{"new": "value"},
@@ -519,5 +519,59 @@ func TestSetBotContentParity_RESTvsMCP(t *testing.T) {
 	}
 	if restBot.Content != "rewritten content" {
 		t.Errorf("content not applied: %q", restBot.Content)
+	}
+}
+
+// TestRESTCreateBot_RejectsUnknownTool: a tool name the registry does not
+// know must fail the create rather than being merged into the baseline
+// and stored. A stored dead name is silently ignored at invoke time, so
+// a typo would leave the operator with a Bot missing a capability they
+// believe it has.
+func TestRESTCreateBot_RejectsUnknownTool(t *testing.T) {
+	deps, st, _ := newDeps(t)
+
+	rec := do(t, orgapi.Handler(deps), http.MethodPost, "/bots", orgapi.CreateBotRequest{
+		ID:      "b-typo",
+		Content: "# Typo",
+		Tools:   []string{mcptools.ChatName, "not_a_real_tool_abc"},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "not_a_real_tool_abc") {
+		t.Errorf("error should name the offending tool; body=%s", rec.Body)
+	}
+	if _, err := st.Nodes.Get(context.Background(), "org-test", "b-typo"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("rejected create left a bot row: %v", err)
+	}
+}
+
+// TestRESTUpdateBot_RejectsUnknownTool: the same guard on the patch path.
+func TestRESTUpdateBot_RejectsUnknownTool(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	bot, err := orgchart.NewNode("b-eng", "# Eng", []tool.Name{mcptools.ChatName}, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Nodes.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := do(t, orgapi.Handler(deps), http.MethodPatch, "/bots/b-eng", orgapi.UpdateBotRequest{
+		Tools: []string{mcptools.ChatName, "totally_fake_tool_xyz"},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "totally_fake_tool_xyz") {
+		t.Errorf("error should name the offending tool; body=%s", rec.Body)
+	}
+	got, err := st.Nodes.Get(ctx, "org-test", "b-eng")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameNames(got.Tools, []tool.Name{mcptools.ChatName}) {
+		t.Fatalf("rejected patch mutated the row: %v", got.Tools)
 	}
 }

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -937,14 +937,11 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	// read through a closure — by the time any per-org reconcile runs,
 	// RegisterBuiltins has populated it.
 	reg := mcptools.NewRegistry()
-	knownTools := func() map[tool.Name]bool {
-		all := reg.List()
-		out := make(map[tool.Name]bool, len(all))
-		for _, t := range all {
-			out[t.Name()] = true
-		}
-		return out
-	}
+	knownTools := mcptools.Catalogue(reg)
+	// The MCP surface builds its own nodes service off this Config, so it
+	// needs the same catalogue — otherwise a tool name only the REST path
+	// rejects would still be writable over MCP.
+	deps.KnownTools = knownTools
 	svc := buildOrgServices(st, &deps, bc, dispatcher, inboundProvisioners, knownTools)
 
 	// Auto-manage one Slack Trigger per connected workspace.


### PR DESCRIPTION
## The bug

Tool names weren't validated on the REST bot surface. `totally_fake_tool_xyz` was accepted with HTTP 200 on `PATCH /orgs/{org}/bots/{id}` and persisted to the DB; on create, `not_a_real_tool_abc` was merged into the default baseline and stored. A stored name the registry doesn't know is silently ignored at invoke time, so a typo leaves the operator with a Bot missing a capability they believe it has.

## Root cause

Two things:

1. **The write choke point had no guard.** `createBot` / `updateBot` passed `req.Tools` straight through to `lifecycle.Create` and `nodes.Update`, which wrote whatever they were given. Only the MCP tools validated — and each carried its own private copy of the check (`attach_tool`, `detach_tool`, `create_bot`), which is exactly the drift the `nodes` package doc says it exists to prevent: *"the single home for the node-mutation logic the MCP tools and REST handlers drive, so the semantics cannot drift between callers."*

2. **A live wiring gap.** `mcptools.Config.KnownTools` was never set at the composition root, so the nodes service the MCP surface builds had no catalogue at all. Only the REST-side service (built by `buildOrgServices`) got one.

## The fix

One validation, at the choke point:

- `nodes.ErrUnknownTool` + `(*Nodes).ValidateTools`, enforced in `Create`, `Update` (when the tools patch is non-nil), and `AttachTools`.
- `lifecycle.Create` pre-flights it alongside the existing source validation, so a typo doesn't create an agent app and then roll it back.
- `errStatus` maps it to 400.
- Deleted the duplicated `validateRegisteredTools`. `detach_tool` calls the service's version explicitly, because `DetachTools` treats an unknown name as a no-op and without the check a typo would look like it worked.
- `mcptools.Catalogue(reg)` replaces the hand-rolled closure at the composition root, and `deps.KnownTools` is now wired.

An unwired or empty catalogue skips the check — the same rule `convergeToolNames` already follows for pruning: a runtime that hasn't wired the registry must not guess a name is wrong.

## Tests

Red first. The two REST tests failed exactly as reported — `status = 201` on create, and `200` with `"tools":["chat","totally_fake_tool_xyz"]` persisted on PATCH.

- `validate_tools_test.go`: rejection on create/update/attach with no row written and no mutation, plus the accept path, the unwired-catalogue case, and human nodes (no tools, must not be rejected).
- `bots_rest_test.go`: 400 + offending name in the body + unchanged row, for both POST and PATCH.
- The REST harness now wires the real registry catalogue the way the composition root does, which is what makes those tests meaningful. That required `TestRESTUpdateAgentRollsBackOrgProfile` to use real tool names instead of `old_tool`/`new_tool`.

`go test ./pkg/org/... ./pkg/server/` passes.

## Live verification (dev stack, org `test`)

```
PATCH tools:[chat,totally_fake_tool_xyz]  → 400 {"error":"update bot: unknown tool \"totally_fake_tool_xyz\""}, DB row unchanged
POST  tools:[chat,not_a_real_tool_abc]    → 400, no org_bots row, apps count 2→2 (no orphan agent app)
PATCH tools:[...existing, list_projects]  → 200, persisted  (then restored to the original list)
```

**NOT verified live: the MCP path.** The MCP gateway requires a session-scoped API key I'd have to manufacture. It's covered by the `bulk_tools_test` assertions, which now run with the catalogue wired as production does.

## Noted, not fixed

`assets.go:309,347` writes `WithTools(...)` directly on the node row, bypassing the service. Those values come from a fixed internal `toolsForKind` set rather than operator input, so it isn't this bug — but it is a second write path outside the choke point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
