### PR TITLE
fix(specs): recover from missing legacy coding agent

### DIFF
--- a/api/pkg/services/spec_task_execution_config.go
+++ b/api/pkg/services/spec_task_execution_config.go
@@ -47,7 +47,7 @@ func (s *SpecDrivenTaskService) migrateSpecTaskCodeAgentConfig(
 		if legacyProjectAppID != "" {
 			app, err := s.store.GetApp(ctx, legacyProjectAppID)
 			if err != nil {
-				if project.CodeAgentConfig == nil || !errors.Is(err, store.ErrNotFound) {
+				if !errors.Is(err, store.ErrNotFound) {
 					return fmt.Errorf("load legacy project coding agent %s: %w", legacyProjectAppID, err)
 				}
 				project.DefaultHelixAppID = ""
@@ -56,6 +56,7 @@ func (s *SpecDrivenTaskService) migrateSpecTaskCodeAgentConfig(
 				}
 				log.Warn().Str("project_id", project.ID).Str("legacy_app_id", legacyProjectAppID).
 					Msg("Cleared missing legacy project App after code-agent config migration")
+				legacyProjectAppID = ""
 				app = nil
 			}
 			if app != nil {
@@ -114,7 +115,7 @@ func (s *SpecDrivenTaskService) migrateSpecTaskCodeAgentConfig(
 		config = external_agent.ApplyExecutionOverrides(config, task.CodeAgentOverrides)
 	}
 	if config == nil {
-		return fmt.Errorf("no code-agent configuration is available")
+		return fmt.Errorf("no coding agent is configured; select one for this task or project and retry")
 	}
 
 	task.CodeAgentConfig = config

--- a/api/pkg/services/spec_task_execution_config_test.go
+++ b/api/pkg/services/spec_task_execution_config_test.go
@@ -127,3 +127,96 @@ func TestMigrateSpecTaskCodeAgentConfigClearsProjectAppAfterPartialMigration(t *
 
 	require.NoError(t, service.migrateSpecTaskCodeAgentConfig(context.Background(), task, project))
 }
+
+func TestMigrateSpecTaskCodeAgentConfigRecoversTaskConfigFromMissingProjectApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := &SpecDrivenTaskService{store: mockStore}
+	config := &types.CodeAgentExecutionConfig{
+		Runtime: types.CodeAgentRuntimeCodexCLI, CredentialType: types.CodeAgentCredentialTypeSubscription, Model: "gpt-5.6-sol",
+	}
+	project := &types.Project{ID: "project-1", DefaultHelixAppID: "app-missing"}
+	task := &types.SpecTask{ID: "task-1", ProjectID: project.ID, CodeAgentConfig: config}
+
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-missing").Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().UpdateProject(gomock.Any(), project).DoAndReturn(func(_ context.Context, got *types.Project) error {
+		require.Empty(t, got.DefaultHelixAppID)
+		return nil
+	})
+
+	require.NoError(t, service.migrateSpecTaskCodeAgentConfig(context.Background(), task, project))
+	require.Equal(t, config, task.CodeAgentConfig)
+}
+
+func TestMigrateSpecTaskCodeAgentConfigRecoversProjectConfigFromMissingProjectApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := &SpecDrivenTaskService{store: mockStore}
+	config := &types.CodeAgentExecutionConfig{
+		Runtime: types.CodeAgentRuntimeCodexCLI, CredentialType: types.CodeAgentCredentialTypeSubscription, Model: "gpt-5.6-sol",
+	}
+	project := &types.Project{ID: "project-1", DefaultHelixAppID: "app-missing", CodeAgentConfig: config}
+	task := &types.SpecTask{ID: "task-1", ProjectID: project.ID}
+
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-missing").Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().UpdateProject(gomock.Any(), project).DoAndReturn(func(_ context.Context, got *types.Project) error {
+		require.Empty(t, got.DefaultHelixAppID)
+		return nil
+	})
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), task).DoAndReturn(func(_ context.Context, got *types.SpecTask) error {
+		require.Equal(t, config, got.CodeAgentConfig)
+		return nil
+	})
+
+	require.NoError(t, service.migrateSpecTaskCodeAgentConfig(context.Background(), task, project))
+}
+
+func TestMigrateSpecTaskCodeAgentConfigRecoversLegacyTaskAppFromMissingProjectApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := &SpecDrivenTaskService{store: mockStore}
+	project := &types.Project{ID: "project-1", DefaultHelixAppID: "app-missing"}
+	task := &types.SpecTask{ID: "task-1", ProjectID: project.ID, HelixAppID: "app-legacy"}
+	app := legacyCodingApp(types.AgentKindCoding)
+
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-missing").Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().UpdateProject(gomock.Any(), project).DoAndReturn(func(_ context.Context, got *types.Project) error {
+		require.Empty(t, got.DefaultHelixAppID)
+		return nil
+	})
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-legacy").Return(app, nil)
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), task).DoAndReturn(func(_ context.Context, got *types.SpecTask) error {
+		require.Empty(t, got.HelixAppID)
+		require.NotNil(t, got.CodeAgentConfig)
+		return nil
+	})
+
+	require.NoError(t, service.migrateSpecTaskCodeAgentConfig(context.Background(), task, project))
+}
+
+func TestMigrateSpecTaskCodeAgentConfigReportsMissingProjectAgent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := &SpecDrivenTaskService{store: mockStore}
+	project := &types.Project{ID: "project-1", DefaultHelixAppID: "app-missing"}
+	task := &types.SpecTask{ID: "task-1", ProjectID: project.ID}
+
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-missing").Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().UpdateProject(gomock.Any(), project).DoAndReturn(func(_ context.Context, got *types.Project) error {
+		require.Empty(t, got.DefaultHelixAppID)
+		return nil
+	})
+
+	err := service.migrateSpecTaskCodeAgentConfig(context.Background(), task, project)
+	require.EqualError(t, err, "no coding agent is configured; select one for this task or project and retry")
+	require.NotContains(t, err.Error(), "app-missing")
+}
+
+func TestMigrateSpecTaskCodeAgentConfigReportsProjectlessTaskWithoutConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := &SpecDrivenTaskService{store: store.NewMockStore(ctrl)}
+	task := &types.SpecTask{ID: "task-1"}
+
+	err := service.migrateSpecTaskCodeAgentConfig(context.Background(), task, nil)
+	require.EqualError(t, err, "no coding agent is configured; select one for this task or project and retry")
+}


### PR DESCRIPTION
## Summary
- clear stale legacy project coding-agent references when the App has been deleted
- continue from task, project, or legacy task-owned configuration when available
- return an actionable configuration error without exposing internal App IDs

## Testing
- `CGO_ENABLED=1 go test ./pkg/services -run 'TestMigrateSpecTaskCodeAgentConfig' -count=1`
- `CGO_ENABLED=1 go test ./pkg/services -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`