### PR TITLE
fix(org): let users clear stuck agent work

### DIFF
--- a/api/pkg/org/application/activations/activations.go
+++ b/api/pkg/org/application/activations/activations.go
@@ -51,6 +51,10 @@ type SessionResetter interface {
 	ResetSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionID string) error
 }
 
+type OutstandingCanceller interface {
+	CancelOutstanding(ctx context.Context, orgID string, workerID orgchart.NodeID) error
+}
+
 // ErrActivateUnavailable is returned by Activate when the project
 // ensurer or dispatcher isn't wired. Adapters map it to 501.
 var ErrActivateUnavailable = errors.New("activate is not wired in this deployment")
@@ -71,6 +75,7 @@ type Activations struct {
 	sessions   SessionResolver
 	stopper    DesktopStopper
 	resetter   SessionResetter
+	canceller  OutstandingCanceller
 }
 
 // Deps are the constructor-injected collaborators for New. Repo may be
@@ -88,6 +93,7 @@ type Deps struct {
 	Sessions   SessionResolver
 	Stopper    DesktopStopper
 	Resetter   SessionResetter
+	Canceller  OutstandingCanceller
 }
 
 // New constructs the Activations service.
@@ -105,6 +111,7 @@ func New(deps Deps) *Activations {
 		sessions:   deps.Sessions,
 		stopper:    deps.Stopper,
 		resetter:   deps.Resetter,
+		canceller:  deps.Canceller,
 	}
 }
 
@@ -179,6 +186,11 @@ func (a *Activations) Stop(ctx context.Context, orgID string, workerID orgchart.
 	if err := orgchart.ValidID(string(workerID)); err != nil {
 		return StopResult{}, fmt.Errorf("worker id: %w", err)
 	}
+	if a.canceller != nil {
+		if err := a.canceller.CancelOutstanding(ctx, orgID, workerID); err != nil {
+			return StopResult{}, fmt.Errorf("cancel outstanding activations: %w", err)
+		}
+	}
 	var sessionID string
 	if a.sessions != nil {
 		sessionID, _ = a.sessions.SessionID(ctx, orgID, workerID)
@@ -199,6 +211,11 @@ func (a *Activations) Stop(ctx context.Context, orgID string, workerID orgchart.
 func (a *Activations) Restart(ctx context.Context, orgID string, workerID orgchart.NodeID) (ActivateResult, error) {
 	if err := orgchart.ValidID(string(workerID)); err != nil {
 		return ActivateResult{}, fmt.Errorf("worker id: %w", err)
+	}
+	if a.canceller != nil {
+		if err := a.canceller.CancelOutstanding(ctx, orgID, workerID); err != nil {
+			return ActivateResult{}, fmt.Errorf("cancel outstanding activations: %w", err)
+		}
 	}
 	var sessionID string
 	if a.sessions != nil {

--- a/api/pkg/org/application/activations/activations_test.go
+++ b/api/pkg/org/application/activations/activations_test.go
@@ -19,10 +19,16 @@ func (fakeEnsurer) Ensure(_ context.Context, _ string, _ orgchart.NodeID) (strin
 	return "prj-1", "app-1", "repo-1", nil
 }
 
-type fakeDispatcher struct{ gotID activation.ID }
+type fakeDispatcher struct {
+	gotID  activation.ID
+	events *[]string
+}
 
 func (f *fakeDispatcher) DispatchManual(_ context.Context, _ string, _ orgchart.NodeID, activationID activation.ID) {
 	f.gotID = activationID
+	if f.events != nil {
+		*f.events = append(*f.events, "dispatch")
+	}
 }
 
 // TestActivate_PreAllocatesAuditRow: with a wired repo, Activate mints the
@@ -105,6 +111,19 @@ type fakeResetter struct {
 	bot    orgchart.NodeID
 }
 
+type fakeCanceller struct {
+	called bool
+	events *[]string
+}
+
+func (f *fakeCanceller) CancelOutstanding(_ context.Context, _ string, _ orgchart.NodeID) error {
+	f.called = true
+	if f.events != nil {
+		*f.events = append(*f.events, "cancel")
+	}
+	return nil
+}
+
 func (f *fakeResetter) ResetSession(_ context.Context, orgID string, workerID orgchart.NodeID, sessionID string) error {
 	f.called = sessionID
 	f.org = orgID
@@ -115,9 +134,11 @@ func (f *fakeResetter) ResetSession(_ context.Context, orgID string, workerID or
 func TestStop_NoSessionIsNoop(t *testing.T) {
 	t.Parallel()
 	stopper := &fakeStopper{}
+	canceller := &fakeCanceller{}
 	svc := New(Deps{
-		Sessions: fakeSessions{id: ""},
-		Stopper:  stopper,
+		Sessions:  fakeSessions{id: ""},
+		Stopper:   stopper,
+		Canceller: canceller,
 	})
 	res, err := svc.Stop(context.Background(), "org-test", "w-mark")
 	if err != nil {
@@ -128,6 +149,9 @@ func TestStop_NoSessionIsNoop(t *testing.T) {
 	}
 	if stopper.called != "" {
 		t.Fatalf("StopDesktop called with %q, want no call", stopper.called)
+	}
+	if !canceller.called {
+		t.Fatal("outstanding activations were not cancelled")
 	}
 }
 
@@ -152,8 +176,10 @@ func TestStop_StopsDesktop(t *testing.T) {
 
 func TestRestart_ResetsThenActivates(t *testing.T) {
 	t.Parallel()
-	disp := &fakeDispatcher{}
+	events := []string{}
+	disp := &fakeDispatcher{events: &events}
 	resetter := &fakeResetter{}
+	canceller := &fakeCanceller{events: &events}
 	svc := New(Deps{
 		Repo:       memory.New().Activations,
 		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
@@ -162,6 +188,7 @@ func TestRestart_ResetsThenActivates(t *testing.T) {
 		Dispatcher: disp,
 		Sessions:   fakeSessions{id: "ses_old"},
 		Resetter:   resetter,
+		Canceller:  canceller,
 	})
 	res, err := svc.Restart(context.Background(), "org-test", "w-mark")
 	if err != nil {
@@ -169,6 +196,12 @@ func TestRestart_ResetsThenActivates(t *testing.T) {
 	}
 	if resetter.called != "ses_old" || resetter.bot != "w-mark" {
 		t.Fatalf("resetter = %+v, want ses_old / w-mark", resetter)
+	}
+	if !canceller.called {
+		t.Fatal("outstanding activations were not cancelled before restart")
+	}
+	if len(events) != 2 || events[0] != "cancel" || events[1] != "dispatch" {
+		t.Fatalf("restart order = %v, want [cancel dispatch]", events)
 	}
 	if res.ActivationID != "a-restart" {
 		t.Fatalf("activation id = %q, want a-restart", res.ActivationID)

--- a/api/pkg/org/infrastructure/agentdelivery/queue.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue.go
@@ -125,6 +125,23 @@ func (q *Queue) CleanupAgent(ctx context.Context, orgID string, agentID orgchart
 	return nil
 }
 
+// CancelOutstanding discards queued and in-flight deliveries without marking
+// the agent removed, so Restart can enqueue a clean activation immediately.
+func (q *Queue) CancelOutstanding(ctx context.Context, orgID string, agentID orgchart.NodeID) error {
+	name := consumerName(orgID, agentID)
+	lock := q.publishLock(name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := q.pubsub.DeleteDurableConsumer(ctx, streamName, name); err != nil {
+		return err
+	}
+	q.mu.Lock()
+	delete(q.active, name)
+	q.mu.Unlock()
+	return q.pubsub.PurgeDurableSubject(ctx, streamName, subjectFor(orgID, agentID))
+}
+
 func (q *Queue) RestoreAgent(orgID string, agentID orgchart.NodeID) {
 	name := consumerName(orgID, agentID)
 	lock := q.publishLock(name)

--- a/api/pkg/org/infrastructure/agentdelivery/queue_test.go
+++ b/api/pkg/org/infrastructure/agentdelivery/queue_test.go
@@ -124,3 +124,32 @@ func TestQueueCleanupAgentRemovesConsumerAndPendingMessages(t *testing.T) {
 	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerHire, EventID: "recreated"})
 	require.Equal(t, "recreated", <-seen)
 }
+
+func TestQueueCancelOutstandingAllowsFreshActivation(t *testing.T) {
+	n, err := pubsub.NewInMemoryNats()
+	require.NoError(t, err)
+	defer n.Close()
+
+	seen := make(chan string, 2)
+	q, err := New(context.Background(), n, func(_ context.Context, _ string, _ orgchart.NodeID, triggers []activation.Trigger) error {
+		seen <- triggers[0].EventID
+		if triggers[0].EventID == "old" {
+			return errors.New("unconfigured")
+		}
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	defer q.Close()
+
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "old"})
+	require.Equal(t, "old", <-seen)
+	require.NoError(t, q.CancelOutstanding(context.Background(), "org-test", "agent-a"))
+
+	q.Enqueue("org-test", "agent-a", activation.Trigger{Kind: activation.TriggerManual, EventID: "fresh"})
+	select {
+	case got := <-seen:
+		require.Equal(t, "fresh", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("fresh activation remained blocked behind cancelled delivery")
+	}
+}

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -702,6 +702,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	})
 	dispatcher := dispatch.New(st, spawnerFn, logger)
 	var agentDelivery lifecycle.AgentDeliveryLifecycle
+	var activationCanceller activations.OutstandingCanceller
 	if provider, ok := cfg.APIServer.pubsub.(pubsub.DurablePubSub); ok {
 		durableQueue, err := agentdelivery.New(ctx, provider, activation.Spawn(spawnerFn), logger)
 		if err != nil {
@@ -712,6 +713,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 		}
 		dispatcher.RegisterActivationQueue(durableQueue)
 		agentDelivery = durableQueue
+		activationCanceller = durableQueue
 	}
 	// slackWS resolves the encrypted workspace install, both for inbound
 	// team-id resolution and for Worker secret bindings (a Worker replying
@@ -1060,6 +1062,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 		Sessions:   workerRuntime,
 		Stopper:    sessionResetter,
 		Resetter:   sessionResetter,
+		Canceller:  activationCanceller,
 	})
 	deps.Activations = svc.Activations
 	// Share the processors service with MCP tools so create_processor uses

--- a/frontend/src/components/session/SessionPromptQueue.test.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SessionPromptQueue from './SessionPromptQueue'
+
+const mocks = vi.hoisted(() => ({
+  deletePrompt: vi.fn(),
+  listPrompts: vi.fn(),
+}))
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => ({
+    getApiClient: () => ({ v1PromptHistoryDelete: mocks.deletePrompt }),
+  }),
+}))
+
+vi.mock('../../services/promptHistoryService', () => ({
+  listSessionPromptHistory: (...args: unknown[]) => mocks.listPrompts(...args),
+}))
+
+describe('SessionPromptQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.deletePrompt.mockResolvedValue({})
+    mocks.listPrompts.mockResolvedValue({
+      entries: [{ id: 'prompt-1', status: 'sending', content: 'stuck prompt' }],
+    })
+  })
+
+  it('deletes a stuck prompt and refreshes the queue', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SessionPromptQueue sessionId="session-1" />
+      </QueryClientProvider>,
+    )
+
+    await screen.findByText('stuck prompt')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove from queue' }))
+
+    await waitFor(() => expect(mocks.deletePrompt).toHaveBeenCalledWith('prompt-1'))
+    await waitFor(() => expect(mocks.listPrompts).toHaveBeenCalledTimes(2))
+  })
+})

--- a/frontend/src/components/session/SessionPromptQueue.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.tsx
@@ -11,10 +11,11 @@
  * affordance here as on spec-task pages.
  */
 import React, { useState } from 'react'
-import { Box, Button, Chip, Stack, Typography } from '@mui/material'
+import { Box, Button, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material'
 import ScheduleIcon from '@mui/icons-material/Schedule'
 import RestartAltIcon from '@mui/icons-material/RestartAlt'
-import { useQuery } from '@tanstack/react-query'
+import CloseIcon from '@mui/icons-material/Close'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import useApi from '../../hooks/useApi'
 import { listSessionPromptHistory } from '../../services/promptHistoryService'
 import { TypesPromptHistoryEntry } from '../../api/api'
@@ -31,6 +32,7 @@ const VISIBLE_STATUSES = new Set(['pending', 'sending', 'failed'])
 const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) => {
   const api = useApi()
   const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
   const [isRestarting, setIsRestarting] = useState(false)
 
   const { data } = useQuery({
@@ -57,6 +59,12 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
       .finally(() => setIsRestarting(false))
   }
 
+  const handleRemove = (entryId: string) => {
+    apiClient.v1PromptHistoryDelete(entryId)
+      .then(() => queryClient.invalidateQueries({ queryKey: ['session-prompt-queue', sessionId] }))
+      .catch((err: unknown) => console.warn('Failed to delete prompt from backend:', err))
+  }
+
   const queuedCount = visible.filter((e) => e.status !== 'failed').length
 
   return (
@@ -78,6 +86,7 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
       </Stack>
       <Stack spacing={0.5}>
         {visible.map((e) => {
+          const entryID = e.id
           const status = classifyPromptQueueEntry({
             status: e.status,
             errorMessage: e.error_message,
@@ -117,6 +126,18 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
                 >
                   {e.content}
                 </Typography>
+                {entryID && (
+                  <Tooltip title="Remove from queue">
+                    <IconButton
+                      size="small"
+                      aria-label="Remove from queue"
+                      onClick={() => handleRemove(entryID)}
+                      sx={{ p: 0.5, flexShrink: 0 }}
+                    >
+                      <CloseIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </Tooltip>
+                )}
               </Stack>
               {isFailed && (
                 <Stack direction="row" alignItems="center" spacing={1} sx={{ pl: 0.5 }}>


### PR DESCRIPTION
Fixes the recovery gaps reported in #3099.

- Cancel outstanding durable agent activations when users stop or restart an agent.
- Purge the poisoned per-agent FIFO lane before restart enqueues fresh work.
- Add a Remove action for stuck session prompt queue entries using the existing delete endpoint.

Tests:
- go test ./pkg/org/infrastructure/agentdelivery ./pkg/org/application/activations ./pkg/server -run TestQueueCancelOutstandingAllowsFreshActivation\|TestStop_NoSessionIsNoop\|TestRestart_ResetsThenActivates\|^$ -count=1
- yarn vitest run src/components/session/SessionPromptQueue.test.tsx
- git diff --check

Full frontend TypeScript checking remains blocked on main by the existing WorkspaceReviewMessage.ts filename casing conflict.