### PR TITLE
Right-size spec-task sandbox defaults and replay stream init on reconnect

### DIFF
--- a/api/pkg/cli/sandbox/sandbox.go
+++ b/api/pkg/cli/sandbox/sandbox.go
@@ -249,7 +249,7 @@ Pass --project to associate the sandbox with a project (optional).`,
 	cmd.Flags().StringVar(&name, "name", "", "Display name")
 	cmd.Flags().StringVar(&runtime, "runtime", "", "Configured runtime name (e.g. headless-ubuntu, node22). Empty = server default.")
 	cmd.Flags().StringVar(&image, "image", "", "Custom Docker image (requires HELIX_SANDBOX_ALLOW_CUSTOM_IMAGE=true on the server)")
-	cmd.Flags().StringVar(&size, "size", "small", "Resource size: small=1CPU/2GB, medium=4CPU/8GB, large=8CPU/16GB")
+	cmd.Flags().StringVar(&size, "size", "small", "Resource size: small=1CPU/2GB, medium=4CPU/8GB, large=8CPU/16GB, xlarge=12CPU/24GB, 2xlarge=16CPU/32GB")
 	cmd.Flags().IntVar(&ttl, "ttl", 600, "Lifetime in seconds")
 	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for status=running")
 	cmd.Flags().BoolVar(&persistent, "persistent", false, "Mount a persistent workspace volume that survives container restarts")
@@ -264,8 +264,12 @@ func parseSandboxSize(size string) (int, int, error) {
 		return 4, 8192, nil
 	case "large", "8cpu-16gb":
 		return 8, 16384, nil
+	case "xlarge", "12cpu-24gb":
+		return 12, 24576, nil
+	case "2xlarge", "16cpu-32gb":
+		return 16, 32768, nil
 	default:
-		return 0, 0, fmt.Errorf("invalid sandbox size %q: use small, medium, or large", size)
+		return 0, 0, fmt.Errorf("invalid sandbox size %q: use small, medium, large, xlarge, or 2xlarge", size)
 	}
 }
 

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -187,6 +187,18 @@ type Sandboxes struct {
 	// internal mirror serving the same JSON shape for air-gapped installs.
 	// Empty uses the public GitHub API.
 	OpenCodeReleasesURL string `envconfig:"HELIX_OPENCODE_RELEASES_URL"`
+
+	// DefaultSpecTaskVCPUs / DefaultSpecTaskMemoryMB size the desktop container a
+	// spec task gets when neither the task nor its project chose a size. They must
+	// form a valid preset (types.SandboxResourceOverrides.ValidPreset) — memory is
+	// keyed off vCPUs everywhere else in the system, so an arbitrary pairing here
+	// would produce a container the UI cannot represent and a failed resize cannot
+	// roll back to. An invalid pair fails startup rather than being ignored.
+	//
+	// The defaults below are the correct out-of-the-box values; these exist so an
+	// operator with a bigger or smaller box can move them without a rebuild.
+	DefaultSpecTaskVCPUs    int `envconfig:"HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS" default:"12"`
+	DefaultSpecTaskMemoryMB int `envconfig:"HELIX_SPEC_TASK_SANDBOX_DEFAULT_MEMORY_MB" default:"24576"`
 }
 
 // Compute configures the cloud-provisioning side of Helix's sandbox
@@ -456,6 +468,17 @@ func LoadServerConfig() (ServerConfig, error) {
 			return ServerConfig{}, err
 		}
 		cfg.WebServer.AssetSSHProxyAddress = address
+	}
+	// The spec task sandbox default is read from packages that have no config
+	// handle (desktopBillingResources is a free function; HydraExecutor holds no
+	// ServerConfig), so it is installed as a process-wide value here rather than
+	// threaded through ten constructors. Set once, before anything serves.
+	if err := types.SetDefaultSpecTaskSandboxResources(types.SandboxResourceOverrides{
+		VCPUs:    cfg.Sandboxes.DefaultSpecTaskVCPUs,
+		MemoryMB: cfg.Sandboxes.DefaultSpecTaskMemoryMB,
+	}); err != nil {
+		return ServerConfig{}, fmt.Errorf(
+			"HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB: %w", err)
 	}
 	return cfg, nil
 }

--- a/api/pkg/external-agent/task_overrides_test.go
+++ b/api/pkg/external-agent/task_overrides_test.go
@@ -75,8 +75,43 @@ func TestSandboxResourceOverridesValidPreset(t *testing.T) {
 	require.True(t, (types.SandboxResourceOverrides{VCPUs: 1, MemoryMB: 2048}).ValidPreset())
 	require.True(t, (types.SandboxResourceOverrides{VCPUs: 4, MemoryMB: 8192}).ValidPreset())
 	require.True(t, (types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384}).ValidPreset())
+	require.True(t, (types.SandboxResourceOverrides{VCPUs: 12, MemoryMB: 24576}).ValidPreset())
+	require.True(t, (types.SandboxResourceOverrides{VCPUs: 16, MemoryMB: 32768}).ValidPreset())
 	require.False(t, (types.SandboxResourceOverrides{VCPUs: 4, MemoryMB: 4096}).ValidPreset())
 	require.False(t, (types.SandboxResourceOverrides{}).ValidPreset())
+}
+
+// The rungs that predate the 2026-08-24 ladder extension must stay valid: every
+// ValidPreset() call site guards an incoming request, so a rung that stopped
+// being a preset would make the next update of an existing row fail. 178 rows on
+// meta hold 8/16384 as a deliberate choice.
+func TestSandboxResourceOverridesExistingRungsStayValid(t *testing.T) {
+	for _, legacy := range []types.SandboxResourceOverrides{
+		{VCPUs: 1, MemoryMB: 2048},
+		{VCPUs: 4, MemoryMB: 8192},
+		{VCPUs: 8, MemoryMB: 16384},
+	} {
+		require.True(t, legacy.ValidPreset(), "rung %+v must remain selectable", legacy)
+	}
+}
+
+func TestSetDefaultSpecTaskSandboxResources(t *testing.T) {
+	original := *types.DefaultSpecTaskSandboxResources()
+	t.Cleanup(func() {
+		require.NoError(t, types.SetDefaultSpecTaskSandboxResources(original))
+	})
+
+	require.NoError(t, types.SetDefaultSpecTaskSandboxResources(
+		types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384}))
+	require.Equal(t, types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384},
+		types.EffectiveSpecTaskSandboxResources(nil))
+
+	// An operator who configures a pair off the ladder is told, not silently
+	// given something else — and the previously installed value survives.
+	require.Error(t, types.SetDefaultSpecTaskSandboxResources(
+		types.SandboxResourceOverrides{VCPUs: 6, MemoryMB: 12288}))
+	require.Equal(t, types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384},
+		types.EffectiveSpecTaskSandboxResources(nil))
 }
 
 func TestEffectiveSpecTaskSandboxResourcesUsesDefault(t *testing.T) {

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1101,8 +1102,23 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 	return hostConfig, nil
 }
 
+// sandboxResourceLimits converts a preset into Docker's units.
+//
+// vCPUs are clamped to the host's CPU count because Docker REJECTS a NanoCPUs
+// above it outright ("Range of CPUs is from 0.01 to N.00, as there are only N
+// CPUs available") — an unclamped default larger than a small host would fail
+// container creation rather than degrade. Memory needs no such clamp: Docker
+// accepts a limit above host RAM, and an unreachable ceiling is strictly better
+// than one that OOM-kills the desktop.
 func sandboxResourceLimits(vcpus, memoryMB int) (nanoCPUs, memory, memorySwap int64) {
 	if vcpus > 0 {
+		if hostCPUs := runtime.NumCPU(); vcpus > hostCPUs {
+			log.Warn().
+				Int("requested_vcpus", vcpus).
+				Int("host_cpus", hostCPUs).
+				Msg("Clamping sandbox vCPUs to host CPU count; Docker rejects a larger limit")
+			vcpus = hostCPUs
+		}
 		nanoCPUs = int64(vcpus) * 1_000_000_000
 	}
 	if memoryMB > 0 {

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -43,6 +44,24 @@ func TestSandboxResourceLimits(t *testing.T) {
 	}
 	if memorySwap != wantMemory*2 {
 		t.Fatalf("MemorySwap = %d, want %d", memorySwap, wantMemory*2)
+	}
+}
+
+// Docker refuses a NanoCPUs above the host CPU count outright, so an unclamped
+// default larger than a small host fails container creation rather than degrade.
+func TestSandboxResourceLimitsClampsVCPUsToHost(t *testing.T) {
+	hostCPUs := runtime.NumCPU()
+
+	nanoCPUs, _, _ := sandboxResourceLimits(hostCPUs*2, 1024)
+	if want := int64(hostCPUs) * 1_000_000_000; nanoCPUs != want {
+		t.Fatalf("NanoCPUs = %d, want %d (clamped to host)", nanoCPUs, want)
+	}
+
+	// Memory is deliberately NOT clamped: Docker accepts a limit above host RAM,
+	// and an unreachable ceiling beats one that OOM-kills the desktop.
+	_, memory, _ := sandboxResourceLimits(1, 1024*1024)
+	if want := int64(1024*1024) * 1024 * 1024; memory != want {
+		t.Fatalf("Memory = %d, want %d (unclamped)", memory, want)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks.go
@@ -197,22 +197,21 @@ func (s *SpecTasks) Create(ctx context.Context, orgID string, workerID orgchart.
 	}
 
 	// Sandbox size and runtime resolve exactly as CreateTaskFromPrompt resolves
-	// them for the REST path: explicit value, else the project default, else
-	// the global default. A Worker filing a task through MCP must land on the
-	// same sandbox it would have got through the UI.
+	// them for the REST path: explicit value, else the project default, else nil
+	// and the global default is applied at container-create time. A Worker filing
+	// a task through MCP must land on the same sandbox it would have got through
+	// the UI.
 	var sandboxResources *types.SandboxResourceOverrides
 	if in.SandboxVCPUs != 0 {
 		preset, ok := types.SpecTaskSandboxPresetForVCPUs(in.SandboxVCPUs)
 		if !ok {
-			return runtime.SpecTaskView{}, fmt.Errorf("sandbox_vcpus must be 1, 4 or 8 (got %d)", in.SandboxVCPUs)
+			return runtime.SpecTaskView{}, fmt.Errorf("sandbox_vcpus must be one of %s (got %d)",
+				types.SpecTaskSandboxVCPUList(), in.SandboxVCPUs)
 		}
 		sandboxResources = preset
 	} else if project.DefaultSandboxResourceOverrides != nil {
 		projectResources := *project.DefaultSandboxResourceOverrides
 		sandboxResources = &projectResources
-	}
-	if sandboxResources == nil {
-		sandboxResources = types.DefaultSpecTaskSandboxResources()
 	}
 
 	sandboxRuntime := types.SandboxRuntime(strings.TrimSpace(in.SandboxRuntime))

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks_sandbox_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks_sandbox_test.go
@@ -94,9 +94,14 @@ func TestSpecTasks_CreateFallsBackToProjectSandboxDefaults(t *testing.T) {
 	}
 }
 
-// With neither an explicit value nor a project default, the global defaults
-// apply — a task must never be created with an empty sandbox spec.
-func TestSpecTasks_CreateUsesGlobalSandboxDefaults(t *testing.T) {
+// With neither an explicit value nor a project default, the row stores NO
+// override and the global default is resolved at container-create time.
+//
+// Materializing it here is what froze every task created after 1eff4e801 at
+// 4 vCPU / 8 GB: a stored override is indistinguishable from a user's choice, so
+// a raised default could never reach those rows. Asserting nil is the point of
+// this test, not an accident of it.
+func TestSpecTasks_CreateLeavesGlobalSandboxDefaultUnmaterialized(t *testing.T) {
 	t.Parallel()
 	task, err := createInProject(t, plainProject(), runtime.CreateSpecTaskInput{
 		Name: "Ordinary", Description: "no overrides",
@@ -104,8 +109,13 @@ func TestSpecTasks_CreateUsesGlobalSandboxDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if task.SandboxResourceOverrides == nil || !task.SandboxResourceOverrides.ValidPreset() {
-		t.Fatalf("resources = %+v, want the global default preset", task.SandboxResourceOverrides)
+	if task.SandboxResourceOverrides != nil {
+		t.Fatalf("resources = %+v, want nil so the live default applies at start",
+			task.SandboxResourceOverrides)
+	}
+	// Nil still resolves to a usable preset for the container that eventually starts.
+	if effective := types.EffectiveSpecTaskSandboxResources(task.SandboxResourceOverrides); !effective.ValidPreset() {
+		t.Fatalf("effective resources = %+v, want a valid preset", effective)
 	}
 	if task.SandboxRuntime != types.SandboxRuntimeUbuntuDesktop {
 		t.Fatalf("runtime = %q, want the global default ubuntu-desktop", task.SandboxRuntime)
@@ -122,8 +132,10 @@ func TestSpecTasks_CreateRejectsUnknownSandboxSize(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a vCPU count with no preset")
 	}
-	if !strings.Contains(err.Error(), "1, 4 or 8") {
-		t.Fatalf("err = %v, want it to name the legal sizes", err)
+	// Derived, not hand-copied: a Worker reads this message and retries with a
+	// size from it, so a stale list here would hide a stale list in production.
+	if !strings.Contains(err.Error(), types.SpecTaskSandboxVCPUList()) {
+		t.Fatalf("err = %v, want it to name the legal sizes %s", err, types.SpecTaskSandboxVCPUList())
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -250,7 +250,8 @@ type CreateSpecTaskInput struct {
 	SkipPlanning   bool     `json:"skip_planning,omitempty"`
 	DependsOn      []string `json:"depends_on,omitempty"`
 
-	// SandboxVCPUs picks the sandbox size preset (1, 4 or 8; memory follows).
+	// SandboxVCPUs picks the sandbox size preset by vCPU count; memory follows.
+	// The selectable counts are types.SpecTaskSandboxPresets.
 	// SandboxRuntime picks ubuntu-desktop or headless-ubuntu. Both are 0/""
 	// for "use the project default".
 	//

--- a/api/pkg/org/interfaces/mcptools/spec_tasks.go
+++ b/api/pkg/org/interfaces/mcptools/spec_tasks.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // This file holds the MCP spec-task tools — the surface a helix-org
@@ -49,11 +50,15 @@ var createSpecTaskSchema = mustSchema[createSpecTaskArgs]()
 func (t *CreateSpecTask) Name() tool.Name                 { return CreateSpecTaskName }
 func (t *CreateSpecTask) InputSchema() *jsonschema.Schema { return createSpecTaskSchema }
 func (t *CreateSpecTask) Description() string {
+	// The ladder is rendered from types.SpecTaskSandboxPresets rather than spelled
+	// out here: a Worker follows this prose literally, so a stale copy makes it
+	// pass a vCPU count the API then rejects.
 	return "Create a new spec task. Provide a short name and a high-level " +
 		"description of the desired outcome. Optional: project_id (a project you manage in " +
 		"your org — omit to use your own project), type (feature|bug|refactor), priority " +
 		"(low|medium|high|critical), skip_planning (go straight to implementation), depends_on " +
-		"(task IDs), sandbox_vcpus (1, 4 or 8 — memory follows; omit for the project default), " +
+		"(task IDs), sandbox_vcpus (" + types.SpecTaskSandboxVCPUList() +
+		" — memory follows; omit for the project default), " +
 		"sandbox_runtime (headless-ubuntu for agent-only work, ubuntu-desktop when the task " +
 		"needs a GUI; omit for the project default). " +
 		"The task runs on the coding agent and model configured for the project, which is your " +

--- a/api/pkg/proxy/resilient.go
+++ b/api/pkg/proxy/resilient.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	ErrReconnectFailed    = errors.New("reconnection failed")
-	ErrInputBufferFull    = errors.New("input buffer full")
-	ErrOutputBufferFull   = errors.New("output buffer full")
+	ErrReconnectFailed  = errors.New("reconnection failed")
+	ErrInputBufferFull  = errors.New("input buffer full")
+	ErrOutputBufferFull = errors.New("output buffer full")
 )
 
 const (
@@ -46,20 +46,40 @@ type DialFunc func(ctx context.Context) (net.Conn, error)
 // UpgradeFunc is a function that performs WebSocket upgrade on a connection
 type UpgradeFunc func(conn net.Conn) error
 
+// SessionReplay carries per-connection state that the backend learns from the
+// client's first frames and would otherwise lose when the backend reconnects.
+//
+// It is the frame-level sibling of CreateWebSocketUpgradeFunc's extraHeaders:
+// both re-apply state that only the original handshake carried, and both belong
+// on the reconnect path rather than only on the initial connection. The header
+// path re-sends what WE know about the caller; this path re-sends what the
+// CLIENT told the backend. Dropping either leaves a half-configured backend —
+// for the desktop stream that means a socket stuck in its 30s init read, which
+// is the bug this exists to fix.
+type SessionReplay interface {
+	// Observe is fed every byte the client sends, in order. Implementations must
+	// be cheap once they have what they need.
+	Observe(b []byte)
+	// Frames returns bytes to write to a freshly-upgraded backend connection
+	// before proxying resumes. Nil when there is nothing to replay.
+	Frames() []byte
+}
+
 // ResilientProxy provides a bidirectional proxy that survives brief server-side disconnections.
 // The client connection (browser) stays alive while the server connection (RevDial to desktop)
 // can be reconnected transparently. Both directions are buffered during reconnection.
 type ResilientProxy struct {
 	// Configuration
-	sessionID    string
-	dialFunc     DialFunc    // Function to dial server (via connman)
-	upgradeFunc  UpgradeFunc // Function to upgrade connection to WebSocket
-	bufferSize   int
+	sessionID   string
+	dialFunc    DialFunc      // Function to dial server (via connman)
+	upgradeFunc UpgradeFunc   // Function to upgrade connection to WebSocket
+	replay      SessionReplay // Optional per-connection state to re-send after reconnect
+	bufferSize  int
 
 	// Connections
-	clientConn    net.Conn // Browser connection (stable)
+	clientConn    net.Conn   // Browser connection (stable)
 	clientWriteMu sync.Mutex // Serializes writes to clientConn (copier + close-frame senders)
-	serverConn    net.Conn // Server connection (may reconnect)
+	serverConn    net.Conn   // Server connection (may reconnect)
 	serverMu      sync.Mutex
 
 	// Input buffering (client → server direction)
@@ -73,12 +93,12 @@ type ResilientProxy struct {
 	outputBufferPos int
 
 	// State
-	reconnecting   atomic.Bool
-	closed         atomic.Bool
-	done           chan struct{}
-	reconnectDone  chan struct{} // Signals reconnection completed
-	reconnectMu    sync.Mutex    // Protects reconnection initiation
-	serverError    chan error    // Channel to signal server errors for reconnection
+	reconnecting  atomic.Bool
+	closed        atomic.Bool
+	done          chan struct{}
+	reconnectDone chan struct{} // Signals reconnection completed
+	reconnectMu   sync.Mutex    // Protects reconnection initiation
+	serverError   chan error    // Channel to signal server errors for reconnection
 
 	// Stats
 	reconnectCount      atomic.Int64
@@ -93,7 +113,10 @@ type ResilientProxyConfig struct {
 	ServerConn  net.Conn
 	DialFunc    DialFunc
 	UpgradeFunc UpgradeFunc
-	BufferSize  int // Size of each direction's buffer (default 512KB)
+	// Replay re-sends per-connection state the client established on the original
+	// socket (the desktop stream's init frame). Nil disables replay.
+	Replay     SessionReplay
+	BufferSize int // Size of each direction's buffer (default 512KB)
 }
 
 // NewResilientProxy creates a new resilient proxy
@@ -109,6 +132,7 @@ func NewResilientProxy(cfg ResilientProxyConfig) *ResilientProxy {
 		serverConn:    cfg.ServerConn,
 		dialFunc:      cfg.DialFunc,
 		upgradeFunc:   cfg.UpgradeFunc,
+		replay:        cfg.Replay,
 		bufferSize:    bufSize,
 		inputBuffer:   make([]byte, bufSize),
 		outputBuffer:  make([]byte, bufSize),
@@ -234,6 +258,13 @@ func (p *ResilientProxy) copyClientToServer(ctx context.Context) error {
 
 		if n == 0 {
 			continue
+		}
+
+		// Watch the client stream for state the backend will need again after a
+		// reconnect. Done before the write/buffer branch so it sees every byte
+		// regardless of which path the data takes.
+		if p.replay != nil {
+			p.replay.Observe(buf[:n])
 		}
 
 		// If reconnecting, buffer the data and wait
@@ -519,6 +550,26 @@ func (p *ResilientProxy) reconnect(ctx context.Context) error {
 		p.serverMu.Lock()
 		p.serverConn = newConn
 		p.serverMu.Unlock()
+
+		// Re-send per-connection state BEFORE the buffered input. The backend is
+		// blocked waiting for it and will not process anything else until it
+		// arrives; the buffered bytes are whatever the client sent while we were
+		// down, which belongs after.
+		if p.replay != nil {
+			if frames := p.replay.Frames(); len(frames) > 0 {
+				if _, err := newConn.Write(frames); err != nil {
+					log.Warn().
+						Str("session_id", p.sessionID).
+						Err(err).
+						Msg("Failed to replay session state to reconnected backend")
+				} else {
+					log.Debug().
+						Str("session_id", p.sessionID).
+						Int("bytes", len(frames)).
+						Msg("Replayed session state to reconnected backend")
+				}
+			}
+		}
 
 		// Flush buffered data in both directions
 		if err := p.flushInputBuffer(); err != nil {

--- a/api/pkg/proxy/streaminit.go
+++ b/api/pkg/proxy/streaminit.go
@@ -1,0 +1,224 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// maxInitPrefix bounds how much of the client stream we will buffer looking for
+// the init frame. A stream client sends init within its first few hundred bytes;
+// anything that has sent 64KB of binary without a text frame is not one, and we
+// stop rather than grow without limit.
+const maxInitPrefix = 64 * 1024
+
+// opcodeText is the only WebSocket opcode this parser acts on (RFC 6455 §5.2);
+// binary, ping, pong and close frames are counted and skipped.
+const opcodeText = 0x1
+
+// StreamInitReplay captures the desktop stream's `init` frame from the client
+// byte stream and re-sends it after each backend reconnect.
+//
+// desktop-bridge blocks on a mandatory init text frame with a 30s read deadline
+// before it will start a streamer (api/pkg/desktop/ws_stream.go). The browser
+// sends it once, on the original socket. ResilientProxy re-dials the backend
+// transparently, so without replay every reconnect produces a backend socket
+// that waits 30s, dies, and reconnects — while the client socket stays open and
+// the user sees a live-but-frozen picture with no error anywhere.
+//
+// This parses only as much WebSocket framing as it takes to find one text frame
+// in the client→server direction. ResilientProxy is otherwise a raw byte proxy
+// and deliberately stays that way.
+type StreamInitReplay struct {
+	mu sync.Mutex
+	// pending holds client bytes not yet resolved into complete frames.
+	pending []byte
+	// frame is the encoded replay, ready to write. Nil until init is seen.
+	frame []byte
+	// done stops all further parsing: one init per connection, and a later text
+	// frame is not session state.
+	done bool
+}
+
+func NewStreamInitReplay() *StreamInitReplay { return &StreamInitReplay{} }
+
+// Observe feeds client bytes to the frame parser. It becomes a no-op once the
+// init frame has been captured (or the prefix bound is exceeded).
+func (r *StreamInitReplay) Observe(b []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done || len(b) == 0 {
+		return
+	}
+
+	r.pending = append(r.pending, b...)
+	for {
+		payload, opcode, consumed, ok := parseClientFrame(r.pending)
+		if !ok {
+			break // incomplete frame; wait for more bytes
+		}
+		r.pending = r.pending[consumed:]
+		if opcode == opcodeText {
+			r.capture(payload)
+			return
+		}
+		// Binary keepalives, ping/pong and close are skipped, exactly as
+		// desktop-bridge skips them while waiting for init.
+	}
+
+	if len(r.pending) > maxInitPrefix {
+		log.Warn().
+			Int("buffered", len(r.pending)).
+			Msg("No stream init frame within prefix bound; giving up on init replay")
+		r.pending = nil
+		r.done = true
+	}
+}
+
+// capture stores the replay frame for an observed init payload. Caller holds mu.
+func (r *StreamInitReplay) capture(payload []byte) {
+	r.pending = nil
+	r.done = true
+
+	replayed, err := clearUserRetry(payload)
+	if err != nil {
+		// Not JSON we understand. Replaying it verbatim would risk re-asserting
+		// user_retry, so decline to replay rather than guess.
+		log.Warn().Err(err).Msg("Stream init frame is not usable JSON; init replay disabled")
+		return
+	}
+
+	frame, err := encodeClientTextFrame(replayed)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to encode stream init replay frame")
+		return
+	}
+	r.frame = frame
+}
+
+// Frames returns the encoded init frame, or nil if none was captured — a
+// reconnect that happens before the client sent init replays nothing rather
+// than sending garbage into the backend's init read.
+func (r *StreamInitReplay) Frames() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.frame == nil {
+		return nil
+	}
+	out := make([]byte, len(r.frame))
+	copy(out, r.frame)
+	return out
+}
+
+// clearUserRetry removes user_retry from an init payload.
+//
+// user_retry marks an explicit user-initiated retry (the Restart button) and is
+// the only thing that clears a latched shared-video circuit breaker
+// (api/pkg/desktop/ws_stream.go). A proxy reconnect is by definition automatic:
+// if replay preserved the flag, one press of Restart would re-assert it on every
+// subsequent backend drop, the breaker would reset each time, and it could never
+// latch — which is the retry storm the breaker exists to stop. The Restart button
+// is unaffected; it opens a NEW client socket whose init is not a replay.
+//
+// Decoded into a map rather than desktop.StreamConfig on purpose: round-tripping
+// through the struct would drop fields a newer browser sends that this build does
+// not know about, and re-emit omitempty fields the client deliberately left out.
+// Everything except user_retry passes through unchanged.
+func clearUserRetry(payload []byte) ([]byte, error) {
+	var config map[string]any
+	if err := json.Unmarshal(payload, &config); err != nil {
+		return nil, err
+	}
+	delete(config, "user_retry")
+	return json.Marshal(config)
+}
+
+// parseClientFrame decodes one WebSocket frame from a client (masked) stream.
+//
+// Returns the unmasked payload, the opcode, how many bytes the frame occupied,
+// and whether a complete frame was available. A continuation opcode reports the
+// frame's own opcode; init is sent unfragmented by every stream client, so a
+// fragmented text frame simply is not recognised as init.
+func parseClientFrame(b []byte) (payload []byte, opcode byte, consumed int, ok bool) {
+	if len(b) < 2 {
+		return nil, 0, 0, false
+	}
+	opcode = b[0] & 0x0f
+	masked := b[1]&0x80 != 0
+	length := uint64(b[1] & 0x7f)
+	offset := 2
+
+	switch length {
+	case 126:
+		if len(b) < offset+2 {
+			return nil, 0, 0, false
+		}
+		length = uint64(binary.BigEndian.Uint16(b[offset : offset+2]))
+		offset += 2
+	case 127:
+		if len(b) < offset+8 {
+			return nil, 0, 0, false
+		}
+		length = binary.BigEndian.Uint64(b[offset : offset+8])
+		offset += 8
+	}
+
+	var maskKey []byte
+	if masked {
+		if len(b) < offset+4 {
+			return nil, 0, 0, false
+		}
+		maskKey = b[offset : offset+4]
+		offset += 4
+	}
+
+	// A 64-bit length from a hostile or corrupt stream must not be used to size
+	// an allocation; we only ever slice what has actually arrived.
+	if length > maxInitPrefix || uint64(len(b)) < uint64(offset)+length {
+		return nil, 0, 0, false
+	}
+
+	payload = make([]byte, length)
+	copy(payload, b[offset:offset+int(length)])
+	if masked {
+		for i := range payload {
+			payload[i] ^= maskKey[i%4]
+		}
+	}
+	return payload, opcode, offset + int(length), true
+}
+
+// encodeClientTextFrame builds a masked, unfragmented text frame. Client→server
+// frames must be masked (RFC 6455 §5.3), and the payload changed when user_retry
+// was stripped, so this re-encodes rather than replaying the original bytes.
+func encodeClientTextFrame(payload []byte) ([]byte, error) {
+	var maskKey [4]byte
+	if _, err := rand.Read(maskKey[:]); err != nil {
+		return nil, err
+	}
+
+	header := []byte{0x80 | opcodeText} // FIN + text
+	length := len(payload)
+	switch {
+	case length < 126:
+		header = append(header, 0x80|byte(length))
+	case length <= 0xffff:
+		header = append(header, 0x80|126, byte(length>>8), byte(length))
+	default:
+		header = append(header, 0x80|127)
+		var extended [8]byte
+		binary.BigEndian.PutUint64(extended[:], uint64(length))
+		header = append(header, extended[:]...)
+	}
+	header = append(header, maskKey[:]...)
+
+	frame := make([]byte, 0, len(header)+length)
+	frame = append(frame, header...)
+	for i, c := range payload {
+		frame = append(frame, c^maskKey[i%4])
+	}
+	return frame, nil
+}

--- a/api/pkg/proxy/streaminit_test.go
+++ b/api/pkg/proxy/streaminit_test.go
@@ -296,3 +296,43 @@ func TestResilientProxyWithoutReplayIsUnchanged(t *testing.T) {
 	p := NewResilientProxy(ResilientProxyConfig{SessionID: "test"})
 	require.Nil(t, p.replay)
 }
+
+// The other half of the read-only guarantee, and the invariant SessionReplay is
+// modelled on: X-Helix-Readonly rides on the upgrade, and the upgrade func runs
+// again on every reconnect. Replay cannot re-grant input because privilege never
+// travels in the init payload — it travels here, and it is re-sent every time.
+//
+// Untested before this change despite the doc comment asserting it.
+func TestUpgradeFuncReemitsExtraHeadersOnEveryUpgrade(t *testing.T) {
+	upgrade := CreateWebSocketUpgradeFunc("/ws/stream", "dGhlIHNhbXBsZSBub25jZQ==", "X-Helix-Readonly", "1")
+
+	// Two independent upgrades stand in for the original connection and the
+	// reconnect: the func holds no state, so both must carry the header.
+	for attempt := 1; attempt <= 2; attempt++ {
+		ours, theirs := net.Pipe()
+
+		got := make(chan string, 1)
+		go func() {
+			defer theirs.Close()
+			buf := make([]byte, 1024)
+			n, err := theirs.Read(buf)
+			if err != nil {
+				got <- ""
+				return
+			}
+			got <- string(buf[:n])
+			// Minimal 101 so the upgrade func returns rather than blocking.
+			_, _ = theirs.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n" +
+				"Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n"))
+		}()
+
+		err := upgrade(ours)
+		ours.Close()
+		require.NoError(t, err, "upgrade %d", attempt)
+
+		request := <-got
+		require.Contains(t, request, "X-Helix-Readonly: 1",
+			"upgrade %d dropped the read-only header; a reconnect would silently re-grant input", attempt)
+		require.Contains(t, request, "GET /ws/stream HTTP/1.1")
+	}
+}

--- a/api/pkg/proxy/streaminit_test.go
+++ b/api/pkg/proxy/streaminit_test.go
@@ -1,0 +1,298 @@
+package proxy
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// clientTextFrame builds a masked client text frame, as a browser would send.
+func clientTextFrame(t *testing.T, payload string) []byte {
+	t.Helper()
+	frame, err := encodeClientTextFrame([]byte(payload))
+	require.NoError(t, err)
+	return frame
+}
+
+// clientBinaryFrame builds a masked client binary frame — the 13-byte keepalives
+// the stream client sends before and during init.
+func clientBinaryFrame(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	require.Less(t, len(payload), 126, "helper only builds short frames")
+	mask := []byte{0xa1, 0xb2, 0xc3, 0xd4}
+	frame := []byte{0x82, 0x80 | byte(len(payload))}
+	frame = append(frame, mask...)
+	for i, c := range payload {
+		frame = append(frame, c^mask[i%4])
+	}
+	return frame
+}
+
+// decodeReplay parses a frame produced by StreamInitReplay back into its JSON.
+func decodeReplay(t *testing.T, frame []byte) map[string]any {
+	t.Helper()
+	payload, opcode, consumed, ok := parseClientFrame(frame)
+	require.True(t, ok, "replay frame must be complete")
+	require.Equal(t, byte(opcodeText), opcode, "replay must be a text frame")
+	require.Equal(t, len(frame), consumed, "replay must be exactly one frame")
+	require.True(t, frame[1]&0x80 != 0, "client frames must be masked (RFC 6455 §5.3)")
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(payload, &out))
+	return out
+}
+
+func TestStreamInitReplayCapturesInit(t *testing.T) {
+	replay := NewStreamInitReplay()
+	require.Nil(t, replay.Frames(), "nothing to replay before init is seen")
+
+	replay.Observe(clientTextFrame(t, `{"type":"init","width":1920,"height":1080,"fps":60}`))
+
+	config := decodeReplay(t, replay.Frames())
+	require.Equal(t, "init", config["type"])
+	require.EqualValues(t, 1920, config["width"])
+	require.EqualValues(t, 1080, config["height"])
+	require.EqualValues(t, 60, config["fps"])
+}
+
+// The headline requirement: a reconnect must re-send init, or desktop-bridge
+// sits in its 30s read and the browser shows a frozen picture with no error.
+func TestReconnectReplaysInit(t *testing.T) {
+	clientLocal, clientRemote := net.Pipe()
+	defer clientLocal.Close()
+	defer clientRemote.Close()
+
+	serverInitial, _ := net.Pipe()
+
+	// Each dial hands back one end of a fresh pipe and records the other, so the
+	// test can read exactly what the proxy wrote to the reconnected backend.
+	var mu sync.Mutex
+	var reconnected net.Conn
+	dialed := make(chan struct{}, 1)
+	dialFunc := func(_ context.Context) (net.Conn, error) {
+		ours, theirs := net.Pipe()
+		mu.Lock()
+		reconnected = theirs
+		mu.Unlock()
+		dialed <- struct{}{}
+		return ours, nil
+	}
+
+	replay := NewStreamInitReplay()
+	p := NewResilientProxy(ResilientProxyConfig{
+		SessionID:  "test",
+		ClientConn: clientLocal,
+		ServerConn: serverInitial,
+		DialFunc:   dialFunc,
+		Replay:     replay,
+	})
+
+	// The client sent init on the original socket, exactly once.
+	replay.Observe(clientTextFrame(t,
+		`{"type":"init","width":1920,"height":1080,"session_id":"ses_1"}`))
+
+	// Kill the backend and let the proxy re-dial.
+	serverInitial.Close()
+	go func() { _ = p.reconnect(context.Background()) }()
+
+	select {
+	case <-dialed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxy never re-dialled the backend")
+	}
+
+	mu.Lock()
+	backend := reconnected
+	mu.Unlock()
+	require.NotNil(t, backend)
+	defer backend.Close()
+
+	require.NoError(t, backend.SetReadDeadline(time.Now().Add(5*time.Second)))
+	buf := make([]byte, 512)
+	n, err := backend.Read(buf)
+	require.NoError(t, err, "reconnected backend must receive the replayed init")
+
+	config := decodeReplay(t, buf[:n])
+	require.Equal(t, "init", config["type"],
+		"the first thing a reconnected backend sees must be init")
+	require.Equal(t, "ses_1", config["session_id"],
+		"replay must subscribe to the same shared source, not a new one")
+	require.EqualValues(t, 1920, config["width"])
+}
+
+// A replayed init must NOT count as a user-initiated retry. user_retry is the
+// only thing that clears a latched shared-video circuit breaker; if replay
+// preserved it, one press of Restart would re-assert it on every later backend
+// drop and the breaker could never latch.
+func TestReplayedInitHasUserRetryCleared(t *testing.T) {
+	replay := NewStreamInitReplay()
+	replay.Observe(clientTextFrame(t,
+		`{"type":"init","width":1280,"user_retry":true,"user_name":"alice"}`))
+
+	config := decodeReplay(t, replay.Frames())
+	require.NotContains(t, config, "user_retry",
+		"a proxy reconnect is automatic and must not reset the circuit breaker")
+
+	// Everything else survives untouched.
+	require.Equal(t, "init", config["type"])
+	require.EqualValues(t, 1280, config["width"])
+	require.Equal(t, "alice", config["user_name"])
+}
+
+// An unknown field from a newer browser must survive replay: the payload is
+// decoded as a map precisely so this build does not silently drop it.
+func TestReplayPreservesUnknownFields(t *testing.T) {
+	replay := NewStreamInitReplay()
+	replay.Observe(clientTextFrame(t, `{"type":"init","future_knob":"keep me"}`))
+
+	config := decodeReplay(t, replay.Frames())
+	require.Equal(t, "keep me", config["future_knob"])
+}
+
+func TestStreamInitReplaySkipsBinaryKeepalives(t *testing.T) {
+	replay := NewStreamInitReplay()
+
+	// The client sends 13-byte binary keepalives before init, which
+	// desktop-bridge also skips while waiting.
+	replay.Observe(clientBinaryFrame(t, make([]byte, 13)))
+	replay.Observe(clientBinaryFrame(t, make([]byte, 13)))
+	require.Nil(t, replay.Frames(), "binary frames are not session state")
+
+	replay.Observe(clientTextFrame(t, `{"type":"init","width":800}`))
+	require.EqualValues(t, 800, decodeReplay(t, replay.Frames())["width"])
+}
+
+// One init per connection: a later text frame is not session state and must not
+// overwrite what the backend needs to be re-told.
+func TestStreamInitReplayKeepsFirstTextFrame(t *testing.T) {
+	replay := NewStreamInitReplay()
+	replay.Observe(clientTextFrame(t, `{"type":"init","width":1920}`))
+	replay.Observe(clientTextFrame(t, `{"type":"init","width":640}`))
+
+	require.EqualValues(t, 1920, decodeReplay(t, replay.Frames())["width"])
+}
+
+// Frames arrive split across TCP reads; the parser is fed 32KB chunks and must
+// not assume a read boundary lines up with a frame boundary.
+func TestStreamInitReplayHandlesSplitFrames(t *testing.T) {
+	frame := clientTextFrame(t, `{"type":"init","width":1920,"height":1080}`)
+
+	replay := NewStreamInitReplay()
+	for i := 0; i < len(frame); i++ {
+		replay.Observe(frame[i : i+1])
+	}
+
+	require.EqualValues(t, 1920, decodeReplay(t, replay.Frames())["width"])
+}
+
+func TestParseClientFrameLengthForms(t *testing.T) {
+	// 7-bit length.
+	short := clientTextFrame(t, `{"type":"init"}`)
+	payload, opcode, consumed, ok := parseClientFrame(short)
+	require.True(t, ok)
+	require.Equal(t, byte(opcodeText), opcode)
+	require.Equal(t, len(short), consumed)
+	require.JSONEq(t, `{"type":"init"}`, string(payload))
+
+	// 16-bit extended length.
+	medium := make([]byte, 200)
+	for i := range medium {
+		medium[i] = 'a'
+	}
+	mediumFrame, err := encodeClientTextFrame(medium)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x80|126), mediumFrame[1], "200 bytes must use the 16-bit form")
+	payload, _, consumed, ok = parseClientFrame(mediumFrame)
+	require.True(t, ok)
+	require.Equal(t, len(mediumFrame), consumed)
+	require.Equal(t, medium, payload)
+
+	// 64-bit extended length, hand-built so the parser is tested rather than a
+	// round-trip against our own encoder.
+	body := []byte(`{"type":"init"}`)
+	huge := []byte{0x81, 0x80 | 127}
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(body)))
+	huge = append(huge, length[:]...)
+	mask := []byte{1, 2, 3, 4}
+	huge = append(huge, mask...)
+	for i, c := range body {
+		huge = append(huge, c^mask[i%4])
+	}
+	payload, _, consumed, ok = parseClientFrame(huge)
+	require.True(t, ok)
+	require.Equal(t, len(huge), consumed)
+	require.JSONEq(t, `{"type":"init"}`, string(payload))
+}
+
+func TestParseClientFrameIncomplete(t *testing.T) {
+	frame := clientTextFrame(t, `{"type":"init","width":1920}`)
+	for i := 0; i < len(frame); i++ {
+		_, _, _, ok := parseClientFrame(frame[:i])
+		require.False(t, ok, "a partial frame at %d bytes must not parse", i)
+	}
+	_, _, _, ok := parseClientFrame(frame)
+	require.True(t, ok)
+}
+
+// Malformed JSON must disable replay rather than be re-sent verbatim: replaying
+// bytes we cannot read risks re-asserting user_retry.
+func TestStreamInitReplayDeclinesNonJSON(t *testing.T) {
+	replay := NewStreamInitReplay()
+	replay.Observe(clientTextFrame(t, `not json at all`))
+	require.Nil(t, replay.Frames())
+}
+
+// A stream that never yields a parseable frame must not grow the buffer without
+// limit. A 64-bit length beyond the prefix bound is the corrupt/hostile case:
+// the parser refuses to size an allocation from it, so nothing ever completes.
+func TestStreamInitReplayBoundsPrefix(t *testing.T) {
+	replay := NewStreamInitReplay()
+
+	header := []byte{0x82, 0x80 | 127}
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], 1<<40) // far beyond maxInitPrefix
+	header = append(header, length[:]...)
+	header = append(header, 1, 2, 3, 4) // mask key
+	replay.Observe(header)
+
+	for i := 0; i < 80; i++ {
+		replay.Observe(make([]byte, 1024))
+	}
+
+	replay.mu.Lock()
+	pending := len(replay.pending)
+	done := replay.done
+	replay.mu.Unlock()
+
+	require.True(t, done, "parser must give up rather than buffer forever")
+	require.Zero(t, pending)
+	require.Nil(t, replay.Frames())
+}
+
+// Replay and the read-only header are the two halves of the same requirement and
+// must compose: the header re-grants nothing, and the init payload has no
+// privilege field to carry.
+func TestReplayCarriesNoPrivilegeField(t *testing.T) {
+	replay := NewStreamInitReplay()
+	replay.Observe(clientTextFrame(t,
+		`{"type":"init","width":1920,"user_name":"alice","user_id":"u1"}`))
+
+	config := decodeReplay(t, replay.Frames())
+	for _, forbidden := range []string{"readonly", "read_only", "X-Helix-Readonly"} {
+		require.NotContains(t, config, forbidden,
+			"privilege lives in the upgrade header, never in the init payload")
+	}
+}
+
+// Nil Replay must leave the proxy behaving exactly as it did before.
+func TestResilientProxyWithoutReplayIsUnchanged(t *testing.T) {
+	p := NewResilientProxy(ResilientProxyConfig{SessionID: "test"})
+	require.Nil(t, p.replay)
+}

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -37,10 +37,16 @@ type resourcePreset struct {
 	MemoryMB int
 }
 
+// Kept in step with types.SpecTaskSandboxPresets so a size offered on one
+// surface is not refused on the other. The sandboxes API's own default is
+// deliberately unchanged (the first rung): size here is an explicit user choice
+// at create time, not a default silently applied to work the user did not size.
 var allowedResourcePresets = []resourcePreset{
 	{VCPUs: 1, MemoryMB: 2048},
 	{VCPUs: 4, MemoryMB: 8192},
 	{VCPUs: 8, MemoryMB: 16384},
+	{VCPUs: 12, MemoryMB: 24576},
+	{VCPUs: 16, MemoryMB: 32768},
 }
 
 func resolveSandboxResources(req *types.CreateSandboxRequest) (int, int, error) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -34763,7 +34763,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "default_sandbox_resource_overrides": {
-                    "description": "Default sandbox resources copied into each new SpecTask. Nil values from\nlegacy projects resolve to the standard 4 vCPU / 8 GB preset.",
+                    "description": "Default sandbox resources copied into each new SpecTask. Nil means the\nproject expresses no preference and the task resolves the global default at\ncontainer-create time.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SandboxResourceOverrides"

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -36928,6 +36928,14 @@ const docTemplate = `{
                     "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
                     "type": "string"
                 },
+                "default_spec_task_sandbox": {
+                    "description": "DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it\nspecifies none. It is operator-configurable\n(HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read\nit from here rather than hardcode a copy — otherwise an operator who moves\nthe default gets a task selector that marks the wrong rung \"Default\" while\ncontainers come up at the configured size.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxResourceOverrides"
+                        }
+                    ]
+                },
                 "deployment_id": {
                     "type": "string"
                 },

--- a/api/pkg/server/external_agent_handlers.go
+++ b/api/pkg/server/external_agent_handlers.go
@@ -1484,6 +1484,17 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 	}
 	upgradeFunc := proxy.CreateWebSocketUpgradeFunc("/ws/stream", wsKey, streamUpgradeHeaders...)
 
+	// The two halves of per-connection state that a reconnect must re-apply: the
+	// headers we know about the caller (above) and the init frame the client sent
+	// (below). desktop-bridge will not start a streamer without init, so a
+	// reconnect that dropped it leaves the backend stuck in a 30s read while the
+	// browser shows a live-but-frozen picture.
+	//
+	// Read-only is enforced entirely by the header, which this replay cannot
+	// touch: StreamConfig carries no privilege field, so a replayed init cannot
+	// re-grant input to an embed-key viewer.
+	streamInitReplay := proxy.NewStreamInitReplay()
+
 	// Create resilient proxy
 	resilientProxy := proxy.NewResilientProxy(proxy.ResilientProxyConfig{
 		SessionID:   proxySessionID,
@@ -1491,6 +1502,7 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 		ServerConn:  serverConn,
 		DialFunc:    dialFunc,
 		UpgradeFunc: upgradeFunc,
+		Replay:      streamInitReplay,
 	})
 	defer resilientProxy.Close()
 

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -100,6 +100,7 @@ func (apiServer *HelixAPIServer) getConfig(ctx context.Context) (types.ServerCon
 		DeploymentID:                           deploymentID,
 		OrganizationsCreateEnabledForNonAdmins: apiServer.Cfg.Organizations.CreateEnabledForNonAdmins,
 		Edition:                                apiServer.Cfg.Edition,
+		DefaultSpecTaskSandbox:                 *types.DefaultSpecTaskSandboxResources(),
 		DefaultChatSystemPrompt:                types.DefaultChatSystemPrompt,
 		DevSubdomain:                           apiServer.Cfg.WebServer.DevSubdomain,
 		PreviewURLHTTPS:                        apiServer.Cfg.WebServer.PreviewURLHTTPS,

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -36924,6 +36924,14 @@
                     "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
                     "type": "string"
                 },
+                "default_spec_task_sandbox": {
+                    "description": "DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it\nspecifies none. It is operator-configurable\n(HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read\nit from here rather than hardcode a copy — otherwise an operator who moves\nthe default gets a task selector that marks the wrong rung \"Default\" while\ncontainers come up at the configured size.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxResourceOverrides"
+                        }
+                    ]
+                },
                 "deployment_id": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -34759,7 +34759,7 @@
                     "type": "string"
                 },
                 "default_sandbox_resource_overrides": {
-                    "description": "Default sandbox resources copied into each new SpecTask. Nil values from\nlegacy projects resolve to the standard 4 vCPU / 8 GB preset.",
+                    "description": "Default sandbox resources copied into each new SpecTask. Nil means the\nproject expresses no preference and the task resolves the global default at\ncontainer-create time.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SandboxResourceOverrides"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -9915,6 +9915,16 @@ definitions:
           direct model chats when the user has not customised one. Surfaced to
           the frontend so the chat-settings page can prefill the textbox.
         type: string
+      default_spec_task_sandbox:
+        allOf:
+        - $ref: '#/definitions/types.SandboxResourceOverrides'
+        description: |-
+          DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it
+          specifies none. It is operator-configurable
+          (HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read
+          it from here rather than hardcode a copy — otherwise an operator who moves
+          the default gets a task selector that marks the wrong rung "Default" while
+          containers come up at the configured size.
       deployment_id:
         type: string
       dev_subdomain:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -8266,8 +8266,9 @@ definitions:
         allOf:
         - $ref: '#/definitions/types.SandboxResourceOverrides'
         description: |-
-          Default sandbox resources copied into each new SpecTask. Nil values from
-          legacy projects resolve to the standard 4 vCPU / 8 GB preset.
+          Default sandbox resources copied into each new SpecTask. Nil means the
+          project expresses no preference and the task resolves the global default at
+          container-create time.
       default_sandbox_runtime:
         allOf:
         - $ref: '#/definitions/types.SandboxRuntime'

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -154,13 +154,16 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 			return nil, fmt.Errorf("failed to get project: %w", err)
 		}
 	}
+	// Deliberately left nil when neither the request nor the project chose a size:
+	// a stored override means "someone chose this", not "this was the default the
+	// day the row was written". Materializing it here froze every task created
+	// after 1eff4e801 at 4 vCPU / 8 GB, so a raised default could never reach
+	// them. The default is resolved at container-create time instead — see
+	// HydraExecutor.resolveSpecTaskLaunchConfig.
 	sandboxResources := req.SandboxResourceOverrides
 	if sandboxResources == nil && project != nil && project.DefaultSandboxResourceOverrides != nil {
 		projectResources := *project.DefaultSandboxResourceOverrides
 		sandboxResources = &projectResources
-	}
-	if sandboxResources == nil {
-		sandboxResources = types.DefaultSpecTaskSandboxResources()
 	}
 	sandboxRuntime := req.SandboxRuntime
 	if sandboxRuntime == "" && project != nil {

--- a/api/pkg/store/migrations/0009_unmaterialize_spec_task_sandbox_default.down.sql
+++ b/api/pkg/store/migrations/0009_unmaterialize_spec_task_sandbox_default.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible. Which NULLs previously held 4/8192 is not recorded, and
+-- re-materializing every NULL would write an override onto the thousands of rows
+-- that never had one — recreating the bug this migration removes.

--- a/api/pkg/store/migrations/0009_unmaterialize_spec_task_sandbox_default.up.sql
+++ b/api/pkg/store/migrations/0009_unmaterialize_spec_task_sandbox_default.up.sql
@@ -1,0 +1,30 @@
+-- Between 1eff4e801 (2026-08-10) and this migration, CreateTaskFromPrompt wrote
+-- the global default onto rows that had no explicit size, freezing those tasks
+-- at 4 vCPU / 8 GB forever — a raised default could never reach them. NULL means
+-- "no override, use the live default", which is what these rows meant all along.
+--
+-- Match the old default pair EXACTLY. Rows holding {"vcpus": 8, "memory_mb":
+-- 16384} are deliberate user choices (178 of them on meta alone) and must never
+-- be caught by this. Do not generalise the predicate to "any row equal to some
+-- default": 8/16384 has been a selectable preset the whole time, so equality
+-- with a default does not imply the value was materialized.
+--
+-- Verify with the same query that sized the problem, before and after:
+--   SELECT sandbox_resource_overrides, count(*) FROM spec_tasks GROUP BY 1;
+-- The 8/16384 count must be identical afterwards.
+DO $$
+BEGIN
+    IF to_regclass('spec_tasks') IS NULL
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = current_schema()
+                AND table_name = 'spec_tasks'
+                AND column_name = 'sandbox_resource_overrides'
+        ) THEN
+        RETURN;
+    END IF;
+
+    UPDATE spec_tasks
+    SET sandbox_resource_overrides = NULL
+    WHERE sandbox_resource_overrides = '{"vcpus": 4, "memory_mb": 8192}'::jsonb;
+END $$;

--- a/api/pkg/types/project.go
+++ b/api/pkg/types/project.go
@@ -242,8 +242,9 @@ type Project struct {
 	// Default sandbox environment for new spec tasks. Empty values from legacy
 	// projects resolve to the full desktop runtime.
 	DefaultSandboxRuntime SandboxRuntime `json:"default_sandbox_runtime,omitempty" gorm:"size:64"`
-	// Default sandbox resources copied into each new SpecTask. Nil values from
-	// legacy projects resolve to the standard 4 vCPU / 8 GB preset.
+	// Default sandbox resources copied into each new SpecTask. Nil means the
+	// project expresses no preference and the task resolves the global default at
+	// container-create time.
 	DefaultSandboxResourceOverrides *SandboxResourceOverrides `json:"default_sandbox_resource_overrides,omitempty" gorm:"type:jsonb;serializer:json"`
 
 	ProjectManagerHelixAppID string `json:"project_manager_helix_app_id"`

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"gorm.io/datatypes"
@@ -82,10 +84,41 @@ type StartPlanningOptions struct {
 	Timezone string `json:"timezone,omitempty"`
 }
 
+// Compile-time fallback for the spec task sandbox size. Config overrides it at
+// startup via SetDefaultSpecTaskSandboxResources; this is what a binary with no
+// configuration does, so it has to be a correct answer on its own.
+//
+// 12 vCPU / 24 GB is the size measured to fix the 2026-08-24 streaming outage:
+// the 4 vCPU / 8 GB predecessor left desktop containers at 99.999% of memory.max
+// with CFS throttling on 80% of periods, which stretched GStreamer's
+// set_state(PLAYING) from under a second to 43-100s. Real steady-state demand of
+// an uncapped desktop runs 2-30 GiB.
 const (
-	DefaultSpecTaskSandboxVCPUs    = 4
-	DefaultSpecTaskSandboxMemoryMB = 8192
+	DefaultSpecTaskSandboxVCPUs    = 12
+	DefaultSpecTaskSandboxMemoryMB = 24576
 )
+
+// configuredSpecTaskSandboxDefault holds the operator-configured default. Nil
+// until SetDefaultSpecTaskSandboxResources runs, so a binary that never
+// configures one keeps the compile-time constants above.
+var configuredSpecTaskSandboxDefault atomic.Pointer[SandboxResourceOverrides]
+
+// SetDefaultSpecTaskSandboxResources installs the operator-configured default
+// sandbox size. Call it once from startup, before anything serves — it is read
+// without synchronisation on every task start and is not meant to change under a
+// running server.
+//
+// It rejects a pair that is not a valid preset rather than accepting a size the
+// UI cannot represent and a failed resize cannot roll back to.
+func SetDefaultSpecTaskSandboxResources(r SandboxResourceOverrides) error {
+	if !r.ValidPreset() {
+		return fmt.Errorf(
+			"default spec task sandbox %d vCPU / %d MB is not a valid preset (vCPUs must be one of %s, with memory following)",
+			r.VCPUs, r.MemoryMB, specTaskSandboxVCPUList())
+	}
+	configuredSpecTaskSandboxDefault.Store(&r)
+	return nil
+}
 
 // SandboxResourceOverrides is the desired CPU and memory limit for the single
 // desktop container owned by a SpecTask. A nil value resolves to the SpecTask
@@ -95,7 +128,29 @@ type SandboxResourceOverrides struct {
 	MemoryMB int `json:"memory_mb,omitempty"`
 }
 
+// SpecTaskSandboxPresets is the ladder of selectable sandbox sizes, ordered
+// smallest first. vCPU is the key: memory is never independently selectable, so
+// every rung must have a distinct vCPU count. Adding a rung here extends both
+// SpecTaskSandboxPresetForVCPUs and ValidPreset; keep it in step with
+// frontend/src/constants/sandboxPresets.ts, which mirrors it for the UI.
+//
+// Existing rungs must stay valid: a stored value that stops being a preset is
+// rejected by every ValidPreset() call site the next time the row is updated.
+var SpecTaskSandboxPresets = []SandboxResourceOverrides{
+	{VCPUs: 1, MemoryMB: 2048},
+	{VCPUs: 4, MemoryMB: 8192},
+	{VCPUs: 8, MemoryMB: 16384},
+	{VCPUs: 12, MemoryMB: 24576},
+	{VCPUs: 16, MemoryMB: 32768},
+}
+
+// DefaultSpecTaskSandboxResources returns the operator-configured default, or
+// the compile-time constants when nothing configured one.
 func DefaultSpecTaskSandboxResources() *SandboxResourceOverrides {
+	if configured := configuredSpecTaskSandboxDefault.Load(); configured != nil {
+		resources := *configured
+		return &resources
+	}
 	return &SandboxResourceOverrides{
 		VCPUs:    DefaultSpecTaskSandboxVCPUs,
 		MemoryMB: DefaultSpecTaskSandboxMemoryMB,
@@ -109,40 +164,41 @@ func EffectiveSpecTaskSandboxResources(resources *SandboxResourceOverrides) Sand
 	return *resources
 }
 
-// SpecTaskSandboxPresetForVCPUs maps a vCPU count to its full preset. Memory
-// is not independently selectable — the UI offers three fixed sizes and
-// ValidPreset rejects any other pairing — so callers that take only a vCPU
-// count (the org MCP create tool, for one) resolve the memory here rather than
-// each restating the table and risking a combination ValidPreset refuses.
+// SpecTaskSandboxPresetForVCPUs maps a vCPU count to its full preset. Memory is
+// not independently selectable — ValidPreset rejects any other pairing — so
+// callers that take only a vCPU count (the org MCP create tool, for one) resolve
+// the memory here rather than each restating the table and risking a combination
+// ValidPreset refuses.
 //
 // Returns false for a vCPU count that has no preset.
 func SpecTaskSandboxPresetForVCPUs(vcpus int) (*SandboxResourceOverrides, bool) {
-	preset := SandboxResourceOverrides{VCPUs: vcpus}
-	switch vcpus {
-	case 1:
-		preset.MemoryMB = 2048
-	case 4:
-		preset.MemoryMB = 8192
-	case 8:
-		preset.MemoryMB = 16384
-	default:
-		return nil, false
+	for _, preset := range SpecTaskSandboxPresets {
+		if preset.VCPUs == vcpus {
+			return &preset, true
+		}
 	}
-	return &preset, true
+	return nil, false
 }
 
 func (r SandboxResourceOverrides) ValidPreset() bool {
-	switch r.VCPUs {
-	case 1:
-		return r.MemoryMB == 2048
-	case 4:
-		return r.MemoryMB == 8192
-	case 8:
-		return r.MemoryMB == 16384
-	default:
-		return false
-	}
+	preset, ok := SpecTaskSandboxPresetForVCPUs(r.VCPUs)
+	return ok && preset.MemoryMB == r.MemoryMB
 }
+
+// specTaskSandboxVCPUList renders the selectable vCPU counts for an error
+// message, so the ladder is stated in one place rather than hand-copied into
+// every validation failure.
+func specTaskSandboxVCPUList() string {
+	counts := make([]string, 0, len(SpecTaskSandboxPresets))
+	for _, preset := range SpecTaskSandboxPresets {
+		counts = append(counts, strconv.Itoa(preset.VCPUs))
+	}
+	return strings.Join(counts, ", ")
+}
+
+// SpecTaskSandboxVCPUList is the selectable vCPU counts as a human-readable
+// list, for tool descriptions and validation errors.
+func SpecTaskSandboxVCPUList() string { return specTaskSandboxVCPUList() }
 
 // EffectiveSpecTaskSandboxRuntime keeps legacy tasks on the full desktop while
 // allowing newly-created tasks to opt into the headless agent runtime.

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1207,6 +1207,13 @@ type ServerConfigForFrontend struct {
 	// Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
 	MaxConcurrentDesktops int    `json:"max_concurrent_desktops"`
 	Edition               string `json:"edition,omitempty"` // "mac-desktop", "server", "cloud", etc.
+	// DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it
+	// specifies none. It is operator-configurable
+	// (HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read
+	// it from here rather than hardcode a copy — otherwise an operator who moves
+	// the default gets a task selector that marks the wrong rung "Default" while
+	// containers come up at the configured size.
+	DefaultSpecTaskSandbox SandboxResourceOverrides `json:"default_spec_task_sandbox"`
 	// DefaultChatSystemPrompt is the system prompt the platform applies to
 	// direct model chats when the user has not customised one. Surfaced to
 	// the frontend so the chat-settings page can prefill the textbox.

--- a/design/2026-08-24-sandbox-defaults-and-stream-init-replay.md
+++ b/design/2026-08-24-sandbox-defaults-and-stream-init-replay.md
@@ -1,0 +1,294 @@
+# Sandbox defaults that work out of the box, and stream `init` replay on reconnect
+
+2026-08-24. Two defects from one outage (meta / node01, task
+`spt_01m0s0vktb0twdtwz7cmk6wgtg`, session `ses_01m0s0vkvq89563fdkxza4cry6`). The
+symptom was "video streaming is broken". It was not a video bug.
+
+## The outage
+
+The desktop container sat at 99.999% of its 8 GiB `memory.max`, with
+`memory.pressure full avg60=55.6%` and `cpu.stat nr_throttled 20319/25366`. Under
+that starvation GStreamer's `set_state(PLAYING)` took 43–100 s instead of under a
+second. `desktop-bridge` sends `StreamInit` only *after* `streamer.Start()`
+returns, so the browser timed out, closed, and every later write hit
+`broken pipe`. Each retry sent a fresh `init`, tripping
+`[SHARED_VIDEO] Evicted dead source in GetOrCreate` and leaking pipelines. It
+never converged.
+
+`docker update --memory 24g --memory-swap 48g --cpus 12` on the live container
+took CPU from 397% (CFS-throttled at the 4-vCPU cap) to 1213%, the pipeline
+started in the same second, and `helix spectask stream --duration 30` returned
+1638 frames at 54.6 FPS. Nothing else changed.
+
+Underneath that, a second bug: the stream proxy never replays `init` when it
+re-dials the backend, so *any* backend drop leaves the stream permanently dead
+until the user reloads the page.
+
+---
+
+## Part A — the chosen default: 12 vCPU / 24576 MB
+
+### Why 24 GB
+
+Steady-state memory of desktop containers on node01, sampled 2026-08-24:
+
+| container | usage | limit |
+|---|---|---|
+| `01m0sbr51axfh4gmm30xct6f0k` | 7.29 GiB | 8 GiB |
+| `01m0s0vkvq89563fdkxza4cry6` | 7.89 GiB | 8 GiB ← the outage |
+| `01m0cm7thsmwf3aydezsntg2rg` | 8.32 GiB | 16 GiB |
+| `01kzzym0gtzhg57e891mj1466x` | 6.57 GiB | 16 GiB |
+| `01kz6r8hvd8b2eav84r5cryfs3` | 5.56 GiB | 16 GiB |
+| `01kzdznnqrvwfwf0ppgf098tmk` | 9.67 GiB | uncapped |
+| `01kz6r9czzj9tzs1twxn0ff1qd` | **29.75 GiB** | uncapped |
+
+A container pinned at its limit is a **censored** observation, not a
+measurement — its real demand is `≥` what is shown. Treating the two 8 GiB rows
+that way, sorted lower bounds are 5.56, 6.57, ≥7.29, ≥7.89, 8.32, 9.67, 29.75,
+putting p90 at roughly **21 GiB** — itself a lower bound.
+
+The rule we set was that the p90 task must not sit inside 90% of its ceiling.
+21 / 0.9 = 23.3 GiB, so the ceiling has to be at least 24 GiB. 16 GiB would put
+the p90 at ~131% of its ceiling, i.e. an OOM rather than a margin.
+
+12 vCPU comes from the measurement, not extrapolation: at the 4-vCPU cap the
+container was throttled on 80% of periods, and raising it to 12 took observed
+utilisation to 1213%.
+
+So the default is exactly the configuration proven live to fix this outage.
+
+### The ladder
+
+`1/2048`, `4/8192`, `8/16384`, **`12/24576`**, **`16/32768`** — 2 GB per vCPU
+throughout. `SpecTaskSandboxPresetForVCPUs` and `ValidPreset` now derive from one
+`SpecTaskSandboxPresets` table so they cannot drift.
+
+All pre-existing rungs stay valid, deliberately. Re-keying 8 from 16384 to 24576
+(so the default could stay at 8 vCPU) would make every stored
+`{"vcpus": 8, "memory_mb": 16384}` fail `ValidPreset()` and be rejected on the
+next update of that row — 178 such rows on meta, all deliberate user choices.
+
+### Docker rejects a CPU limit above the host
+
+`--cpus` greater than the host CPU count is a hard error
+(`Range of CPUs is from 0.01 to N.00`), so a 12-vCPU default would fail container
+creation outright on any smaller host — defeating the point of this change.
+`sandboxResourceLimits` now clamps vCPUs to `runtime.NumCPU()` and logs when it
+does. Memory is deliberately **not** clamped: Docker accepts a limit above host
+RAM, and an unreachable ceiling beats one that OOM-kills the desktop.
+
+### Operator configuration
+
+`HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS` / `_MEMORY_MB` on `config.Sandboxes`,
+defaulting to 12/24576 so out-of-the-box behaviour is correct with no env set.
+An invalid pair fails startup rather than being ignored:
+
+```
+failed to load server config: HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB:
+default spec task sandbox 6 vCPU / 12288 MB is not a valid preset
+(vCPUs must be one of 1, 4, 8, 12, 16, with memory following)
+```
+
+Installed as a process-wide value from `LoadServerConfig` rather than threaded
+through constructors: `DefaultSpecTaskSandboxResources()` is read from packages
+with no config handle at all (`desktopBillingResources` is a free function,
+`HydraExecutor` holds no `ServerConfig`), and the value is immutable after
+startup.
+
+### Migration strategy for materialized rows
+
+Commit `1eff4e801` (2026-08-10) made `CreateTaskFromPrompt` write the default
+onto the row. The brief assumed every task since was affected; the real counts on
+meta were:
+
+| rows | value | action |
+|---|---|---|
+| 4102 | `NULL` | nothing to do |
+| 178 | `{"vcpus": 8, "memory_mb": 16384}` | **never touch** — real user choices |
+| 31 | `{"vcpus": 4, "memory_mb": 8192}` | the only stale rows |
+
+**Both halves of the fix, because either alone is insufficient:**
+
+1. **Stop materializing.** Both create paths now store `nil` when neither the
+   request nor the project chose a size. `resolveSpecTaskLaunchConfig` already
+   resolves `nil` to the live default at container-create time. A stored override
+   now means "someone chose this", not "this was the default the day the row was
+   written".
+2. **Backfill** (`0009_unmaterialize_spec_task_sandbox_default`) NULLs rows
+   holding *exactly* the old pair. Writing `NULL` rather than the new pair is the
+   point: a NULLed row tracks every future default change, whereas an explicit
+   `12/24576` would be frozen exactly the way `4/8192` was, recreating this
+   ticket the next time the default moves.
+
+The predicate matches the exact object and nothing else. Verified on seeded data:
+both 4/8192 rows (including a differently-key-ordered one, which `jsonb`
+normalises) became `NULL`; `8/16384` and a near-miss `4/4096` were untouched;
+re-running changed nothing.
+
+Project rows are deliberately not touched — a project only stores an override
+when an admin explicitly set one.
+
+### Two gaps that only end-to-end testing found
+
+**The frontend was re-materializing the default.** With the server fixed, new
+rows *still* came back with `{"vcpus": 12, "memory_mb": 24576}` written on them,
+because both create forms initialised their state to the default and
+`buildNewChatTaskRequest` sends the field whenever it is truthy. Same freeze,
+new value. Both forms now hold `undefined` until the user picks a size; the
+selectors already render the default for an undefined value, so the UI is
+unchanged.
+
+**The UI's "· Default" marker lied to operators.** The marker came from a
+hardcoded frontend constant, so with `HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS=8`
+set the selector marked 12 vCPU as Default while containers came up at 8/16384.
+`/api/v1/config` now carries `default_spec_task_sandbox` and
+`useDefaultSandboxPreset` reads it.
+
+Generalising: making a value operator-configurable on the server is only half the
+job if a client renders its own copy of it, and removing a materialized default
+on the server is only half the job if a client keeps sending it.
+
+---
+
+## Part B — replay `init` on reconnect
+
+### The bug
+
+`proxy.ResilientProxy` re-dials the backend transparently, but
+`CreateWebSocketUpgradeFunc` redoes only the HTTP upgrade. `desktop-bridge`
+blocks on a mandatory `{"type":"init"}` text frame with a 30 s read deadline
+before it will start a streamer. The browser sent that frame once, on the
+original socket. So every reconnect produced a backend socket that waited 30 s,
+died and reconnected — eight cycles in the outage log — while the *client* socket
+stayed open, showing a live-but-frozen picture with no error surfaced anywhere.
+
+### The mechanism
+
+`SessionReplay` is the frame-level sibling of `CreateWebSocketUpgradeFunc`'s
+`extraHeaders`. That doc comment already argues the principle — headers belong on
+the upgrade func *because it also runs on reconnect*, and dropping them "would
+silently restore the privilege mid-session". `init` has the identical
+requirement and was missed. The header path re-sends what *we* know about the
+caller; this path re-sends what the *client* told the backend.
+
+`StreamInitReplay` carries a minimal RFC 6455 client-frame parser — enough to
+find the first text frame in the client→server direction and no more.
+`ResilientProxy` is otherwise a raw byte proxy and deliberately stays that way.
+Client frames are masked, so the replay is re-encoded with a fresh mask key
+(required anyway, since the payload changes).
+
+The replay is written to the new backend **before** the buffered input: the
+backend is blocked in its init read and processes nothing else first.
+
+### Decision: a replayed init has `user_retry` cleared
+
+`user_retry` marks an explicit user-initiated retry (the Restart button) and is
+the only thing that clears a latched shared-video circuit breaker. A proxy
+reconnect is by definition automatic. If replay preserved the flag, one press of
+Restart would re-assert it on every subsequent backend drop, the breaker would
+reset each time, and **it could never latch** — which is exactly the retry storm
+the breaker exists to stop, and exactly what the outage log shows. The Restart
+button is unaffected: it opens a new client socket whose init is not a replay.
+
+The payload is decoded to `map[string]any`, not `desktop.StreamConfig`.
+Round-tripping the struct would drop fields a newer browser sends that this build
+does not know about, and re-emit `omitempty` fields the client deliberately
+omitted. Everything except `user_retry` passes through unchanged.
+
+Malformed JSON disables replay rather than being re-sent verbatim — replaying
+bytes we cannot read risks re-asserting `user_retry`.
+
+### Read-only safety
+
+`StreamConfig` has no privilege field. Read-only is enforced entirely by
+`X-Helix-Readonly`, set server-side on the upgrade and already re-applied on
+every reconnect. Replay therefore *cannot* re-grant input to an embed-key
+viewer — there is no lever in the payload to pull. Both halves are now covered by
+tests, including the header-on-reconnect invariant, which the doc comment
+asserted but nothing tested.
+
+### The shared pipeline survives
+
+A real backend drop produced
+`[SHARED_VIDEO] Client subscribed (grace period reconnection, starting catchup)`
+— not `Evicted dead source in GetOrCreate`, not `Created new source`. The
+registry's 60 s grace period holds the source alive across the reconnect window,
+so the replayed init re-subscribes to the live pipeline rather than restarting
+it. No leak, no 43 s stall.
+
+### Known limitation: frame boundaries across a drop
+
+`ResilientProxy` buffers bytes, not frames. `copyClientToServer` discards
+`Write`'s returned byte count and re-buffers the whole chunk, and 32KB reads do
+not align with frame boundaries, so a drop mid-frame can desync the resumed
+stream. Both causes predate this change. Fixing it properly means making the byte
+proxy frame-aware in the hot path of every proxied byte; for this stream every
+client→server frame is small (13-byte keepalives, input events), so desync needs
+a frame split across TCP segments *and* a write failure inside that window.
+Documented rather than fixed.
+
+---
+
+## Verification
+
+All in the inner Helix at `localhost:8080`, against a real spec task.
+
+**Part A**
+
+- Fresh task row: `sandbox_resource_overrides` is `NULL`.
+- Its container:
+  `Memory=25769803776 NanoCpus=12000000000 MemorySwap=51539607552` — 24 GiB,
+  12 vCPU, 48 GiB swap. Exactly the configuration that fixed the outage.
+- `helix spectask stream --duration 30` → 1894 frames, 60 instant / 63.1 avg FPS
+  at 1920x1080.
+- Selector shows all five rungs with 12 vCPU / 24 GB marked "· Default".
+- Config override to 8/16384: `/api/v1/config` reports it, the "· Default" marker
+  moves to the 8 vCPU rung. Invalid pair 6/12288: startup refuses with the
+  message quoted above. Env removed: back to 12/24576.
+- Migration on seeded data: 4/8192 → NULL (including key-order variant),
+  8/16384 and 4/4096 untouched, second run a no-op.
+
+**Part B**
+
+Forcing a real reconnect needs care. **Killing `desktop-bridge` does not exercise
+the replay path** — it hosts the RevDial client, so `dialFunc` fails all three
+attempts, the proxy gives up, and the *browser* opens a fresh socket with its own
+init. The give-away is `reconnect_count=0`. Drop only the backend TCP socket
+instead:
+
+```bash
+docker exec helix-sandbox-nvidia-1 docker exec <container> \
+  ss -K state established '( sport = :9876 )'
+```
+
+Observed chain:
+
+```
+API    Server connection error, attempting reconnection
+         error="websocket: close 1006 (abnormal closure): unexpected EOF"
+API    Replayed session state to reconnected backend  bytes=297
+API    Reconnected successfully, resuming proxy  reconnect_count=1
+bridge stream WebSocket connected            11:44:24.975
+bridge stream init received … user_retry=false  11:44:24.976   ← 1ms, not 30s
+bridge [SHARED_VIDEO] Client subscribed (grace period reconnection, starting catchup)
+```
+
+`failed to read init message` across the entire bridge log: **0**. Video resumed
+unattended with no page reload; `helix spectask stream --duration 30` after the
+reconnect returned 1844 frames at 61.5 avg FPS.
+
+## Notes for whoever touches this next
+
+- **vCPU is the primary key of a sandbox preset.** Memory is always derived from
+  it. Never make memory independently selectable.
+- **`ValidPreset()` guards requests, never reads.** Nothing validates a preset
+  loaded from the DB, and `sandboxResourceLimits` just multiplies. A row can hold
+  a size no rung represents: the backend honours it and the frontend silently
+  renders no selection. `sandboxPresetsFor()` now surfaces such a value instead
+  of dropping it.
+- **Docker rejects `--cpus` above host CPU count but accepts memory above host
+  RAM.** That asymmetry is why CPU needs clamping and memory does not.
+- **`ResilientProxy` is a raw byte proxy** with no frame awareness. Anything
+  needing frame semantics brings its own parser.
+- When sizing anything from `docker stats`, a container pinned at its limit is a
+  censored observation, not a measurement.

--- a/design/2026-08-24-sandbox-defaults-and-stream-init-replay.md
+++ b/design/2026-08-24-sandbox-defaults-and-stream-init-replay.md
@@ -128,6 +128,30 @@ re-running changed nothing.
 Project rows are deliberately not touched — a project only stores an override
 when an admin explicitly set one.
 
+### How the migration actually gets applied
+
+Worth writing down, because most schema work here goes through GORM AutoMigrate
+and this does not.
+
+`PostgresStore.runMigrations()` calls `MigrateUp()` **before** `AutoMigrate`.
+`MigrateUp` is `golang-migrate` over `//go:embed migrations/*.sql`, tracked in
+the `helix_migrations` table. So:
+
+- A new `NNNN_name.up.sql` file is picked up automatically. There is no registry
+  to add to.
+- **Migrations run before the tables exist on a fresh database.** That is why
+  0009 opens with a `to_regclass('spec_tasks') IS NULL` guard, matching the
+  house pattern in 0006. Without it, a fresh install would fail at startup.
+- A failing migration is loud, not silent: `runMigrations` returns
+  `failed to run version migrations` and startup aborts.
+
+Verified end-to-end through the real runner rather than by piping SQL into
+`psql`: seed a 4/8192 row plus an 8/16384 control, `UPDATE helix_migrations SET
+version = 8`, restart the API. Result — version back to 9 with `dirty = false`,
+the 4/8192 row NULLed, the 8/16384 control untouched. Separately, running 0009
+against a schema with no `spec_tasks` table exits cleanly, confirming the
+fresh-install guard.
+
 ### Two gaps that only end-to-end testing found
 
 **The frontend was re-materializing the default.** With the server fixed, new

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6286,6 +6286,15 @@ export interface TypesServerConfigForFrontend {
    * the frontend so the chat-settings page can prefill the textbox.
    */
   default_chat_system_prompt?: string;
+  /**
+   * DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it
+   * specifies none. It is operator-configurable
+   * (HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read
+   * it from here rather than hardcode a copy — otherwise an operator who moves
+   * the default gets a task selector that marks the wrong rung "Default" while
+   * containers come up at the configured size.
+   */
+  default_spec_task_sandbox?: TypesSandboxResourceOverrides;
   deployment_id?: string;
   /**
    * DevSubdomain is the base domain used for sandbox preview hostnames.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -5209,8 +5209,9 @@ export interface TypesProject {
    */
   default_repo_id?: string;
   /**
-   * Default sandbox resources copied into each new SpecTask. Nil values from
-   * legacy projects resolve to the standard 4 vCPU / 8 GB preset.
+   * Default sandbox resources copied into each new SpecTask. Nil means the
+   * project expresses no preference and the task resolves the global default at
+   * container-create time.
    */
   default_sandbox_resource_overrides?: TypesSandboxResourceOverrides;
   /**

--- a/frontend/src/components/agent/CodeAgentExecutionControls.tsx
+++ b/frontend/src/components/agent/CodeAgentExecutionControls.tsx
@@ -26,6 +26,7 @@ import { getCodeAgentEffortOptions } from './CodeAgentEffortSelect'
 import { useHasEnabledCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
 import CodeAgentConfigPicker from './CodeAgentConfigPicker'
 import { CodeAgentConfigChangeSource } from '../../utils/codeAgentExecutionConfig'
+import { DEFAULT_SANDBOX_PRESET, sandboxPresetsFor } from '../../constants/sandboxPresets'
 
 type MaybePromise = void | Promise<unknown>
 
@@ -48,14 +49,6 @@ export interface CodeAgentExecutionControlsProps {
   /** Select the recommended available harness and model when a new task has no config. */
   autoSelectDefault?: boolean
 }
-
-const SANDBOX_PRESETS = [
-  { vcpus: 1, memory_mb: 2048, description: '2 GB RAM' },
-  { vcpus: 4, memory_mb: 8192, description: '8 GB RAM' },
-  { vcpus: 8, memory_mb: 16384, description: '16 GB RAM' },
-] as const
-
-const DEFAULT_SANDBOX_PRESET = SANDBOX_PRESETS[1]
 
 const compactButtonSx = {
   height: 28,
@@ -104,6 +97,7 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
   const resources = sandboxResourceOverrides?.vcpus
     ? sandboxResourceOverrides
     : DEFAULT_SANDBOX_PRESET
+  const sandboxPresets = sandboxPresetsFor(resources.vcpus, resources.memory_mb)
   const runtimeEnvironment = sandboxRuntime || TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop
   const showSandboxRuntime = sandboxRuntime !== undefined || !!onSandboxRuntimeChange
   const sandboxRuntimeLocked = showSandboxRuntime && !onSandboxRuntimeChange
@@ -287,7 +281,7 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
         transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >
         <ListSubheader disableSticky>Compute</ListSubheader>
-        {SANDBOX_PRESETS.map((preset) => (
+        {sandboxPresets.map((preset) => (
           <MenuItem
             key={preset.vcpus}
             selected={preset.vcpus === resources.vcpus}

--- a/frontend/src/components/agent/CodeAgentExecutionControls.tsx
+++ b/frontend/src/components/agent/CodeAgentExecutionControls.tsx
@@ -26,7 +26,8 @@ import { getCodeAgentEffortOptions } from './CodeAgentEffortSelect'
 import { useHasEnabledCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
 import CodeAgentConfigPicker from './CodeAgentConfigPicker'
 import { CodeAgentConfigChangeSource } from '../../utils/codeAgentExecutionConfig'
-import { DEFAULT_SANDBOX_PRESET, sandboxPresetsFor } from '../../constants/sandboxPresets'
+import { sandboxPresetsFor } from '../../constants/sandboxPresets'
+import { useDefaultSandboxPreset } from '../../hooks/useDefaultSandboxPreset'
 
 type MaybePromise = void | Promise<unknown>
 
@@ -94,9 +95,10 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
     && value?.service_tier === 'fast'
     ? `${effortLabel} · Fast`
     : effortLabel
+  const defaultSandboxPreset = useDefaultSandboxPreset()
   const resources = sandboxResourceOverrides?.vcpus
     ? sandboxResourceOverrides
-    : DEFAULT_SANDBOX_PRESET
+    : defaultSandboxPreset
   const sandboxPresets = sandboxPresetsFor(resources.vcpus, resources.memory_mb)
   const runtimeEnvironment = sandboxRuntime || TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop
   const showSandboxRuntime = sandboxRuntime !== undefined || !!onSandboxRuntimeChange
@@ -294,7 +296,7 @@ const CodeAgentExecutionControls: FC<CodeAgentExecutionControlsProps> = ({
           >
             <Typography variant="body2" sx={{ flex: 1 }}>{preset.vcpus} vCPU</Typography>
             <Typography variant="caption" color="text.secondary">
-              {preset.description}{preset.vcpus === DEFAULT_SANDBOX_PRESET.vcpus ? ' · Default' : ''}
+              {preset.description}{preset.vcpus === defaultSandboxPreset.vcpus ? ' · Default' : ''}
             </Typography>
           </MenuItem>
         ))}

--- a/frontend/src/components/sandboxes/CreateSandboxDialog.tsx
+++ b/frontend/src/components/sandboxes/CreateSandboxDialog.tsx
@@ -40,10 +40,16 @@ const DEFAULT_RUNTIME = (TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu ?? 'he
 // the sandbox is deleted or the container is recreated.
 const PERSISTENT_WORKSPACE_PATH = '/home/retro/work'
 
+// Kept in step with the spec-task ladder (constants/sandboxPresets.ts and
+// types.SpecTaskSandboxPresets) so a size offered on one surface is not refused
+// on the other. The default stays 'small': size here is an explicit choice at
+// create time, not a default silently applied to work the user did not size.
 const RESOURCE_PRESETS = [
   { value: 'small', label: '1 CPU / 2GB RAM', vcpus: 1, memoryMB: 2048 },
   { value: 'medium', label: '4 CPU / 8GB RAM', vcpus: 4, memoryMB: 8192 },
   { value: 'large', label: '8 CPU / 16GB RAM', vcpus: 8, memoryMB: 16384 },
+  { value: 'xlarge', label: '12 CPU / 24GB RAM', vcpus: 12, memoryMB: 24576 },
+  { value: '2xlarge', label: '16 CPU / 32GB RAM', vcpus: 16, memoryMB: 32768 },
 ]
 
 // CreateSandboxDialog asks for a name, runtime, and optional TTL/env.

--- a/frontend/src/components/session/ProjectChatItemTooltip.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemTooltip.test.tsx
@@ -5,6 +5,7 @@ import { TypesCodeAgentCredentialType, TypesCodeAgentRuntime, TypesSandboxRuntim
 import { AppsContext, IAppsContext } from '../../contexts/apps'
 import type { IApp } from '../../types'
 import ProjectChatItemTooltip from './ProjectChatItemTooltip'
+import { DEFAULT_SANDBOX_PRESET } from '../../constants/sandboxPresets'
 
 const appsContext = (apps: IApp[]): IAppsContext => ({
   apps,
@@ -96,7 +97,9 @@ describe('ProjectChatItemTooltip', () => {
 
     fireEvent.mouseOver(screen.getByRole('button', { name: 'Legacy task row' }))
 
-    expect(await screen.findByText('4 vCPU · 8 GB RAM')).toBeInTheDocument()
+    expect(await screen.findByText(
+      `${DEFAULT_SANDBOX_PRESET.vcpus} vCPU · ${DEFAULT_SANDBOX_PRESET.memory_mb / 1024} GB RAM`,
+    )).toBeInTheDocument()
     expect(screen.getByText('Full Desktop')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/session/projectChatItemDetails.ts
+++ b/frontend/src/components/session/projectChatItemDetails.ts
@@ -3,6 +3,7 @@ import type { IApp } from '../../types'
 import { effectiveSpecTaskSandboxRuntime } from '../../utils/specTaskSandboxRuntime'
 import { getAgentHarnessLabel, getAgentHarnessModel, getAgentHarnessRuntime } from '../agent/AgentHarness'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
+import { DEFAULT_SANDBOX_PRESET } from '../../constants/sandboxPresets'
 
 export type ProjectChatItemDetails = {
   repository?: string
@@ -61,8 +62,8 @@ export const getProjectChatItemDetails = ({
 
   if (item.kind !== 'spec-task' || !item.task) return details
 
-  const vcpus = item.task.sandbox_resource_overrides?.vcpus || 4
-  const memoryMb = item.task.sandbox_resource_overrides?.memory_mb || 8192
+  const vcpus = item.task.sandbox_resource_overrides?.vcpus || DEFAULT_SANDBOX_PRESET.vcpus
+  const memoryMb = item.task.sandbox_resource_overrides?.memory_mb || DEFAULT_SANDBOX_PRESET.memory_mb
   const memory = memoryMb % 1024 === 0
     ? `${memoryMb / 1024} GB RAM`
     : `${memoryMb} MB RAM`

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -61,6 +61,7 @@ import {
   preferredSpecTaskSandboxRuntime,
   saveSpecTaskSandboxRuntimePreference,
 } from "../../utils/specTaskSandboxRuntime";
+import { DEFAULT_SANDBOX_PRESET, defaultSandboxResourceOverrides } from "../../constants/sandboxPresets";
 
 const ATTACHMENT_ACCEPT_ATTR = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
   .flatMap(([mime, exts]) => [mime, ...exts])
@@ -147,10 +148,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const missingCodeAgents = !loadingCodeAgents && !hasCodeAgents;
 
   const [codeAgentConfig, setCodeAgentConfig] = useState<TypesCodeAgentExecutionConfig>();
-  const [sandboxResourceOverrides, setSandboxResourceOverrides] = useState<TypesSandboxResourceOverrides>({
-    vcpus: 4,
-    memory_mb: 8192,
-  });
+  const [sandboxResourceOverrides, setSandboxResourceOverrides] = useState<TypesSandboxResourceOverrides>(
+    defaultSandboxResourceOverrides(),
+  );
   const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
     preferredSpecTaskSandboxRuntime(projectId),
   );
@@ -334,9 +334,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   }, [projectId, project?.default_sandbox_runtime]);
 
   const projectDefaultSandboxVCPUs =
-    project?.default_sandbox_resource_overrides?.vcpus || 4;
+    project?.default_sandbox_resource_overrides?.vcpus || DEFAULT_SANDBOX_PRESET.vcpus;
   const projectDefaultSandboxMemoryMB =
-    project?.default_sandbox_resource_overrides?.memory_mb || 8192;
+    project?.default_sandbox_resource_overrides?.memory_mb || DEFAULT_SANDBOX_PRESET.memory_mb;
   const projectCodeAgentConfigKey = JSON.stringify(
     project?.code_agent_config ?? null,
   );

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -148,9 +148,8 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const missingCodeAgents = !loadingCodeAgents && !hasCodeAgents;
 
   const [codeAgentConfig, setCodeAgentConfig] = useState<TypesCodeAgentExecutionConfig>();
-  const [sandboxResourceOverrides, setSandboxResourceOverrides] = useState<TypesSandboxResourceOverrides>(
-    defaultSandboxResourceOverrides(),
-  );
+  const [sandboxResourceOverrides, setSandboxResourceOverrides] =
+    useState<TypesSandboxResourceOverrides | undefined>();
   const [sandboxRuntime, setSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
     preferredSpecTaskSandboxRuntime(projectId),
   );
@@ -333,19 +332,24 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     );
   }, [projectId, project?.default_sandbox_runtime]);
 
-  const projectDefaultSandboxVCPUs =
-    project?.default_sandbox_resource_overrides?.vcpus || DEFAULT_SANDBOX_PRESET.vcpus;
-  const projectDefaultSandboxMemoryMB =
-    project?.default_sandbox_resource_overrides?.memory_mb || DEFAULT_SANDBOX_PRESET.memory_mb;
+  // Undefined when the project expresses no preference, so the create request
+  // omits sandbox_resource_overrides entirely and the server resolves the live
+  // default at container-create time. Sending the default explicitly would
+  // materialize it onto the row and freeze that task at today's value forever —
+  // the exact bug 1eff4e801 introduced. The selector still *displays* the
+  // default for an undefined value.
+  const projectDefaultSandboxVCPUs = project?.default_sandbox_resource_overrides?.vcpus;
+  const projectDefaultSandboxMemoryMB = project?.default_sandbox_resource_overrides?.memory_mb;
   const projectCodeAgentConfigKey = JSON.stringify(
     project?.code_agent_config ?? null,
   );
 
   useEffect(() => {
-    setSandboxResourceOverrides({
-      vcpus: projectDefaultSandboxVCPUs,
-      memory_mb: projectDefaultSandboxMemoryMB,
-    });
+    setSandboxResourceOverrides(
+      projectDefaultSandboxVCPUs && projectDefaultSandboxMemoryMB
+        ? { vcpus: projectDefaultSandboxVCPUs, memory_mb: projectDefaultSandboxMemoryMB }
+        : undefined,
+    );
   }, [projectId, projectDefaultSandboxVCPUs, projectDefaultSandboxMemoryMB]);
 
   const handleSandboxRuntimeChange = (runtime: TypesSandboxRuntime) => {
@@ -410,10 +414,11 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     // Labels intentionally kept — they persist to the next task via localStorage
     setSelectedDependencyTaskIds([]);
     setCodeAgentConfig(project?.code_agent_config);
-    setSandboxResourceOverrides({
-      vcpus: projectDefaultSandboxVCPUs,
-      memory_mb: projectDefaultSandboxMemoryMB,
-    });
+    setSandboxResourceOverrides(
+      projectDefaultSandboxVCPUs && projectDefaultSandboxMemoryMB
+        ? { vcpus: projectDefaultSandboxVCPUs, memory_mb: projectDefaultSandboxMemoryMB }
+        : undefined,
+    );
     setSandboxRuntime(
       preferredSpecTaskSandboxRuntime(
         projectId,

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { TypesCodeAgentRuntime, TypesSandboxRuntime } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
 import SpecTaskExecutionControls from "./SpecTaskExecutionControls";
+import { DEFAULT_SANDBOX_PRESET } from "../../constants/sandboxPresets";
 
 vi.mock("../../hooks/useSnackbar", () => ({
   default: () => ({ success: vi.fn(), error: vi.fn() }),
@@ -135,7 +136,7 @@ describe("SpecTaskExecutionControls", () => {
     expect(executionConfig).toHaveTextContent("Compute:");
     expect(executionConfig).toHaveTextContent("deepseek-v4-flash");
     expect(executionConfig).toHaveTextContent("Medium");
-    expect(executionConfig).toHaveTextContent("4 vCPU");
+    expect(executionConfig).toHaveTextContent(`${DEFAULT_SANDBOX_PRESET.vcpus} vCPU`);
     const harness = screen.getByLabelText("Harness: opencode");
     expect(harness).toHaveTextContent("opencode");
     expect(harness.querySelector('[data-harness-mark="opencode"]')).toBeInTheDocument();
@@ -284,7 +285,7 @@ describe("SpecTaskExecutionControls", () => {
     )).toBeInTheDocument();
   });
 
-  it("shows the effective 4 vCPU default for legacy tasks without an override", () => {
+  it("shows the effective default for legacy tasks without an override", () => {
     render(
       <SpecTaskExecutionControls
         agents={[codexAgent]}
@@ -294,7 +295,8 @@ describe("SpecTaskExecutionControls", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Change sandbox size" })).toHaveTextContent("4 vCPU");
+    expect(screen.getByRole("button", { name: "Change sandbox size" }))
+      .toHaveTextContent(`${DEFAULT_SANDBOX_PRESET.vcpus} vCPU`);
     expect(screen.queryByText("Uncapped")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -29,6 +29,11 @@ import { getCodeAgentEffortOptions } from "../agent/CodeAgentEffortSelect";
 import { useModelReasoningEfforts } from "../../hooks/useModelReasoningEfforts";
 import SpecTaskModelPicker from "./SpecTaskModelPicker";
 import { codeAgentExecutionConfigFromApp } from "../../utils/codeAgentExecutionConfig";
+import {
+  DEFAULT_SANDBOX_PRESET,
+  SandboxPreset,
+  sandboxPresetsFor,
+} from "../../constants/sandboxPresets";
 
 type MaybePromise = void | Promise<unknown>;
 
@@ -52,14 +57,6 @@ interface SpecTaskExecutionControlsProps {
   compact?: boolean;
   grouped?: boolean;
 }
-
-const SANDBOX_PRESETS = [
-  { vcpus: 1, memory_mb: 2048, label: "1 CPU", description: "2 GB RAM" },
-  { vcpus: 4, memory_mb: 8192, label: "4 CPU", description: "8 GB RAM" },
-  { vcpus: 8, memory_mb: 16384, label: "8 CPU", description: "16 GB RAM" },
-] as const;
-
-const DEFAULT_SANDBOX_PRESET = SANDBOX_PRESETS[1];
 
 const compactButtonSx = {
   height: 28,
@@ -151,6 +148,8 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
   const effectiveSandboxResources = sandboxResourceOverrides?.vcpus
     ? sandboxResourceOverrides
     : DEFAULT_SANDBOX_PRESET;
+  const sandboxPresets = sandboxPresetsFor(
+    effectiveSandboxResources.vcpus, effectiveSandboxResources.memory_mb);
   const sandboxLabel = `${effectiveSandboxResources.vcpus} vCPU`;
   const effectiveSandboxRuntime = sandboxRuntime
     || TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop;
@@ -199,7 +198,7 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
     );
   };
 
-  const selectSandbox = async (preset: typeof SANDBOX_PRESETS[number]) => {
+  const selectSandbox = async (preset: SandboxPreset) => {
     if (!onSandboxResourceOverridesChange) return;
     setCpuAnchor(null);
     setIsSaving(true);
@@ -401,7 +400,7 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
         transformOrigin={{ vertical: "bottom", horizontal: "left" }}
       >
         <ListSubheader disableSticky>Compute</ListSubheader>
-        {SANDBOX_PRESETS.map((preset) => (
+        {sandboxPresets.map((preset) => (
           <MenuItem
             key={preset.vcpus}
             selected={preset.vcpus === effectiveSandboxResources.vcpus}

--- a/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
+++ b/frontend/src/components/tasks/SpecTaskExecutionControls.tsx
@@ -29,11 +29,8 @@ import { getCodeAgentEffortOptions } from "../agent/CodeAgentEffortSelect";
 import { useModelReasoningEfforts } from "../../hooks/useModelReasoningEfforts";
 import SpecTaskModelPicker from "./SpecTaskModelPicker";
 import { codeAgentExecutionConfigFromApp } from "../../utils/codeAgentExecutionConfig";
-import {
-  DEFAULT_SANDBOX_PRESET,
-  SandboxPreset,
-  sandboxPresetsFor,
-} from "../../constants/sandboxPresets";
+import { SandboxPreset, sandboxPresetsFor } from "../../constants/sandboxPresets";
+import { useDefaultSandboxPreset } from "../../hooks/useDefaultSandboxPreset";
 
 type MaybePromise = void | Promise<unknown>;
 
@@ -145,9 +142,10 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
   // runtime list stands. See api/pkg/model/reasoning_efforts.go.
   const supportedEfforts = useModelReasoningEfforts(effectiveModel);
   const effortOptions = getCodeAgentEffortOptions(runtime, supportedEfforts);
+  const defaultSandboxPreset = useDefaultSandboxPreset();
   const effectiveSandboxResources = sandboxResourceOverrides?.vcpus
     ? sandboxResourceOverrides
-    : DEFAULT_SANDBOX_PRESET;
+    : defaultSandboxPreset;
   const sandboxPresets = sandboxPresetsFor(
     effectiveSandboxResources.vcpus, effectiveSandboxResources.memory_mb);
   const sandboxLabel = `${effectiveSandboxResources.vcpus} vCPU`;
@@ -411,7 +409,7 @@ const SpecTaskExecutionControls: FC<SpecTaskExecutionControlsProps> = ({
             <Typography variant="body2" sx={{ flex: 1, whiteSpace: "nowrap" }}>{preset.vcpus} vCPU</Typography>
             <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>
               {preset.description}
-              {preset.vcpus === DEFAULT_SANDBOX_PRESET.vcpus ? " · Default" : ""}
+              {preset.vcpus === defaultSandboxPreset.vcpus ? " · Default" : ""}
             </Typography>
           </MenuItem>
         ))}

--- a/frontend/src/constants/sandboxPresets.test.ts
+++ b/frontend/src/constants/sandboxPresets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SANDBOX_PRESET,
+  SANDBOX_PRESETS,
+  defaultSandboxResourceOverrides,
+  sandboxPresetsFor,
+} from './sandboxPresets'
+
+describe('sandbox presets', () => {
+  it('mirrors the Go ladder in api/pkg/types/simple_spec_task.go', () => {
+    expect(SANDBOX_PRESETS.map((preset) => [preset.vcpus, preset.memory_mb])).toEqual([
+      [1, 2048],
+      [4, 8192],
+      [8, 16384],
+      [12, 24576],
+      [16, 32768],
+    ])
+  })
+
+  it('keys every rung on a distinct vCPU count', () => {
+    const vcpus = SANDBOX_PRESETS.map((preset) => preset.vcpus)
+    expect(new Set(vcpus).size).toBe(vcpus.length)
+  })
+
+  it('defaults to 12 vCPU / 24 GB', () => {
+    expect(DEFAULT_SANDBOX_PRESET.vcpus).toBe(12)
+    expect(DEFAULT_SANDBOX_PRESET.memory_mb).toBe(24576)
+  })
+
+  it('sends only the two numeric fields to the API', () => {
+    expect(defaultSandboxResourceOverrides()).toEqual({ vcpus: 12, memory_mb: 24576 })
+  })
+
+  // The 31 rows backfilled on meta hold 12/24576. Before the 12-vCPU rung
+  // existed the menu had nothing selected for them, which reads as "no sandbox
+  // configured" rather than "24 GB".
+  it('offers a rung matching a stored 12 vCPU value', () => {
+    const presets = sandboxPresetsFor(12, 24576)
+    expect(presets).toEqual(SANDBOX_PRESETS)
+    expect(presets.find((preset) => preset.vcpus === 12)).toBeDefined()
+  })
+
+  // Nothing validates a preset read from the database — every ValidPreset() call
+  // site guards an incoming request — so an off-ladder row must stay visible.
+  it('surfaces an off-ladder stored value instead of dropping it', () => {
+    const presets = sandboxPresetsFor(6, 12288)
+    expect(presets).toHaveLength(SANDBOX_PRESETS.length + 1)
+    expect(presets.find((preset) => preset.vcpus === 6)).toMatchObject({
+      vcpus: 6,
+      memory_mb: 12288,
+      description: '12 GB RAM',
+    })
+    expect(presets.map((preset) => preset.vcpus)).toEqual([1, 4, 6, 8, 12, 16])
+  })
+
+  it('leaves the ladder alone when no size is stored', () => {
+    expect(sandboxPresetsFor(undefined, undefined)).toEqual(SANDBOX_PRESETS)
+  })
+})

--- a/frontend/src/constants/sandboxPresets.ts
+++ b/frontend/src/constants/sandboxPresets.ts
@@ -1,0 +1,53 @@
+/**
+ * The sandbox size ladder, mirroring types.SpecTaskSandboxPresets in
+ * api/pkg/types/simple_spec_task.go. vCPU is the key — memory is never
+ * independently selectable — so every rung has a distinct vCPU count.
+ *
+ * Both `label` and `description` are kept: SpecTaskExecutionControls renders
+ * both, CodeAgentExecutionControls renders only `description`. Dropping either
+ * silently blanks one menu.
+ */
+export interface SandboxPreset {
+  vcpus: number
+  memory_mb: number
+  label: string
+  description: string
+}
+
+export const SANDBOX_PRESETS: SandboxPreset[] = [
+  { vcpus: 1, memory_mb: 2048, label: '1 CPU', description: '2 GB RAM' },
+  { vcpus: 4, memory_mb: 8192, label: '4 CPU', description: '8 GB RAM' },
+  { vcpus: 8, memory_mb: 16384, label: '8 CPU', description: '16 GB RAM' },
+  { vcpus: 12, memory_mb: 24576, label: '12 CPU', description: '24 GB RAM' },
+  { vcpus: 16, memory_mb: 32768, label: '16 CPU', description: '32 GB RAM' },
+]
+
+/** Mirrors DefaultSpecTaskSandboxVCPUs / DefaultSpecTaskSandboxMemoryMB. */
+export const DEFAULT_SANDBOX_PRESET: SandboxPreset = SANDBOX_PRESETS[3]
+
+/** The two numeric fields the API accepts — never send label/description. */
+export const defaultSandboxResourceOverrides = () => ({
+  vcpus: DEFAULT_SANDBOX_PRESET.vcpus,
+  memory_mb: DEFAULT_SANDBOX_PRESET.memory_mb,
+})
+
+/**
+ * The rungs to offer for a given stored value.
+ *
+ * A row can hold a size that is not on the ladder: nothing validates a preset
+ * read from the database (every ValidPreset() call site guards an *incoming*
+ * request), and rows have been hand-edited in the past. Such a value used to
+ * leave the menu with nothing selected, which reads as "no sandbox configured"
+ * rather than "a size we don't have a rung for". Append it instead so it is
+ * visible and selected.
+ */
+export const sandboxPresetsFor = (vcpus?: number, memoryMB?: number): SandboxPreset[] => {
+  if (!vcpus || SANDBOX_PRESETS.some((preset) => preset.vcpus === vcpus)) {
+    return SANDBOX_PRESETS
+  }
+  const memory = memoryMB ? `${Math.round(memoryMB / 1024)} GB RAM` : 'custom size'
+  return [
+    ...SANDBOX_PRESETS,
+    { vcpus, memory_mb: memoryMB ?? 0, label: `${vcpus} CPU`, description: memory },
+  ].sort((a, b) => a.vcpus - b.vcpus)
+}

--- a/frontend/src/hooks/useDefaultSandboxPreset.ts
+++ b/frontend/src/hooks/useDefaultSandboxPreset.ts
@@ -1,0 +1,41 @@
+import { useAccount } from '../contexts/account'
+import {
+  DEFAULT_SANDBOX_PRESET,
+  SandboxPreset,
+  SANDBOX_PRESETS,
+} from '../constants/sandboxPresets'
+
+/**
+ * The sandbox size a new spec task gets when it specifies none.
+ *
+ * The default is operator-configurable server-side
+ * (HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the "· Default" marker
+ * and the pre-selected rung have to come from /api/v1/config. Hardcoding the
+ * frontend constant would mark the wrong rung "Default" on any install that
+ * moved it, while containers came up at the configured size — a UI that lies
+ * about what the user is about to get.
+ *
+ * Falls back to the compile-time constant when config has not loaded yet, so
+ * first paint matches an unconfigured install.
+ */
+export const useDefaultSandboxPreset = (): SandboxPreset => {
+  const account = useAccount()
+  const configured = account.serverConfig?.default_spec_task_sandbox
+
+  if (!configured?.vcpus || !configured?.memory_mb) {
+    return DEFAULT_SANDBOX_PRESET
+  }
+  const known = SANDBOX_PRESETS.find((preset) => preset.vcpus === configured.vcpus)
+  if (known && known.memory_mb === configured.memory_mb) {
+    return known
+  }
+  // An operator can only configure a valid preset (the server rejects anything
+  // else at startup), so this is a version skew between API and frontend.
+  // Render what the server actually resolved rather than a stale rung.
+  return {
+    vcpus: configured.vcpus,
+    memory_mb: configured.memory_mb,
+    label: `${configured.vcpus} CPU`,
+    description: `${Math.round(configured.memory_mb / 1024)} GB RAM`,
+  }
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -59,7 +59,6 @@ import {
   preferredSpecTaskSandboxRuntime,
   saveSpecTaskSandboxRuntimePreference,
 } from '../utils/specTaskSandboxRuntime'
-import { defaultSandboxResourceOverrides } from '../constants/sandboxPresets'
 
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
 const TASK_ATTACHMENT_ACCEPT = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
@@ -134,9 +133,13 @@ const Home: FC = () => {
     readNewChatReasoningEffort(localStorage.getItem('helix_reasoning_effort'))
   ))
   const [taskCodeAgentConfig, setTaskCodeAgentConfig] = useState<TypesCodeAgentExecutionConfig>()
-  const [taskSandboxResources, setTaskSandboxResources] = useState<TypesSandboxResourceOverrides>(
-    defaultSandboxResourceOverrides(),
-  )
+  // Undefined until the user picks a size, so the create request omits
+  // sandbox_resource_overrides and the server resolves the live default at
+  // container-create time. Sending the default explicitly would materialize it
+  // onto the row and pin that task to today's value forever. The selector still
+  // displays the default for an undefined value.
+  const [taskSandboxResources, setTaskSandboxResources] =
+    useState<TypesSandboxResourceOverrides | undefined>()
   const [taskSandboxRuntime, setTaskSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
     preferredSpecTaskSandboxRuntime(requestedProjectId),
   )
@@ -171,7 +174,7 @@ const Home: FC = () => {
   // effect above would reset a chosen sandbox size the moment picking a harness
   // seeded the project default and refreshed the project.
   useEffect(() => {
-    setTaskSandboxResources(defaultSandboxResourceOverrides())
+    setTaskSandboxResources(undefined)
     setTaskSandboxRuntime(preferredSpecTaskSandboxRuntime(
       selectedProjectId,
       selectedProject?.default_sandbox_runtime,

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -59,6 +59,7 @@ import {
   preferredSpecTaskSandboxRuntime,
   saveSpecTaskSandboxRuntimePreference,
 } from '../utils/specTaskSandboxRuntime'
+import { defaultSandboxResourceOverrides } from '../constants/sandboxPresets'
 
 const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
 const TASK_ATTACHMENT_ACCEPT = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
@@ -133,10 +134,9 @@ const Home: FC = () => {
     readNewChatReasoningEffort(localStorage.getItem('helix_reasoning_effort'))
   ))
   const [taskCodeAgentConfig, setTaskCodeAgentConfig] = useState<TypesCodeAgentExecutionConfig>()
-  const [taskSandboxResources, setTaskSandboxResources] = useState<TypesSandboxResourceOverrides>({
-    vcpus: 4,
-    memory_mb: 8192,
-  })
+  const [taskSandboxResources, setTaskSandboxResources] = useState<TypesSandboxResourceOverrides>(
+    defaultSandboxResourceOverrides(),
+  )
   const [taskSandboxRuntime, setTaskSandboxRuntime] = useState<TypesSandboxRuntime>(() =>
     preferredSpecTaskSandboxRuntime(requestedProjectId),
   )
@@ -171,7 +171,7 @@ const Home: FC = () => {
   // effect above would reset a chosen sandbox size the moment picking a harness
   // seeded the project default and refreshed the project.
   useEffect(() => {
-    setTaskSandboxResources({ vcpus: 4, memory_mb: 8192 })
+    setTaskSandboxResources(defaultSandboxResourceOverrides())
     setTaskSandboxRuntime(preferredSpecTaskSandboxRuntime(
       selectedProjectId,
       selectedProject?.default_sandbox_runtime,

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -9915,6 +9915,16 @@ definitions:
           direct model chats when the user has not customised one. Surfaced to
           the frontend so the chat-settings page can prefill the textbox.
         type: string
+      default_spec_task_sandbox:
+        allOf:
+        - $ref: '#/definitions/types.SandboxResourceOverrides'
+        description: |-
+          DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it
+          specifies none. It is operator-configurable
+          (HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read
+          it from here rather than hardcode a copy — otherwise an operator who moves
+          the default gets a task selector that marks the wrong rung "Default" while
+          containers come up at the configured size.
       deployment_id:
         type: string
       dev_subdomain:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -8266,8 +8266,9 @@ definitions:
         allOf:
         - $ref: '#/definitions/types.SandboxResourceOverrides'
         description: |-
-          Default sandbox resources copied into each new SpecTask. Nil values from
-          legacy projects resolve to the standard 4 vCPU / 8 GB preset.
+          Default sandbox resources copied into each new SpecTask. Nil means the
+          project expresses no preference and the task resolves the global default at
+          container-create time.
       default_sandbox_runtime:
         allOf:
         - $ref: '#/definitions/types.SandboxRuntime'

--- a/openapi.json
+++ b/openapi.json
@@ -41490,6 +41490,14 @@
                         "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
                         "type": "string"
                     },
+                    "default_spec_task_sandbox": {
+                        "description": "DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it\nspecifies none. It is operator-configurable\n(HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read\nit from here rather than hardcode a copy — otherwise an operator who moves\nthe default gets a task selector that marks the wrong rung \"Default\" while\ncontainers come up at the configured size.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                            }
+                        ]
+                    },
                     "deployment_id": {
                         "type": "string"
                     },

--- a/openapi.json
+++ b/openapi.json
@@ -39325,7 +39325,7 @@
                         "type": "string"
                     },
                     "default_sandbox_resource_overrides": {
-                        "description": "Default sandbox resources copied into each new SpecTask. Nil values from\nlegacy projects resolve to the standard 4 vCPU / 8 GB preset.",
+                        "description": "Default sandbox resources copied into each new SpecTask. Nil means the\nproject expresses no preference and the task resolves the global default at\ncontainer-create time.",
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/types.SandboxResourceOverrides"

--- a/swagger.json
+++ b/swagger.json
@@ -36924,6 +36924,14 @@
                     "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
                     "type": "string"
                 },
+                "default_spec_task_sandbox": {
+                    "description": "DefaultSpecTaskSandbox is the sandbox size a new spec task gets when it\nspecifies none. It is operator-configurable\n(HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS/_MEMORY_MB), so the UI has to read\nit from here rather than hardcode a copy — otherwise an operator who moves\nthe default gets a task selector that marks the wrong rung \"Default\" while\ncontainers come up at the configured size.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxResourceOverrides"
+                        }
+                    ]
+                },
                 "deployment_id": {
                     "type": "string"
                 },

--- a/swagger.json
+++ b/swagger.json
@@ -34759,7 +34759,7 @@
                     "type": "string"
                 },
                 "default_sandbox_resource_overrides": {
-                    "description": "Default sandbox resources copied into each new SpecTask. Nil values from\nlegacy projects resolve to the standard 4 vCPU / 8 GB preset.",
+                    "description": "Default sandbox resources copied into each new SpecTask. Nil means the\nproject expresses no preference and the task resolves the global default at\ncontainer-create time.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SandboxResourceOverrides"


### PR DESCRIPTION
## Summary

Two defects from one outage on 2026-08-24 (task `spt_01m0s0vktb0twdtwz7cmk6wgtg`,
session `ses_01m0s0vkvq89563fdkxza4cry6`). The symptom was "video streaming is
broken". It was not a video bug. Part A and Part B are separate commits so either
half can be reverted alone. Full reasoning:
`design/2026-08-24-sandbox-defaults-and-stream-init-replay.md`.

### ⚠️ Contains an irreversible data migration

`0009_unmaterialize_spec_task_sandbox_default` NULLs
`spec_tasks.sandbox_resource_overrides` on rows holding **exactly**
`{"vcpus": 4, "memory_mb": 8192}`. It deliberately never matches
`{"vcpus": 8, "memory_mb": 16384}` — 178 such rows on meta are real user choices,
not materialized defaults. The down migration is a documented no-op: which NULLs
previously held 4/8192 is not recorded, and re-materializing all NULLs would
write an override onto the 4102 rows that never had one.

Run this before and after, and confirm the 8/16384 total is unchanged:

```sql
SELECT sandbox_resource_overrides, count(*) FROM spec_tasks GROUP BY 1;
```

On meta the migration is a **no-op** — those 31 rows were hand-backfilled to
12/24576 on 2026-08-24 and no longer match the old pair.

### Part A — the default sandbox was below the real workload

The desktop container sat at 99.999% of its 8 GiB `memory.max` with CFS
throttling on 80% of periods. Under that starvation GStreamer's
`set_state(PLAYING)` took 43–100 s instead of under a second, so the browser
timed out waiting for `StreamInit` and every retry leaked another pipeline.
`docker update --memory 24g --memory-swap 48g --cpus 12` fixed it instantly with
nothing else changed.

**New default: 12 vCPU / 24576 MB** — exactly that configuration. Treating
containers pinned at their cap as *censored* observations rather than
measurements, p90 real demand is ≈21 GiB, so the "p90 must sit under 90% of its
ceiling" rule forces a ceiling of at least 24 GiB; 16 GiB would put the p90 at
~131% of its ceiling.

- **Ladder:** `1/2048`, `4/8192`, `8/16384`, **`12/24576`**, **`16/32768`**.
  2 GB per vCPU throughout. Every pre-existing rung stays valid, so no stored
  value is retroactively rejected by `ValidPreset`.
  `SpecTaskSandboxPresetForVCPUs` and `ValidPreset` now derive from one table
  instead of two hand-maintained switches.
- **Operator-configurable:** `HELIX_SPEC_TASK_SANDBOX_DEFAULT_VCPUS` /
  `_MEMORY_MB`, defaulting to 12/24576 so out-of-the-box behaviour is correct
  with no env set. An invalid pair fails startup rather than being ignored.
- **CPU clamp:** Docker rejects `--cpus` above the host CPU count outright, so a
  12-vCPU default would break container creation on any smaller host — defeating
  the point of this change. `sandboxResourceLimits` clamps to `runtime.NumCPU()`
  and logs when it does. Memory is deliberately not clamped; Docker accepts a
  limit above host RAM, and an unreachable ceiling beats one that OOM-kills.
- **Materialization:** both create paths now store `nil` when nobody chose a
  size, and the default resolves at container-create time. A stored override now
  means "someone chose this", not "this was the default the day the row was
  written".
- Every duplicated copy of the ladder moved with it, including five sites the
  brief did not list and the org MCP tool description prose (Workers read that
  string literally and would keep passing the old ladder).

Two gaps that only end-to-end testing caught — both would have shipped the
original bug at a new value:

- The **frontend kept re-materializing the default**: both create forms
  initialised their state to it and always sent it, so rows still came back with
  `{"vcpus": 12, "memory_mb": 24576}` written on them. Removing a materialized
  default server-side is only half the job if a client keeps sending it.
- The UI's **"· Default" marker lied to operators**: it came from a hardcoded
  frontend constant, so with the env override set the selector marked 12 vCPU
  while containers came up at 8/16384. `/api/v1/config` now carries
  `default_spec_task_sandbox`.

### Part B — the stream proxy never replayed `init`

`ResilientProxy` re-dials the backend transparently but redid only the HTTP
upgrade. `desktop-bridge` blocks on a mandatory `init` frame with a 30 s read
deadline, so every reconnect produced a backend socket that waited 30 s, died and
reconnected — while the *client* socket stayed open, showing a live-but-frozen
picture with **no error surfaced anywhere**. Only a page reload escaped it.
Part A caused the drops in this outage; this fires on any future drop.

`SessionReplay` is the frame-level sibling of `CreateWebSocketUpgradeFunc`'s
`extraHeaders`, whose doc comment already argues this exact principle for the
other piece of per-connection state. It carries a minimal RFC 6455 client-frame
parser — enough to find the first text frame and no more; `ResilientProxy`
otherwise stays a raw byte proxy.

**A replayed init has `user_retry` cleared.** It is the only thing that clears a
latched shared-video circuit breaker, and a proxy reconnect is by definition
automatic. Preserving it would mean one press of Restart re-asserts it on every
later drop, so the breaker could never latch — the retry storm it exists to stop.
The Restart button is unaffected: it opens a new client socket whose init is not
a replay.

Read-only is unaffected: `StreamConfig` has no privilege field, so replay has no
lever to pull; privilege rides on `X-Helix-Readonly`, which the upgrade func
already re-sends on every reconnect. Both halves are now covered by tests,
including that header-on-reconnect invariant, which the doc comment asserted but
nothing tested.

**Known limitation, documented not fixed:** `ResilientProxy` buffers bytes, not
frames, so a drop mid-frame can desync the resumed stream. Both causes
(`copyClientToServer` discarding `Write`'s byte count; 32KB reads not aligning
with frame boundaries) predate this change, and fixing it properly means making
the byte proxy frame-aware in the hot path of every proxied byte.

## Testing

Tested end-to-end in the inner Helix at `localhost:8080` against a real spec task,
not by unit test alone.

**Part A**

- Fresh task row: `sandbox_resource_overrides` is `NULL` — the default is no
  longer materialized.
- Its container:
  `Memory=25769803776 NanoCpus=12000000000 MemorySwap=51539607552` — 24 GiB /
  12 vCPU / 48 GiB swap, exactly the configuration that fixed the outage.
- `helix spectask stream --duration 30` → **1894 frames, 60 instant / 63.1 avg
  FPS** at 1920x1080.
- Selector renders all five rungs with 12 vCPU / 24 GB marked "· Default".
- Config override to 8/16384: `/api/v1/config` reports it and the Default marker
  moves to the 8 vCPU rung. Invalid pair 6/12288 refuses startup with
  `default spec task sandbox 6 vCPU / 12288 MB is not a valid preset (vCPUs must
  be one of 1, 4, 8, 12, 16, with memory following)`. Env removed → back to
  12/24576.
- Migration against seeded data covering all three real-world cases: both 4/8192
  rows became `NULL` (including a differently-key-ordered one, which `jsonb`
  normalises), `8/16384` and a near-miss `4/4096` were untouched, and a second
  run changed nothing.

**Part B — a real reconnect, not the happy path.**

Killing `desktop-bridge` does **not** exercise the replay path: it hosts the
RevDial client, so the proxy fails to re-dial and the browser simply opens a
fresh socket. The give-away is `reconnect_count=0`, and believing that first run
would have been a false positive. Dropping only the backend TCP socket
(`ss -K state established '( sport = :9876 )'`) gives:

```
API    Server connection error … close 1006 (abnormal closure): unexpected EOF
API    Replayed session state to reconnected backend  bytes=297
API    Reconnected successfully, resuming proxy  reconnect_count=1
bridge stream WebSocket connected               11:44:24.975
bridge stream init received … user_retry=false  11:44:24.976   ← 1 ms, not 30 s
bridge [SHARED_VIDEO] Client subscribed (grace period reconnection, starting catchup)
```

- `failed to read init message` across the entire bridge log: **0**.
- Subscribed to the **existing** shared source — no `Evicted dead source`, so no
  pipeline restart and no leak. The registry's 60 s grace period covers exactly
  this window.
- Video resumed unattended with no page reload; a post-reconnect stream check
  returned 1844 frames at 61.5 avg FPS.

**Not live-tested:** a read-only embed-key viewer across a reconnect. Covered
structurally instead — `StreamConfig` has no privilege field, plus new tests that
the replayed payload carries none and that the upgrade func re-emits
`X-Helix-Readonly` on every upgrade.

**Build and suites:** `go build ./pkg/...` and the frontend build both pass. All
affected Go packages and the full vitest suite pass. Two failures on this box —
`TestDiskPressureSuite` (no `zpool` binary) and `MonacoEditorClipboard` (a
suite-ordering flake) — were confirmed identical on `origin/main` via a temporary
worktree, so they are pre-existing and unrelated.

## Screenshots

![Ladder with 12 vCPU / 24 GB marked Default](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002936_sandbox-defaults-that/screenshots/01-sandbox-ladder-12-default.png)
![Video playing on the task detail page](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002936_sandbox-defaults-that/screenshots/02-task-desktop-video.png)
![Config override moves the Default marker to 8 vCPU](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002936_sandbox-defaults-that/screenshots/03-config-override-8vcpu-default.png)
![Video live after a real proxy reconnect](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002936_sandbox-defaults-that/screenshots/05-video-live-after-proxy-replay.png)

## Supersedes

`spt_01m0evm3dpanc1sfktywbxhes4` ("Raise Default Spec-Task Sandbox to 8 vCPU /
16 GB", stuck in `spec_review` since 2026-08-20). Its frontend de-duplication
plan and OpenAPI fan-out warning are lifted here; it should be closed as
superseded rather than implemented separately.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01m0sh2mqx8491eg62fkp9qrap)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002936_sandbox-defaults-that/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002936_sandbox-defaults-that/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002936_sandbox-defaults-that/tasks.md)

🚀 Built with [Helix](https://helix.ml)