### PR TITLE
fix(providers): inherit globals in coding agent configs

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -93,7 +93,7 @@ type ContextServerConfig struct {
 // oauthTokenGetter is optional - if provided, OAuth tokens will be injected into stdio MCPs.
 // providerSnapshot is an optional list of provider records visible to the owner
 // (env-baked globals + DB-backed). When non-nil, the agent's stored provider
-// reference (ID for DB-backed, canonical name for globals) is resolved
+// reference (stable ID, or a legacy canonical name) is resolved
 // against it; the resolved provider's current name is used in the model
 // prefix written to settings.json. A missing provider is treated as
 // misconfiguration and Agent.DefaultModel is left unset. Pass nil to skip
@@ -128,6 +128,7 @@ func GenerateZedMCPConfig(
 	assistant := FindZedExternalAssistant(app)
 
 	provider, model := AssistantModelSelection(assistant)
+	providerName := provider
 
 	// Decide whether the agent's stored model fields are usable. There are
 	// two failure modes we MUST NOT paper over:
@@ -155,6 +156,7 @@ func GenerateZedMCPConfig(
 		// without a parent app. Keep the legacy SaaS-friendly default so
 		// those sessions still come up.
 		provider = "anthropic"
+		providerName = provider
 		model = "claude-sonnet-4-6"
 	} else if usesUpstreamSubscription(assistant) {
 		// Subscription credentials only make sense for runtimes that handle
@@ -198,7 +200,10 @@ func GenerateZedMCPConfig(
 				Str("resolved_id", resolved.ID).
 				Msg("zed-config: agent stores provider by name (legacy); re-save the agent so it stores the immutable provider ID")
 		}
-		provider = resolved.Name
+		providerName = resolved.Name
+		if resolved.ID != "" {
+			provider = resolved.ID
+		}
 	}
 
 	// Configure agent. Permissions / ShowOnboarding / AutoOpenPanel are always
@@ -213,7 +218,7 @@ func GenerateZedMCPConfig(
 		// Map Helix provider to Zed's provider type and format model name
 		// Zed only knows: anthropic, openai, google, ollama, copilot, lmstudio, deepseek
 		// All other providers (nebius, together, openrouter, etc.) use OpenAI-compatible API
-		zedProvider, zedModel := mapHelixToZedProvider(provider, model)
+		zedProvider, zedModel := mapHelixToZedProviderToken(providerName, provider, model)
 		// Set feature-specific models to prevent Zed from using its hardcoded
 		// gpt-4.1-mini default for "fast" operations (see
 		// zed-industries/zed#31420). If not set, these fall back to
@@ -552,8 +557,9 @@ func getAPIKeyForProvider(provider string) string {
 // stored IDs. After such a fallback the agent should be re-saved so it picks
 // up the immutable reference.
 type ProviderRef struct {
-	ID   string // empty for env-baked global providers (openai, anthropic, ...)
-	Name string // current canonical name; for DB-backed providers this is the admin-set label
+	ID           string
+	Name         string
+	EndpointType types.ProviderEndpointType
 }
 
 // FindZedExternalAssistant returns the assistant config that owns the
@@ -620,13 +626,35 @@ func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byL
 			return p, false, true
 		}
 	}
+	if types.IsGlobalProviderID(token) || strings.HasPrefix(token, "pe_") {
+		return ProviderRef{}, false, false
+	}
+	var selected *ProviderRef
 	for _, p := range snapshot {
 		if types.CanonicalProviderName(p.Name) == types.CanonicalProviderName(token) {
-			byLegacy := p.ID != "" // global with no ID is a normal match, not legacy
-			return p, byLegacy, true
+			if selected == nil || providerRefPrecedence(p) > providerRefPrecedence(*selected) {
+				candidate := p
+				selected = &candidate
+			}
 		}
 	}
+	if selected != nil {
+		return *selected, selected.ID != token, true
+	}
 	return ProviderRef{}, false, false
+}
+
+func providerRefPrecedence(ref ProviderRef) int {
+	switch {
+	case ref.EndpointType == types.ProviderEndpointTypeOrg || ref.EndpointType == types.ProviderEndpointTypeUser:
+		return 3
+	case strings.HasPrefix(ref.ID, "pe_"):
+		return 2
+	case types.IsGlobalProviderID(ref.ID):
+		return 1
+	default:
+		return 3
+	}
 }
 
 // CodeAgentRuntimeAllowsProvider keeps native vendor CLIs on the API shape
@@ -817,7 +845,11 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 //	helixProvider="openai", model="gpt-4o" → zedProvider="openai", zedModel="openai/gpt-4o"
 //	helixProvider="nebius", model="Qwen/Qwen3-Coder" → zedProvider="openai", zedModel="nebius/Qwen/Qwen3-Coder"
 func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel string) {
-	provider := types.CanonicalProviderName(helixProvider)
+	return mapHelixToZedProviderToken(helixProvider, helixProvider, model)
+}
+
+func mapHelixToZedProviderToken(providerName, routingToken, model string) (zedProvider, zedModel string) {
+	provider := types.CanonicalProviderName(providerName)
 
 	switch provider {
 	case "anthropic":
@@ -834,7 +866,7 @@ func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel s
 		// All other providers (openai, nebius, together, openrouter, azure, google, etc.)
 		// route through Zed's OpenAI provider → Helix's OpenAI-compatible proxy.
 		// Model is prefixed with provider name so Helix can route to the correct backend.
-		return "openai", fmt.Sprintf("%s/%s", helixProvider, model)
+		return "openai", fmt.Sprintf("%s/%s", routingToken, model)
 	}
 }
 

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -621,7 +621,7 @@ func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byL
 		}
 	}
 	for _, p := range snapshot {
-		if strings.EqualFold(p.Name, token) {
+		if types.CanonicalProviderName(p.Name) == types.CanonicalProviderName(token) {
 			byLegacy := p.ID != "" // global with no ID is a normal match, not legacy
 			return p, byLegacy, true
 		}
@@ -634,6 +634,7 @@ func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byL
 // OpenAI Responses. The general-purpose harnesses continue to accept any
 // provider exposed through Helix's OpenAI-compatible proxy.
 func CodeAgentRuntimeAllowsProvider(runtime types.CodeAgentRuntime, providerName string) bool {
+	providerName = types.CanonicalProviderName(providerName)
 	switch runtime {
 	case types.CodeAgentRuntimeClaudeCode:
 		return strings.EqualFold(providerName, string(types.ProviderAnthropic))
@@ -784,7 +785,7 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 	hasAnthropic := false
 	hasOpenAICompat := false
 	for _, p := range snapshot {
-		if strings.EqualFold(p.Name, "anthropic") {
+		if types.CanonicalProviderName(p.Name) == string(types.ProviderAnthropic) {
 			hasAnthropic = true
 		} else {
 			hasOpenAICompat = true
@@ -816,7 +817,7 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 //	helixProvider="openai", model="gpt-4o" → zedProvider="openai", zedModel="openai/gpt-4o"
 //	helixProvider="nebius", model="Qwen/Qwen3-Coder" → zedProvider="openai", zedModel="nebius/Qwen/Qwen3-Coder"
 func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel string) {
-	provider := strings.ToLower(helixProvider)
+	provider := types.CanonicalProviderName(helixProvider)
 
 	switch provider {
 	case "anthropic":

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -155,6 +155,19 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			why:              "control case: env-baked global (no ID) resolves by canonical name; anthropic model id passes through verbatim to match Zed's /v1/models listing",
 		},
 		{
+			name: "legacy_anthropic_task_ref_routes_to_org_endpoint",
+			assistants: []types.AssistantConfig{{
+				AgentType:        types.AgentTypeZedExternal,
+				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+				Provider:         "anthropic",
+				Model:            "claude-sonnet-4-5",
+			}},
+			snapshot:         []ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
+			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
+			wantMisconfig:    false,
+			why:              "legacy task refs must resolve to the organization Anthropic row and retain Anthropic routing",
+		},
+		{
 			name: "legacy_name_match_still_works_for_unsaved_agents",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
@@ -394,6 +407,17 @@ func TestMigrateLegacyProviderRefs(t *testing.T) {
 			wantGenericGen: "pe_user_provider_01",
 			why:            "GenerationModelProvider migrates the same way as the legacy Provider field",
 		},
+		{
+			name: "legacy_anthropic_preset_name_rewrites_to_org_id",
+			assistant: types.AssistantConfig{
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-5",
+			},
+			snapshot:     []ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
+			wantChanged:  true,
+			wantProvider: "pe_org_anthropic",
+			why:          "legacy Anthropic task refs heal to the visible organization endpoint ID",
+		},
 	}
 
 	for _, tc := range cases {
@@ -493,6 +517,13 @@ func TestBuildLanguageModels(t *testing.T) {
 		{
 			name:     "anthropic-only does not inject openai",
 			snapshot: []ProviderRef{{Name: "anthropic"}},
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+			},
+		},
+		{
+			name:     "legacy anthropic preset name injects anthropic",
+			snapshot: []ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
 			want: map[string]LanguageModelConfig{
 				"anthropic": {APIURL: helixURL},
 			},

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -46,13 +46,13 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 	helixURL := "http://api:8080"
 	helixToken := "test-token"
 
-	// Synthetic globals (no ID) and DB-backed providers (with ID) used by
+	// Synthetic globals and DB-backed providers used by
 	// the cases below. Renames are demonstrated by mutating the .Name of a
 	// DB-backed provider while keeping its .ID stable; the agent's stored
 	// reference (the .ID) survives the rename.
 	var (
-		globalOpenAI    = ProviderRef{ID: "", Name: "openai"}
-		globalAnthropic = ProviderRef{ID: "", Name: "anthropic"}
+		globalOpenAI    = ProviderRef{ID: "global/openai", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal}
+		globalAnthropic = ProviderRef{ID: "global/anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}
 		dbScalewayID    = "pe_scaleway_01"
 		dbScaleway      = ProviderRef{ID: dbScalewayID, Name: "scaleway"}
 		dbScalewayPrime = ProviderRef{ID: dbScalewayID, Name: "scaleway-prime"} // same ID, renamed
@@ -107,7 +107,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModel:         "qwen3-coder-480b",
 			}},
 			snapshot:         []ProviderRef{dbScalewayPrime, globalOpenAI}, // admin renamed scaleway → scaleway-prime
-			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway-prime/qwen3-coder-480b"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "pe_scaleway_01/qwen3-coder-480b"},
 			wantMisconfig:    false,
 			why:              "P1-3 core: provider rename must be a no-op for the agent — ID resolves to current name",
 		},
@@ -119,7 +119,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModel:         "qwen3-coder-480b",
 			}},
 			snapshot:         []ProviderRef{dbScaleway, globalOpenAI},
-			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "pe_scaleway_01/qwen3-coder-480b"},
 			wantMisconfig:    false,
 			why:              "control case: agent stored ID resolves to canonical scaleway name",
 		},
@@ -138,7 +138,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModel:         "gpt-4o", // stale template default
 			}},
 			snapshot:         []ProviderRef{dbGLM, globalOpenAI},
-			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "glm-helix/glm-5.1"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "pe_glm_01/glm-5.1"},
 			wantMisconfig:    false,
 			why:              "zed_external source of truth is Model/Provider; the GenerationModel quartet must not shadow it",
 		},
@@ -162,10 +162,22 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				Provider:         "anthropic",
 				Model:            "claude-sonnet-4-5",
 			}},
-			snapshot:         []ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
+			snapshot:         []ProviderRef{{ID: "global/anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}, {ID: "pe_org_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg}},
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
 			wantMisconfig:    false,
 			why:              "legacy task refs must resolve to the organization Anthropic row and retain Anthropic routing",
+		},
+		{
+			name: "explicit_global_openai_keeps_scoped_routing_token",
+			assistants: []types.AssistantConfig{{
+				AgentType: types.AgentTypeZedExternal,
+				Provider:  "global/openai",
+				Model:     "gpt-5.4",
+			}},
+			snapshot:         []ProviderRef{{ID: "pe_org_openai", Name: "user/openai", EndpointType: types.ProviderEndpointTypeOrg}, globalOpenAI},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "global/openai/gpt-5.4"},
+			wantMisconfig:    false,
+			why:              "an explicit env-global selection must not degrade to a bare vendor token",
 		},
 		{
 			name: "legacy_name_match_still_works_for_unsaved_agents",
@@ -175,7 +187,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModel:         "gpt-5.4",
 			}},
 			snapshot:         []ProviderRef{globalOpenAI}, // global has Name=openai
-			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "openai/gpt-5.4"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "global/openai/gpt-5.4"},
 			wantMisconfig:    false,
 			why:              "legacy fallback: agents stored before ID-based references still resolve via case-insensitive name match",
 		},
@@ -321,6 +333,21 @@ func TestMapHelixToZedProvider(t *testing.T) {
 			assert.Equal(t, tt.wantModel, gotModel)
 		})
 	}
+}
+
+func TestResolveProviderScopesLegacyAndExactRefs(t *testing.T) {
+	snapshot := []ProviderRef{
+		{ID: "global/anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_global", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_org", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+	}
+
+	legacy, _, ok := ResolveProvider("anthropic", snapshot)
+	assert.True(t, ok)
+	assert.Equal(t, "pe_org", legacy.ID)
+	forcedGlobal, _, ok := ResolveProvider("global/anthropic", snapshot)
+	assert.True(t, ok)
+	assert.Equal(t, "global/anthropic", forcedGlobal.ID)
 }
 
 // TestMigrateLegacyProviderRefs covers the on-the-fly heal path that lets

--- a/api/pkg/openai/manager/anthropic_endpoint_test.go
+++ b/api/pkg/openai/manager/anthropic_endpoint_test.go
@@ -18,6 +18,7 @@ func TestIsAnthropicAPIEndpoint(t *testing.T) {
 	}{
 		{"canonical name", types.ProviderEndpoint{Name: "anthropic"}, true},
 		{"display name (EqualFold)", types.ProviderEndpoint{Name: "Anthropic"}, true},
+		{"legacy preset name", types.ProviderEndpoint{Name: "user/anthropic"}, true},
 		{"base url match", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com/v1"}, true},
 		{"lookalike host not matched", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com.proxy.evil.com/v1"}, false},
 		{"openai", types.ProviderEndpoint{Name: "openai", BaseURL: "https://api.openai.com/v1"}, false},
@@ -45,6 +46,7 @@ func (suite *MultiClientManagerTestSuite) Test_InitializeClient_AnthropicAuth() 
 	}{
 		{"anthropic by name", types.ProviderEndpoint{Name: "anthropic", APIKey: "test-key"}, true},
 		{"Anthropic display name", types.ProviderEndpoint{Name: "Anthropic", APIKey: "test-key"}, true},
+		{"legacy preset name", types.ProviderEndpoint{Name: "user/anthropic", APIKey: "test-key"}, true},
 		{"openai falls through to bearer", types.ProviderEndpoint{Name: "openai", APIKey: "test-key"}, false},
 		{"vertex excluded -> bearer", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1", APIKey: "test-key"}, false},
 	}

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -469,7 +469,7 @@ func selectProviderEndpoint(endpoints []*types.ProviderEndpoint, providerRef str
 	}
 	var selected *types.ProviderEndpoint
 	for _, endpoint := range endpoints {
-		if !strings.EqualFold(endpoint.Name, providerRef) {
+		if types.CanonicalProviderName(endpoint.Name) != types.CanonicalProviderName(providerRef) {
 			continue
 		}
 		ownerEndpointType := types.ProviderEndpointTypeUser
@@ -496,7 +496,7 @@ func isAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
 	if endpoint.VertexProjectID != "" {
 		return false
 	}
-	if strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic)) {
+	if types.CanonicalProviderName(endpoint.Name) == string(types.ProviderAnthropic) {
 		return true
 	}
 	// Host-exact match so a lookalike like api.anthropic.com.proxy.evil.com

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -398,7 +398,7 @@ func (m *MultiClientManager) ListProviderEndpointsForOwner(ctx context.Context, 
 	return endpoints, nil
 }
 
-func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest) (openai.Client, error) {
+func (m *MultiClientManager) GetClient(ctx context.Context, req *GetClientRequest) (openai.Client, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -414,26 +414,39 @@ func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest)
 			Msg("TRACE: Provider manager GetClient called with app ID")
 	}
 
-	m.globalClientsMu.RLock()
-	defer m.globalClientsMu.RUnlock()
+	var userProviders []*types.ProviderEndpoint
+	loadStoredClient := func() (openai.Client, bool, error) {
+		var err error
+		userProviders, err = m.store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
+			Owner:      req.Owner,
+			OwnerType:  req.OwnerType,
+			WithGlobal: true,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		provider := selectProviderEndpoint(userProviders, req.Provider, req.OwnerType)
+		if provider == nil {
+			return nil, false, nil
+		}
+		client, err := m.initializeClient(provider)
+		return client, true, err
+	}
+	if req.Owner != "" {
+		if client, found, err := loadStoredClient(); err != nil || found {
+			return client, err
+		}
+	}
 
+	m.globalClientsMu.RLock()
 	client, ok := m.globalClients[types.Provider(req.Provider)]
+	m.globalClientsMu.RUnlock()
 	if ok {
 		return client.client, nil
 	}
-
-	userProviders, err := m.store.ListProviderEndpoints(context.Background(), &store.ListProviderEndpointsQuery{
-		Owner:      req.Owner,
-		OwnerType:  req.OwnerType,
-		WithGlobal: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, provider := range userProviders {
-		if provider.Name == req.Provider || provider.ID == req.Provider {
-			return m.initializeClient(provider)
+	if req.Owner == "" {
+		if client, found, err := loadStoredClient(); err != nil || found {
+			return client, err
 		}
 	}
 
@@ -446,6 +459,28 @@ func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest)
 		availableProviders = append(availableProviders, provider.Name)
 	}
 	return nil, fmt.Errorf("no client found for provider: %s, available providers: [%s]", req.Provider, strings.Join(availableProviders, ", "))
+}
+
+func selectProviderEndpoint(endpoints []*types.ProviderEndpoint, providerRef string, ownerType types.OwnerType) *types.ProviderEndpoint {
+	for _, endpoint := range endpoints {
+		if endpoint.ID == providerRef {
+			return endpoint
+		}
+	}
+	var selected *types.ProviderEndpoint
+	for _, endpoint := range endpoints {
+		if !strings.EqualFold(endpoint.Name, providerRef) {
+			continue
+		}
+		ownerEndpointType := types.ProviderEndpointTypeUser
+		if ownerType == types.OwnerTypeOrg {
+			ownerEndpointType = types.ProviderEndpointTypeOrg
+		}
+		if selected == nil || endpoint.EndpointType == ownerEndpointType {
+			selected = endpoint
+		}
+	}
+	return selected
 }
 
 // isAnthropicAPIEndpoint reports whether a DB/UI-configured provider endpoint

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -41,7 +41,7 @@ type ProviderManager interface {
 	ListProviders(ctx context.Context, owner string) ([]types.Provider, error)
 	ListProvidersForOwner(ctx context.Context, owner string, ownerType types.OwnerType) ([]types.Provider, error)
 	// ListProviderEndpoints returns the full provider records visible to the
-	// owner: synthetic entries for env-baked global providers (ID="",
+	// owner: synthetic entries for env-baked global providers (ID="global/<name>",
 	// Name=canonical) plus DB-backed user/org provider records. Used by
 	// agent-config code paths that need to resolve an agent's stored
 	// provider reference (an immutable ID for DB-backed, the canonical name
@@ -358,7 +358,7 @@ func (m *MultiClientManager) ListProvidersForOwner(ctx context.Context, owner st
 
 // ListProviderEndpoints returns full provider records visible to the owner.
 // Env-baked globals are returned as synthetic *ProviderEndpoint values with
-// ID="" and Name=canonical; DB-backed user/org providers are returned with
+// ID="global/<name>" and Name=canonical; DB-backed user/org providers are returned with
 // their real ID and current admin-set Name. Use this when callers need to
 // resolve an agent's stored provider reference to its current canonical name
 // — the agent record stores the immutable ID, settings.json carries the
@@ -376,6 +376,7 @@ func (m *MultiClientManager) ListProviderEndpointsForOwner(ctx context.Context, 
 	endpoints := make([]*types.ProviderEndpoint, 0, len(m.globalClients))
 	for provider := range m.globalClients {
 		endpoints = append(endpoints, &types.ProviderEndpoint{
+			ID:           types.GlobalProviderID(string(provider)),
 			Name:         string(provider),
 			EndpointType: types.ProviderEndpointTypeGlobal,
 		})
@@ -412,6 +413,15 @@ func (m *MultiClientManager) GetClient(ctx context.Context, req *GetClientReques
 			Str("provider", req.Provider).
 			Str("owner", req.Owner).
 			Msg("TRACE: Provider manager GetClient called with app ID")
+	}
+	if types.IsGlobalProviderID(req.Provider) {
+		m.globalClientsMu.RLock()
+		client, ok := m.globalClients[types.Provider(types.CanonicalProviderName(req.Provider))]
+		m.globalClientsMu.RUnlock()
+		if ok {
+			return client.client, nil
+		}
+		return nil, fmt.Errorf("no client found for provider: %s", req.Provider)
 	}
 
 	var userProviders []*types.ProviderEndpoint

--- a/api/pkg/openai/manager/provider_manager_test.go
+++ b/api/pkg/openai/manager/provider_manager_test.go
@@ -81,18 +81,18 @@ func (suite *MultiClientManagerTestSuite) Test_GetClientUsesOrganizationOwnershi
 	suite.NotNil(client)
 }
 
-func (suite *MultiClientManagerTestSuite) Test_GetClientPrefersOrganizationProviderOverEnvironmentGlobal() {
-	suite.cfg.Providers.OpenAI.APIKey = "env-key"
-	suite.cfg.Providers.OpenAI.APIKeyFromFile = ""
+func (suite *MultiClientManagerTestSuite) Test_GetClientPrefersLegacyNamedOrganizationAnthropicOverEnvironmentGlobal() {
+	suite.cfg.Providers.Anthropic.APIKey = "env-key"
+	suite.cfg.Providers.Anthropic.APIKeyFromFile = ""
 	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).
 		Return([]*types.ProviderEndpoint{
-			{ID: "pe_global", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal, APIKey: "db-global-key"},
-			{ID: "pe_org", Name: "openai", EndpointType: types.ProviderEndpointTypeOrg, APIKey: "org-key"},
+			{ID: "pe_global", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal, APIKey: "db-global-key"},
+			{ID: "pe_org", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg, APIKey: "org-key", BaseURL: "https://api.anthropic.com/v1"},
 		}, nil)
 
 	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
 	client, err := manager.GetClient(context.Background(), &GetClientRequest{
-		Provider: "openai", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+		Provider: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
 	})
 
 	suite.NoError(err)

--- a/api/pkg/openai/manager/provider_manager_test.go
+++ b/api/pkg/openai/manager/provider_manager_test.go
@@ -81,6 +81,41 @@ func (suite *MultiClientManagerTestSuite) Test_GetClientUsesOrganizationOwnershi
 	suite.NotNil(client)
 }
 
+func (suite *MultiClientManagerTestSuite) Test_GetClientPrefersOrganizationProviderOverEnvironmentGlobal() {
+	suite.cfg.Providers.OpenAI.APIKey = "env-key"
+	suite.cfg.Providers.OpenAI.APIKeyFromFile = ""
+	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).
+		Return([]*types.ProviderEndpoint{
+			{ID: "pe_global", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal, APIKey: "db-global-key"},
+			{ID: "pe_org", Name: "openai", EndpointType: types.ProviderEndpointTypeOrg, APIKey: "org-key"},
+		}, nil)
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	client, err := manager.GetClient(context.Background(), &GetClientRequest{
+		Provider: "openai", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+	})
+
+	suite.NoError(err)
+	loggingClient, ok := client.(*logger.LoggingMiddleware)
+	suite.Require().True(ok)
+	suite.Equal("org-key", loggingClient.APIKey())
+}
+
+func (suite *MultiClientManagerTestSuite) Test_GetClientResolvesDatabaseGlobalWithoutOwner() {
+	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).
+		Return([]*types.ProviderEndpoint{{
+			ID: "pe_global", Name: "custom", EndpointType: types.ProviderEndpointTypeGlobal, APIKey: "db-global-key",
+		}}, nil)
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	client, err := manager.GetClient(context.Background(), &GetClientRequest{Provider: "custom"})
+
+	suite.NoError(err)
+	loggingClient, ok := client.(*logger.LoggingMiddleware)
+	suite.Require().True(ok)
+	suite.Equal("db-global-key", loggingClient.APIKey())
+}
+
 func (suite *MultiClientManagerTestSuite) Test_WatchAndUpdateClient() {
 	// Create a temporary file for testing
 	tmpDir := suite.T().TempDir()

--- a/api/pkg/openai/manager/provider_manager_test.go
+++ b/api/pkg/openai/manager/provider_manager_test.go
@@ -101,6 +101,21 @@ func (suite *MultiClientManagerTestSuite) Test_GetClientPrefersLegacyNamedOrgani
 	suite.Equal("org-key", loggingClient.APIKey())
 }
 
+func (suite *MultiClientManagerTestSuite) Test_GetClientExplicitGlobalBypassesOrganizationProvider() {
+	suite.cfg.Providers.Anthropic.APIKey = "env-key"
+	suite.cfg.Providers.Anthropic.APIKeyFromFile = ""
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	client, err := manager.GetClient(context.Background(), &GetClientRequest{
+		Provider: "global/anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+	})
+
+	suite.NoError(err)
+	loggingClient, ok := client.(*logger.LoggingMiddleware)
+	suite.Require().True(ok)
+	suite.Equal("env-key", loggingClient.APIKey())
+}
+
 func (suite *MultiClientManagerTestSuite) Test_GetClientResolvesDatabaseGlobalWithoutOwner() {
 	suite.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).
 		Return([]*types.ProviderEndpoint{{

--- a/api/pkg/server/code_agent_provider_endpoint.go
+++ b/api/pkg/server/code_agent_provider_endpoint.go
@@ -67,35 +67,40 @@ func (s *HelixAPIServer) resolveCodeAgentProviderEndpoint(
 		return nil, fmt.Errorf("provider reference is required")
 	}
 
-	if !strings.HasPrefix(providerRef, "pe_") {
-		switch {
-		case strings.EqualFold(providerRef, string(types.ProviderOpenAI)):
-			return s.getBuiltInOpenAIProviderEndpoint()
-		case strings.EqualFold(providerRef, string(types.ProviderAnthropic)):
-			return s.getBuiltInProviderEndpoint(ctx, string(types.ProviderAnthropic))
-		}
-	}
-
-	if s.providerManager == nil {
-		return nil, fmt.Errorf("provider manager is not configured")
-	}
 	ownerID := user.ID
 	ownerType := types.OwnerTypeUser
 	if user.OrganizationID != "" {
 		ownerID = user.OrganizationID
 		ownerType = types.OwnerTypeOrg
 	}
-	endpoints, err := s.providerManager.ListProviderEndpointsForOwner(ctx, ownerID, ownerType)
-	if err != nil {
-		return nil, fmt.Errorf("list providers: %w", err)
-	}
-	for _, endpoint := range endpoints {
-		if endpoint.ID == providerRef || strings.EqualFold(endpoint.Name, providerRef) {
-			if endpoint.ID == "" {
-				return s.getBuiltInProviderEndpoint(ctx, endpoint.Name)
-			}
-			return endpoint, nil
+	if s.providerManager != nil {
+		endpoints, err := s.providerManager.ListProviderEndpointsForOwner(ctx, ownerID, ownerType)
+		if err != nil {
+			return nil, fmt.Errorf("list providers: %w", err)
 		}
+		for _, endpoint := range endpoints {
+			if endpoint != nil && endpoint.ID != "" && endpoint.ID == providerRef {
+				return endpoint, nil
+			}
+		}
+		for _, endpoint := range resolveProviderEndpointPrecedence(endpoints) {
+			if providerEndpointMatchesRef(endpoint, providerRef) {
+				if endpoint.ID == "" {
+					return s.getBuiltInProviderEndpoint(ctx, types.CanonicalProviderName(endpoint.Name))
+				}
+				return endpoint, nil
+			}
+		}
+	}
+
+	switch types.CanonicalProviderName(providerRef) {
+	case string(types.ProviderOpenAI):
+		return s.getBuiltInOpenAIProviderEndpoint()
+	case string(types.ProviderAnthropic):
+		return s.getBuiltInProviderEndpoint(ctx, string(types.ProviderAnthropic))
+	}
+	if s.providerManager == nil {
+		return nil, fmt.Errorf("provider manager is not configured")
 	}
 	return nil, fmt.Errorf("provider %q is not available to this task", providerRef)
 }

--- a/api/pkg/server/code_agent_provider_endpoint.go
+++ b/api/pkg/server/code_agent_provider_endpoint.go
@@ -73,23 +73,21 @@ func (s *HelixAPIServer) resolveCodeAgentProviderEndpoint(
 		ownerID = user.OrganizationID
 		ownerType = types.OwnerTypeOrg
 	}
+	if types.IsGlobalProviderID(providerRef) {
+		endpoint, err := s.getBuiltInProviderEndpoint(ctx, types.CanonicalProviderName(providerRef))
+		if err != nil {
+			return nil, err
+		}
+		endpoint.ID = providerRef
+		return endpoint, nil
+	}
 	if s.providerManager != nil {
 		endpoints, err := s.providerManager.ListProviderEndpointsForOwner(ctx, ownerID, ownerType)
 		if err != nil {
 			return nil, fmt.Errorf("list providers: %w", err)
 		}
-		for _, endpoint := range endpoints {
-			if endpoint != nil && endpoint.ID != "" && endpoint.ID == providerRef {
-				return endpoint, nil
-			}
-		}
-		for _, endpoint := range resolveProviderEndpointPrecedence(endpoints) {
-			if providerEndpointMatchesRef(endpoint, providerRef) {
-				if endpoint.ID == "" {
-					return s.getBuiltInProviderEndpoint(ctx, types.CanonicalProviderName(endpoint.Name))
-				}
-				return endpoint, nil
-			}
+		if endpoint := resolveProviderEndpointRef(endpoints, providerRef); endpoint != nil {
+			return endpoint, nil
 		}
 	}
 

--- a/api/pkg/server/code_agent_provider_endpoint_test.go
+++ b/api/pkg/server/code_agent_provider_endpoint_test.go
@@ -44,25 +44,21 @@ func TestCodeAgentProviderSelectionKeepsLegacyAppFallbackWithModelOverride(t *te
 func TestResolveCodeAgentProviderEndpointResolvesSyntheticGlobalOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	providerManager := manager.NewMockProviderManager(ctrl)
-	synthetic := &types.ProviderEndpoint{
-		Name:         "togetherai",
-		EndpointType: types.ProviderEndpointTypeGlobal,
-	}
-	providerManager.EXPECT().
-		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
-		Return([]*types.ProviderEndpoint{synthetic}, nil)
+	synthetic := &types.ProviderEndpoint{ID: "global/togetherai", Name: "togetherai", EndpointType: types.ProviderEndpointTypeGlobal}
 	providerManager.EXPECT().
 		ListProviderEndpoints(gomock.Any(), "").
 		Return([]*types.ProviderEndpoint{synthetic}, nil)
 
 	server := &HelixAPIServer{
-		Cfg:             &config.ServerConfig{},
+		Cfg: &config.ServerConfig{Providers: config.Providers{TogetherAI: config.TogetherAI{
+			APIKey: "global-key",
+		}}},
 		providerManager: providerManager,
 	}
 	endpoint, err := server.resolveCodeAgentProviderEndpoint(context.Background(), &types.User{
 		ID:             "user_1",
 		OrganizationID: "org_1",
-	}, "togetherai")
+	}, "global/togetherai")
 
 	require.NoError(t, err)
 	require.Same(t, synthetic, endpoint)

--- a/api/pkg/server/code_agent_provider_endpoint_test.go
+++ b/api/pkg/server/code_agent_provider_endpoint_test.go
@@ -67,3 +67,47 @@ func TestResolveCodeAgentProviderEndpointResolvesSyntheticGlobalOnce(t *testing.
 	require.NoError(t, err)
 	require.Same(t, synthetic, endpoint)
 }
+
+func TestResolveCodeAgentProviderEndpointPrefersLegacyNamedOrganizationAnthropic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	orgEndpoint := &types.ProviderEndpoint{
+		ID:           "pe_org_anthropic",
+		Name:         "user/anthropic",
+		EndpointType: types.ProviderEndpointTypeOrg,
+	}
+	providerManager.EXPECT().
+		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{
+			{Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			orgEndpoint,
+		}, nil)
+
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}, providerManager: providerManager}
+	endpoint, err := server.resolveCodeAgentProviderEndpoint(context.Background(), &types.User{
+		ID: "user_1", OrganizationID: "org_1",
+	}, "anthropic")
+
+	require.NoError(t, err)
+	require.Same(t, orgEndpoint, endpoint)
+}
+
+func TestResolveCodeAgentProviderEndpointKeepsExplicitDatabaseID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	globalEndpoint := &types.ProviderEndpoint{ID: "pe_global_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}
+	providerManager.EXPECT().
+		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{
+			globalEndpoint,
+			{ID: "pe_org_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+		}, nil)
+
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}, providerManager: providerManager}
+	endpoint, err := server.resolveCodeAgentProviderEndpoint(context.Background(), &types.User{
+		ID: "user_1", OrganizationID: "org_1",
+	}, "pe_global_anthropic")
+
+	require.NoError(t, err)
+	require.Same(t, globalEndpoint, endpoint)
+}

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -468,6 +468,10 @@ func (s *HelixAPIServer) findProviderWithModel(ctx context.Context, modelName, o
 	globalProviders, err := s.providerManager.ListProviders(ctx, "")
 	if err == nil {
 		for _, globalProvider := range globalProviders {
+			globalRef := types.GlobalProviderID(string(globalProvider))
+			if strings.HasPrefix(modelName, globalRef+"/") {
+				return globalRef, strings.TrimPrefix(modelName, globalRef+"/")
+			}
 			residue := modelName
 			if strings.HasPrefix(modelName, string(globalProvider)+"/") {
 				residue = modelName[len(globalProvider)+1:]
@@ -529,6 +533,9 @@ func (s *HelixAPIServer) findProviderWithModel(ctx context.Context, modelName, o
 	//      stripping the provider's literal `Name + "/"` prefix and
 	//      matching the residue against cached/static ids.
 	for _, provider := range providers {
+		if provider.ID != "" && strings.HasPrefix(modelName, provider.ID+"/") {
+			return provider.ID, strings.TrimPrefix(modelName, provider.ID+"/")
+		}
 		residue := modelName
 		if strings.HasPrefix(modelName, provider.Name+"/") {
 			residue = modelName[len(provider.Name)+1:]

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -131,6 +131,26 @@ func (s *FindProviderWithModelSuite) TestGlobal_PrefixedIDMatchesViaResidue() {
 	s.Equal("gpt-4o", bare)
 }
 
+func (s *FindProviderWithModelSuite) TestExplicitEnvironmentGlobalRefRemainsScoped() {
+	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{types.ProviderOpenAI}, nil)
+
+	provider, bare := s.server.findProviderWithModel(context.Background(), "global/openai/gpt-5.4", "user_x", "org_test")
+	s.Equal("global/openai", provider)
+	s.Equal("gpt-5.4", bare)
+}
+
+func (s *FindProviderWithModelSuite) TestExplicitOrganizationRefRemainsScopedWithSameVendorGlobal() {
+	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{types.ProviderOpenAI}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{
+		{ID: "pe_global_openai", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_org_openai", Name: "user/openai", Owner: "org_test", EndpointType: types.ProviderEndpointTypeOrg},
+	}, nil).AnyTimes()
+
+	provider, bare := s.server.findProviderWithModel(context.Background(), "pe_org_openai/gpt-5.4", "user_x", "org_test")
+	s.Equal("pe_org_openai", provider)
+	s.Equal("gpt-5.4", bare)
+}
+
 // Unknown model — no cache hit anywhere — returns the empty pair so the
 // caller can fall through to ParseProviderFromModel and ultimately to
 // getClient's default-provider fence.

--- a/api/pkg/server/org_code_agent_harness_handlers.go
+++ b/api/pkg/server/org_code_agent_harness_handlers.go
@@ -254,10 +254,8 @@ func (apiServer *HelixAPIServer) validateOrgCodeAgentHarness(
 	if err != nil {
 		return fmt.Errorf("failed to list providers: %w", err)
 	}
-	for _, endpoint := range filterProviderEndpointsForHarness(endpoints, harness, runtime) {
-		if providerEndpointMatchesRef(endpoint, providerRef) {
-			return nil
-		}
+	if resolveProviderEndpointRef(filterProviderEndpointsForHarness(endpoints, harness, runtime), providerRef) != nil {
+		return nil
 	}
 	return fmt.Errorf("provider %q is not enabled for coding-agent harness %q in this organization", providerRef, runtime)
 }

--- a/api/pkg/server/org_code_agent_harness_handlers.go
+++ b/api/pkg/server/org_code_agent_harness_handlers.go
@@ -119,15 +119,12 @@ func (apiServer *HelixAPIServer) buildOrgCodeAgentHarnessStatuses(ctx context.Co
 		status := &types.OrgCodeAgentHarnessStatus{
 			Runtime:              runtime,
 			Enabled:              true,
-			ProviderRefs:         []string{},
 			SupportsSubscription: runtime.SupportsSubscriptionCredentials(),
 		}
 		if policy != nil {
 			status.Enabled = policy.Enabled
 			status.SubscriptionEnabled = policy.SubscriptionEnabled
-			if policy.ProviderRefs != nil {
-				status.ProviderRefs = policy.ProviderRefs
-			}
+			status.ProviderRefs = policy.ProviderRefs
 		}
 		switch runtime {
 		case types.CodeAgentRuntimeClaudeCode:
@@ -250,10 +247,19 @@ func (apiServer *HelixAPIServer) validateOrgCodeAgentHarness(
 		}
 		return nil
 	}
-	if providerRef != "" && !harness.AllowsProvider(providerRef) {
-		return fmt.Errorf("provider %q is not enabled for coding-agent harness %q in this organization", providerRef, runtime)
+	if providerRef == "" {
+		return nil
 	}
-	return nil
+	endpoints, err := apiServer.listEndpointsForApp(ctx, "", &types.App{OrganizationID: orgID})
+	if err != nil {
+		return fmt.Errorf("failed to list providers: %w", err)
+	}
+	for _, endpoint := range filterProviderEndpointsForHarness(endpoints, harness, runtime) {
+		if providerEndpointMatchesRef(endpoint, providerRef) {
+			return nil
+		}
+	}
+	return fmt.Errorf("provider %q is not enabled for coding-agent harness %q in this organization", providerRef, runtime)
 }
 
 func (apiServer *HelixAPIServer) loadOrgCodeAgentHarnessPolicy(
@@ -267,7 +273,6 @@ func (apiServer *HelixAPIServer) loadOrgCodeAgentHarnessPolicy(
 			OrganizationID: orgID,
 			Runtime:        runtime,
 			Enabled:        true,
-			ProviderRefs:   []string{},
 		}, nil
 	}
 	if err != nil {
@@ -275,9 +280,6 @@ func (apiServer *HelixAPIServer) loadOrgCodeAgentHarnessPolicy(
 	}
 	if harness == nil {
 		return nil, fmt.Errorf("failed to load coding-agent harness policy: store returned no policy")
-	}
-	if harness.ProviderRefs == nil {
-		harness.ProviderRefs = []string{}
 	}
 	return harness, nil
 }

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -171,7 +171,7 @@ func TestNormalizeHarnessCredentialSources(t *testing.T) {
 func TestFilterProviderEndpointsByRefs(t *testing.T) {
 	endpoints := []*types.ProviderEndpoint{
 		{ID: "provider-1", Name: "renamed"},
-		{ID: "", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "global/openai", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
 		{ID: "provider-2", Name: "other"},
 	}
 	filtered := filterProviderEndpointsByRefs(endpoints, []string{"provider-1"})
@@ -181,19 +181,18 @@ func TestFilterProviderEndpointsByRefs(t *testing.T) {
 	filtered = filterProviderEndpointsByRefs(endpoints, []string{})
 	require.NotNil(t, filtered)
 	assert.Empty(t, filtered)
-}
 
-func TestResolveProviderEndpointPrecedence(t *testing.T) {
-	resolved := resolveProviderEndpointPrecedence([]*types.ProviderEndpoint{
-		{ID: "", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+	endpoints = []*types.ProviderEndpoint{
+		{ID: "global/openai", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
 		{ID: "pe_global", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
 		{ID: "pe_org", Name: "user/openai", EndpointType: types.ProviderEndpointTypeOrg},
-		{ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
-	})
-
-	require.Len(t, resolved, 2)
-	assert.Equal(t, "pe_org", resolved[0].ID)
-	assert.Equal(t, "pe_anthropic", resolved[1].ID)
+	}
+	filtered = filterProviderEndpointsByRefs(endpoints, []string{"openai"})
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "pe_org", filtered[0].ID)
+	filtered = filterProviderEndpointsByRefs(endpoints, []string{"global/openai"})
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "global/openai", filtered[0].ID)
 }
 
 func TestFilterProviderEndpointsForHarness(t *testing.T) {

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -187,7 +187,7 @@ func TestResolveProviderEndpointPrecedence(t *testing.T) {
 	resolved := resolveProviderEndpointPrecedence([]*types.ProviderEndpoint{
 		{ID: "", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
 		{ID: "pe_global", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
-		{ID: "pe_org", Name: "openai", EndpointType: types.ProviderEndpointTypeOrg},
+		{ID: "pe_org", Name: "user/openai", EndpointType: types.ProviderEndpointTypeOrg},
 		{ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
 	})
 

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -29,17 +30,20 @@ func TestValidateOrgCodeAgentHarness(t *testing.T) {
 		storeErr       error
 		credentialType types.CodeAgentCredentialType
 		providerRef    string
+		endpoints      []*types.ProviderEndpoint
 		wantErr        string
 	}{
-		{name: "legacy nil denies provider", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
-		{name: "provider allowed", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1"},
-		{name: "provider denied", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-2"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
+		{name: "nil inherits visible provider", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{{ID: "provider-1", Name: "anthropic"}}},
+		{name: "explicit provider allowed", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{{ID: "provider-1", Name: "anthropic"}}},
+		{name: "explicit empty denies provider", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{{ID: "provider-1", Name: "anthropic"}}, wantErr: "is not enabled"},
+		{name: "provider not visible to org", row: &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{}, wantErr: "is not enabled"},
+		{name: "native runtime rejects incompatible provider", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{{ID: "provider-1", Name: "togetherai"}}, wantErr: "is not enabled"},
 		{name: "provider denied in subscription mode", row: &types.OrgCodeAgentHarness{Enabled: true, SubscriptionEnabled: boolPointer(true), ProviderRefs: []string{"provider-1"}}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
 		{name: "subscription ignores usage provider", row: &types.OrgCodeAgentHarness{Enabled: true, SubscriptionEnabled: boolPointer(true), ProviderRefs: []string{}}, credentialType: types.CodeAgentCredentialTypeSubscription, providerRef: "openai"},
 		{name: "subscription denied by legacy nil", row: &types.OrgCodeAgentHarness{Enabled: true}, credentialType: types.CodeAgentCredentialTypeSubscription, wantErr: "subscription credentials are not enabled"},
 		{name: "subscription explicitly disabled", row: &types.OrgCodeAgentHarness{Enabled: true, SubscriptionEnabled: boolPointer(false)}, credentialType: types.CodeAgentCredentialTypeSubscription, wantErr: "subscription credentials are not enabled"},
 		{name: "disabled", row: &types.OrgCodeAgentHarness{Enabled: false}, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "not enabled"},
-		{name: "missing denies API access", storeErr: store.ErrNotFound, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "is not enabled"},
+		{name: "missing policy inherits visible provider", storeErr: store.ErrNotFound, credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", endpoints: []*types.ProviderEndpoint{{ID: "provider-1", Name: "anthropic"}}},
 		{name: "store failure", storeErr: fmt.Errorf("database unavailable"), credentialType: types.CodeAgentCredentialTypeAPIKey, providerRef: "provider-1", wantErr: "failed to load"},
 	}
 
@@ -48,6 +52,13 @@ func TestValidateOrgCodeAgentHarness(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockStore := store.NewMockStore(ctrl)
 			server := &HelixAPIServer{Store: mockStore}
+			if tc.endpoints != nil {
+				providerManager := manager.NewMockProviderManager(ctrl)
+				providerManager.EXPECT().
+					ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
+					Return(tc.endpoints, nil)
+				server.providerManager = providerManager
+			}
 			mockStore.EXPECT().GetOrgCodeAgentHarness(
 				gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode,
 			).Return(tc.row, tc.storeErr)
@@ -160,17 +171,47 @@ func TestNormalizeHarnessCredentialSources(t *testing.T) {
 func TestFilterProviderEndpointsByRefs(t *testing.T) {
 	endpoints := []*types.ProviderEndpoint{
 		{ID: "provider-1", Name: "renamed"},
-		{ID: "", Name: "openai"},
+		{ID: "", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
 		{ID: "provider-2", Name: "other"},
 	}
-	filtered := filterProviderEndpointsByRefs(endpoints, []string{"provider-1", "openai"})
-	require.Len(t, filtered, 2)
+	filtered := filterProviderEndpointsByRefs(endpoints, []string{"provider-1"})
+	require.Len(t, filtered, 1)
 	assert.Equal(t, "provider-1", filtered[0].ID)
-	assert.Equal(t, "openai", filtered[1].Name)
 
 	filtered = filterProviderEndpointsByRefs(endpoints, []string{})
 	require.NotNil(t, filtered)
 	assert.Empty(t, filtered)
+}
+
+func TestResolveProviderEndpointPrecedence(t *testing.T) {
+	resolved := resolveProviderEndpointPrecedence([]*types.ProviderEndpoint{
+		{ID: "", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_global", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_org", Name: "openai", EndpointType: types.ProviderEndpointTypeOrg},
+		{ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+	})
+
+	require.Len(t, resolved, 2)
+	assert.Equal(t, "pe_org", resolved[0].ID)
+	assert.Equal(t, "pe_anthropic", resolved[1].ID)
+}
+
+func TestFilterProviderEndpointsForHarness(t *testing.T) {
+	endpoints := []*types.ProviderEndpoint{
+		{ID: "pe_anthropic", Name: "anthropic"},
+		{ID: "pe_together", Name: "togetherai"},
+	}
+
+	inherited := filterProviderEndpointsForHarness(endpoints, &types.OrgCodeAgentHarness{Enabled: true}, types.CodeAgentRuntimeClaudeCode)
+	require.Len(t, inherited, 1)
+	assert.Equal(t, "pe_anthropic", inherited[0].ID)
+
+	explicitNone := filterProviderEndpointsForHarness(endpoints, &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{}}, types.CodeAgentRuntimeZedAgent)
+	assert.Empty(t, explicitNone)
+
+	allowlisted := filterProviderEndpointsForHarness(endpoints, &types.OrgCodeAgentHarness{Enabled: true, ProviderRefs: []string{"pe_together"}}, types.CodeAgentRuntimeZedAgent)
+	require.Len(t, allowlisted, 1)
+	assert.Equal(t, "pe_together", allowlisted[0].ID)
 }
 
 func boolPointer(value bool) *bool {
@@ -212,8 +253,7 @@ func TestBuildOrgCodeAgentHarnessStatuses(t *testing.T) {
 	assert.Equal(t, []string{"provider-1"}, byRuntime[types.CodeAgentRuntimeClaudeCode].ProviderRefs)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeClaudeCode].ViewerHasSubscription)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeCodexCLI].Enabled)
-	require.NotNil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
-	assert.Empty(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
+	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
 	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].SubscriptionEnabled)
 	assert.False(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ViewerHasSubscription)
 }

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -522,8 +522,12 @@ func (s *HelixAPIServer) refreshProviderModels(ctx context.Context, providerEndp
 // outside this singleflight, where it can't leak between endpoints.
 func (s *HelixAPIServer) fetchUpstreamModels(ctx context.Context, providerEndpoint *types.ProviderEndpoint) ([]types.OpenAIModel, error) {
 	result, err, _ := s.modelFetchGroup.Do(providerEndpoint.BaseURL, func() (interface{}, error) {
+		providerRef := providerEndpoint.Name
+		if providerEndpoint.ID != "" {
+			providerRef = providerEndpoint.ID
+		}
 		clientRequest := &manager.GetClientRequest{
-			Provider: providerEndpoint.Name,
+			Provider: providerRef,
 			Owner:    providerEndpoint.Owner,
 		}
 		if providerEndpoint.OwnerType == types.OwnerTypeOrg {

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -185,6 +185,7 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 
 		providerEndpoints = append(providerEndpoints, s.globalProviderEndpoint(provider))
 	}
+	providerEndpoints = resolveProviderEndpointPrecedence(providerEndpoints)
 
 	// Set default
 	for idx := range providerEndpoints {

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -160,18 +160,7 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Build a set of existing provider names to avoid duplicates
-	existingProviderNames := make(map[string]bool)
-	for _, ep := range providerEndpoints {
-		existingProviderNames[ep.Name] = true
-	}
-
 	for _, provider := range globalProviderEndpoints {
-		// Skip if this provider already exists in the database
-		if existingProviderNames[string(provider)] {
-			continue
-		}
-
 		// Sandbox-absorbs-runner equivalent of the old runnerController
 		// gate: skip the Helix provider when no sandbox is currently
 		// serving any model. Otherwise the picker offers an option that
@@ -185,7 +174,6 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 
 		providerEndpoints = append(providerEndpoints, s.globalProviderEndpoint(provider))
 	}
-	providerEndpoints = resolveProviderEndpointPrecedence(providerEndpoints)
 
 	// Set default
 	for idx := range providerEndpoints {
@@ -315,7 +303,7 @@ func (s *HelixAPIServer) globalProviderEndpoint(provider types.Provider) *types.
 	}
 
 	return &types.ProviderEndpoint{
-		ID:             "-",
+		ID:             types.GlobalProviderID(string(provider)),
 		Name:           string(provider),
 		Description:    "",
 		BaseURL:        baseURL,

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -729,43 +729,51 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		endpoint.Owner = user.ID
 	}
 
-	// Check for duplicate names
-	var (
-		existingProviders []types.Provider
-		err               error
-	)
-	if endpoint.OwnerType == types.OwnerTypeOrg {
-		existingProviders, err = s.providerManager.ListProvidersForOwner(r.Context(), endpoint.Owner, types.OwnerTypeOrg)
-	} else {
-		existingProviders, err = s.providerManager.ListProviders(r.Context(), endpoint.Owner)
-	}
-	if err != nil {
-		log.Err(err).Msg("error listing providers")
-		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	for _, provider := range existingProviders {
-		if string(provider) == endpoint.Name {
-			http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", endpoint.Name), http.StatusBadRequest)
-			return
+	// Default endpoint visibility to the authenticated owner scope.
+	if endpoint.EndpointType == "" {
+		if endpoint.OwnerType == types.OwnerTypeOrg {
+			endpoint.EndpointType = types.ProviderEndpointTypeOrg
+		} else {
+			endpoint.EndpointType = types.ProviderEndpointTypeUser
 		}
 	}
 
-	// Default to user endpoint type if not specified
-	if endpoint.EndpointType == "" {
-		endpoint.EndpointType = types.ProviderEndpointTypeUser
-	}
-
-	// Only admins can add global endpoints
-	if endpoint.EndpointType == types.ProviderEndpointTypeGlobal && !isAdmin {
-		http.Error(rw, "Only admins can add global endpoints", http.StatusForbidden)
+	switch endpoint.EndpointType {
+	case types.ProviderEndpointTypeGlobal:
+		if !isAdmin {
+			http.Error(rw, "Only admins can add global endpoints", http.StatusForbidden)
+			return
+		}
+	case types.ProviderEndpointTypeOrg:
+		if endpoint.OwnerType != types.OwnerTypeOrg {
+			http.Error(rw, "Organization provider endpoints require an organization owner", http.StatusBadRequest)
+			return
+		}
+	case types.ProviderEndpointTypeUser:
+		if endpoint.OwnerType != types.OwnerTypeUser {
+			http.Error(rw, "Personal provider endpoints require a user owner", http.StatusBadRequest)
+			return
+		}
+	default:
+		http.Error(rw, fmt.Sprintf("Unsupported endpoint type %q", endpoint.EndpointType), http.StatusBadRequest)
 		return
 	}
 
 	// Only admins can add endpoints with API key path auth
 	if endpoint.APIKeyFromFile != "" && !isAdmin {
 		http.Error(rw, "Only admins can add endpoints with API key path auth", http.StatusForbidden)
+		return
+	}
+
+	endpoint.Name = strings.TrimSpace(endpoint.Name)
+	duplicate, err := s.providerEndpointNameExists(ctx, &endpoint, "")
+	if err != nil {
+		log.Err(err).Msg("error listing providers for name validation")
+		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if duplicate {
+		http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", endpoint.Name), http.StatusBadRequest)
 		return
 	}
 
@@ -796,6 +804,38 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		http.Error(rw, "Internal server error", http.StatusInternalServerError)
 		return
 	}
+}
+
+func (s *HelixAPIServer) providerEndpointNameExists(ctx context.Context, endpoint *types.ProviderEndpoint, excludeID string) (bool, error) {
+	query := &store.ListProviderEndpointsQuery{Owner: endpoint.Owner}
+	switch endpoint.EndpointType {
+	case types.ProviderEndpointTypeGlobal:
+		query.Owner = ""
+		query.WithGlobal = true
+	case types.ProviderEndpointTypeOrg:
+		query.OwnerType = types.OwnerTypeOrg
+	case types.ProviderEndpointTypeUser:
+		query.OwnerType = types.OwnerTypeUser
+	default:
+		return false, fmt.Errorf("unsupported provider endpoint type %q", endpoint.EndpointType)
+	}
+	endpoints, err := s.Store.ListProviderEndpoints(ctx, query)
+	if err != nil {
+		return false, err
+	}
+	wantedName := types.CanonicalProviderName(strings.TrimSpace(endpoint.Name))
+	for _, existing := range endpoints {
+		if existing == nil || existing.ID == excludeID || existing.EndpointType != endpoint.EndpointType {
+			continue
+		}
+		if endpoint.EndpointType != types.ProviderEndpointTypeGlobal && existing.Owner != endpoint.Owner {
+			continue
+		}
+		if types.CanonicalProviderName(strings.TrimSpace(existing.Name)) == wantedName {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // updateProviderEndpoint godoc
@@ -887,10 +927,12 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	// "system"), which the UI treats as read-only, permanently stranding it. This
 	// now matches createProviderEndpoint, which leaves a global endpoint owned by
 	// its admin creator.
+	identityChanged := false
 	if updatedEndpoint.EndpointType != "" && updatedEndpoint.EndpointType != existingEndpoint.EndpointType {
 		switch updatedEndpoint.EndpointType {
 		case types.ProviderEndpointTypeGlobal:
 			existingEndpoint.EndpointType = updatedEndpoint.EndpointType
+			identityChanged = true
 		default:
 			http.Error(rw, fmt.Sprintf("Unsupported endpoint type switch to %q", updatedEndpoint.EndpointType), http.StatusBadRequest)
 			return
@@ -899,27 +941,22 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 
 	// Preserve ID and ownership information
 	// Update name if provided and different from existing
-	if updatedEndpoint.Name != "" && updatedEndpoint.Name != existingEndpoint.Name {
+	if updatedEndpoint.Name != "" && strings.TrimSpace(updatedEndpoint.Name) != existingEndpoint.Name {
 		newName := strings.TrimSpace(updatedEndpoint.Name)
-		// Check for duplicate names with other providers
-		var existingProviders []types.Provider
-		if existingEndpoint.OwnerType == types.OwnerTypeOrg {
-			existingProviders, err = s.providerManager.ListProvidersForOwner(ctx, existingEndpoint.Owner, types.OwnerTypeOrg)
-		} else {
-			existingProviders, err = s.providerManager.ListProviders(ctx, existingEndpoint.Owner)
-		}
+		existingEndpoint.Name = newName
+		identityChanged = true
+	}
+	if identityChanged {
+		duplicate, err := s.providerEndpointNameExists(ctx, existingEndpoint, existingEndpoint.ID)
 		if err != nil {
 			log.Err(err).Msg("error listing providers for name validation")
 			http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		for _, provider := range existingProviders {
-			if string(provider) == newName {
-				http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", newName), http.StatusBadRequest)
-				return
-			}
+		if duplicate {
+			http.Error(rw, fmt.Sprintf("Provider with name '%s' already exists", existingEndpoint.Name), http.StatusBadRequest)
+			return
 		}
-		existingEndpoint.Name = newName
 	}
 	existingEndpoint.Description = updatedEndpoint.Description
 	if updatedEndpoint.Icon != nil {

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -332,7 +332,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 	warmDone := make(chan struct{})
 
 	s.manager.EXPECT().GetClient(gomock.Any(), &manager.GetClientRequest{
-		Provider: "my-ollama",
+		Provider: "ep_123",
 		Owner:    "user_id",
 	}).DoAndReturn(func(_ context.Context, req *manager.GetClientRequest) (openai.Client, error) {
 		defer close(warmDone)

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -153,6 +153,22 @@ func (s *ProviderHandlersSuite) TestListProviders() {
 	s.Require().Equal("0.0008", resp[0].AvailableModels[1].ModelInfo.Pricing.Prompt)
 }
 
+func (s *ProviderHandlersSuite) TestListProvidersKeepsDatabaseAndEnvironmentGlobalDuplicates() {
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{{
+		ID: "pe_global_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal,
+	}}, nil)
+	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{types.ProviderAnthropic}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider-endpoints", nil).WithContext(s.authCtx)
+	rr := httptest.NewRecorder()
+	s.server.listProviderEndpoints(rr, req)
+
+	var endpoints []*types.ProviderEndpoint
+	s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &endpoints))
+	s.Require().Len(endpoints, 2)
+	s.ElementsMatch([]string{"pe_global_anthropic", "global/anthropic"}, []string{endpoints[0].ID, endpoints[1].ID})
+}
+
 func (s *ProviderHandlersSuite) TestListProviders_NoModelInfo() {
 	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{
 		{

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -298,7 +298,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		ProvidersManagementEnabled: true,
 	}, nil)
 
-	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{Owner: "user_id", OwnerType: types.OwnerTypeUser}).Return(nil, nil)
 
 	createdEndpoint := &types.ProviderEndpoint{
 		ID:           "ep_123",
@@ -351,6 +351,194 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		s.Equal("called", warmAPIKeySeen.Load(), "cache warm goroutine should have run")
 	case <-time.After(5 * time.Second):
 		s.Fail("cache warm goroutine did not complete in time")
+	}
+}
+
+func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_ValidatesCanonicalNameWithinEffectiveScope() {
+	s.server.authMiddleware = &authMiddleware{
+		store: s.store,
+		cfg:   authMiddlewareConfig{adminUserIDs: []string{"user_id"}},
+	}
+	s.server.Cfg.Providers.Anthropic.APIKey = "env-anthropic-key"
+
+	tests := []struct {
+		name      string
+		endpoint  types.ProviderEndpoint
+		existing  []*types.ProviderEndpoint
+		duplicate bool
+		malformed bool
+	}{
+		{
+			name: "org may coexist with db and env global",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+				EndpointType: types.ProviderEndpointTypeOrg},
+			existing: []*types.ProviderEndpoint{{ID: "pe_global", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}},
+		},
+		{
+			name: "same org canonical duplicate rejected",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+				EndpointType: types.ProviderEndpointTypeOrg},
+			existing:  []*types.ProviderEndpoint{{ID: "pe_org", Name: "anthropic", Owner: "org_1", EndpointType: types.ProviderEndpointTypeOrg}},
+			duplicate: true,
+		},
+		{
+			name: "same org legacy duplicate rejected",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+				EndpointType: types.ProviderEndpointTypeOrg},
+			existing:  []*types.ProviderEndpoint{{ID: "pe_org", Name: "user/anthropic", Owner: "org_1", EndpointType: types.ProviderEndpointTypeOrg}},
+			duplicate: true,
+		},
+		{
+			name:      "org owner defaults to org scope",
+			endpoint:  types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg},
+			existing:  []*types.ProviderEndpoint{{ID: "pe_org", Name: "user/anthropic", Owner: "org_1", EndpointType: types.ProviderEndpointTypeOrg}},
+			duplicate: true,
+		},
+		{
+			name: "other org may use same canonical name",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+				EndpointType: types.ProviderEndpointTypeOrg},
+			existing: []*types.ProviderEndpoint{{ID: "pe_other_org", Name: "user/anthropic", Owner: "org_2", EndpointType: types.ProviderEndpointTypeOrg}},
+		},
+		{
+			name:     "db global may coexist with env global and personal row",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			existing: []*types.ProviderEndpoint{{ID: "pe_personal", Name: "anthropic", Owner: "user_2", EndpointType: types.ProviderEndpointTypeUser}},
+		},
+		{
+			name: "org owner with personal type rejected",
+			endpoint: types.ProviderEndpoint{Name: "anthropic", Owner: "org_1", OwnerType: types.OwnerTypeOrg,
+				EndpointType: types.ProviderEndpointTypeUser},
+			malformed: true,
+		},
+		{
+			name:      "user owner with org type rejected",
+			endpoint:  types.ProviderEndpoint{Name: "anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+			malformed: true,
+		},
+		{
+			name:      "team scope rejected",
+			endpoint:  types.ProviderEndpoint{Name: "anthropic", EndpointType: types.ProviderEndpointTypeTeam},
+			malformed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{ProvidersManagementEnabled: true}, nil)
+			if tt.endpoint.OwnerType == types.OwnerTypeOrg {
+				expectOrgOwner(s.store, tt.endpoint.Owner, "user_id")
+			}
+			if !tt.malformed {
+				query := &store.ListProviderEndpointsQuery{Owner: "user_id", OwnerType: types.OwnerTypeUser}
+				effectiveType := tt.endpoint.EndpointType
+				if effectiveType == "" && tt.endpoint.OwnerType == types.OwnerTypeOrg {
+					effectiveType = types.ProviderEndpointTypeOrg
+				}
+				if effectiveType == types.ProviderEndpointTypeOrg {
+					query.Owner = tt.endpoint.Owner
+					query.OwnerType = types.OwnerTypeOrg
+				} else if effectiveType == types.ProviderEndpointTypeGlobal {
+					query = &store.ListProviderEndpointsQuery{WithGlobal: true}
+				}
+				s.store.EXPECT().ListProviderEndpoints(gomock.Any(), query).Return(tt.existing, nil)
+			}
+			if !tt.duplicate && !tt.malformed {
+				s.store.EXPECT().CreateProviderEndpoint(gomock.Any(), gomock.Any()).Return(nil, errors.New("create reached"))
+			}
+
+			body, err := json.Marshal(tt.endpoint)
+			s.Require().NoError(err)
+			req := httptest.NewRequest(http.MethodPost, "/v1/provider-endpoints", bytes.NewReader(body)).WithContext(s.authCtx)
+			rr := httptest.NewRecorder()
+			s.server.createProviderEndpoint(rr, req)
+
+			if tt.duplicate {
+				s.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+				s.Contains(rr.Body.String(), "already exists")
+			} else if tt.malformed {
+				s.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+			} else {
+				s.Equal(http.StatusInternalServerError, rr.Code, rr.Body.String())
+				s.Contains(rr.Body.String(), "create reached")
+			}
+		})
+	}
+}
+
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_ValidatesRenameAndTypeSwitchScope() {
+	tests := []struct {
+		name      string
+		existing  *types.ProviderEndpoint
+		update    types.UpdateProviderEndpoint
+		rows      []*types.ProviderEndpoint
+		duplicate bool
+	}{
+		{
+			name: "rename may coexist with db global",
+			existing: &types.ProviderEndpoint{ID: "pe_current", Name: "old", Owner: "user_id", OwnerType: types.OwnerTypeUser,
+				EndpointType: types.ProviderEndpointTypeUser},
+			update: types.UpdateProviderEndpoint{Name: "anthropic"},
+			rows: []*types.ProviderEndpoint{
+				{ID: "pe_current", Name: "old", Owner: "user_id", EndpointType: types.ProviderEndpointTypeUser},
+				{ID: "pe_global", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			},
+		},
+		{
+			name: "rename rejects legacy duplicate in user scope",
+			existing: &types.ProviderEndpoint{ID: "pe_current", Name: "old", Owner: "user_id", OwnerType: types.OwnerTypeUser,
+				EndpointType: types.ProviderEndpointTypeUser},
+			update: types.UpdateProviderEndpoint{Name: "anthropic"},
+			rows: []*types.ProviderEndpoint{
+				{ID: "pe_current", Name: "old", Owner: "user_id", EndpointType: types.ProviderEndpointTypeUser},
+				{ID: "pe_duplicate", Name: "user/anthropic", Owner: "user_id", EndpointType: types.ProviderEndpointTypeUser},
+			},
+			duplicate: true,
+		},
+		{
+			name: "unchanged name rejects type switch into duplicate global scope",
+			existing: &types.ProviderEndpoint{ID: "pe_current", Name: "anthropic", Owner: "user_id", OwnerType: types.OwnerTypeUser,
+				EndpointType: types.ProviderEndpointTypeUser},
+			update: types.UpdateProviderEndpoint{Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			rows: []*types.ProviderEndpoint{
+				{ID: "pe_current", Name: "anthropic", Owner: "user_id", EndpointType: types.ProviderEndpointTypeUser},
+				{ID: "pe_global", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			},
+			duplicate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{ProvidersManagementEnabled: true}, nil)
+			s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: tt.existing.ID}).Return(tt.existing, nil)
+			query := &store.ListProviderEndpointsQuery{Owner: tt.existing.Owner, OwnerType: types.OwnerTypeUser}
+			if tt.update.EndpointType == types.ProviderEndpointTypeGlobal {
+				query = &store.ListProviderEndpointsQuery{WithGlobal: true}
+			}
+			s.store.EXPECT().ListProviderEndpoints(gomock.Any(), query).Return(tt.rows, nil)
+			if !tt.duplicate {
+				s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, endpoint *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+						return endpoint, nil
+					})
+			}
+
+			body, err := json.Marshal(tt.update)
+			s.Require().NoError(err)
+			req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+tt.existing.ID, bytes.NewReader(body))
+			req = req.WithContext(setRequestUser(context.Background(), types.User{ID: "user_id", Admin: true}))
+			req = mux.SetURLVars(req, map[string]string{"id": tt.existing.ID})
+			rr := httptest.NewRecorder()
+			s.server.updateProviderEndpoint(rr, req)
+
+			if tt.duplicate {
+				s.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+				s.Contains(rr.Body.String(), "already exists")
+			} else {
+				s.Equal(http.StatusOK, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }
 
@@ -651,6 +839,7 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchUserToGlobal() 
 	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
 		ID: endpointID,
 	}).Return(existing, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{WithGlobal: true}).Return([]*types.ProviderEndpoint{existing}, nil)
 	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
 			s.Equal(types.ProviderEndpointTypeGlobal, ep.EndpointType)
@@ -791,7 +980,7 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_AdminUpdatesPresentat
 			s.True(ep.BillingEnabled)
 			return ep, nil
 		})
-	s.manager.EXPECT().ListProviders(gomock.Any(), "admin_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{WithGlobal: true}).Return([]*types.ProviderEndpoint{existing}, nil)
 
 	update := types.UpdateProviderEndpoint{
 		Name:           "DeepSeek Production",
@@ -975,7 +1164,7 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_RenameInvalidatesOldK
 	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
 		ID: endpointID,
 	}).Return(existing, nil)
-	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{Owner: "user_id", OwnerType: types.OwnerTypeUser}).Return(nil, nil)
 	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
 			s.Equal("new-name", ep.Name)
@@ -1198,7 +1387,7 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_NonAdminAllowedBySyst
 	})
 	s.Require().NoError(err)
 
-	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{Owner: "user_id", OwnerType: types.OwnerTypeUser}).Return(nil, nil)
 	s.store.EXPECT().CreateProviderEndpoint(gomock.Any(), gomock.Any()).Return(&types.ProviderEndpoint{
 		ID:           "ep_openrouter",
 		Name:         "my-openrouter",
@@ -1212,11 +1401,14 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_NonAdminAllowedBySyst
 	warmDone := make(chan struct{})
 	s.manager.EXPECT().GetClient(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ *manager.GetClientRequest) (openai.Client, error) {
-			defer close(warmDone)
 			return s.openAiClient, nil
 		})
 	s.openAiClient.EXPECT().ListModels(gomock.Any()).Return([]types.OpenAIModel{{ID: "gpt-4o"}}, nil)
-	s.modelInfoProvider.EXPECT().GetModelInfo(gomock.Any(), gomock.Any()).Return(nil, errors.New("not found"))
+	s.modelInfoProvider.EXPECT().GetModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *model.ModelInfoRequest) (*types.ModelInfo, error) {
+			close(warmDone)
+			return nil, errors.New("not found")
+		})
 
 	req, err := http.NewRequest("POST", "/v1/provider-endpoints", bytes.NewReader(body))
 	s.Require().NoError(err)

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -691,6 +691,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	isSubscription := assistant.CodeAgentCredentialType.IsSubscription()
 
 	providerName, modelName := external_agent.AssistantModelSelection(assistant)
+	providerKind := providerName
 
 	// Resolve the agent's stored provider token (ID or legacy name) to the
 	// provider's current canonical name. Required so the model prefix here
@@ -698,7 +699,12 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	// see comment in buildCodeAgentConfig.
 	if providerSnapshot != nil && providerName != "" {
 		if resolved, _, ok := external_agent.ResolveProvider(providerName, providerSnapshot); ok {
-			providerName = resolved.Name
+			providerKind = resolved.Name
+			if resolved.ID != "" {
+				providerName = resolved.ID
+			} else {
+				providerName = resolved.Name
+			}
 		}
 	}
 
@@ -708,7 +714,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 		return nil
 	}
 
-	provider := types.CanonicalProviderName(providerName)
+	provider := types.CanonicalProviderName(providerKind)
 	var baseURL, apiType, agentName, model string
 
 	// The runtime choice determines how the LLM is configured in Zed
@@ -1144,7 +1150,9 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorI
 func filterProviderEndpointsByRefs(endpoints []*types.ProviderEndpoint, refs []string) []*types.ProviderEndpoint {
 	allowed := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
-		allowed[ref] = struct{}{}
+		if endpoint := resolveProviderEndpointRef(endpoints, ref); endpoint != nil {
+			allowed[endpoint.ID] = struct{}{}
+		}
 	}
 	filtered := make([]*types.ProviderEndpoint, 0, len(endpoints))
 	for _, endpoint := range endpoints {
@@ -1153,13 +1161,6 @@ func filterProviderEndpointsByRefs(endpoints []*types.ProviderEndpoint, refs []s
 		}
 		if _, ok := allowed[endpoint.ID]; ok {
 			filtered = append(filtered, endpoint)
-			continue
-		}
-		for ref := range allowed {
-			if providerEndpointMatchesRef(endpoint, ref) {
-				filtered = append(filtered, endpoint)
-				break
-			}
 		}
 	}
 	return filtered
@@ -1186,28 +1187,28 @@ func filterProviderEndpointsForHarness(
 }
 
 func providerEndpointMatchesRef(endpoint *types.ProviderEndpoint, ref string) bool {
-	return endpoint != nil && (endpoint.ID == ref || types.CanonicalProviderName(endpoint.Name) == types.CanonicalProviderName(ref))
+	return endpoint != nil && endpoint.ID != "" && endpoint.ID == ref
 }
 
-func resolveProviderEndpointPrecedence(endpoints []*types.ProviderEndpoint) []*types.ProviderEndpoint {
-	resolved := make([]*types.ProviderEndpoint, 0, len(endpoints))
-	byName := make(map[string]int, len(endpoints))
+func resolveProviderEndpointRef(endpoints []*types.ProviderEndpoint, ref string) *types.ProviderEndpoint {
 	for _, endpoint := range endpoints {
-		if endpoint == nil {
-			continue
-		}
-		name := types.CanonicalProviderName(endpoint.Name)
-		idx, exists := byName[name]
-		if !exists {
-			byName[name] = len(resolved)
-			resolved = append(resolved, endpoint)
-			continue
-		}
-		if providerEndpointPrecedence(endpoint) > providerEndpointPrecedence(resolved[idx]) {
-			resolved[idx] = endpoint
+		if providerEndpointMatchesRef(endpoint, ref) {
+			return endpoint
 		}
 	}
-	return resolved
+	if types.IsGlobalProviderID(ref) || strings.HasPrefix(ref, "pe_") {
+		return nil
+	}
+	var selected *types.ProviderEndpoint
+	for _, endpoint := range endpoints {
+		if endpoint == nil || types.CanonicalProviderName(endpoint.Name) != types.CanonicalProviderName(ref) {
+			continue
+		}
+		if selected == nil || providerEndpointPrecedence(endpoint) > providerEndpointPrecedence(selected) {
+			selected = endpoint
+		}
+	}
+	return selected
 }
 
 func providerEndpointPrecedence(endpoint *types.ProviderEndpoint) int {
@@ -1227,7 +1228,7 @@ func providerSnapshotFromEndpoints(endpoints []*types.ProviderEndpoint) []extern
 		if ep == nil {
 			continue
 		}
-		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name})
+		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name, EndpointType: ep.EndpointType})
 	}
 	return refs
 }
@@ -1244,7 +1245,7 @@ func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorI
 		if err != nil {
 			return nil, err
 		}
-		return resolveProviderEndpointPrecedence(endpoints), nil
+		return endpoints, nil
 	}
 	return apiServer.providerManager.ListProviderEndpoints(ctx, actorID)
 }

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -1132,14 +1132,10 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorI
 				runtime = types.CodeAgentRuntimeZedAgent
 			}
 			harness, err := apiServer.loadOrgCodeAgentHarnessPolicy(ctx, app.OrganizationID, runtime)
-			switch {
-			case err != nil:
+			if err != nil {
 				return nil, err
-			case !harness.Enabled:
-				endpoints = []*types.ProviderEndpoint{}
-			case harness.ProviderRefs != nil:
-				endpoints = filterProviderEndpointsByRefs(endpoints, harness.ProviderRefs)
 			}
+			endpoints = filterProviderEndpointsForHarness(endpoints, harness, runtime)
 		}
 	}
 	return providerSnapshotFromEndpoints(endpoints), nil
@@ -1155,15 +1151,74 @@ func filterProviderEndpointsByRefs(endpoints []*types.ProviderEndpoint, refs []s
 		if endpoint == nil {
 			continue
 		}
-		ref := endpoint.ID
-		if ref == "" {
-			ref = endpoint.Name
-		}
-		if _, ok := allowed[ref]; ok {
+		if _, ok := allowed[endpoint.ID]; ok {
 			filtered = append(filtered, endpoint)
+			continue
+		}
+		for ref := range allowed {
+			if strings.EqualFold(endpoint.Name, ref) {
+				filtered = append(filtered, endpoint)
+				break
+			}
 		}
 	}
 	return filtered
+}
+
+func filterProviderEndpointsForHarness(
+	endpoints []*types.ProviderEndpoint,
+	harness *types.OrgCodeAgentHarness,
+	runtime types.CodeAgentRuntime,
+) []*types.ProviderEndpoint {
+	if !harness.Enabled || harness.AllowsSubscription() {
+		return []*types.ProviderEndpoint{}
+	}
+	compatible := make([]*types.ProviderEndpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint != nil && external_agent.CodeAgentRuntimeAllowsProvider(runtime, endpoint.Name) {
+			compatible = append(compatible, endpoint)
+		}
+	}
+	if harness.ProviderRefs == nil {
+		return compatible
+	}
+	return filterProviderEndpointsByRefs(compatible, harness.ProviderRefs)
+}
+
+func providerEndpointMatchesRef(endpoint *types.ProviderEndpoint, ref string) bool {
+	return endpoint != nil && (endpoint.ID == ref || strings.EqualFold(endpoint.Name, ref))
+}
+
+func resolveProviderEndpointPrecedence(endpoints []*types.ProviderEndpoint) []*types.ProviderEndpoint {
+	resolved := make([]*types.ProviderEndpoint, 0, len(endpoints))
+	byName := make(map[string]int, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint == nil {
+			continue
+		}
+		name := strings.ToLower(endpoint.Name)
+		idx, exists := byName[name]
+		if !exists {
+			byName[name] = len(resolved)
+			resolved = append(resolved, endpoint)
+			continue
+		}
+		if providerEndpointPrecedence(endpoint) > providerEndpointPrecedence(resolved[idx]) {
+			resolved[idx] = endpoint
+		}
+	}
+	return resolved
+}
+
+func providerEndpointPrecedence(endpoint *types.ProviderEndpoint) int {
+	switch {
+	case endpoint.EndpointType == types.ProviderEndpointTypeOrg:
+		return 3
+	case endpoint.EndpointType == types.ProviderEndpointTypeGlobal && endpoint.ID != "" && endpoint.ID != "-":
+		return 2
+	default:
+		return 1
+	}
 }
 
 func providerSnapshotFromEndpoints(endpoints []*types.ProviderEndpoint) []external_agent.ProviderRef {
@@ -1185,7 +1240,11 @@ func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorI
 		return nil, nil
 	}
 	if app != nil && app.OrganizationID != "" {
-		return apiServer.providerManager.ListProviderEndpointsForOwner(ctx, app.OrganizationID, types.OwnerTypeOrg)
+		endpoints, err := apiServer.providerManager.ListProviderEndpointsForOwner(ctx, app.OrganizationID, types.OwnerTypeOrg)
+		if err != nil {
+			return nil, err
+		}
+		return resolveProviderEndpointPrecedence(endpoints), nil
 	}
 	return apiServer.providerManager.ListProviderEndpoints(ctx, actorID)
 }

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -708,7 +708,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 		return nil
 	}
 
-	provider := strings.ToLower(providerName)
+	provider := types.CanonicalProviderName(providerName)
 	var baseURL, apiType, agentName, model string
 
 	// The runtime choice determines how the LLM is configured in Zed
@@ -1156,7 +1156,7 @@ func filterProviderEndpointsByRefs(endpoints []*types.ProviderEndpoint, refs []s
 			continue
 		}
 		for ref := range allowed {
-			if strings.EqualFold(endpoint.Name, ref) {
+			if providerEndpointMatchesRef(endpoint, ref) {
 				filtered = append(filtered, endpoint)
 				break
 			}
@@ -1186,7 +1186,7 @@ func filterProviderEndpointsForHarness(
 }
 
 func providerEndpointMatchesRef(endpoint *types.ProviderEndpoint, ref string) bool {
-	return endpoint != nil && (endpoint.ID == ref || strings.EqualFold(endpoint.Name, ref))
+	return endpoint != nil && (endpoint.ID == ref || types.CanonicalProviderName(endpoint.Name) == types.CanonicalProviderName(ref))
 }
 
 func resolveProviderEndpointPrecedence(endpoints []*types.ProviderEndpoint) []*types.ProviderEndpoint {
@@ -1196,7 +1196,7 @@ func resolveProviderEndpointPrecedence(endpoints []*types.ProviderEndpoint) []*t
 		if endpoint == nil {
 			continue
 		}
-		name := strings.ToLower(endpoint.Name)
+		name := types.CanonicalProviderName(endpoint.Name)
 		idx, exists := byName[name]
 		if !exists {
 			byName[name] = len(resolved)

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -880,7 +880,7 @@ func (apiServer *HelixAPIServer) applyAdvertisedModelLimits(ctx context.Context,
 
 	bareModelName := strings.TrimPrefix(modelName, cfg.Provider+"/")
 	for _, endpoint := range endpoints {
-		if endpoint == nil || endpoint.Name != cfg.Provider {
+		if endpoint == nil || (endpoint.ID != cfg.Provider && endpoint.Name != cfg.Provider) {
 			continue
 		}
 

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -37,7 +37,7 @@ func TestGetProviderSnapshotMissingHarnessPolicyIncludesGlobalProviders(t *testi
 	providerManager.EXPECT().
 		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
 		Return([]*types.ProviderEndpoint{
-			{ID: "", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			{ID: "global/anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
 			{ID: "pe_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
 		}, nil)
 	mockStore.EXPECT().
@@ -47,7 +47,10 @@ func TestGetProviderSnapshotMissingHarnessPolicyIncludesGlobalProviders(t *testi
 	snapshot, err := server.getProviderSnapshot(context.Background(), "user_1", app)
 
 	require.NoError(t, err)
-	require.Equal(t, []external_agent.ProviderRef{{ID: "pe_anthropic", Name: "user/anthropic"}}, snapshot)
+	require.Equal(t, []external_agent.ProviderRef{
+		{ID: "global/anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+		{ID: "pe_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+	}, snapshot)
 }
 
 func TestGetProviderSnapshotSubscriptionExcludesGlobalProviders(t *testing.T) {

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -139,7 +139,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 			},
 			snapshot: []external_agent.ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
 			want: &types.CodeAgentConfig{
-				Provider:  "user/anthropic",
+				Provider:  "pe_org_anthropic",
 				Model:     "claude-sonnet-4-20250514",
 				AgentName: "zed-agent",
 				BaseURL:   "http://localhost:8080/v1",
@@ -608,7 +608,7 @@ func TestBuildCodeAgentConfigProviderAdvertisedContextLength(t *testing.T) {
 
 			if tt.providerListErr == nil {
 				providerManager.EXPECT().
-					GetClient(gomock.Any(), &manager.GetClientRequest{Provider: providerName, Owner: "user-1"}).
+					GetClient(gomock.Any(), &manager.GetClientRequest{Provider: "pe_ds4", Owner: "user-1"}).
 					Return(providerClient, nil)
 				providerClient.EXPECT().
 					ListModels(gomock.Any()).
@@ -646,7 +646,11 @@ func TestBuildCodeAgentConfigProviderAdvertisedContextLength(t *testing.T) {
 			require.NotNil(t, got)
 			assert.Equal(t, tt.wantContext, got.MaxTokens)
 			assert.Equal(t, tt.wantOutputTokens, got.MaxOutputTokens)
-			assert.Equal(t, providerName+"/"+modelName, got.Model)
+			if tt.providerListErr == nil {
+				assert.Equal(t, "pe_ds4/"+modelName, got.Model)
+			} else {
+				assert.Equal(t, providerName+"/"+modelName, got.Model)
+			}
 		})
 	}
 }

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dgraph-io/ristretto/v2"
 	"github.com/helixml/helix/api/pkg/config"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
@@ -18,7 +19,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestGetProviderSnapshotMissingHarnessPolicyHidesVisibleProviders(t *testing.T) {
+func TestGetProviderSnapshotMissingHarnessPolicyIncludesGlobalProviders(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
 	providerManager := manager.NewMockProviderManager(ctrl)
@@ -35,10 +36,40 @@ func TestGetProviderSnapshotMissingHarnessPolicyHidesVisibleProviders(t *testing
 	}
 	providerManager.EXPECT().
 		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
-		Return([]*types.ProviderEndpoint{{ID: "pe_anthropic", Name: "anthropic"}}, nil)
+		Return([]*types.ProviderEndpoint{{ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}}, nil)
 	mockStore.EXPECT().
 		GetOrgCodeAgentHarness(gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode).
 		Return(nil, store.ErrNotFound)
+
+	snapshot, err := server.getProviderSnapshot(context.Background(), "user_1", app)
+
+	require.NoError(t, err)
+	require.Equal(t, []external_agent.ProviderRef{{ID: "pe_anthropic", Name: "anthropic"}}, snapshot)
+}
+
+func TestGetProviderSnapshotSubscriptionExcludesGlobalProviders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{Store: mockStore, providerManager: providerManager}
+	app := &types.App{
+		OrganizationID: "org_1",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			AgentType:               types.AgentTypeZedExternal,
+			CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+			CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+		}}}},
+	}
+	providerManager.EXPECT().
+		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{{
+			ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal,
+		}}, nil)
+	mockStore.EXPECT().
+		GetOrgCodeAgentHarness(gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode).
+		Return(&types.OrgCodeAgentHarness{
+			Enabled: true, SubscriptionEnabled: boolPointer(true), ProviderRefs: []string{},
+		}, nil)
 
 	snapshot, err := server.getProviderSnapshot(context.Background(), "user_1", app)
 

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -36,7 +36,10 @@ func TestGetProviderSnapshotMissingHarnessPolicyIncludesGlobalProviders(t *testi
 	}
 	providerManager.EXPECT().
 		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
-		Return([]*types.ProviderEndpoint{{ID: "pe_anthropic", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal}}, nil)
+		Return([]*types.ProviderEndpoint{
+			{ID: "", Name: "anthropic", EndpointType: types.ProviderEndpointTypeGlobal},
+			{ID: "pe_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+		}, nil)
 	mockStore.EXPECT().
 		GetOrgCodeAgentHarness(gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode).
 		Return(nil, store.ErrNotFound)
@@ -44,7 +47,7 @@ func TestGetProviderSnapshotMissingHarnessPolicyIncludesGlobalProviders(t *testi
 	snapshot, err := server.getProviderSnapshot(context.Background(), "user_1", app)
 
 	require.NoError(t, err)
-	require.Equal(t, []external_agent.ProviderRef{{ID: "pe_anthropic", Name: "anthropic"}}, snapshot)
+	require.Equal(t, []external_agent.ProviderRef{{ID: "pe_anthropic", Name: "user/anthropic"}}, snapshot)
 }
 
 func TestGetProviderSnapshotSubscriptionExcludesGlobalProviders(t *testing.T) {
@@ -87,6 +90,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 	tests := []struct {
 		name      string
 		assistant *types.AssistantConfig
+		snapshot  []external_agent.ProviderRef
 		want      *types.CodeAgentConfig
 	}{
 		{
@@ -121,6 +125,23 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 				APIType:         "openai",
 				Runtime:         types.CodeAgentRuntimeZedAgent,
 				ReasoningEffort: types.ReasoningEffortNone,
+			},
+		},
+		{
+			name: "legacy anthropic task ref resolves org endpoint for zed_agent",
+			assistant: &types.AssistantConfig{
+				Provider:         "anthropic",
+				Model:            "claude-sonnet-4-20250514",
+				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+			},
+			snapshot: []external_agent.ProviderRef{{ID: "pe_org_anthropic", Name: "user/anthropic"}},
+			want: &types.CodeAgentConfig{
+				Provider:  "user/anthropic",
+				Model:     "claude-sonnet-4-20250514",
+				AgentName: "zed-agent",
+				BaseURL:   "http://localhost:8080/v1",
+				APIType:   "anthropic",
+				Runtime:   types.CodeAgentRuntimeZedAgent,
 			},
 		},
 		{
@@ -386,7 +407,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL, nil)
+			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL, tt.snapshot)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/api/pkg/types/org_code_agent_harness.go
+++ b/api/pkg/types/org_code_agent_harness.go
@@ -8,8 +8,8 @@ import (
 // OrgCodeAgentHarness records whether an organization permits one coding
 // harness and which provider endpoints that harness may use. Models
 // deliberately do not live here: a task selects a model from the allowed
-// providers' current model lists when it starts. API providers and subscription
-// credentials are both opt-in.
+// providers' current model lists when it starts. API providers inherit by
+// default; subscription credentials remain opt-in.
 type OrgCodeAgentHarness struct {
 	ID        string    `json:"id" gorm:"primaryKey"`
 	Created   time.Time `json:"created"`
@@ -24,8 +24,8 @@ type OrgCodeAgentHarness struct {
 	// remain in API-provider mode until an owner explicitly connects or selects
 	// a subscription.
 	SubscriptionEnabled *bool `json:"subscription_enabled"`
-	// Nil and an empty list allow no providers. Providers must be explicitly
-	// enabled for each harness.
+	// Nil inherits every compatible provider visible to the organization. An
+	// empty list disables API providers; a non-empty list is an allowlist.
 	ProviderRefs []string `json:"provider_refs" gorm:"type:jsonb;serializer:json"`
 }
 
@@ -57,10 +57,6 @@ type OrgCodeAgentHarnessStatus struct {
 	ProviderRefs          []string         `json:"provider_refs"`
 	SupportsSubscription  bool             `json:"supports_subscription"`
 	ViewerHasSubscription bool             `json:"viewer_has_subscription"`
-}
-
-func (h *OrgCodeAgentHarness) AllowsProvider(providerRef string) bool {
-	return !h.AllowsSubscription() && slices.Contains(h.ProviderRefs, providerRef)
 }
 
 func (h *OrgCodeAgentHarness) AllowsSubscription() bool {

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -39,10 +39,20 @@ func IsGlobalProvider(provider string) bool {
 
 func CanonicalProviderName(provider string) string {
 	name := strings.ToLower(provider)
-	if strings.HasPrefix(name, "user/") && IsGlobalProvider(strings.TrimPrefix(name, "user/")) {
-		return strings.TrimPrefix(name, "user/")
+	for _, prefix := range []string{"user/", "global/"} {
+		if strings.HasPrefix(name, prefix) && IsGlobalProvider(strings.TrimPrefix(name, prefix)) {
+			return strings.TrimPrefix(name, prefix)
+		}
 	}
 	return name
+}
+
+func GlobalProviderID(provider string) string {
+	return "global/" + CanonicalProviderName(provider)
+}
+
+func IsGlobalProviderID(provider string) bool {
+	return strings.HasPrefix(strings.ToLower(provider), "global/") && IsGlobalProvider(CanonicalProviderName(provider))
 }
 
 type ProviderEndpointType string

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -34,6 +35,14 @@ func IsGlobalProvider(provider string) bool {
 		}
 	}
 	return false
+}
+
+func CanonicalProviderName(provider string) string {
+	name := strings.ToLower(provider)
+	if strings.HasPrefix(name, "user/") && IsGlobalProvider(strings.TrimPrefix(name, "user/")) {
+		return strings.TrimPrefix(name, "user/")
+	}
+	return name
 }
 
 type ProviderEndpointType string

--- a/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
@@ -346,6 +346,38 @@ describe('CodeAgentConfigPicker', () => {
     }), 'user')
   })
 
+  it('shows duplicate vendor scopes and stores the selected endpoint ID', () => {
+    providerState.providers = [
+      {
+        id: 'pe_org_anthropic',
+        name: 'user/anthropic',
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+        status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+        available_models: [{ id: 'org-claude', enabled: true, type: 'chat' }],
+      },
+      {
+        id: 'global/anthropic',
+        name: 'anthropic',
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
+        status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+        available_models: [{ id: 'global-claude', enabled: true, type: 'chat' }],
+      },
+    ]
+    const onChange = vi.fn()
+    renderPicker(<CodeAgentConfigPicker onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Change coding agent' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Zed Agent' }))
+
+    expect(screen.getByText('Probably / Anthropic')).toBeInTheDocument()
+    expect(screen.getByText('Global / Anthropic')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Select global-claude from Global / Anthropic' }))
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      provider_ref: 'global/anthropic',
+      model: 'global-claude',
+    }), 'user')
+  })
+
   it('keeps older native models in a collapsed legacy section', () => {
     renderPicker(<CodeAgentConfigPicker onChange={vi.fn()} />)
     fireEvent.click(screen.getByRole('button', { name: 'Change coding agent' }))

--- a/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
@@ -7,6 +7,7 @@ import {
   TypesCodeAgentCredentialType,
   TypesCodeAgentExecutionConfig,
   TypesCodeAgentRuntime,
+  TypesProviderEndpointType,
   TypesProviderEndpointStatus,
 } from '../../api/api'
 import CodeAgentConfigPicker from './CodeAgentConfigPicker'
@@ -72,6 +73,7 @@ describe('CodeAgentConfigPicker', () => {
       {
         id: 'provider-1',
         name: 'OpenAI',
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
         status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
         available_models: [
           { id: 'api-model', enabled: true, type: 'text' },
@@ -82,6 +84,7 @@ describe('CodeAgentConfigPicker', () => {
       {
         id: 'provider-2',
         name: 'Anthropic',
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
         status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
         available_models: [
           { id: 'claude-api-model', enabled: true, type: 'chat' },
@@ -129,6 +132,10 @@ describe('CodeAgentConfigPicker', () => {
   })
 
   it('hides models from providers disabled for the selected harness', () => {
+    providerState.providers = providerState.providers.map((provider) => ({
+      ...provider,
+      endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+    }))
     harnessState.harnesses = harnessState.harnesses.map((harness) =>
       harness.runtime === TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent
         ? { ...harness, provider_refs: ['provider-2'] }
@@ -140,6 +147,18 @@ describe('CodeAgentConfigPicker', () => {
     expect(screen.queryByText('OpenAI')).not.toBeInTheDocument()
     expect(screen.getByText('claude-api-model')).toBeInTheDocument()
     expect(screen.getAllByText('Anthropic').length).toBeGreaterThan(0)
+  })
+
+  it('treats an explicit empty provider list as API providers disabled', () => {
+    harnessState.harnesses = harnessState.harnesses.map((harness) =>
+      harness.runtime === TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent
+        ? { ...harness, provider_refs: [] }
+        : harness)
+    renderPicker(<CodeAgentConfigPicker onChange={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Change coding agent' }))
+
+    expect(screen.queryByText('api-model')).not.toBeInTheDocument()
+    expect(screen.queryByText('claude-api-model')).not.toBeInTheDocument()
   })
 
   it('does not expose cached models from a disconnected provider', () => {
@@ -365,6 +384,10 @@ describe('CodeAgentConfigPicker', () => {
   })
 
   it('does not mutate an existing task whose provider is no longer allowed', async () => {
+    providerState.providers = providerState.providers.map((provider) => ({
+      ...provider,
+      endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+    }))
     harnessState.harnesses = harnessState.harnesses.map((harness) =>
       harness.runtime === TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode
         ? { ...harness, subscription_enabled: false, provider_refs: ['provider-2'] }

--- a/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
@@ -323,6 +323,8 @@ describe('CodeAgentConfigPicker', () => {
   })
 
   it('writes the provider and model selected in chat into the task config', () => {
+    providerState.providers = providerState.providers.map((provider) =>
+      provider.id === 'provider-2' ? { ...provider, name: 'user/anthropic' } : provider)
     harnessState.harnesses = harnessState.harnesses.map((harness) =>
       harness.runtime === TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode
         ? { ...harness, subscription_enabled: false }

--- a/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
@@ -18,7 +18,7 @@ const providerState = vi.hoisted(() => ({ providers: [] as any[] }))
 const navigate = vi.hoisted(() => vi.fn())
 
 vi.mock('../../services/orgService', () => ({
-  useGetOrgByName: () => ({ data: { id: 'org-1' }, isLoading: false }),
+  useGetOrgByName: () => ({ data: { id: 'org-1', display_name: 'Probably' }, isLoading: false }),
 }))
 vi.mock('../../services/providersService', () => ({
   useListProviders: () => ({ data: providerState.providers, isLoading: false }),
@@ -127,8 +127,8 @@ describe('CodeAgentConfigPicker', () => {
 
     expect(screen.getByText('api-model')).toBeInTheDocument()
     expect(screen.getByText('claude-api-model')).toBeInTheDocument()
-    expect(screen.getAllByText('OpenAI').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Anthropic').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Global / OpenAI').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Global / Anthropic').length).toBeGreaterThan(0)
   })
 
   it('hides models from providers disabled for the selected harness', () => {
@@ -144,9 +144,9 @@ describe('CodeAgentConfigPicker', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Change coding agent' }))
 
     expect(screen.queryByText('api-model')).not.toBeInTheDocument()
-    expect(screen.queryByText('OpenAI')).not.toBeInTheDocument()
+    expect(screen.queryByText('Probably / OpenAI')).not.toBeInTheDocument()
     expect(screen.getByText('claude-api-model')).toBeInTheDocument()
-    expect(screen.getAllByText('Anthropic').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Probably / Anthropic').length).toBeGreaterThan(0)
   })
 
   it('treats an explicit empty provider list as API providers disabled', () => {
@@ -324,7 +324,9 @@ describe('CodeAgentConfigPicker', () => {
 
   it('writes the provider and model selected in chat into the task config', () => {
     providerState.providers = providerState.providers.map((provider) =>
-      provider.id === 'provider-2' ? { ...provider, name: 'user/anthropic' } : provider)
+      provider.id === 'provider-2'
+        ? { ...provider, name: 'user/anthropic', endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg }
+        : provider)
     harnessState.harnesses = harnessState.harnesses.map((harness) =>
       harness.runtime === TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode
         ? { ...harness, subscription_enabled: false }
@@ -333,7 +335,9 @@ describe('CodeAgentConfigPicker', () => {
     renderPicker(<CodeAgentConfigPicker onChange={onChange} />)
     fireEvent.click(screen.getByRole('button', { name: 'Change coding agent' }))
     fireEvent.click(screen.getByRole('button', { name: 'Claude Code' }))
-    fireEvent.click(screen.getByText('claude-fable-5'))
+    const option = screen.getByRole('button', { name: 'Select claude-fable-5 from Probably / Anthropic' })
+    expect(option).toHaveTextContent('Probably / Anthropic')
+    fireEvent.click(option)
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
       credential_type: TypesCodeAgentCredentialType.CodeAgentCredentialTypeAPIKey,

--- a/frontend/src/components/agent/CodeAgentConfigPicker.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../services/codeAgentHarnessesService'
 import NoCodeAgentsDialog from './NoCodeAgentsDialog'
 import AgentHarness, { getAgentHarnessLabel } from './AgentHarness'
+import { getProviderEndpointLabel } from '../providers/ProviderEndpointIcon'
 import {
   providerEndpointIsConnected,
   providerEndpointMatchesRef,
@@ -104,7 +105,7 @@ function isSubscriptionRuntime(runtime: Runtime): boolean {
     || runtime === TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI
 }
 
-function apiModelOptions(providers: TypesProviderEndpoint[]): ModelOption[] {
+function apiModelOptions(providers: TypesProviderEndpoint[], organizationName?: string): ModelOption[] {
   return providers.flatMap((provider) => (provider.available_models || [])
     .filter((model) => model.enabled
       && (!model.type || model.type === 'chat' || model.type === 'text'))
@@ -113,7 +114,7 @@ function apiModelOptions(providers: TypesProviderEndpoint[]): ModelOption[] {
       id: model.id || '',
       label: model.id || 'Unnamed model',
       provider,
-      providerLabel: provider.name || 'Provider',
+      providerLabel: getProviderEndpointLabel(provider, organizationName),
       credentialType: TypesCodeAgentCredentialType.CodeAgentCredentialTypeAPIKey,
     }))
     .filter((model) => !!model.id))
@@ -346,10 +347,11 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     : isSubscriptionRuntime(runtime) && (runtime === TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode
       ? !!claudeSubscriptions?.some((subscription) => subscription.owner_type === 'user')
       : !!codexSubscriptions?.some((subscription) => subscription.owner_type === 'user'))
+  const organizationName = org?.display_name || org?.name
   const allowedProviders = providersAllowedForHarness(providers, runtimeStatus, !!orgName, runtime)
   const models = [
     ...(subscriptionAvailable ? subscriptionModelOptions(runtime) : []),
-    ...apiModelOptions(allowedProviders),
+    ...apiModelOptions(allowedProviders, organizationName),
   ]
   const visibleModels = models.filter((model) => matchesAllTokens(
     query,
@@ -373,7 +375,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     === TypesCodeAgentCredentialType.CodeAgentCredentialTypeSubscription
     && value.runtime
     ? subscriptionModelOptions(value.runtime)
-    : apiModelOptions(configuredProviders)
+    : apiModelOptions(configuredProviders, organizationName)
   const modelLabel = configuredModels.find((model) => model.id === value?.model
     && (!model.provider || matchesStoredRef(model.provider, value?.provider_ref || '')))?.label
     || value?.model?.split('/').pop()
@@ -412,6 +414,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     return (
       <Button
         key={model.key}
+        aria-label={`Select ${model.label} from ${model.providerLabel}`}
         fullWidth
         onClick={() => chooseModel(model)}
         sx={{

--- a/frontend/src/components/agent/CodeAgentConfigPicker.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.tsx
@@ -45,7 +45,7 @@ import AgentHarness, { getAgentHarnessLabel } from './AgentHarness'
 import { getProviderEndpointLabel } from '../providers/ProviderEndpointIcon'
 import {
   providerEndpointIsConnected,
-  providerEndpointMatchesRef,
+  resolveProviderEndpointRef,
   providersForCodeAgentHarness,
   providerSupportsCodeAgentRuntime,
   providersForCodeAgentRuntime,
@@ -257,8 +257,8 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
   const selectedRuntimeEnabled = !orgName
     || !!findHarnessStatus(orgHarnesses, value?.runtime)?.enabled
   const configuredRuntimeStatus = findHarnessStatus(orgHarnesses, value?.runtime)
-  const selectedProvider = providersForCodeAgentRuntime(providers, value?.runtime).find((provider) =>
-    matchesStoredRef(provider, value?.provider_ref || ''))
+  const runtimeProviders = providersForCodeAgentRuntime(providers, value?.runtime)
+  const selectedProvider = resolveProviderEndpointRef(runtimeProviders, value?.provider_ref)
   const selectedProviderRuntimeCompatible = value?.credential_type
     === TypesCodeAgentCredentialType.CodeAgentCredentialTypeSubscription
     || (!!selectedProvider
@@ -273,7 +273,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
         && configuredRuntimeStatus?.subscription_enabled !== true
         && (configuredRuntimeStatus?.provider_refs == null
         || configuredRuntimeStatus.provider_refs.some((ref) =>
-          providerEndpointMatchesRef(selectedProvider, ref)))))
+          resolveProviderEndpointRef(runtimeProviders, ref)?.id === selectedProvider.id))))
   const selectedConfigurationAllowed = selectedRuntimeEnabled && selectedSourceAllowed
   const unconfigured = !value?.runtime
     || !value?.model
@@ -377,7 +377,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     ? subscriptionModelOptions(value.runtime)
     : apiModelOptions(configuredProviders, organizationName)
   const modelLabel = configuredModels.find((model) => model.id === value?.model
-    && (!model.provider || matchesStoredRef(model.provider, value?.provider_ref || '')))?.label
+    && (!model.provider || matchesStoredRef(model.provider, value?.provider_ref || '', providers)))?.label
     || value?.model?.split('/').pop()
     || 'Select model'
 
@@ -385,7 +385,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     const sameRuntime = value?.runtime === runtime
       && value?.credential_type === model.credentialType
       && (model.provider
-        ? matchesStoredRef(model.provider, value?.provider_ref || '')
+        ? matchesStoredRef(model.provider, value?.provider_ref || '', providers)
         : !value?.provider_ref)
     onChange({
       runtime,
@@ -410,7 +410,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
     const selected = value?.runtime === runtime
       && value?.credential_type === model.credentialType
       && value?.model === model.id
-      && (!model.provider || matchesStoredRef(model.provider, value?.provider_ref || ''))
+      && (!model.provider || matchesStoredRef(model.provider, value?.provider_ref || '', providers))
     return (
       <Button
         key={model.key}

--- a/frontend/src/components/agent/CodeAgentConfigPicker.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.tsx
@@ -44,6 +44,8 @@ import NoCodeAgentsDialog from './NoCodeAgentsDialog'
 import AgentHarness, { getAgentHarnessLabel } from './AgentHarness'
 import {
   providerEndpointIsConnected,
+  providerEndpointMatchesRef,
+  providersForCodeAgentHarness,
   providerSupportsCodeAgentRuntime,
   providersForCodeAgentRuntime,
 } from '../../utils/codeAgentProviders'
@@ -123,12 +125,8 @@ function providersAllowedForHarness(
   enforceOrgPolicy: boolean,
   runtime: Runtime,
 ): TypesProviderEndpoint[] {
-  const compatible = providersForCodeAgentRuntime(providers, runtime)
-    .filter(providerEndpointIsConnected)
-  if (enforceOrgPolicy && harness?.subscription_enabled === true) return []
-  if (!enforceOrgPolicy || harness?.provider_refs == null) return compatible
-  const allowed = new Set(harness.provider_refs)
-  return compatible.filter((provider) => allowed.has(providerRef(provider)))
+  if (enforceOrgPolicy) return providersForCodeAgentHarness(providers, harness, runtime)
+  return providersForCodeAgentRuntime(providers, runtime).filter(providerEndpointIsConnected)
 }
 
 function subscriptionModelOptions(runtime: Runtime): ModelOption[] {
@@ -258,7 +256,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
   const selectedRuntimeEnabled = !orgName
     || !!findHarnessStatus(orgHarnesses, value?.runtime)?.enabled
   const configuredRuntimeStatus = findHarnessStatus(orgHarnesses, value?.runtime)
-  const selectedProvider = providers.find((provider) =>
+  const selectedProvider = providersForCodeAgentRuntime(providers, value?.runtime).find((provider) =>
     matchesStoredRef(provider, value?.provider_ref || ''))
   const selectedProviderRuntimeCompatible = value?.credential_type
     === TypesCodeAgentCredentialType.CodeAgentCredentialTypeSubscription
@@ -273,7 +271,8 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
       : !!value?.provider_ref && selectedProviderRuntimeCompatible
         && configuredRuntimeStatus?.subscription_enabled !== true
         && (configuredRuntimeStatus?.provider_refs == null
-        || configuredRuntimeStatus.provider_refs.includes(value.provider_ref))))
+        || configuredRuntimeStatus.provider_refs.some((ref) =>
+          providerEndpointMatchesRef(selectedProvider, ref)))))
   const selectedConfigurationAllowed = selectedRuntimeEnabled && selectedSourceAllowed
   const unconfigured = !value?.runtime
     || !value?.model

--- a/frontend/src/components/create/AdvancedModelPicker.test.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.test.tsx
@@ -12,10 +12,10 @@ vi.mock('../../services/userService', () => ({
   useGetUserTokenUsage: () => ({ data: undefined, isLoading: false }),
 }))
 vi.mock('../../services/orgService', () => ({
-  useGetOrgByName: () => ({ data: undefined, isLoading: false }),
+  useGetOrgByName: () => ({ data: { id: 'org-1', display_name: 'Probably' }, isLoading: false }),
 }))
 vi.mock('../../hooks/useRouter', () => ({
-  default: () => ({ params: {} }),
+  default: () => ({ params: { org_id: 'probably' } }),
 }))
 
 describe('AdvancedModelPicker', () => {
@@ -24,6 +24,7 @@ describe('AdvancedModelPicker', () => {
       {
         id: 'openai-provider',
         name: 'OpenAI',
+        endpoint_type: 'global',
         base_url: 'https://api.openai.com/v1',
         available_models: [
           { id: 'gpt-5.6-sol', enabled: true, type: 'chat' },
@@ -33,6 +34,7 @@ describe('AdvancedModelPicker', () => {
       {
         id: 'anthropic-provider',
         name: 'Anthropic',
+        endpoint_type: 'org',
         base_url: 'https://api.anthropic.com/v1',
         available_models: [
           { id: 'claude-opus-5', enabled: true, type: 'chat' },
@@ -42,6 +44,7 @@ describe('AdvancedModelPicker', () => {
       {
         id: 'custom-provider',
         name: 'Custom',
+        endpoint_type: 'user',
         base_url: 'http://models.local/v1',
         available_models: [
           { id: 'gpt-4-custom', enabled: true, type: 'chat' },
@@ -64,7 +67,9 @@ describe('AdvancedModelPicker', () => {
     const dialog = within(screen.getByRole('dialog'))
 
     expect(dialog.getByText('gpt-5.6-sol')).toBeInTheDocument()
+    expect(dialog.getByRole('listitem', { name: 'Select gpt-5.6-sol from Global / OpenAI' })).toHaveTextContent('Global / OpenAI')
     expect(dialog.getByText('claude-opus-5')).toBeInTheDocument()
+    expect(dialog.getByRole('listitem', { name: 'Select claude-opus-5 from Probably / Anthropic' })).toHaveTextContent('Probably / Anthropic')
     expect(dialog.getByText('gpt-4-custom')).toBeInTheDocument()
     expect(dialog.queryByText('gpt-4o')).not.toBeInTheDocument()
     expect(dialog.queryByText('claude-opus-4-1')).not.toBeInTheDocument()

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -42,6 +42,7 @@ import DarkDialog from '../dialog/DarkDialog';
 import useLightTheme from '../../hooks/useLightTheme';
 
 import { useGetOrgByName } from '../../services/orgService';
+import { providerEndpointMatchesRef } from '../../utils/codeAgentProviders';
 
 import useRouter from '../../hooks/useRouter';
 import { isLegacyNativeModel, nativeProviderForEndpoint } from '../../utils/nativeModels';
@@ -140,10 +141,7 @@ export const providerRef = (provider: TypesProviderEndpoint | undefined): string
 // (current scheme) then falls back to a case-insensitive name match
 // (globals + legacy agents stored before the switch to ID-based references).
 export const matchesStoredRef = (provider: TypesProviderEndpoint | undefined, storedRef: string | undefined): boolean => {
-  if (!provider || !storedRef) return false;
-  if (hasRealID(provider) && provider.id === storedRef) return true;
-  if (provider.name && provider.name.toLowerCase() === storedRef.toLowerCase()) return true;
-  return false;
+  return providerEndpointMatchesRef(provider, storedRef);
 };
 
 function fuzzySearch(query: string, models: ModelWithProvider[], modelType: string) {

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -46,6 +46,7 @@ import { providerEndpointMatchesRef } from '../../utils/codeAgentProviders';
 
 import useRouter from '../../hooks/useRouter';
 import { isLegacyNativeModel, nativeProviderForEndpoint } from '../../utils/nativeModels';
+import { getProviderEndpointLabel } from '../providers/ProviderEndpointIcon';
 
 interface AdvancedModelPickerProps {
   selectedModelId?: string;
@@ -594,9 +595,11 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
               const isGlobalProvider = model.provider?.endpoint_type === 'global';
               const isGlobalProviderDisabled = isGlobalProvider && isMonthlyLimitReached;
               const isModelDisabled = Boolean(isDisabled || isGlobalProviderDisabled);
+              const providerLabel = getProviderEndpointLabel(model.provider, org?.display_name || org?.name);
 
               const listItemContent = (
                 <ListItem
+                  aria-label={`Select ${model.id || 'Unnamed Model'} from ${providerLabel}`}
                   onClick={() => !isModelDisabled && model.id && handleSelectModel(providerRef(model.provider), model.id)}
                   disabled={isModelDisabled}
                   sx={{
@@ -621,7 +624,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
                     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 56, mr: 1 }}>
                       <ProviderIcon provider={model.provider} />
                       <Typography variant="caption" sx={{ color: lightTheme.textColorFaded, fontSize: '0.6rem', mt: 0.5, textAlign: 'center', lineHeight: 1.1 }}>
-                        {model.provider.name}
+                        {providerLabel}
                       </Typography>
                     </Box>
                     <ListItemText

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -42,7 +42,7 @@ import DarkDialog from '../dialog/DarkDialog';
 import useLightTheme from '../../hooks/useLightTheme';
 
 import { useGetOrgByName } from '../../services/orgService';
-import { providerEndpointMatchesRef } from '../../utils/codeAgentProviders';
+import { resolveProviderEndpointRef } from '../../utils/codeAgentProviders';
 
 import useRouter from '../../hooks/useRouter';
 import { isLegacyNativeModel, nativeProviderForEndpoint } from '../../utils/nativeModels';
@@ -141,8 +141,8 @@ export const providerRef = (provider: TypesProviderEndpoint | undefined): string
 // Matches a stored agent reference against a provider. Tries ID first
 // (current scheme) then falls back to a case-insensitive name match
 // (globals + legacy agents stored before the switch to ID-based references).
-export const matchesStoredRef = (provider: TypesProviderEndpoint | undefined, storedRef: string | undefined): boolean => {
-  return providerEndpointMatchesRef(provider, storedRef);
+export const matchesStoredRef = (provider: TypesProviderEndpoint | undefined, storedRef: string | undefined, providers: TypesProviderEndpoint[] = []): boolean => {
+  return !!provider && resolveProviderEndpointRef(providers.length ? providers : [provider], storedRef)?.id === provider.id;
 };
 
 function fuzzySearch(query: string, models: ModelWithProvider[], modelType: string) {
@@ -283,7 +283,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
           // Try to find a model of the right type from the same provider first
           let newModel = allModels.find(model =>
             model.type === effectiveType &&
-            matchesStoredRef(model.provider, selectedProvider)
+            matchesStoredRef(model.provider, selectedProvider, providers || [])
           );
 
           // If no model found from the same provider, fall back to any provider
@@ -317,7 +317,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
     const selectedModel = allModels.find(model => model.id === selectedModelId);
     let providerName = selectedModel?.provider?.name;
     if (!providerName && selectedProvider) {
-      const matched = providers?.find((p: TypesProviderEndpoint) => matchesStoredRef(p, selectedProvider));
+      const matched = resolveProviderEndpointRef(providers || [], selectedProvider);
       providerName = matched?.name || selectedProvider;
     }
     if (providerName) {

--- a/frontend/src/components/providers/AddProviderDialog.tsx
+++ b/frontend/src/components/providers/AddProviderDialog.tsx
@@ -35,6 +35,7 @@ interface AddProviderDialogProps {
     name: string;
     description: string;
     base_url: string;
+    endpoint_name?: string;
     configurable_base_url?: boolean;
     optional_api_key?: boolean; // If provider doesn't need an API key
     is_custom?: boolean; // If true, the user picks the endpoint name

--- a/frontend/src/components/providers/AddProviderDialog.tsx
+++ b/frontend/src/components/providers/AddProviderDialog.tsx
@@ -161,7 +161,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
 
       // For brand-new custom providers the user picks the endpoint name.
       // Existing custom providers keep their name (edits to the name aren't exposed here).
-      let endpointName = provider.id;
+      let endpointName = provider.endpoint_name || provider.id;
       if (provider.is_custom) {
         if (isEditing && existingProvider?.name) {
           endpointName = existingProvider.name;

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
@@ -25,18 +25,20 @@ describe('CodeAgentHarnessesSection', () => {
         harnesses={[{ ...harnesses[0], subscription_enabled: false }]}
         endpoints={[{
           id: 'provider-1',
-          name: 'anthropic',
-          endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
+          name: 'user/anthropic',
+          endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
           status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
           available_models: [{ id: 'model-1', enabled: true, type: 'chat' }],
         }]}
+        organizationName="Probably"
         onChange={onChange}
       />,
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
     expect(screen.getByText('Inheriting all compatible providers')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Disable anthropic for Claude Code' }))
+    expect(screen.getByText('Probably / Anthropic')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Disable Probably / Anthropic for Claude Code' }))
     expect(onChange).toHaveBeenCalledWith({
       runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
       enabled: true,
@@ -60,15 +62,15 @@ describe('CodeAgentHarnessesSection', () => {
       />,
     )
 
-    expect(screen.queryByText('anthropic')).not.toBeInTheDocument()
+    expect(screen.queryByText('Anthropic')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
 
-    expect(screen.getByText('anthropic')).toBeInTheDocument()
+    expect(screen.getByText('Anthropic')).toBeInTheDocument()
     expect(screen.getByText('developer@example.com · Claude Max Subscription')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Manage subscription' })).toBeInTheDocument()
     expect(screen.queryByText('task-selected-model')).not.toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: 'Disable subscription for Claude Code' })).toBeChecked()
-    expect(screen.getByRole('checkbox', { name: 'Enable anthropic for Claude Code' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Enable Anthropic for Claude Code' })).not.toBeChecked()
     expect(screen.getByText('API providers')).toBeInTheDocument()
     expect(screen.getByRole('button', {
       name: 'API-provider mode is exclusive with subscription mode. Enabled providers expose their models in the task chat.',
@@ -109,8 +111,8 @@ describe('CodeAgentHarnessesSection', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
-    expect(screen.queryByText('openai')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Disable anthropic for Claude Code' }))
+    expect(screen.queryByText('OpenAI')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Disable Anthropic for Claude Code' }))
 
     expect(onChange).toHaveBeenCalledWith({
       runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
@@ -135,7 +137,7 @@ describe('CodeAgentHarnessesSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
     expect(screen.getByText('No API providers enabled')).toBeInTheDocument()
-    expect(screen.getByRole('checkbox', { name: 'Enable anthropic for Claude Code' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Enable Anthropic for Claude Code' })).not.toBeChecked()
   })
 
   it('disables a provider switch until its API connection is healthy', () => {
@@ -153,7 +155,7 @@ describe('CodeAgentHarnessesSection', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
-    const providerSwitch = screen.getByRole('checkbox', { name: 'Enable anthropic for Claude Code' })
+    const providerSwitch = screen.getByRole('checkbox', { name: 'Enable Anthropic for Claude Code' })
     expect(providerSwitch).not.toBeChecked()
     expect(providerSwitch).toBeDisabled()
     expect(screen.getByText('Not connected')).toBeInTheDocument()
@@ -195,7 +197,7 @@ describe('CodeAgentHarnessesSection', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Enable anthropic for Claude Code' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Enable Anthropic for Claude Code' }))
 
     expect(onChange).toHaveBeenCalledWith({
       runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
@@ -280,8 +282,8 @@ describe('CodeAgentHarnessesSection', () => {
     const subscriptionSwitch = screen.getByRole('checkbox', { name: 'Enable subscription for Codex' })
     expect(subscriptionSwitch).not.toBeChecked()
     expect(subscriptionSwitch).toBeDisabled()
-    expect(screen.getByText('openai')).toBeInTheDocument()
-    expect(screen.getByRole('checkbox', { name: 'Disable openai for Codex' })).toBeChecked()
+    expect(screen.getByText('OpenAI')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Disable OpenAI for Codex' })).toBeChecked()
   })
 
   it('keeps a disabled-off subscription switch when disconnected', () => {

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
@@ -140,6 +140,45 @@ describe('CodeAgentHarnessesSection', () => {
     expect(screen.getByRole('checkbox', { name: 'Enable Anthropic for Claude Code' })).not.toBeChecked()
   })
 
+  it('resolves a legacy vendor ref to one provider without enabling its global duplicate', () => {
+    const onChange = vi.fn()
+    render(
+      <CodeAgentHarnessesSection
+        harnesses={[{ ...harnesses[0], subscription_enabled: false, provider_refs: ['anthropic'] }]}
+        endpoints={[
+          {
+            id: 'pe_org_anthropic',
+            name: 'user/anthropic',
+            endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+            status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+            available_models: [{ id: 'org-model', enabled: true, type: 'chat' }],
+          },
+          {
+            id: 'global/anthropic',
+            name: 'anthropic',
+            endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
+            status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+            available_models: [{ id: 'global-model', enabled: true, type: 'chat' }],
+          },
+        ]}
+        organizationName="Probably"
+        onChange={onChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
+    expect(screen.getByRole('checkbox', { name: 'Disable Probably / Anthropic for Claude Code' })).toBeChecked()
+    const globalProvider = screen.getByRole('checkbox', { name: 'Enable Global / Anthropic for Claude Code' })
+    expect(globalProvider).not.toBeChecked()
+    fireEvent.click(globalProvider)
+    expect(onChange).toHaveBeenCalledWith({
+      runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
+      enabled: true,
+      provider_refs: ['pe_org_anthropic', 'global/anthropic'],
+      subscription_enabled: false,
+    })
+  })
+
   it('disables a provider switch until its API connection is healthy', () => {
     render(
       <CodeAgentHarnessesSection

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   TypesCodeAgentRuntime,
   TypesOrgCodeAgentHarnessStatus,
+  TypesProviderEndpointType,
   TypesProviderEndpointStatus,
 } from '../../api/api'
 import CodeAgentHarnessesSection from './CodeAgentHarnessesSection'
@@ -17,6 +18,32 @@ const harnesses: TypesOrgCodeAgentHarnessStatus[] = [{
 }]
 
 describe('CodeAgentHarnessesSection', () => {
+  it('shows inherited providers as enabled controls', () => {
+    const onChange = vi.fn()
+    render(
+      <CodeAgentHarnessesSection
+        harnesses={[{ ...harnesses[0], subscription_enabled: false }]}
+        endpoints={[{
+          id: 'provider-1',
+          name: 'anthropic',
+          endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
+          status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+          available_models: [{ id: 'model-1', enabled: true, type: 'chat' }],
+        }]}
+        onChange={onChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
+    expect(screen.getByText('Inheriting all compatible providers')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Disable anthropic for Claude Code' }))
+    expect(onChange).toHaveBeenCalledWith({
+      runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
+      enabled: true,
+      provider_refs: [],
+    })
+  })
+
   it('expands a harness to show provider controls without exposing model policy', () => {
     render(
       <CodeAgentHarnessesSection
@@ -52,7 +79,11 @@ describe('CodeAgentHarnessesSection', () => {
     const onChange = vi.fn()
     render(
       <CodeAgentHarnessesSection
-        harnesses={[{ ...harnesses[0], subscription_enabled: false }]}
+        harnesses={[{
+          ...harnesses[0],
+          subscription_enabled: false,
+          provider_refs: ['provider-2', 'provider-temporarily-unavailable'],
+        }]}
         endpoints={[
           {
             id: 'provider-1',
@@ -103,6 +134,7 @@ describe('CodeAgentHarnessesSection', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
+    expect(screen.getByText('No API providers enabled')).toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: 'Enable anthropic for Claude Code' })).not.toBeChecked()
   })
 
@@ -228,6 +260,7 @@ describe('CodeAgentHarnessesSection', () => {
           enabled: true,
           supports_subscription: true,
           viewer_has_subscription: false,
+          provider_refs: ['provider-1'],
         }]}
         endpoints={[{
           id: 'provider-1',

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
@@ -16,6 +16,7 @@ import {
 import CodeAgentHarnessRow, { HARNESS_SWITCH_SLOT_SX, HarnessHealth } from './CodeAgentHarnessRow'
 import { providerRef } from '../create/AdvancedModelPicker'
 import { getAgentHarnessLabel } from '../agent/AgentHarness'
+import { getProviderEndpointLabel } from './ProviderEndpointIcon'
 import {
   providerEndpointIsConnected,
   providerEndpointMatchesRef,
@@ -31,6 +32,7 @@ const CodeAgentHarnessesSection: FC<{
   endpoints: TypesProviderEndpoint[]
   loading?: boolean
   readOnly?: boolean
+  organizationName?: string
   subscriptionAction?: (runtime: string) => ReactNode
   subscriptionIdentity?: (runtime: string) => ReactNode
   onChange: (update: TypesOrgCodeAgentHarnessUpdate) => void
@@ -39,6 +41,7 @@ const CodeAgentHarnessesSection: FC<{
   endpoints,
   loading = false,
   readOnly = false,
+  organizationName,
   subscriptionAction,
   subscriptionIdentity,
   onChange,
@@ -191,6 +194,7 @@ const CodeAgentHarnessesSection: FC<{
                   >
                     {compatibleEndpoints.map((endpoint) => {
                       const ref = providerRef(endpoint)
+                      const endpointLabel = getProviderEndpointLabel(endpoint, organizationName)
                       const connected = providerEndpointIsConnected(endpoint)
                       const checked = !subscriptionEnabled
                         && connected
@@ -205,7 +209,7 @@ const CodeAgentHarnessesSection: FC<{
                           spacing={1}
                         >
                           <Box sx={{ minWidth: 0 }}>
-                            <Typography variant="body2">{endpoint.name || 'Unnamed provider'}</Typography>
+                            <Typography variant="body2">{endpointLabel}</Typography>
                             {!connected && (
                               <Typography variant="caption" color="text.secondary">
                                 Not connected
@@ -223,7 +227,7 @@ const CodeAgentHarnessesSection: FC<{
                                 checked={checked}
                                 disabled={readOnly || !connected}
                                 inputProps={{
-                                  'aria-label': `${checked ? 'Disable' : 'Enable'} ${endpoint.name || 'unnamed provider'} for ${harnessLabel}`,
+                                  'aria-label': `${checked ? 'Disable' : 'Enable'} ${endpointLabel} for ${harnessLabel}`,
                                 }}
                                 onChange={(_, enabled) => {
                                   const current = harness.provider_refs == null

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
@@ -18,6 +18,7 @@ import { providerRef } from '../create/AdvancedModelPicker'
 import { getAgentHarnessLabel } from '../agent/AgentHarness'
 import {
   providerEndpointIsConnected,
+  providerEndpointMatchesRef,
   providersForCodeAgentRuntime,
   requiredProviderNameForRuntime,
 } from '../../utils/codeAgentProviders'
@@ -58,15 +59,14 @@ const CodeAgentHarnessesSection: FC<{
       {harnesses.map((harness) => {
         const compatibleEndpoints = providersForCodeAgentRuntime(endpoints, harness.runtime)
         const connectedEndpoints = compatibleEndpoints.filter(providerEndpointIsConnected)
-        const allowedProviderRefs = harness.provider_refs == null
-          ? null
-          : new Set(harness.provider_refs)
+        const allowedProviderRefs = harness.provider_refs
         const subscriptionEnabled = harness.subscription_enabled === true
         const allowedEndpoints = subscriptionEnabled
           ? []
           : allowedProviderRefs == null
             ? connectedEndpoints
-            : connectedEndpoints.filter((endpoint) => allowedProviderRefs.has(providerRef(endpoint)))
+            : connectedEndpoints.filter((endpoint) =>
+              allowedProviderRefs.some((ref) => providerEndpointMatchesRef(endpoint, ref)))
         const viewerHasSubscription = !!harness.viewer_has_subscription
         const hasSubscription = harness.supports_subscription
           && subscriptionEnabled
@@ -170,6 +170,13 @@ const CodeAgentHarnessesSection: FC<{
                     </IconButton>
                   </Tooltip>
                 </Stack>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  {harness.provider_refs == null
+                    ? 'Inheriting all compatible providers'
+                    : harness.provider_refs.length === 0
+                      ? 'No API providers enabled'
+                      : 'Using a custom provider selection'}
+                </Typography>
                 {compatibleEndpoints.length > 0 ? (
                   <Stack
                     sx={{
@@ -187,7 +194,8 @@ const CodeAgentHarnessesSection: FC<{
                       const connected = providerEndpointIsConnected(endpoint)
                       const checked = !subscriptionEnabled
                         && connected
-                        && (allowedProviderRefs == null || allowedProviderRefs.has(ref))
+                        && (allowedProviderRefs == null
+                        || allowedProviderRefs.some((candidate) => providerEndpointMatchesRef(endpoint, candidate)))
                       return (
                         <Stack
                           key={ref}
@@ -219,14 +227,12 @@ const CodeAgentHarnessesSection: FC<{
                                 }}
                                 onChange={(_, enabled) => {
                                   const current = harness.provider_refs == null
-                                    // Preserve temporarily unavailable endpoints
-                                    // when materializing the legacy all-providers policy.
                                     ? [...new Set(compatibleEndpoints.map(providerRef))]
                                     : harness.provider_refs.filter((candidate) =>
-                                      compatibleEndpoints.some((endpoint) => providerRef(endpoint) === candidate))
+                                      compatibleEndpoints.some((endpoint) => providerEndpointMatchesRef(endpoint, candidate)))
                                   const next = enabled
                                     ? [...new Set([...current, ref])]
-                                    : current.filter((candidate) => candidate !== ref)
+                                    : current.filter((candidate) => !providerEndpointMatchesRef(endpoint, candidate))
                                   onChange({
                                     runtime: harness.runtime!,
                                     enabled: harness.enabled ?? false,

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
@@ -19,7 +19,7 @@ import { getAgentHarnessLabel } from '../agent/AgentHarness'
 import { getProviderEndpointLabel } from './ProviderEndpointIcon'
 import {
   providerEndpointIsConnected,
-  providerEndpointMatchesRef,
+  resolveProviderEndpointRef,
   providersForCodeAgentRuntime,
   requiredProviderNameForRuntime,
 } from '../../utils/codeAgentProviders'
@@ -69,7 +69,7 @@ const CodeAgentHarnessesSection: FC<{
           : allowedProviderRefs == null
             ? connectedEndpoints
             : connectedEndpoints.filter((endpoint) =>
-              allowedProviderRefs.some((ref) => providerEndpointMatchesRef(endpoint, ref)))
+              allowedProviderRefs.some((ref) => resolveProviderEndpointRef(connectedEndpoints, ref)?.id === endpoint.id))
         const viewerHasSubscription = !!harness.viewer_has_subscription
         const hasSubscription = harness.supports_subscription
           && subscriptionEnabled
@@ -199,7 +199,7 @@ const CodeAgentHarnessesSection: FC<{
                       const checked = !subscriptionEnabled
                         && connected
                         && (allowedProviderRefs == null
-                        || allowedProviderRefs.some((candidate) => providerEndpointMatchesRef(endpoint, candidate)))
+                        || allowedProviderRefs.some((candidate) => resolveProviderEndpointRef(compatibleEndpoints, candidate)?.id === endpoint.id))
                       return (
                         <Stack
                           key={ref}
@@ -232,11 +232,13 @@ const CodeAgentHarnessesSection: FC<{
                                 onChange={(_, enabled) => {
                                   const current = harness.provider_refs == null
                                     ? [...new Set(compatibleEndpoints.map(providerRef))]
-                                    : harness.provider_refs.filter((candidate) =>
-                                      compatibleEndpoints.some((endpoint) => providerEndpointMatchesRef(endpoint, candidate)))
+                                    : harness.provider_refs.map((candidate) =>
+                                      resolveProviderEndpointRef(compatibleEndpoints, candidate))
+                                      .filter((endpoint): endpoint is TypesProviderEndpoint => !!endpoint)
+                                      .map(providerRef)
                                   const next = enabled
                                     ? [...new Set([...current, ref])]
-                                    : current.filter((candidate) => !providerEndpointMatchesRef(endpoint, candidate))
+                                    : current.filter((candidate) => candidate !== ref)
                                   onChange({
                                     runtime: harness.runtime!,
                                     enabled: harness.enabled ?? false,

--- a/frontend/src/components/providers/ProviderEndpointIcon.test.ts
+++ b/frontend/src/components/providers/ProviderEndpointIcon.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { TypesProviderEndpointType } from '../../api/api'
+import { getProviderEndpointLabel, getProviderPresetDefinition } from './ProviderEndpointIcon'
+
+describe('provider endpoint presentation', () => {
+  it('uses the preset brand name with explicit endpoint scope', () => {
+    expect(getProviderEndpointLabel(
+      { name: 'user/anthropic', endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg },
+      'Probably',
+    )).toBe('Probably / Anthropic')
+    expect(getProviderEndpointLabel({ name: 'anthropic', endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal })).toBe('Global / Anthropic')
+    expect(getProviderEndpointLabel({ name: 'anthropic', endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeUser })).toBe('Personal / Anthropic')
+  })
+
+  it('classifies canonical Anthropic as its preset', () => {
+    expect(getProviderPresetDefinition({ name: 'anthropic' })?.id).toBe('user/anthropic')
+  })
+
+  it('preserves a custom provider name on an Anthropic base URL', () => {
+    const endpoint = {
+      name: 'claude-proxy',
+      base_url: 'https://api.anthropic.com/v1',
+      endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+    }
+    expect(getProviderPresetDefinition(endpoint)).toBeUndefined()
+    expect(getProviderEndpointLabel(endpoint)).toBe('Organization / claude-proxy')
+  })
+})

--- a/frontend/src/components/providers/ProviderEndpointIcon.tsx
+++ b/frontend/src/components/providers/ProviderEndpointIcon.tsx
@@ -28,6 +28,30 @@ export const getProviderIconDefinition = (endpoint: Pick<TypesProviderEndpoint, 
   ))
 }
 
+export const getProviderPresetDefinition = (endpoint: Pick<TypesProviderEndpoint, 'icon' | 'name' | 'base_url'>) => {
+  const name = endpoint.name?.toLowerCase()
+  if (!name) return undefined
+  return PROVIDERS.find(provider => !provider.is_custom && (
+    provider.id.toLowerCase() === name
+    || provider.endpoint_name?.toLowerCase() === name
+    || providerIconKey(provider) === name
+  ))
+}
+
+export const getProviderEndpointLabel = (
+  endpoint: Pick<TypesProviderEndpoint, 'icon' | 'name' | 'base_url' | 'endpoint_type'>,
+  organizationName?: string,
+) => {
+  const name = getProviderPresetDefinition(endpoint)?.name || endpoint.name || 'Unnamed provider'
+  const scope = {
+    org: organizationName?.trim() || 'Organization',
+    global: 'Global',
+    user: 'Personal',
+    team: 'Team',
+  }[endpoint.endpoint_type || '']
+  return scope ? `${scope} / ${name}` : name
+}
+
 export const ProviderMark: FC<{ provider: Provider; size?: number }> = ({ provider, size = 24 }) => {
   const Logo = provider.logo
   if (typeof Logo === 'string') {

--- a/frontend/src/components/providers/types.test.ts
+++ b/frontend/src/components/providers/types.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { PROVIDERS } from './types'
+
+describe('provider presets', () => {
+  it('creates Anthropic endpoints with the canonical provider name', () => {
+    expect(PROVIDERS.find((provider) => provider.id === 'user/anthropic')).toMatchObject({
+      endpoint_name: 'anthropic',
+    })
+  })
+})

--- a/frontend/src/components/providers/types.ts
+++ b/frontend/src/components/providers/types.ts
@@ -24,6 +24,7 @@ export interface Provider {
   logo: string | React.ComponentType<React.SVGProps<SVGSVGElement>> | React.ComponentType<any>;
   
   base_url: string;
+  endpoint_name?: string;
   configurable_base_url?: boolean;
 
   optional_api_key?: boolean; // If provider doesn't need an API key
@@ -73,6 +74,7 @@ export const PROVIDERS: Provider[] = [
   },
   {
     id: 'user/anthropic',
+    endpoint_name: 'anthropic',
     alias: ['anthropic', 'anthropic-api'],
     name: 'Anthropic',
     description: 'Access Anthropic Claude models for advanced language tasks.',

--- a/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
@@ -8,9 +8,9 @@ import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
 import { buildPickerAgents } from "./SpecTaskModelPicker";
 
 const providers = [
-  { id: "pe_anthropic", name: "anthropic", model: "claude-model" },
+  { id: "pe_anthropic", name: "user/anthropic", model: "claude-model" },
   { id: "pe_openai", name: "openai", model: "gpt-model" },
-  { id: "pe_together", name: "togetherai", model: "together-model" },
+  { id: "pe_together", name: "user/togetherai", model: "together-model" },
 ].map(({ model, ...provider }) => ({
   ...provider,
   status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
@@ -52,10 +52,18 @@ describe("buildPickerAgents", () => {
     expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, [])).toEqual([]);
     expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, ["pe_together"]))
       .toEqual(["together-model"]);
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, ["togetherai"]))
+      .toEqual(["together-model"]);
   });
 
   it("applies native harness provider compatibility", () => {
     expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode)).toEqual(["claude-model"]);
     expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI)).toEqual(["gpt-model"]);
+    expect(buildPickerAgents(
+      [agent(TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode)],
+      providers,
+      [{ runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode, enabled: true }],
+      true,
+    )[0].models[0].provider?.id).toBe("pe_anthropic");
   });
 });

--- a/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
@@ -76,4 +76,34 @@ describe("buildPickerAgents", () => {
       "Probably",
     )[0].models[0].providerLabel).toBe("Probably / Anthropic");
   });
+
+  it("keeps duplicate vendor scopes distinct and resolves legacy refs once", () => {
+    const duplicateProviders = [
+      {
+        id: "global/anthropic",
+        name: "anthropic",
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeGlobal,
+        status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+        available_models: [{ id: "global-model", enabled: true, type: "chat" }],
+      },
+      {
+        id: "pe_org_anthropic",
+        name: "user/anthropic",
+        endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
+        status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+        available_models: [{ id: "org-model", enabled: true, type: "chat" }],
+      },
+    ];
+    const build = (providerRefs?: string[]) => buildPickerAgents(
+      [agent(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent)],
+      duplicateProviders,
+      [{ runtime: TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, enabled: true, provider_refs: providerRefs }],
+      true,
+      "Probably",
+    )[0].models;
+
+    expect(build().map(({ provider }) => provider?.id)).toEqual(["global/anthropic", "pe_org_anthropic"]);
+    expect(build(["anthropic"]).map(({ provider }) => provider?.id)).toEqual(["pe_org_anthropic"]);
+    expect(build(["global/anthropic"]).map(({ provider }) => provider?.id)).toEqual(["global/anthropic"]);
+  });
 });

--- a/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   TypesCodeAgentRuntime,
+  TypesProviderEndpointType,
   TypesProviderEndpointStatus,
 } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
@@ -13,6 +14,7 @@ const providers = [
   { id: "pe_together", name: "user/togetherai", model: "together-model" },
 ].map(({ model, ...provider }) => ({
   ...provider,
+  endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeOrg,
   status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
   available_models: [{ id: model, enabled: true, type: "chat" }],
 }));
@@ -64,6 +66,14 @@ describe("buildPickerAgents", () => {
       providers,
       [{ runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode, enabled: true }],
       true,
+      "Probably",
     )[0].models[0].provider?.id).toBe("pe_anthropic");
+    expect(buildPickerAgents(
+      [agent(TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode)],
+      providers,
+      [{ runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode, enabled: true }],
+      true,
+      "Probably",
+    )[0].models[0].providerLabel).toBe("Probably / Anthropic");
   });
 });

--- a/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TypesCodeAgentRuntime,
+  TypesProviderEndpointStatus,
+} from "../../api/api";
+import { AGENT_TYPE_ZED_EXTERNAL, IApp } from "../../types";
+import { buildPickerAgents } from "./SpecTaskModelPicker";
+
+const providers = [
+  { id: "pe_anthropic", name: "anthropic", model: "claude-model" },
+  { id: "pe_openai", name: "openai", model: "gpt-model" },
+  { id: "pe_together", name: "togetherai", model: "together-model" },
+].map(({ model, ...provider }) => ({
+  ...provider,
+  status: TypesProviderEndpointStatus.ProviderEndpointStatusOK,
+  available_models: [{ id: model, enabled: true, type: "chat" }],
+}));
+
+function agent(runtime: TypesCodeAgentRuntime): IApp {
+  return {
+    id: `app-${runtime}`,
+    config: {
+      helix: {
+        name: runtime,
+        assistants: [{
+          agent_type: AGENT_TYPE_ZED_EXTERNAL,
+          code_agent_runtime: runtime,
+          code_agent_credential_type: "api_key",
+        }],
+      },
+    },
+  } as IApp;
+}
+
+function models(runtime: TypesCodeAgentRuntime, providerRefs?: string[]): string[] {
+  return buildPickerAgents(
+    [agent(runtime)],
+    providers,
+    [{ runtime, enabled: true, provider_refs: providerRefs }],
+    true,
+  )[0].models.map(({ id }) => id);
+}
+
+describe("buildPickerAgents", () => {
+  it("applies inherited, empty, and allowlisted provider policy", () => {
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent)).toEqual([
+      "claude-model",
+      "gpt-model",
+      "together-model",
+    ]);
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, [])).toEqual([]);
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeZedAgent, ["pe_together"]))
+      .toEqual(["together-model"]);
+  });
+
+  it("applies native harness provider compatibility", () => {
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode)).toEqual(["claude-model"]);
+    expect(models(TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI)).toEqual(["gpt-model"]);
+  });
+});

--- a/frontend/src/components/tasks/SpecTaskModelPicker.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.tsx
@@ -26,6 +26,7 @@ import {
 import useRouter from "../../hooks/useRouter";
 import { matchesAllTokens } from "../../utils/searchUtils";
 import AgentHarness from "../agent/AgentHarness";
+import { getProviderEndpointLabel } from "../providers/ProviderEndpointIcon";
 import {
   CLAUDE_SUBSCRIPTION_MODELS,
   CODEX_SUBSCRIPTION_MODELS,
@@ -270,6 +271,7 @@ const SpecTaskModelPickerView: FC<{
                 return (
                   <Button
                     key={`${agent.agent.id}:${option.key}`}
+                    aria-label={`Select ${option.label} from ${option.providerLabel}`}
                     fullWidth
                     onClick={() => {
                       onSelectAgentModel(
@@ -337,6 +339,7 @@ export function buildPickerAgents(
   providers: TypesProviderEndpoint[],
   harnesses: TypesOrgCodeAgentHarnessStatus[] = [],
   enforceOrgPolicy = false,
+  organizationName?: string,
 ): PickerAgent[] {
   return agents.map((agent) => {
     const assistant = getAssistant(agent);
@@ -372,7 +375,7 @@ export function buildPickerAgents(
           id: availableModel.id || "",
           label: availableModel.id || "Unnamed model",
           provider,
-          providerLabel: provider.name || "Provider",
+          providerLabel: getProviderEndpointLabel(provider, organizationName),
         }))
         .filter((availableModel) => availableModel.id));
     }
@@ -397,8 +400,8 @@ const ProviderAwareSpecTaskModelPicker: FC<SpecTaskModelPickerProps> = (props) =
     { enabled: !loadingOrg },
   );
   const pickerAgents = useMemo(
-    () => buildPickerAgents(props.agents, providers, harnesses, !!orgName),
-    [props.agents, providers, harnesses, orgName],
+    () => buildPickerAgents(props.agents, providers, harnesses, !!orgName, org?.display_name || org?.name),
+    [props.agents, providers, harnesses, orgName, org?.display_name, org?.name],
   );
 
   return (

--- a/frontend/src/components/tasks/SpecTaskModelPicker.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.tsx
@@ -32,7 +32,6 @@ import {
   CODEX_SUBSCRIPTION_MODELS,
 } from "../agent/CodingAgentForm";
 import {
-  matchesStoredRef,
   ProviderIcon,
   providerRef,
 } from "../create/AdvancedModelPicker";
@@ -40,6 +39,7 @@ import {
   providerEndpointIsConnected,
   providersForCodeAgentHarness,
   providersForCodeAgentRuntime,
+  resolveProviderEndpointRef,
 } from "../../utils/codeAgentProviders";
 
 export type TaskModelOption = { id: string; label: string };
@@ -100,6 +100,7 @@ const SpecTaskModelPickerView: FC<{
   const searchRef = useRef<HTMLInputElement>(null);
 
   const activeAgent = agents.find(({ agent }) => agent.id === selectedAgentId);
+  const providerEndpoints = agents.flatMap(({ models }) => models.flatMap(({ provider }) => provider ? [provider] : []));
   const browsedAgent = agents.find(({ agent }) => agent.id === browsedAgentId) || activeAgent || agents[0];
   const searching = query.trim().length > 0;
   const visibleModels = useMemo(() => {
@@ -132,7 +133,7 @@ const SpecTaskModelPickerView: FC<{
     || currentExecutionConfig?.runtime
     || "zed_agent";
   const activeModel = activeAgent?.models.find((option) => option.id === model
-    && (!option.provider || matchesStoredRef(option.provider, providerRefValue)))
+    && (!option.provider || resolveProviderEndpointRef(providerEndpoints, providerRefValue)?.id === option.provider.id))
     || activeAgent?.models.find((option) => option.id === model);
   const activeModelLabel = activeModel?.label.replace(/ \(.+\)$/, "")
     || model.split("/").pop()
@@ -266,7 +267,7 @@ const SpecTaskModelPickerView: FC<{
               {visibleModels.map(({ agent, option }) => {
                 const selected = agent.agent.id === activeAgent?.agent.id
                   && option.id === model
-                  && (!option.provider || matchesStoredRef(option.provider, providerRefValue));
+                  && (!option.provider || resolveProviderEndpointRef(providerEndpoints, providerRefValue)?.id === option.provider.id);
                 const agentName = agent.agent.config?.helix?.name || "Unnamed agent";
                 return (
                   <Button

--- a/frontend/src/components/tasks/SpecTaskModelPicker.tsx
+++ b/frontend/src/components/tasks/SpecTaskModelPicker.tsx
@@ -14,10 +14,15 @@ import { ChevronDown, Search } from "lucide-react";
 import type {
   TypesProviderEndpoint,
   TypesAgentExecutionConfig,
+  TypesOrgCodeAgentHarnessStatus,
 } from "../../api/api";
 import { AGENT_TYPE_ZED_EXTERNAL, IApp, IAssistantConfig } from "../../types";
 import { useGetOrgByName } from "../../services/orgService";
 import { useListProviders } from "../../services/providersService";
+import {
+  findHarnessStatus,
+  useOrgCodeAgentHarnesses,
+} from "../../services/codeAgentHarnessesService";
 import useRouter from "../../hooks/useRouter";
 import { matchesAllTokens } from "../../utils/searchUtils";
 import AgentHarness from "../agent/AgentHarness";
@@ -30,6 +35,11 @@ import {
   ProviderIcon,
   providerRef,
 } from "../create/AdvancedModelPicker";
+import {
+  providerEndpointIsConnected,
+  providersForCodeAgentHarness,
+  providersForCodeAgentRuntime,
+} from "../../utils/codeAgentProviders";
 
 export type TaskModelOption = { id: string; label: string };
 
@@ -322,30 +332,39 @@ function getAssistant(agent: IApp): IAssistantConfig | undefined {
   ) || agent.config?.helix?.assistants?.[0];
 }
 
-function buildPickerAgents(
+export function buildPickerAgents(
   agents: IApp[],
   providers: TypesProviderEndpoint[],
+  harnesses: TypesOrgCodeAgentHarnessStatus[] = [],
+  enforceOrgPolicy = false,
 ): PickerAgent[] {
   return agents.map((agent) => {
     const assistant = getAssistant(agent);
     const runtime = assistant?.code_agent_runtime;
     const usesSubscription = assistant?.code_agent_credential_type === "subscription";
+    const harness = findHarnessStatus(harnesses, runtime);
     let models: PickerModel[];
 
-    if (usesSubscription && runtime === "claude_code") {
-      models = CLAUDE_SUBSCRIPTION_MODELS.map((option) => ({
+    const subscriptionAllowed = !enforceOrgPolicy
+      || (!!harness?.enabled
+        && harness.subscription_enabled === true
+        && !!harness.viewer_has_subscription);
+    if (usesSubscription) {
+      const subscriptionModels = runtime === "claude_code"
+        ? CLAUDE_SUBSCRIPTION_MODELS
+        : runtime === "codex_cli"
+          ? CODEX_SUBSCRIPTION_MODELS
+          : [];
+      models = subscriptionAllowed ? subscriptionModels.map((option) => ({
         ...option,
         key: option.id,
-        providerLabel: "Claude Code",
-      }));
-    } else if (usesSubscription && runtime === "codex_cli") {
-      models = CODEX_SUBSCRIPTION_MODELS.map((option) => ({
-        ...option,
-        key: option.id,
-        providerLabel: "Codex",
-      }));
+        providerLabel: runtime === "claude_code" ? "Claude Code" : "Codex",
+      })) : [];
     } else {
-      models = providers.flatMap((provider) => (provider.available_models || [])
+      const allowedProviders = enforceOrgPolicy
+        ? providersForCodeAgentHarness(providers, harness, runtime)
+        : providersForCodeAgentRuntime(providers, runtime).filter(providerEndpointIsConnected);
+      models = allowedProviders.flatMap((provider) => (provider.available_models || [])
         .filter((availableModel) => availableModel.enabled
           && (!availableModel.type || availableModel.type === "chat" || availableModel.type === "text"))
         .map((availableModel) => ({
@@ -365,43 +384,34 @@ function buildPickerAgents(
 const ProviderAwareSpecTaskModelPicker: FC<SpecTaskModelPickerProps> = (props) => {
   const router = useRouter();
   const orgName = router.params.org_id;
+  const needsProviders = props.agents.some((agent) =>
+    getAssistant(agent)?.code_agent_credential_type !== "subscription");
   const { data: org, isLoading: loadingOrg } = useGetOrgByName(orgName, orgName !== undefined);
   const { data: providers = [], isLoading } = useListProviders({
     loadModels: true,
     orgId: org?.id,
-    enabled: !loadingOrg,
+    enabled: !loadingOrg && needsProviders,
   });
+  const { data: harnesses = [], isLoading: loadingHarnesses } = useOrgCodeAgentHarnesses(
+    org?.id,
+    { enabled: !loadingOrg },
+  );
   const pickerAgents = useMemo(
-    () => buildPickerAgents(props.agents, providers),
-    [props.agents, providers],
+    () => buildPickerAgents(props.agents, providers, harnesses, !!orgName),
+    [props.agents, providers, harnesses, orgName],
   );
 
   return (
     <SpecTaskModelPickerView
       {...props}
       agents={pickerAgents}
-      loading={isLoading || loadingOrg}
+      loading={(needsProviders && isLoading) || loadingOrg || loadingHarnesses}
     />
   );
 };
 
-const SubscriptionSpecTaskModelPicker: FC<SpecTaskModelPickerProps> = (props) => {
-  const pickerAgents = useMemo(
-    () => buildPickerAgents(props.agents, []),
-    [props.agents],
-  );
-  return <SpecTaskModelPickerView {...props} agents={pickerAgents} />;
-};
-
 const SpecTaskModelPicker: FC<SpecTaskModelPickerProps> = (props) => {
-  const needsProviders = props.agents.some((agent) => {
-    const assistant = getAssistant(agent);
-    return assistant?.code_agent_credential_type !== "subscription"
-      || (assistant.code_agent_runtime !== "claude_code" && assistant.code_agent_runtime !== "codex_cli");
-  });
-  return needsProviders
-    ? <ProviderAwareSpecTaskModelPicker {...props} />
-    : <SubscriptionSpecTaskModelPicker {...props} />;
+  return <ProviderAwareSpecTaskModelPicker {...props} />;
 };
 
 export default SpecTaskModelPicker;

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -25,6 +25,7 @@ import type { ReactNode } from 'react'
 import { formatCodexAccountDetail, formatCodexAccountRef } from '../components/account/codexSubscriptionUtils';
 import LMStudioModels from '../components/providers/LMStudioModels';
 import CodeAgentHarnessesSection from '../components/providers/CodeAgentHarnessesSection';
+import { getProviderPresetDefinition } from '../components/providers/ProviderEndpointIcon';
 import {
   useOrgCodeAgentHarnesses,
   useUpdateOrgCodeAgentHarnesses,
@@ -193,9 +194,7 @@ const Providers: React.FC = () => {
     e.name === 'lmstudio' || e.name === 'ollama' || e.name?.includes('lmstudio') || e.name?.includes('ollama')
   );
 
-  // User-created custom endpoints: anything whose name doesn't match a predefined PROVIDERS id.
-  const knownProviderIds = new Set(PROVIDERS.map(p => p.id));
-  const customEndpoints = ownedEndpoints.filter(e => e.name && !knownProviderIds.has(e.name));
+  const customEndpoints = ownedEndpoints.filter(endpoint => !getProviderPresetDefinition(endpoint));
 
   // Detected but not yet connected local providers
   const unconnectedDetected = (detectedProviders || []).filter(
@@ -245,6 +244,7 @@ const Providers: React.FC = () => {
             endpoints={allEndpoints}
             loading={(isLoadingCodeAgents || isLoadingOrg) && codeAgentHarnesses.length === 0}
             readOnly={!editAllowed}
+            organizationName={org?.display_name || org?.name}
             onChange={handleCodeAgentChange}
             subscriptionIdentity={subscriptionIdentity}
             subscriptionAction={(runtime) => {
@@ -463,7 +463,7 @@ const Providers: React.FC = () => {
             // Synthetic global providers have id "-" and are configured by the server
             // environment, so they cannot be disconnected from this dialog.
             const existingProvider = provider.is_custom ? undefined : ownedEndpoints.find(
-              endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', '')
+              endpoint => getProviderPresetDefinition(endpoint)?.id === provider.id
             );
             const isConfigured = !!existingProvider;
             return (

--- a/frontend/src/utils/codeAgentProviders.ts
+++ b/frontend/src/utils/codeAgentProviders.ts
@@ -10,16 +10,35 @@ export function providerEndpointMatchesRef(
   ref: string | undefined,
 ): boolean {
   if (!provider || !ref) return false
-  if (provider.id && provider.id !== '-' && provider.id === ref) return true
-  return canonicalProviderName(provider.name) === canonicalProviderName(ref)
+  return !!provider.id && provider.id === ref
 }
 
-function canonicalProviderName(name?: string): string {
+export function canonicalProviderName(name?: string): string {
   const normalized = name?.toLowerCase() || ''
-  const legacyName = normalized.startsWith('user/') ? normalized.slice(5) : normalized
+  const legacyName = normalized.startsWith('user/') || normalized.startsWith('global/')
+    ? normalized.slice(normalized.indexOf('/') + 1)
+    : normalized
   return ['openai', 'togetherai', 'anthropic', 'helix', 'vllm'].includes(legacyName)
     ? legacyName
     : normalized
+}
+
+export function resolveProviderEndpointRef(
+  providers: TypesProviderEndpoint[],
+  ref?: string,
+): TypesProviderEndpoint | undefined {
+  if (!ref) return undefined
+  const exact = providers.find((provider) => providerEndpointMatchesRef(provider, ref))
+  if (exact) return exact
+  if (ref.startsWith('pe_') || ref.startsWith('global/')) return undefined
+  return providers
+    .filter((provider) => canonicalProviderName(provider.name) === canonicalProviderName(ref))
+    .sort((a, b) => providerPrecedence(b) - providerPrecedence(a))[0]
+}
+
+function providerPrecedence(provider: TypesProviderEndpoint): number {
+  if (provider.endpoint_type === 'org' || provider.endpoint_type === 'user') return 3
+  return provider.id?.startsWith('pe_') ? 2 : 1
 }
 
 export function providerEndpointIsConnected(provider: TypesProviderEndpoint): boolean {
@@ -65,6 +84,8 @@ export function providersForCodeAgentHarness(
   const compatible = providersForCodeAgentRuntime(providers, runtime)
     .filter(providerEndpointIsConnected)
   if (harness.provider_refs == null) return compatible
-  return compatible.filter((provider) =>
-    harness.provider_refs?.some((ref) => providerEndpointMatchesRef(provider, ref)))
+  const allowed = new Set(harness.provider_refs
+    .map((ref) => resolveProviderEndpointRef(compatible, ref)?.id)
+    .filter(Boolean))
+  return compatible.filter((provider) => provider.id && allowed.has(provider.id))
 }

--- a/frontend/src/utils/codeAgentProviders.ts
+++ b/frontend/src/utils/codeAgentProviders.ts
@@ -11,7 +11,15 @@ export function providerEndpointMatchesRef(
 ): boolean {
   if (!provider || !ref) return false
   if (provider.id && provider.id !== '-' && provider.id === ref) return true
-  return provider.name?.toLowerCase() === ref.toLowerCase()
+  return canonicalProviderName(provider.name) === canonicalProviderName(ref)
+}
+
+function canonicalProviderName(name?: string): string {
+  const normalized = name?.toLowerCase() || ''
+  const legacyName = normalized.startsWith('user/') ? normalized.slice(5) : normalized
+  return ['openai', 'togetherai', 'anthropic', 'helix', 'vllm'].includes(legacyName)
+    ? legacyName
+    : normalized
 }
 
 export function providerEndpointIsConnected(provider: TypesProviderEndpoint): boolean {
@@ -38,7 +46,7 @@ export function providerSupportsCodeAgentRuntime(
   runtime?: TypesCodeAgentRuntime | string,
 ): boolean {
   const required = requiredProviderNameForRuntime(runtime)
-  return !required || provider.name?.toLowerCase() === required
+  return !required || canonicalProviderName(provider.name) === required
 }
 
 export function providersForCodeAgentRuntime(

--- a/frontend/src/utils/codeAgentProviders.ts
+++ b/frontend/src/utils/codeAgentProviders.ts
@@ -1,8 +1,18 @@
 import {
   TypesCodeAgentRuntime,
+  TypesOrgCodeAgentHarnessStatus,
   TypesProviderEndpoint,
   TypesProviderEndpointStatus,
 } from '../api/api'
+
+export function providerEndpointMatchesRef(
+  provider: TypesProviderEndpoint | undefined,
+  ref: string | undefined,
+): boolean {
+  if (!provider || !ref) return false
+  if (provider.id && provider.id !== '-' && provider.id === ref) return true
+  return provider.name?.toLowerCase() === ref.toLowerCase()
+}
 
 export function providerEndpointIsConnected(provider: TypesProviderEndpoint): boolean {
   return provider.status === TypesProviderEndpointStatus.ProviderEndpointStatusOK
@@ -36,4 +46,17 @@ export function providersForCodeAgentRuntime(
   runtime?: TypesCodeAgentRuntime | string,
 ): TypesProviderEndpoint[] {
   return providers.filter((provider) => providerSupportsCodeAgentRuntime(provider, runtime))
+}
+
+export function providersForCodeAgentHarness(
+  providers: TypesProviderEndpoint[],
+  harness: TypesOrgCodeAgentHarnessStatus | undefined,
+  runtime?: TypesCodeAgentRuntime | string,
+): TypesProviderEndpoint[] {
+  if (!harness?.enabled || harness.subscription_enabled === true) return []
+  const compatible = providersForCodeAgentRuntime(providers, runtime)
+    .filter(providerEndpointIsConnected)
+  if (harness.provider_refs == null) return compatible
+  return compatible.filter((provider) =>
+    harness.provider_refs?.some((ref) => providerEndpointMatchesRef(provider, ref)))
 }


### PR DESCRIPTION
## Summary
- inherit compatible global providers when an org harness has no explicit provider policy
- combine org and global providers with org-scoped endpoints taking precedence by name
- apply the same policy to project, spec-task, backend validation, runtime snapshots, and provider routing

## Tests
- `cd api && go test ./pkg/openai/manager -count=1`
- `cd api && go test ./pkg/server -run 'TestValidateOrgCodeAgentHarness|TestFilterProviderEndpointsByRefs|TestResolveProviderEndpointPrecedence|TestFilterProviderEndpointsForHarness|TestBuildOrgCodeAgentHarnessStatuses|TestGetProviderSnapshot(MissingHarnessPolicyIncludesGlobalProviders|SubscriptionExcludesGlobalProviders)' -count=1`\n- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/ ./pkg/openai/manager/`\n- `cd frontend && yarn test CodeAgentConfigPicker.test.tsx CodeAgentHarnessesSection.test.tsx SpecTaskModelPicker.test.tsx --run` (33 tests passed)\n\n## Known unrelated failure\n- `cd frontend && yarn build` fails because `InteractionInference.tsx` imports the default component `WorkspaceReviewMessage.tsx`, but the existing case-colliding `workspaceReviewMessage.ts` module is resolved instead and has no default export.