### PR TITLE
ci: quote Drone dependency version commands

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1423,7 +1423,7 @@ steps:
         echo "✓ Zed source at $$(git -C /drone/src/external/zed-source rev-parse HEAD)"
       - echo "=== Dependency versions ==="
       - echo "Zed:" && cat /drone/src/zed-commit.txt
-      - . /drone/src/sandbox-versions.txt && echo "Qwen Code: $${QWEN_VERSION}"
+      - '. /drone/src/sandbox-versions.txt && echo "Qwen Code: $${QWEN_VERSION}"'
     volumes:
       - name: sandbox-build-cache
         path: /drone/src/cache
@@ -1922,7 +1922,7 @@ steps:
         echo "✓ Zed source at $$(git rev-parse HEAD)"
       - echo "=== Dependency versions ==="
       - echo "Zed:" && cat /drone/src/zed-commit.txt
-      - . /drone/src/sandbox-versions.txt && echo "Qwen Code: $${QWEN_VERSION}"
+      - '. /drone/src/sandbox-versions.txt && echo "Qwen Code: $${QWEN_VERSION}"'
     volumes:
       - name: sandbox-build-cache
         path: /drone/src/cache


### PR DESCRIPTION
## Summary
- quote both Qwen Code dependency-version commands as YAML scalars
- prevent Drone from parsing `Qwen Code:` as a map

## Verification
- `drone lint --trusted .drone.yml`
- verified every Drone command decodes as a YAML string
- `git diff --check -- .drone.yml`