### PR TITLE
ci: isolate frontend dependencies per build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,8 +35,6 @@ steps:
     volumes:
       - name: yarn-cache
         path: /usr/local/share/.cache/yarn
-      - name: node-modules-cache
-        path: /go/src/github.com/helix-ml/helix/frontend/node_modules
     commands:
       - cd frontend
       - yarn install --frozen-lockfile --check-files
@@ -872,9 +870,6 @@ volumes:
   - name: yarn-cache
     host:
       path: /var/cache/drone/yarn
-  - name: node-modules-cache
-    host:
-      path: /var/cache/drone/node_modules
 ---
 kind: pipeline
 type: docker


### PR DESCRIPTION
## Summary
- stop sharing a mutable frontend `node_modules` directory between Drone builds
- retain the shared Yarn package cache for download performance
- prevent concurrent installs from removing binaries before frontend tests run

## Verification
- `drone lint --trusted .drone.yml`
- verified every Drone command decodes as a YAML string
- fresh `yarn install --frozen-lockfile --check-files`
- Vitest ran 1,012 passing tests locally; one unrelated pre-existing macOS case-collision test failed
- `git diff --check`