### PR TITLE
fix: align Claude subscription sharing with org harness access

### DIFF
--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -549,11 +549,12 @@ func (apiServer *HelixAPIServer) getClaudeSubscription(_ http.ResponseWriter, re
 // UpdateClaudeSubscriptionDelegationRequest sets which organizations may run
 // agents on this subscription for its owner.
 type UpdateClaudeSubscriptionDelegationRequest struct {
-	DelegatedOrgIDs []string `json:"delegated_org_ids"`
+	DelegatedOrgIDs      []string `json:"delegated_org_ids"`
+	SwitchToSubscription bool     `json:"switch_to_subscription,omitempty"`
 }
 
 // @Summary Set which orgs may use a Claude subscription for delegated agent runs
-// @Description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.
+// @Description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.
 // @Tags Claude
 // @Accept json
 // @Produce json
@@ -564,6 +565,7 @@ type UpdateClaudeSubscriptionDelegationRequest struct {
 // @Failure 401 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
+// @Failure 409 {object} system.HTTPError
 // @Security BearerAuth
 // @Router /api/v1/claude-subscriptions/{id}/delegation [put]
 func (apiServer *HelixAPIServer) updateClaudeSubscriptionDelegation(_ http.ResponseWriter, req *http.Request) (*types.ClaudeSubscription, *system.HTTPError) {
@@ -606,6 +608,29 @@ func (apiServer *HelixAPIServer) updateClaudeSubscriptionDelegation(_ http.Respo
 			return nil, system.NewHTTPError403("not a member of organization " + orgID)
 		}
 		granted = append(granted, orgID)
+	}
+
+	harnesses := make(map[string]*types.OrgCodeAgentHarness, len(granted))
+	for _, orgID := range granted {
+		if _, err := apiServer.authorizeOrgOwner(req.Context(), user, orgID); err != nil {
+			return nil, system.NewHTTPError403("only an organization owner can enable Claude Code for " + orgID)
+		}
+		harness, err := apiServer.Store.GetOrgCodeAgentHarness(req.Context(), orgID, types.CodeAgentRuntimeClaudeCode)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return nil, system.NewHTTPError500("failed to resolve Claude Code settings: " + err.Error())
+		}
+		if err == nil && claudeHarnessUsesAPIProviderMode(harness) && !body.SwitchToSubscription {
+			return nil, system.NewHTTPError409("organization " + orgID + " is using API-provider mode; confirm switching Claude Code to the subscription")
+		}
+		if err == nil && harness.SubscriptionEnabled != nil && *harness.SubscriptionEnabled {
+			continue
+		}
+		harnesses[orgID] = harness
+	}
+	for orgID := range harnesses {
+		if err := apiServer.enableSubscriptionCodeAgentHarness(req.Context(), orgID, user.ID, types.CodeAgentRuntimeClaudeCode); err != nil {
+			return nil, system.NewHTTPError500(err.Error())
+		}
 	}
 
 	sub.DelegatedOrgIDs = granted

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -3669,7 +3669,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3725,6 +3725,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -28016,6 +28022,9 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "switch_to_subscription": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/org_code_agent_harness_handlers.go
+++ b/api/pkg/server/org_code_agent_harness_handlers.go
@@ -184,6 +184,10 @@ func normalizeHarnessCredentialSources(update *types.OrgCodeAgentHarnessUpdate) 
 	return nil
 }
 
+func claudeHarnessUsesAPIProviderMode(harness *types.OrgCodeAgentHarness) bool {
+	return harness != nil && !(harness.SubscriptionEnabled != nil && *harness.SubscriptionEnabled) && (harness.ProviderRefs == nil || len(harness.ProviderRefs) > 0)
+}
+
 func (apiServer *HelixAPIServer) viewerHasClaudeSubscription(ctx context.Context, orgID, userID string) (bool, error) {
 	_, err := apiServer.Store.GetEffectiveClaudeSubscription(ctx, userID, orgID)
 	if errors.Is(err, store.ErrNotFound) {

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -169,6 +169,14 @@ func TestNormalizeHarnessCredentialSources(t *testing.T) {
 	})
 }
 
+func TestClaudeHarnessUsesAPIProviderMode(t *testing.T) {
+	assert.True(t, claudeHarnessUsesAPIProviderMode(&types.OrgCodeAgentHarness{}))
+	assert.True(t, claudeHarnessUsesAPIProviderMode(&types.OrgCodeAgentHarness{ProviderRefs: []string{"anthropic"}}))
+	assert.False(t, claudeHarnessUsesAPIProviderMode(nil))
+	assert.False(t, claudeHarnessUsesAPIProviderMode(&types.OrgCodeAgentHarness{ProviderRefs: []string{}}))
+	assert.False(t, claudeHarnessUsesAPIProviderMode(&types.OrgCodeAgentHarness{SubscriptionEnabled: boolPointer(true)}))
+}
+
 func TestFilterProviderEndpointsByRefs(t *testing.T) {
 	endpoints := []*types.ProviderEndpoint{
 		{ID: "provider-1", Name: "renamed"},

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -3665,7 +3665,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3721,6 +3721,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -28012,6 +28018,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "switch_to_subscription": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3301,6 +3301,8 @@ definitions:
         items:
           type: string
         type: array
+      switch_to_subscription:
+        type: boolean
     type: object
   server.VideoStreamingStats:
     properties:
@@ -16033,7 +16035,8 @@ paths:
       consumes:
       - application/json
       description: Grant (or revoke) permission for an organization's orchestrated
-        agents to authenticate as the subscription owner. Only the subscription owner
+        agents to authenticate as the subscription owner. Sharing with an owned organization
+        also enables Claude Code subscription mode there. Only the subscription owner
         may change this.
       parameters:
       - description: Subscription ID
@@ -16068,6 +16071,10 @@ paths:
             $ref: '#/definitions/system.HTTPError'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/system.HTTPError'
       security:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2126,6 +2126,7 @@ export interface ServerTaskSpecsResponse {
 /** Disconnect a Claude subscription */
 export interface ServerUpdateClaudeSubscriptionDelegationRequest {
   delegated_org_ids?: string[];
+  switch_to_subscription?: boolean;
 }
 
 export interface ServerVideoStreamingStats {
@@ -10510,7 +10511,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.
+     * @description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.
      *
      * @tags Claude
      * @name V1ClaudeSubscriptionsDelegationUpdate

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.delegation.test.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.delegation.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ClaudeSubscriptionConnect from './ClaudeSubscriptionConnect'
+
+const delegationUpdate = vi.fn()
+const organizations = [{
+  id: 'org_1',
+  name: 'Hello',
+  memberships: [{ user_id: 'usr_me', role: 'owner' }],
+}]
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => ({
+    get: vi.fn(async () => [{
+      id: 'sub_1',
+      owner_type: 'user',
+      owner_id: 'usr_me',
+      name: 'My Claude Subscription',
+      status: 'active',
+      credential_type: 'oauth',
+      access_token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      delegated_org_ids: [],
+    }]),
+    getApiClient: () => ({
+      v1ClaudeSubscriptionsDelegationUpdate: delegationUpdate,
+    }),
+  }),
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('../../hooks/useAccount', () => ({
+  default: () => ({
+    admin: false,
+    user: { id: 'usr_me' },
+    organizationTools: { organizations },
+  }),
+}))
+
+function renderAccount() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ClaudeSubscriptionConnect variant="account" />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ClaudeSubscriptionConnect delegation', () => {
+  beforeEach(() => delegationUpdate.mockReset())
+
+  it('enables subscription mode when sharing succeeds', async () => {
+    delegationUpdate.mockResolvedValue({ data: {} })
+    renderAccount()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Hello' }))
+
+    await waitFor(() => expect(delegationUpdate).toHaveBeenCalledWith('sub_1', {
+      delegated_org_ids: ['org_1'],
+      switch_to_subscription: undefined,
+    }))
+  })
+
+  it('asks before replacing API-provider mode', async () => {
+    delegationUpdate
+      .mockRejectedValueOnce({ response: { status: 409 } })
+      .mockResolvedValueOnce({ data: {} })
+    renderAccount()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Hello' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText(/currently uses API providers/i)).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Switch and share' }))
+    await waitFor(() => expect(delegationUpdate).toHaveBeenLastCalledWith('sub_1', {
+      delegated_org_ids: ['org_1'],
+      switch_to_subscription: true,
+    }))
+  })
+})

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -123,9 +123,9 @@ const DelegationPicker: FC<DelegationPickerProps> = ({
   return (
     <Box sx={{ mt: 1.5 }}>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-        Let these organizations&apos; agents use this subscription when they run work on your
-        behalf — for example a bot you own that is launched by a shared service account. Without
-        this, your subscription is only used for sessions you own.
+        Sharing with an organization enables Claude Code subscription mode there. Its agents can
+        then use this subscription when they run work on your behalf - for example a bot you own
+        that is launched by a shared service account.
       </Typography>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
         {grantedCount === 0
@@ -305,6 +305,12 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   // Disconnect / delete state
   const [disconnectDialogOpen, setDisconnectDialogOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<string>('')
+  const [delegationConflict, setDelegationConflict] = useState<{
+    id: string
+    orgIDs: string[]
+    organizationID: string
+    organizationName: string
+  } | null>(null)
   const disconnectMutation = useMutation({
     mutationFn: async (id: string) => (await api.getApiClient().v1ClaudeSubscriptionsDelete(id)).data,
     onSuccess: () => {
@@ -319,13 +325,35 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   // service account) authenticate as this subscription's owner. Owner-only, and
   // opt-in per org — without it nobody else's automation can spend your quota.
   const delegationMutation = useMutation({
-    mutationFn: async ({ id, orgIDs }: { id: string; orgIDs: string[] }) => {
-      return api.put(`/api/v1/claude-subscriptions/${id}/delegation`, {
+    mutationFn: async ({ id, orgIDs, switchToSubscription }: {
+      id: string
+      orgIDs: string[]
+      organizationID: string
+      switchToSubscription?: boolean
+    }) => {
+      return (await api.getApiClient().v1ClaudeSubscriptionsDelegationUpdate(id, {
         delegated_org_ids: orgIDs,
-      }, {}, { snackbar: true })
+        switch_to_subscription: switchToSubscription,
+      })).data
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
+      for (const orgID of variables.orgIDs) {
+        queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(orgID) })
+      }
+      setDelegationConflict(null)
+    },
+    onError: (error: any, variables) => {
+      if (error?.response?.status === 409 && !variables.switchToSubscription) {
+        setDelegationConflict({
+          id: variables.id,
+          orgIDs: variables.orgIDs,
+          organizationID: variables.organizationID,
+          organizationName: orgLabel(variables.organizationID),
+        })
+        return
+      }
+      snackbar.error(error?.response?.data?.message || error?.message || 'Could not update subscription sharing')
     },
   })
 
@@ -334,8 +362,40 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
     const next = enabled
       ? Array.from(new Set([...current, orgID]))
       : current.filter((id) => id !== orgID)
-    delegationMutation.mutate({ id: sub.id, orgIDs: next })
+    delegationMutation.mutate({ id: sub.id, orgIDs: next, organizationID: orgID })
   }
+
+  const delegationConflictDialog = (
+    <Dialog open={!!delegationConflict} onClose={() => setDelegationConflict(null)}>
+      <DialogTitle>Switch {delegationConflict?.organizationName} to Claude subscription mode?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This organization currently uses API providers for Claude Code. Sharing your subscription
+          will replace that mode for Claude Code and make your Claude models available in task creation.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={() => setDelegationConflict(null)} sx={{ textTransform: 'none' }}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          disabled={delegationMutation.isPending || !delegationConflict}
+          onClick={() => {
+            if (!delegationConflict) return
+            delegationMutation.mutate({
+              id: delegationConflict.id,
+              orgIDs: delegationConflict.orgIDs,
+              organizationID: delegationConflict.organizationID,
+              switchToSubscription: true,
+            })
+          }}
+          sx={{ textTransform: 'none' }}
+        >
+          {delegationMutation.isPending ? 'Switching...' : 'Switch and share'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
 
   // Setup token dialog state
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false)
@@ -1091,6 +1151,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
 
         {tokenDialog}
         {disconnectDialog}
+        {delegationConflictDialog}
       </>
     )
   }

--- a/frontend/src/components/helix-org/BotRuntimeForm.test.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AgentConfigForm from './BotRuntimeForm'
+
+vi.mock('../account/ClaudeSubscriptionConnect', () => ({
+  useClaudeSubscriptions: () => ({ data: [] }),
+}))
+vi.mock('../../services/codexSubscriptionsService', () => ({
+  useCodexSubscriptions: () => ({ data: [] }),
+}))
+vi.mock('../../services/helixOrgService', () => ({
+  useHelixModelsForProvider: vi.fn(),
+  useHelixProviders: () => ({ data: [] }),
+}))
+vi.mock('../create/AdvancedModelPicker', () => ({
+  AdvancedModelPicker: () => null,
+}))
+vi.mock('../agent/CodeAgentEffortSelect', () => ({
+  default: () => null,
+  getCodeAgentEffortOptions: () => [],
+}))
+vi.mock('../agent/AgentHarness', () => ({
+  default: () => null,
+}))
+
+describe('AgentConfigForm', () => {
+  it('does not show a subscription as connected when the org cannot use it', () => {
+    render(
+      <AgentConfigForm
+        value={{
+          runtime: 'claude_code',
+          credentials: 'subscription',
+          provider: '',
+          model: 'claude-opus-5',
+        }}
+        onChange={vi.fn()}
+        subscriptionAvailability={{ claude: false, codex: false }}
+      />,
+    )
+
+    expect(screen.getByText('(not available for this organization)')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Enable it under Organization Settings > Providers.',
+    )
+    expect(screen.getByRole('radio', { name: /Claude Subscription/ })).toBeDisabled()
+  })
+})

--- a/frontend/src/components/helix-org/BotRuntimeForm.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.tsx
@@ -5,6 +5,7 @@
 // on the settings page, or deferred-until-create in the new-org dialog).
 
 import { FC } from 'react'
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import FormControl from '@mui/material/FormControl'
 import FormControlLabel from '@mui/material/FormControlLabel'
@@ -37,6 +38,11 @@ export interface AgentConfigValue {
   reasoning_effort?: string
 }
 
+export interface AgentSubscriptionAvailability {
+  claude: boolean
+  codex: boolean
+}
+
 // Strong code-generation models to surface first in the picker.
 const RECOMMENDED_MODELS = [
   'claude-opus-4-5-20251101',
@@ -48,15 +54,18 @@ export const AgentConfigForm: FC<{
   onChange: (patch: Partial<AgentConfigValue>) => void
   showReasoningEffort?: boolean
   disabled?: boolean
-}> = ({ value, onChange, showReasoningEffort = false, disabled = false }) => {
+  subscriptionAvailability?: AgentSubscriptionAvailability
+}> = ({ value, onChange, showReasoningEffort = false, disabled = false, subscriptionAvailability }) => {
   const { data: providers } = useHelixProviders()
   const { data: claudeSubscriptions } = useClaudeSubscriptions()
   const { data: codexSubscriptions } = useCodexSubscriptions()
   // Warm the models cache for the currently-selected provider.
   useHelixModelsForProvider(value.provider, { enabled: !!value.provider })
 
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
-  const hasCodexSubscription = (codexSubscriptions?.length ?? 0) > 0
+  const hasClaudeSubscription = subscriptionAvailability?.claude
+    ?? (claudeSubscriptions?.length ?? 0) > 0
+  const hasCodexSubscription = subscriptionAvailability?.codex
+    ?? (codexSubscriptions?.length ?? 0) > 0
   const hasAnthropicProvider = (providers ?? []).includes('anthropic')
   const hasOpenAIProvider = (providers ?? []).includes('openai')
 
@@ -64,6 +73,10 @@ export const AgentConfigForm: FC<{
   const isCodex = value.runtime === 'codex_cli'
   const supportsSubscription = isClaude || isCodex
   const hasRuntimeSubscription = isClaude ? hasClaudeSubscription : isCodex ? hasCodexSubscription : false
+  const subscriptionUnavailableForOrg = !!subscriptionAvailability
+    && supportsSubscription
+    && value.credentials === 'subscription'
+    && !hasRuntimeSubscription
   const hasRuntimeAPIKey = isClaude ? hasAnthropicProvider : isCodex ? hasOpenAIProvider : false
   const apiKeyMode = !supportsSubscription || value.credentials === 'api_key'
   const effortValue = !value.reasoning_effort || value.reasoning_effort === 'none' ? 'default' : value.reasoning_effort
@@ -213,7 +226,9 @@ export const AgentConfigForm: FC<{
                     {hasRuntimeSubscription ? (
                       <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
                     ) : (
-                      <Typography variant="caption" color="text.secondary">(not connected)</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {subscriptionAvailability ? '(not available for this organization)' : '(not connected)'}
+                      </Typography>
                     )}
                   </Box>
                 }
@@ -235,6 +250,11 @@ export const AgentConfigForm: FC<{
               />
             </RadioGroup>
           </FormControl>
+          {subscriptionUnavailableForOrg && (
+            <Alert severity="warning" sx={{ mt: 1 }}>
+              This subscription is not available for this organization. Enable it under Organization Settings &gt; Providers.
+            </Alert>
+          )}
         </Box>
       )}
 

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -7,8 +7,10 @@ import Paper from '@mui/material/Paper'
 import AgentConfigForm, { AgentConfigValue } from './BotRuntimeForm'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
+import { useOrgCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
 import {
   SettingsSpecDTO,
+  useHelixOrgBase,
   useHelixOrgSettings,
   useSetHelixOrgSetting,
 } from '../../services/helixOrgService'
@@ -39,7 +41,11 @@ const decodeAgentConfig = (v: string): AgentConfigValue | undefined => {
 }
 
 const DefaultAgentConfigPanel: FC = () => {
+  const { orgID } = useHelixOrgBase()
   const { data, isLoading } = useHelixOrgSettings()
+  const { data: harnesses = [], isLoading: loadingHarnesses } = useOrgCodeAgentHarnesses(orgID, {
+    enabled: !!orgID,
+  })
   const setMut = useSetHelixOrgSetting()
   const snackbar = useSnackbar()
 
@@ -79,9 +85,26 @@ const DefaultAgentConfigPanel: FC = () => {
       .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
   }
 
+  const subscriptionAvailability = {
+    claude: harnesses.some((harness) => harness.runtime === 'claude_code'
+      && harness.enabled
+      && harness.subscription_enabled === true
+      && harness.viewer_has_subscription),
+    codex: harnesses.some((harness) => harness.runtime === 'codex_cli'
+      && harness.enabled
+      && harness.subscription_enabled === true
+      && harness.viewer_has_subscription),
+  }
+
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
-      {isLoading ? <LoadingSpinner /> : <AgentConfigForm value={value} onChange={handlePatch} />}
+      {isLoading || loadingHarnesses
+        ? <LoadingSpinner />
+        : <AgentConfigForm
+            value={value}
+            onChange={handlePatch}
+            subscriptionAvailability={subscriptionAvailability}
+          />}
     </Paper>
   )
 }

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3301,6 +3301,8 @@ definitions:
         items:
           type: string
         type: array
+      switch_to_subscription:
+        type: boolean
     type: object
   server.VideoStreamingStats:
     properties:
@@ -16033,7 +16035,8 @@ paths:
       consumes:
       - application/json
       description: Grant (or revoke) permission for an organization's orchestrated
-        agents to authenticate as the subscription owner. Only the subscription owner
+        agents to authenticate as the subscription owner. Sharing with an owned organization
+        also enables Claude Code subscription mode there. Only the subscription owner
         may change this.
       parameters:
       - description: Subscription ID
@@ -16068,6 +16071,10 @@ paths:
             $ref: '#/definitions/system.HTTPError'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/system.HTTPError'
       security:

--- a/openapi.json
+++ b/openapi.json
@@ -4325,7 +4325,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.",
                 "tags": [
                     "Claude"
                 ],
@@ -4395,6 +4395,16 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -32578,6 +32588,9 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "switch_to_subscription": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -3665,7 +3665,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Sharing with an owned organization also enables Claude Code subscription mode there. Only the subscription owner may change this.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3721,6 +3721,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -28012,6 +28018,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "switch_to_subscription": {
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
## Summary

- Scope default-agent subscription availability to the current organization and harness policy.
- Sharing a personal Claude subscription with an owned organization now enables Claude Code subscription mode automatically.
- Ask for confirmation before replacing that organization's API-provider mode.
- Keep the Providers switch as an explicit opt-out instead of a second required setup step.
- Add regression coverage for the misleading connected state and delegation flow.

## Validation

- Focused Vitest: 29 passed.
- Targeted Go tests: passed.
- Go build for server, store, and types: passed.
- Frontend production build: blocked by the pre-existing WorkspaceReviewMessage.ts vs workspaceReviewMessage.ts casing conflict in frontend/src/components/session/.