### PR TITLE
test(api): expect deferred config for all runtimes

### DIFF
--- a/api/pkg/server/execution_config_test.go
+++ b/api/pkg/server/execution_config_test.go
@@ -44,6 +44,7 @@ func TestIsDeferredNativeHarnessProjectConfig(t *testing.T) {
 				Runtime:        types.CodeAgentRuntimeOpenCode,
 				CredentialType: types.CodeAgentCredentialTypeAPIKey,
 			},
+			want: true,
 		},
 		{
 			name: "subscription",


### PR DESCRIPTION
## Summary

`isDeferredNativeHarnessProjectConfig` was broadened in `f0e69c1b1` ("allow deferred model selection for all code agent runtimes in project creation") to return `true` for any API-key config without an explicit provider/model, covering all runtimes — not just Claude and Codex. The existing unit test `TestIsDeferredNativeHarnessProjectConfig/generic_harness` still asserted the old native-only behaviour (`want: false` for the `OpenCode` runtime), causing CI build 3964 to fail with `expected: false, actual: true`.

This commit updates the `generic_harness` test case to `want: true`, matching the intended "all runtimes" semantics.

## Testing

- `go test ./pkg/server/ -run 'TestIsDeferredNativeHarnessProjectConfig|TestAppDefaultsUseNativeHarnessExecution' -count=1` — all subtests pass.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m0wa9c8jm9ykwphrn9fwn6h1)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002945_investigate-and-fix-this/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002945_investigate-and-fix-this/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002945_investigate-and-fix-this/tasks.md)

🚀 Built with [Helix](https://helix.ml)