### PR TITLE
Omit spec links from Just Do It pull requests

### DIFF
--- a/api/pkg/services/pr_footer.go
+++ b/api/pkg/services/pr_footer.go
@@ -55,7 +55,7 @@ func RenderPRFooter(value string, repo *types.GitRepository, task *types.SpecTas
 		data.HelixTaskURL = fmt.Sprintf("%s/orgs/%s/projects/%s/tasks/%s",
 			strings.TrimSuffix(helixBaseURL, "/"), orgName, task.ProjectID, task.ID)
 	}
-	if task.DesignDocPath != "" {
+	if task.DesignDocPath != "" && !task.JustDoItMode {
 		data.SpecDocsURL = getSpecDocsBaseURL(repo, task.DesignDocPath)
 	}
 

--- a/api/pkg/services/pr_footer_test.go
+++ b/api/pkg/services/pr_footer_test.go
@@ -32,6 +32,26 @@ func TestRenderDefaultPRFooter(t *testing.T) {
 🚀 Built with [Helix](https://helix.ml)`, footer)
 }
 
+func TestRenderDefaultPRFooterJustDoItOmitsSpecLinks(t *testing.T) {
+	repo := &types.GitRepository{
+		ExternalURL:  "https://github.com/acme/widgets.git",
+		ExternalType: types.ExternalRepositoryTypeGitHub,
+	}
+	task := &types.SpecTask{
+		ID:            "task_123",
+		ProjectID:     "project_123",
+		DesignDocPath: "123-widget",
+		JustDoItMode:  true,
+	}
+
+	footer, err := RenderPRFooter(DefaultPRFooterTemplate, repo, task, "acme", "https://app.helix.ml/")
+	require.NoError(t, err)
+	assert.Equal(t, `---
+🔗 [Open in Helix](https://app.helix.ml/orgs/acme/projects/project_123/tasks/task_123)
+
+🚀 Built with [Helix](https://helix.ml)`, footer)
+}
+
 func TestRenderCustomAndEmptyPRFooter(t *testing.T) {
 	task := &types.SpecTask{ID: "task_123", ProjectID: "project_123"}
 


### PR DESCRIPTION
## Summary
Prevent PR footers for Just Do It tasks from linking to requirements, design, and task documents that are not created when planning is skipped. The Helix task link and attribution remain unchanged.

## Testing
Added a regression test covering the default PR footer for a Just Do It task. The focused Go service tests pass.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m0wka536d1banwwkvsnxzrpv)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002947_httpsgithubcomhelixmlheli/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002947_httpsgithubcomhelixmlheli/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002947_httpsgithubcomhelixmlheli/tasks.md)

🚀 Built with [Helix](https://helix.ml)