### PR TITLE
Mask local MCP environment variables in project settings

### DIFF
--- a/frontend/src/components/app/AddLocalMcpSkillDialog.test.tsx
+++ b/frontend/src/components/app/AddLocalMcpSkillDialog.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TypesAssistantMCP } from '../../api/api'
+import { IAppFlatState } from '../../types'
+import AddLocalMcpSkillDialog from './AddLocalMcpSkillDialog'
+
+describe('AddLocalMcpSkillDialog', () => {
+  it('masks existing environment variable values until explicitly revealed', () => {
+    const skill: TypesAssistantMCP = {
+      name: 'Private MCP',
+      transport: 'stdio',
+      command: 'private-mcp',
+      env: { API_TOKEN: 'screen-share-secret' },
+    }
+
+    render(
+      <AddLocalMcpSkillDialog
+        open
+        onClose={vi.fn()}
+        skill={skill}
+        app={{ mcpTools: [skill] } as IAppFlatState}
+        onUpdate={vi.fn()}
+        isEnabled
+      />,
+    )
+
+    const valueInput = screen.getByPlaceholderText('Value')
+    expect(valueInput).toHaveAttribute('type', 'password')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show value for API_TOKEN' }))
+    expect(valueInput).toHaveAttribute('type', 'text')
+    expect(screen.getByRole('button', { name: 'Hide value for API_TOKEN' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/app/AddLocalMcpSkillDialog.tsx
+++ b/frontend/src/components/app/AddLocalMcpSkillDialog.tsx
@@ -12,9 +12,13 @@ import {
   ListItem,
   Grid,
   Alert,
+  InputAdornment,
+  Tooltip,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { IAppFlatState } from '../../types';
 import { styled } from '@mui/material/styles';
 import DarkDialog from '../dialog/DarkDialog';
@@ -78,6 +82,7 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
   const [description, setDescription] = useState('');
   const [commandLine, setCommandLine] = useState(''); // Single field for "command arg1 arg2..."
   const [env, setEnv] = useState<Record<string, string>>({});
+  const [visibleEnvValues, setVisibleEnvValues] = useState<Record<string, boolean>>({});
 
   const [existingSkillIndex, setExistingSkillIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -128,6 +133,7 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
   };
 
   useEffect(() => {
+    setVisibleEnvValues({});
     if (initialSkill) {
       setName(initialSkill.name || '');
       setDescription(initialSkill.description || '');
@@ -166,6 +172,14 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
     delete newEnv[oldKey];
     newEnv[newKey] = value;
     setEnv(newEnv);
+    setVisibleEnvValues((current) => {
+      const next = { ...current };
+      delete next[oldKey];
+      if (current[oldKey]) {
+        next[newKey] = true;
+      }
+      return next;
+    });
   };
 
   const addEnv = () => {
@@ -176,6 +190,11 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
     const newEnv = { ...env };
     delete newEnv[key];
     setEnv(newEnv);
+    setVisibleEnvValues((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
   };
 
   const handleSave = async () => {
@@ -264,6 +283,7 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
           setDescription('');
           setCommandLine('');
           setEnv({});
+          setVisibleEnvValues({});
           setExistingSkillIndex(null);
           setError(null);
           onClosed?.();
@@ -446,8 +466,29 @@ const AddLocalMcpSkillDialog: React.FC<AddLocalMcpSkillDialogProps> = ({
                           size="small"
                           placeholder="Value"
                           value={value}
+                          type={visibleEnvValues[key] ? 'text' : 'password'}
+                          autoComplete="new-password"
                           onChange={(e) => handleEnvChange(key, e.target.value)}
                           fullWidth
+                          InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">
+                                <Tooltip title={visibleEnvValues[key] ? 'Hide value' : 'Show value'}>
+                                  <IconButton
+                                    aria-label={`${visibleEnvValues[key] ? 'Hide' : 'Show'} value for ${key || 'environment variable'}`}
+                                    onClick={() => setVisibleEnvValues((current) => ({
+                                      ...current,
+                                      [key]: !current[key],
+                                    }))}
+                                    edge="end"
+                                    size="small"
+                                  >
+                                    {visibleEnvValues[key] ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                                  </IconButton>
+                                </Tooltip>
+                              </InputAdornment>
+                            ),
+                          }}
                         />
                       </Grid>
                       <Grid item xs={2}>


### PR DESCRIPTION
## Summary
Mask local MCP environment variable values by default in project settings so credentials and other sensitive configuration are not exposed during screen sharing or in screenshots. Add an accessible per-variable visibility control so users can explicitly reveal a value when needed.

## Testing
- Added a regression test confirming existing environment variable values render as password fields and can be explicitly revealed.
- Ran `yarn test AddLocalMcpSkillDialog.test.tsx` successfully.
- Ran `yarn tsc` successfully.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m0wjrsegmg63edjmz4r2ybk0)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002946_on-project-settings/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002946_on-project-settings/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002946_on-project-settings/tasks.md)

🚀 Built with [Helix](https://helix.ml)