### PR TITLE
fix(chat): show ellipsis for truncated plan steps

### DIFF
--- a/frontend/src/components/session/PlanProgress.test.tsx
+++ b/frontend/src/components/session/PlanProgress.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { ResponseEntry } from "./InteractionInference";
@@ -107,6 +107,19 @@ describe("plan progress normalization", () => {
     expect(screen.getByRole("button", { name: "Collapse plan" })).toBeInTheDocument();
     expect(screen.getByText("Inspect")).toBeInTheDocument();
     expect(screen.getByText("Verify")).toBeInTheDocument();
+  });
+
+  it("shows an ellipsis when expanded plan steps overflow", () => {
+    const longStep = "Implement a deliberately long plan step that cannot fit on one line";
+    render(<PlanProgress steps={[{ step: longStep, status: "inProgress" }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand plan" }));
+
+    expect(within(screen.getByRole("list")).getByText(longStep)).toHaveStyle({
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    });
   });
 
   it("compresses very long plans into a continuous fixed track", () => {

--- a/frontend/src/components/session/PlanProgress.tsx
+++ b/frontend/src/components/session/PlanProgress.tsx
@@ -226,6 +226,10 @@ const PlanChecklist: FC<{ steps: PlanStep[]; composer?: boolean }> = ({ steps, c
               component="span"
               sx={{
                 minWidth: 0,
+                flex: 1,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
                 color: step.status === "inProgress" ? colors.foreground : colors.subtle,
                 opacity: step.status === "completed" ? 0.55 : step.status === "pending" ? 0.7 : 0.9,
               }}


### PR DESCRIPTION
## Summary
- constrain expanded plan checklist labels to their available row width
- render a visible ellipsis when a long step is clipped
- cover the overflow styling with a regression test

## Verification
- `yarn test PlanProgress.test.tsx --run` (11 tests passed)
- `yarn tsc`
- `yarn build`
- live-tested in the Helix AgentChat with four long plan steps; each row overflowed and rendered `text-overflow: ellipsis`
