### PR TITLE
fix(api): stop polling terminal CI results

### DIFF
--- a/api/pkg/services/spec_task_orchestrator_ci.go
+++ b/api/pkg/services/spec_task_orchestrator_ci.go
@@ -37,6 +37,10 @@ func (o *SpecTaskOrchestrator) pollCIStatusForPR(
 	prevHead := repoPR.CIHeadSHA
 	mutated := false
 
+	if prevHead == headSHA && (prevState == CIStatusPassed || prevState == CIStatusFailed) {
+		return false
+	}
+
 	// New commit → reset prevState so we don't suppress a transition
 	// notification when the next commit's CI lands. Persist the SHA
 	// reset even if we fail to fetch the new verdict.

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -1016,6 +1016,39 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_Bac
 	assert.Equal(s.T(), types.TaskStatusPullRequest, task.Status)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_TerminalCISkipsUnchangedHeadAndPollsNewHead() {
+	ctx := context.Background()
+	task := makePullRequestTask(1)
+	task.RepoPullRequests[0].CIStatus = CIStatusNone
+	task.RepoPullRequests[0].CIHeadSHA = "sha-1"
+
+	s.gitService.EXPECT().
+		GetPullRequest(ctx, "repo-1", "1").
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1"}, nil)
+	s.gitService.EXPECT().
+		GetCIStatus(ctx, "repo-1", "1", "sha-1").
+		Return(&types.CIStatus{State: CIStatusPassed}, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, task).Return(nil)
+	s.Require().NoError(s.orchestrator.processExternalPullRequestStatus(ctx, task))
+
+	s.gitService.EXPECT().
+		GetPullRequest(ctx, "repo-1", "1").
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1"}, nil)
+	s.Require().NoError(s.orchestrator.processExternalPullRequestStatus(ctx, task))
+
+	s.gitService.EXPECT().
+		GetPullRequest(ctx, "repo-1", "1").
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-2"}, nil)
+	s.gitService.EXPECT().
+		GetCIStatus(ctx, "repo-1", "1", "sha-2").
+		Return(&types.CIStatus{State: CIStatusRunning}, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, task).Return(nil)
+
+	s.Require().NoError(s.orchestrator.processExternalPullRequestStatus(ctx, task))
+	s.Equal("sha-2", task.RepoPullRequests[0].CIHeadSHA)
+	s.Equal(CIStatusRunning, task.RepoPullRequests[0].CIStatus)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestCheckTaskForExternalPRActivity_NoPRDoesNotTreatBranchAsMerged() {
 	ctx := context.Background()
 	task := &types.SpecTask{


### PR DESCRIPTION
## Summary
- stop fetching CI status after a PR head reaches passed or failed
- resume CI polling immediately when the PR head SHA changes
- keep polling empty, running, and no-CI states

## Testing
- `CGO_ENABLED=1 go test ./pkg/services -run "TestSpecTaskOrchestratorTestSuite|TestCITransition" -count=1`
- `CGO_ENABLED=1 go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`

## Tradeoff
A CI rerun on the same head SHA is not detected after a cached passed or failed result. Detecting that without continued polling requires CI webhooks.