### PR TITLE
fix(spec-tasks): reduce GitHub PR polling

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21230,6 +21230,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/spec-tasks/{taskId}/refresh-pull-request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "spec-tasks"
+                ],
+                "summary": "Refresh a spec task's pull request status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/spec-tasks/{taskId}/specs": {
             "get": {
                 "description": "Get the generated specifications for human review",

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1632,6 +1632,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/spec-tasks/from-prompt", apiServer.createTaskFromPrompt).Methods(http.MethodPost, http.MethodOptions)
 	authRouter.HandleFunc("/spec-tasks", apiServer.listTasks).Methods(http.MethodGet)
 	authRouter.HandleFunc("/spec-tasks/{taskId}", apiServer.getTask).Methods(http.MethodGet)
+	authRouter.HandleFunc("/spec-tasks/{taskId}/refresh-pull-request", apiServer.refreshSpecTaskPullRequest).Methods(http.MethodPost)
 	authRouter.HandleFunc("/spec-tasks/{taskId}", apiServer.updateSpecTask).Methods(http.MethodPut)
 	authRouter.HandleFunc("/agent-tools", apiServer.listAgentToolCatalogue).Methods(http.MethodGet)
 	authRouter.HandleFunc("/spec-tasks/{taskId}/execution-config", apiServer.getSpecTaskExecutionConfig).Methods(http.MethodGet)

--- a/api/pkg/server/spec_task_pull_request_refresh_handler.go
+++ b/api/pkg/server/spec_task_pull_request_refresh_handler.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// refreshSpecTaskPullRequest godoc
+// @Summary Refresh a spec task's pull request status
+// @Description Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.
+// @Tags spec-tasks
+// @Produce json
+// @Param taskId path string true "Task ID"
+// @Success 204
+// @Failure 401 {object} types.APIError
+// @Failure 403 {object} types.APIError
+// @Failure 404 {object} types.APIError
+// @Failure 502 {object} types.APIError
+// @Failure 503 {object} types.APIError
+// @Router /api/v1/spec-tasks/{taskId}/refresh-pull-request [post]
+// @Security BearerAuth
+func (s *HelixAPIServer) refreshSpecTaskPullRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	taskID := mux.Vars(r)["taskId"]
+	task, err := s.Store.GetSpecTask(ctx, taskID)
+	if err != nil {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+
+	user := getRequestUser(r)
+	if user == nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if err := s.authorizeUserToProjectByID(ctx, user, task.ProjectID, types.ActionGet); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if s.specTaskOrchestrator == nil {
+		http.Error(w, "spec task orchestrator unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if err := s.specTaskOrchestrator.RefreshPullRequestStatus(ctx, taskID); err != nil {
+		log.Warn().Err(err).Str("task_id", taskID).Msg("Failed to refresh pull request status")
+		http.Error(w, "failed to refresh pull request status", http.StatusBadGateway)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api/pkg/server/spec_task_pull_request_refresh_handler_test.go
+++ b/api/pkg/server/spec_task_pull_request_refresh_handler_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/services"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRefreshSpecTaskPullRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	task := &types.SpecTask{
+		ID:        "task-1",
+		ProjectID: "project-1",
+		Status:    types.TaskStatusPullRequest,
+	}
+	user := types.User{ID: "user-1"}
+	project := &types.Project{ID: task.ProjectID, UserID: user.ID}
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), task.ID).Return(task, nil).Times(2)
+	mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil)
+
+	server := &HelixAPIServer{
+		Store:                mockStore,
+		specTaskOrchestrator: services.NewSpecTaskOrchestrator(mockStore, nil, nil, nil),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/spec-tasks/task-1/refresh-pull-request", http.NoBody)
+	req = mux.SetURLVars(req, map[string]string{"taskId": task.ID})
+	req = req.WithContext(setRequestUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+
+	server.refreshSpecTaskPullRequest(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+}

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21226,6 +21226,67 @@
                 }
             }
         },
+        "/api/v1/spec-tasks/{taskId}/refresh-pull-request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "spec-tasks"
+                ],
+                "summary": "Refresh a spec task's pull request status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/spec-tasks/{taskId}/specs": {
             "get": {
                 "description": "Get the generated specifications for human review",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -27515,6 +27515,46 @@ paths:
       summary: Get spec-driven task progress
       tags:
       - spec-driven-tasks
+  /api/v1/spec-tasks/{taskId}/refresh-pull-request:
+    post:
+      description: Immediately synchronize pull request and CI status for a task being
+        actively viewed. Requests are coalesced to one poll per task every 30 seconds.
+      parameters:
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Refresh a spec task's pull request status
+      tags:
+      - spec-tasks
   /api/v1/spec-tasks/{taskId}/specs:
     get:
       description: Get the generated specifications for human review

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -43,9 +43,20 @@ type SpecTaskOrchestrator struct {
 	wg                    sync.WaitGroup
 	backlogProjectLocks   sync.Map // map[project_id]*sync.Mutex
 	orchestrationInterval time.Duration
-	prPollInterval        time.Duration // Interval for polling external PR status (default 1 minute)
+	prPollInterval        time.Duration // Scheduler tick interval for external PR status (default 30 seconds)
+	prPollMu              sync.Mutex
+	prPollLast            map[string]time.Time
+	prPollInFlight        map[string]struct{}
 	testMode              bool
 }
+
+const (
+	recentPRPollingWindow   = 30 * time.Minute
+	stalePRPollingWindow    = 24 * time.Hour
+	recentPRPollingInterval = 30 * time.Second
+	stalePRPollingInterval  = 5 * time.Minute
+	oldPRPollingInterval    = time.Hour
+)
 
 // ContainerExecutor defines the interface for container lifecycle management
 type ContainerExecutor interface {
@@ -81,6 +92,8 @@ func NewSpecTaskOrchestrator(
 		containerExecutor:     containerExecutor,
 		stopChan:              make(chan struct{}),
 		orchestrationInterval: 10 * time.Second, // Check every 10 seconds
+		prPollLast:            make(map[string]time.Time),
+		prPollInFlight:        make(map[string]struct{}),
 		testMode:              false,
 	}
 }
@@ -121,7 +134,7 @@ func (o *SpecTaskOrchestrator) Start(ctx context.Context) error {
 	o.wg.Add(1)
 	go o.orchestrationLoop(ctx)
 
-	// Start PR polling loop (runs every 1 minute to check external PR status)
+	// Start the scheduler that checks which PR tasks are due for polling.
 	o.wg.Add(1)
 	go o.prPollLoop(ctx)
 
@@ -254,7 +267,7 @@ func (o *SpecTaskOrchestrator) processTasks(ctx context.Context) {
 		return
 	}
 
-	// Filter to only active tasks (PR polling handled by separate 1-minute loop)
+	// Filter to only active tasks (PR polling is handled by a separate scheduler)
 	activeStatuses := map[types.SpecTaskStatus]bool{
 		types.TaskStatusBacklog:              true,
 		types.TaskStatusQueuedSpecGeneration: true,
@@ -1026,7 +1039,7 @@ func (o *SpecTaskOrchestrator) projectHasExternalRepo(ctx context.Context, proje
 }
 
 // handlePullRequest polls external repo for PR merge status
-// Called from the dedicated PR polling loop (runs every 1 minute)
+// Called from the dedicated PR polling scheduler.
 func (o *SpecTaskOrchestrator) handlePullRequest(ctx context.Context, task *types.SpecTask) error {
 	// Try to create PRs for repos that didn't have the branch ready when the
 	// user first clicked "Open PR". This covers the case where the agent pushes
@@ -1250,14 +1263,15 @@ func (o *SpecTaskOrchestrator) processExternalPullRequestStatus(ctx context.Cont
 	return nil
 }
 
-// prPollLoop polls external repos for PR merge status every minute
+// prPollLoop runs the PR scheduler at the fastest polling cadence. Individual
+// tasks are skipped until their age-based interval has elapsed.
 func (o *SpecTaskOrchestrator) prPollLoop(ctx context.Context) {
 	defer o.wg.Done()
 
-	// Use configured interval or default to 1 minute
+	// Tests can override the scheduler tick independently of task intervals.
 	interval := o.prPollInterval
 	if interval == 0 {
-		interval = 30 * time.Second
+		interval = recentPRPollingInterval
 	}
 
 	ticker := time.NewTicker(interval)
@@ -1288,8 +1302,14 @@ func (o *SpecTaskOrchestrator) pollPullRequests(ctx context.Context) {
 		return
 	}
 
+	now := time.Now()
+	activeTaskIDs := make(map[string]struct{}, len(tasks))
 	for _, task := range tasks {
-		err := o.handlePullRequest(ctx, task)
+		activeTaskIDs[task.ID] = struct{}{}
+		polled, err := o.pollPullRequestTask(ctx, task, pullRequestPollingInterval(task, now), now)
+		if !polled {
+			continue
+		}
 		if err != nil {
 			// Tasks with deleted projects are expected - don't spam logs
 			if isDeletedProjectError(err) {
@@ -1303,6 +1323,94 @@ func (o *SpecTaskOrchestrator) pollPullRequests(ctx context.Context) {
 					Str("task_id", task.ID).
 					Msg("Failed to poll PR status")
 			}
+		}
+	}
+	o.forgetInactivePRPolls(activeTaskIDs)
+}
+
+// RefreshPullRequestStatus performs the same synchronization as the background
+// scheduler for a task actively viewed in the UI. Calls are coalesced with
+// background work and other viewers to at most one poll every 30 seconds.
+func (o *SpecTaskOrchestrator) RefreshPullRequestStatus(ctx context.Context, taskID string) error {
+	task, err := o.store.GetSpecTask(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("get spec task: %w", err)
+	}
+	if task.Status != types.TaskStatusPullRequest {
+		return nil
+	}
+	_, err = o.pollPullRequestTask(ctx, task, recentPRPollingInterval, time.Now())
+	return err
+}
+
+func pullRequestPollingInterval(task *types.SpecTask, now time.Time) time.Duration {
+	startedAt := task.CreatedAt
+	if task.StatusUpdatedAt != nil && !task.StatusUpdatedAt.IsZero() {
+		startedAt = *task.StatusUpdatedAt
+	}
+	if startedAt.IsZero() || startedAt.After(now) {
+		return recentPRPollingInterval
+	}
+
+	age := now.Sub(startedAt)
+	switch {
+	case age >= stalePRPollingWindow:
+		return oldPRPollingInterval
+	case age >= recentPRPollingWindow:
+		return stalePRPollingInterval
+	default:
+		return recentPRPollingInterval
+	}
+}
+
+func (o *SpecTaskOrchestrator) pollPullRequestTask(
+	ctx context.Context,
+	task *types.SpecTask,
+	interval time.Duration,
+	now time.Time,
+) (bool, error) {
+	if !o.beginPRPoll(task.ID, interval, now) {
+		return false, nil
+	}
+	defer o.finishPRPoll(task.ID)
+	return true, o.handlePullRequest(ctx, task)
+}
+
+func (o *SpecTaskOrchestrator) beginPRPoll(taskID string, interval time.Duration, now time.Time) bool {
+	o.prPollMu.Lock()
+	defer o.prPollMu.Unlock()
+	if o.prPollLast == nil {
+		o.prPollLast = make(map[string]time.Time)
+	}
+	if o.prPollInFlight == nil {
+		o.prPollInFlight = make(map[string]struct{})
+	}
+	if _, ok := o.prPollInFlight[taskID]; ok {
+		return false
+	}
+	if last, ok := o.prPollLast[taskID]; ok && now.Sub(last) < interval {
+		return false
+	}
+	o.prPollLast[taskID] = now
+	o.prPollInFlight[taskID] = struct{}{}
+	return true
+}
+
+func (o *SpecTaskOrchestrator) finishPRPoll(taskID string) {
+	o.prPollMu.Lock()
+	defer o.prPollMu.Unlock()
+	delete(o.prPollInFlight, taskID)
+}
+
+func (o *SpecTaskOrchestrator) forgetInactivePRPolls(activeTaskIDs map[string]struct{}) {
+	o.prPollMu.Lock()
+	defer o.prPollMu.Unlock()
+	for taskID := range o.prPollLast {
+		if _, active := activeTaskIDs[taskID]; active {
+			continue
+		}
+		if _, polling := o.prPollInFlight[taskID]; !polling {
+			delete(o.prPollLast, taskID)
 		}
 	}
 }
@@ -1436,8 +1544,10 @@ func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Contex
 					PRURL:          pr.URL,
 					PRState:        string(pr.State),
 				})
+				now := time.Now()
 				task.Status = types.TaskStatusPullRequest
-				task.UpdatedAt = time.Now()
+				task.StatusUpdatedAt = &now
+				task.UpdatedAt = now
 				if err := o.store.UpdateSpecTask(ctx, task); err != nil {
 					return err
 				}

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -937,6 +937,95 @@ func makePullRequestTask(prCount int) *types.SpecTask {
 	}
 }
 
+func TestPullRequestPollingInterval(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		age  time.Duration
+		want time.Duration
+	}{
+		{name: "new task", age: 29 * time.Minute, want: 30 * time.Second},
+		{name: "thirty minutes old", age: 30 * time.Minute, want: 5 * time.Minute},
+		{name: "same day", age: 23*time.Hour + 59*time.Minute, want: 5 * time.Minute},
+		{name: "one day old", age: 24 * time.Hour, want: time.Hour},
+		{name: "older task", age: 7 * 24 * time.Hour, want: time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startedAt := now.Add(-tt.age)
+			task := &types.SpecTask{StatusUpdatedAt: &startedAt}
+			assert.Equal(t, tt.want, pullRequestPollingInterval(task, now))
+		})
+	}
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestPollPullRequestsUsesAgeBasedIntervals() {
+	ctx := context.Background()
+	now := time.Now()
+	recentStarted := now.Add(-10 * time.Minute)
+	staleStarted := now.Add(-2 * time.Hour)
+	oldStarted := now.Add(-48 * time.Hour)
+	recent := makePullRequestTask(1)
+	recent.ID = "recent"
+	recent.StatusUpdatedAt = &recentStarted
+	stale := makePullRequestTask(1)
+	stale.ID = "stale"
+	stale.StatusUpdatedAt = &staleStarted
+	old := makePullRequestTask(1)
+	old.ID = "old"
+	old.StatusUpdatedAt = &oldStarted
+
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{
+		Status: types.TaskStatusPullRequest,
+	}).Return([]*types.SpecTask{recent, stale, old}, nil)
+	s.gitService.EXPECT().GetPullRequest(ctx, "repo-1", "1").Return(nil, fmt.Errorf("upstream unavailable"))
+	s.orchestrator.prPollLast = map[string]time.Time{
+		"recent": now.Add(-time.Minute),
+		"stale":  now.Add(-time.Minute),
+		"old":    now.Add(-time.Minute),
+	}
+
+	s.orchestrator.pollPullRequests(ctx)
+
+	assert.WithinDuration(s.T(), now, s.orchestrator.prPollLast["recent"], time.Second)
+	assert.WithinDuration(s.T(), now.Add(-time.Minute), s.orchestrator.prPollLast["stale"], time.Second)
+	assert.WithinDuration(s.T(), now.Add(-time.Minute), s.orchestrator.prPollLast["old"], time.Second)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestForegroundRefreshCoalescesWithBackgroundPoll() {
+	ctx := context.Background()
+	task := makePullRequestTask(1)
+	startedAt := time.Now().Add(-48 * time.Hour)
+	task.StatusUpdatedAt = &startedAt
+	s.Require().True(s.orchestrator.beginPRPoll(task.ID, time.Minute, time.Now().Add(-5*time.Minute)))
+	s.orchestrator.finishPRPoll(task.ID)
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil).Times(3)
+	pollStarted := make(chan struct{})
+	finishPoll := make(chan struct{})
+	s.gitService.EXPECT().GetPullRequest(ctx, "repo-1", "1").DoAndReturn(
+		func(context.Context, string, string) (*types.PullRequest, error) {
+			close(pollStarted)
+			<-finishPoll
+			return nil, fmt.Errorf("upstream unavailable")
+		},
+	)
+
+	results := make(chan error, 2)
+	go func() { results <- s.orchestrator.RefreshPullRequestStatus(ctx, task.ID) }()
+	select {
+	case <-pollStarted:
+	case <-time.After(time.Second):
+		s.FailNow("foreground poll did not start")
+	}
+	go func() { results <- s.orchestrator.RefreshPullRequestStatus(ctx, task.ID) }()
+	s.Require().NoError(<-results)
+	close(finishPoll)
+	s.Require().NoError(<-results)
+
+	// The completed poll also throttles another immediate foreground refresh.
+	s.Require().NoError(s.orchestrator.RefreshPullRequestStatus(ctx, task.ID))
+}
+
 // Regression test for the pod-restart-triggered "wrongly merged" bug.
 // Before the fix, if GetPullRequest returned an error for every tracked PR
 // in a single poll cycle, the `allMerged` flag stayed at its `true` default

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -997,9 +997,7 @@ func (s *SpecTaskOrchestratorTestSuite) TestForegroundRefreshCoalescesWithBackgr
 	task := makePullRequestTask(1)
 	startedAt := time.Now().Add(-48 * time.Hour)
 	task.StatusUpdatedAt = &startedAt
-	s.Require().True(s.orchestrator.beginPRPoll(task.ID, time.Minute, time.Now().Add(-5*time.Minute)))
-	s.orchestrator.finishPRPoll(task.ID)
-	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil).Times(3)
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil).Times(2)
 	pollStarted := make(chan struct{})
 	finishPoll := make(chan struct{})
 	s.gitService.EXPECT().GetPullRequest(ctx, "repo-1", "1").DoAndReturn(
@@ -1010,19 +1008,41 @@ func (s *SpecTaskOrchestratorTestSuite) TestForegroundRefreshCoalescesWithBackgr
 		},
 	)
 
-	results := make(chan error, 2)
-	go func() { results <- s.orchestrator.RefreshPullRequestStatus(ctx, task.ID) }()
+	backgroundResult := make(chan error, 1)
+	go func() {
+		_, err := s.orchestrator.pollPullRequestTask(
+			ctx,
+			task,
+			pullRequestPollingInterval(task, time.Now()),
+			time.Now(),
+		)
+		backgroundResult <- err
+	}()
 	select {
 	case <-pollStarted:
 	case <-time.After(time.Second):
-		s.FailNow("foreground poll did not start")
+		s.FailNow("background poll did not start")
 	}
-	go func() { results <- s.orchestrator.RefreshPullRequestStatus(ctx, task.ID) }()
-	s.Require().NoError(<-results)
+
+	// The viewer request is coalesced while the scheduler's poll is in flight.
+	s.Require().NoError(s.orchestrator.RefreshPullRequestStatus(ctx, task.ID))
 	close(finishPoll)
-	s.Require().NoError(<-results)
+	s.Require().NoError(<-backgroundResult)
 
 	// The completed poll also throttles another immediate foreground refresh.
+	s.Require().NoError(s.orchestrator.RefreshPullRequestStatus(ctx, task.ID))
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestForegroundRefreshOverridesAgeBasedInterval() {
+	ctx := context.Background()
+	task := makePullRequestTask(1)
+	startedAt := time.Now().Add(-48 * time.Hour)
+	task.StatusUpdatedAt = &startedAt
+	s.Require().True(s.orchestrator.beginPRPoll(task.ID, time.Minute, time.Now().Add(-5*time.Minute)))
+	s.orchestrator.finishPRPoll(task.ID)
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
+	s.gitService.EXPECT().GetPullRequest(ctx, "repo-1", "1").Return(nil, fmt.Errorf("upstream unavailable"))
+
 	s.Require().NoError(s.orchestrator.RefreshPullRequestStatus(ctx, task.ID))
 }
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -18645,6 +18645,23 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.
+     *
+     * @tags spec-tasks
+     * @name V1SpecTasksRefreshPullRequestCreate
+     * @summary Refresh a spec task's pull request status
+     * @request POST:/api/v1/spec-tasks/{taskId}/refresh-pull-request
+     * @secure
+     */
+    v1SpecTasksRefreshPullRequestCreate: (taskId: string, params: RequestParams = {}) =>
+      this.request<void, TypesAPIError>({
+        path: `/api/v1/spec-tasks/${taskId}/refresh-pull-request`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
      * @description Get the generated specifications for human review
      *
      * @tags spec-driven-tasks

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -78,6 +78,7 @@ import {
 import {
   useUpdateSpecTask,
   useSpecTask,
+  useForegroundSpecTaskPRRefresh,
   useCloneGroups,
   useZedThreads,
   useSpecTasks,
@@ -210,6 +211,8 @@ interface SpecTaskDetailContentProps {
   autoOpenReview?: boolean;
   /** Replace route close with reversible content-panel collapse. */
   allowContentCollapse?: boolean;
+  /** Poll GitHub while this task is visible. Disabled for read-only embeds. */
+  enableForegroundPRRefresh?: boolean;
   onClose?: () => void;
   /** Called when user clicks "Review Spec" - if provided, opens in workspace pane instead of navigating */
   onOpenReview?: (
@@ -233,6 +236,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   padContent = false,
   autoOpenReview = true,
   allowContentCollapse = false,
+  enableForegroundPRRefresh = true,
   onClose,
   onOpenReview,
   onTaskArchived,
@@ -281,6 +285,10 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     enabled: !!taskId,
     refetchInterval: 2300, // 2.3s - prime to avoid sync with other polling
   });
+  useForegroundSpecTaskPRRefresh(
+    taskId,
+    enableForegroundPRRefresh && task?.status === TypesSpecTaskStatus.TaskStatusPullRequest,
+  );
   const isHeadless = task?.sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu;
   const { data: currentExecutionConfig } = useGetSpecTaskExecutionConfig(
     taskId,

--- a/frontend/src/pages/EmbedTaskPage.tsx
+++ b/frontend/src/pages/EmbedTaskPage.tsx
@@ -31,7 +31,7 @@ const EmbedTaskPage: FC = () => {
     // DesktopStreamViewer.tsx toggleFullscreen), the iframe's window
     // is resized to the browser viewport and 100dvh expands with it.
     <Box sx={{ height: '100dvh', overflow: 'hidden', backgroundColor: bg }}>
-      <SpecTaskDetailContent taskId={taskId} />
+      <SpecTaskDetailContent taskId={taskId} enableForegroundPRRefresh={false} />
     </Box>
   )
 }

--- a/frontend/src/services/specTaskService.ts
+++ b/frontend/src/services/specTaskService.ts
@@ -41,6 +41,8 @@ const QUERY_KEYS = {
       { projectId, archivedOnly, withDependsOn, labels, limit, offset, sort, participantIds },
     ] as const,
   specTask: (id: string) => ["spec-tasks", id] as const,
+  foregroundPRRefresh: (id: string) =>
+    ["spec-task-pr-refresh", id] as const,
   executionConfig: (id: string) => ["spec-tasks", id, "execution-config"] as const,
   specTaskUsage: (id: string) => ["spec-tasks", id, "usage"] as const,
   taskProgress: (id: string) => ["spec-tasks", id, "progress"] as const,
@@ -252,6 +254,30 @@ export function useSpecTask(
     enabled: options?.enabled !== false && !!taskId,
     refetchInterval:
       options?.refetchInterval !== undefined ? options.refetchInterval : 10000,
+  });
+}
+
+// Keep external PR and CI state fresh while a task detail surface is mounted.
+// React Query pauses this interval for background browser tabs and shares one
+// request between duplicate views of the same task.
+export function useForegroundSpecTaskPRRefresh(taskId: string, enabled: boolean) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useQuery({
+    queryKey: QUERY_KEYS.foregroundPRRefresh(taskId),
+    queryFn: async () => {
+      await api.getApiClient().v1SpecTasksRefreshPullRequestCreate(taskId);
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.specTask(taskId),
+        exact: true,
+      });
+      return null;
+    },
+    enabled: enabled && !!taskId,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    retry: false,
   });
 }
 

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -27515,6 +27515,46 @@ paths:
       summary: Get spec-driven task progress
       tags:
       - spec-driven-tasks
+  /api/v1/spec-tasks/{taskId}/refresh-pull-request:
+    post:
+      description: Immediately synchronize pull request and CI status for a task being
+        actively viewed. Requests are coalesced to one poll per task every 30 seconds.
+      parameters:
+      - description: Task ID
+        in: path
+        name: taskId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/types.APIError'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/types.APIError'
+      security:
+      - BearerAuth: []
+      summary: Refresh a spec task's pull request status
+      tags:
+      - spec-tasks
   /api/v1/spec-tasks/{taskId}/specs:
     get:
       description: Get the generated specifications for human review

--- a/openapi.json
+++ b/openapi.json
@@ -25314,6 +25314,86 @@
                 }
             }
         },
+        "/api/v1/spec-tasks/{taskId}/refresh-pull-request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.",
+                "tags": [
+                    "spec-tasks"
+                ],
+                "summary": "Refresh a spec task's pull request status",
+                "parameters": [
+                    {
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.APIError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/spec-tasks/{taskId}/specs": {
             "get": {
                 "description": "Get the generated specifications for human review",

--- a/swagger.json
+++ b/swagger.json
@@ -21226,6 +21226,67 @@
                 }
             }
         },
+        "/api/v1/spec-tasks/{taskId}/refresh-pull-request": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Immediately synchronize pull request and CI status for a task being actively viewed. Requests are coalesced to one poll per task every 30 seconds.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "spec-tasks"
+                ],
+                "summary": "Refresh a spec task's pull request status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "taskId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/spec-tasks/{taskId}/specs": {
             "get": {
                 "description": "Get the generated specifications for human review",


### PR DESCRIPTION
## Summary

- poll PR tasks every 30 seconds for the first 30 minutes, every 5 minutes until 24 hours, and hourly thereafter
- keep actively viewed authenticated task details on a coalesced 30-second refresh cadence
- share foreground and background throttling and disable foreground refresh for read-only embeds
- expose the foreground refresh through the generated API client

## Testing

- `CGO_ENABLED=1 go test ./pkg/services -count=1`
- `CGO_ENABLED=1 go test ./pkg/server -run "^TestRefreshSpecTaskPullRequest$" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `yarn test src/services/specTaskService.test.ts --run`
- `yarn build`
- authenticated live POST to `http://localhost:8080/api/v1/spec-tasks/{taskId}/refresh-pull-request` returned 204
- independent sub-agent review: no blocking findings

NOT tested: browser interaction because the shared browser preview could not reach `localhost:8080`; the authenticated live API path was exercised directly.