### PR TITLE
fix(code-agents): route org provider models

### DIFF
--- a/api/cmd/settings-sync-daemon/opencode.go
+++ b/api/cmd/settings-sync-daemon/opencode.go
@@ -124,7 +124,7 @@ func (d *SettingsDaemon) buildOpenCodeConfig(baseURL string) openCodeConfig {
 	qualified := openCodeProviderID + "/" + modelID
 
 	model := openCodeModel{
-		Name:     modelID,
+		Name:     strings.TrimPrefix(modelID, d.codeAgentConfig.Provider+"/"),
 		ToolCall: true,
 	}
 	if len(d.codeAgentConfig.InputModalities) > 0 || len(d.codeAgentConfig.OutputModalities) > 0 {

--- a/api/cmd/settings-sync-daemon/opencode_test.go
+++ b/api/cmd/settings-sync-daemon/opencode_test.go
@@ -144,6 +144,20 @@ func TestOpenCodeConfigModelIsProviderQualified(t *testing.T) {
 	assert.Equal(t, float64(32000), limit["output"])
 }
 
+func TestOpenCodeConfigDisplaysModelWithoutProviderRoutingID(t *testing.T) {
+	d := openCodeDaemon()
+	d.codeAgentConfig.Provider = "pe_01m0zdqzjds298g7"
+	d.codeAgentConfig.Model = "pe_01m0zdqzjds298g7/cohere/north-mini-code:free"
+
+	decoded := decodeOpenCodeConfig(t, d.generateAgentServerConfig())
+	assert.Equal(t, "helix/pe_01m0zdqzjds298g7/cohere/north-mini-code:free", decoded["model"])
+
+	providers := decoded["provider"].(map[string]interface{})
+	models := providers["helix"].(map[string]interface{})["models"].(map[string]interface{})
+	model := models["pe_01m0zdqzjds298g7/cohere/north-mini-code:free"].(map[string]interface{})
+	assert.Equal(t, "cohere/north-mini-code:free", model["name"])
+}
+
 // Zero limits would tell opencode the context window is empty, so it would
 // compact after every turn. Unknown limits must be omitted instead.
 func TestOpenCodeConfigOmitsUnknownLimits(t *testing.T) {

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -436,6 +436,7 @@ func (s *HelixAPIServer) isKnownProvider(ctx context.Context, providerName, owne
 	// These are visible to all users but owned by the admin who created them
 	providers, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 		Owner:      ownerID,
+		OwnerType:  types.OwnerTypeUser,
 		WithGlobal: true,
 	})
 	if err == nil {
@@ -500,6 +501,7 @@ func (s *HelixAPIServer) findProviderWithModel(ctx context.Context, modelName, o
 	// Check database-stored provider endpoints for the user (user + global from DB)
 	providers, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 		Owner:      ownerID,
+		OwnerType:  types.OwnerTypeUser,
 		WithGlobal: true,
 	})
 	if err != nil {
@@ -511,6 +513,7 @@ func (s *HelixAPIServer) findProviderWithModel(ctx context.Context, modelName, o
 	if orgID != "" && orgID != ownerID {
 		orgProviders, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 			Owner:      orgID,
+			OwnerType:  types.OwnerTypeOrg,
 			WithGlobal: false, // Global already covered above
 		})
 		if err != nil {

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -141,14 +141,23 @@ func (s *FindProviderWithModelSuite) TestExplicitEnvironmentGlobalRefRemainsScop
 
 func (s *FindProviderWithModelSuite) TestExplicitOrganizationRefRemainsScopedWithSameVendorGlobal() {
 	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{types.ProviderOpenAI}, nil)
-	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner:      "user_x",
+		OwnerType:  types.OwnerTypeUser,
+		WithGlobal: true,
+	}).Return([]*types.ProviderEndpoint{
 		{ID: "pe_global_openai", Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
-		{ID: "pe_org_openai", Name: "user/openai", Owner: "org_test", EndpointType: types.ProviderEndpointTypeOrg},
-	}, nil).AnyTimes()
+	}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), &store.ListProviderEndpointsQuery{
+		Owner:     "org_test",
+		OwnerType: types.OwnerTypeOrg,
+	}).Return([]*types.ProviderEndpoint{
+		{ID: "pe_org_openrouter", Name: "openrouter", Owner: "org_test", OwnerType: types.OwnerTypeOrg, EndpointType: types.ProviderEndpointTypeOrg},
+	}, nil)
 
-	provider, bare := s.server.findProviderWithModel(context.Background(), "pe_org_openai/gpt-5.4", "user_x", "org_test")
-	s.Equal("pe_org_openai", provider)
-	s.Equal("gpt-5.4", bare)
+	provider, bare := s.server.findProviderWithModel(context.Background(), "pe_org_openrouter/cohere/north-mini-code:free", "user_x", "org_test")
+	s.Equal("pe_org_openrouter", provider)
+	s.Equal("cohere/north-mini-code:free", bare)
 }
 
 // Unknown model — no cache hit anywhere — returns the empty pair so the

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -336,6 +336,7 @@ func (s *HelixAPIServer) resolveModelProviderLive(ctx context.Context, modelName
 
 	dbProviders, err := s.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
 		Owner:      ownerID,
+		OwnerType:  types.OwnerTypeUser,
 		WithGlobal: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- route provider-prefixed code-agent models through organization-owned endpoints
- preserve OpenCode routing IDs while showing a readable model label
- cover the OpenRouter and Cohere model shape from the Meta failure

## Tests
- go test ./pkg/server ./cmd/settings-sync-daemon
- go build ./pkg/server ./pkg/store ./pkg/types
- git diff --check