### PR TITLE
Filter provider catalogue by code agent runtime

### DIFF
--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -74,6 +74,7 @@ func (s *HelixAPIServer) isProvidersManagementEnabled(ctx context.Context) bool 
 // @Success 200 {array} types.ProviderEndpoint
 // @Param with_models query bool false "Include models"
 // @Param org_id query string false "Organization ID"
+// @Param code_agent_runtime query string false "Filter by organization code-agent harness policy"
 // @Param all query bool false "Include all endpoints (system admin only)"
 // @Router /api/v1/provider-endpoints [get]
 // @Security BearerAuth
@@ -81,7 +82,20 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 	ctx := r.Context()
 	includeModels := r.URL.Query().Get("with_models") == "true"
 	orgID := r.URL.Query().Get("org_id")
+	runtimeParam := r.URL.Query().Get("code_agent_runtime")
 	all := r.URL.Query().Get("all") == "true"
+	var runtime types.CodeAgentRuntime
+	if runtimeParam != "" {
+		if orgID == "" {
+			http.Error(rw, "org_id is required with code_agent_runtime", http.StatusBadRequest)
+			return
+		}
+		runtime = types.CodeAgentRuntime(runtimeParam)
+		if !types.IsSelectableCodeAgentRuntime(runtime) {
+			http.Error(rw, fmt.Sprintf("unsupported code agent runtime %q", runtime), http.StatusBadRequest)
+			return
+		}
+	}
 
 	if orgID != "" {
 		org, err := s.lookupOrg(ctx, orgID)
@@ -104,6 +118,16 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 		if err != nil {
 			log.Err(err).Msg("error authorizing org member")
 			http.Error(rw, "Could not authorize org member: "+err.Error(), http.StatusForbidden)
+			return
+		}
+	}
+
+	var harness *types.OrgCodeAgentHarness
+	if runtimeParam != "" {
+		var err error
+		harness, err = s.loadOrgCodeAgentHarnessPolicy(ctx, orgID, runtime)
+		if err != nil {
+			writeErrResponse(rw, err, http.StatusInternalServerError)
 			return
 		}
 	}
@@ -173,6 +197,9 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 		}
 
 		providerEndpoints = append(providerEndpoints, s.globalProviderEndpoint(provider))
+	}
+	if harness != nil {
+		providerEndpoints = filterProviderEndpointsForHarness(providerEndpoints, harness, runtime)
 	}
 
 	// Set default

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -169,6 +169,42 @@ func (s *ProviderHandlersSuite) TestListProvidersKeepsDatabaseAndEnvironmentGlob
 	s.ElementsMatch([]string{"pe_global_anthropic", "global/anthropic"}, []string{endpoints[0].ID, endpoints[1].ID})
 }
 
+func (s *ProviderHandlersSuite) TestListProvidersFiltersByCodeAgentRuntime() {
+	s.store.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org_1"}).Return(&types.Organization{ID: "org_1"}, nil)
+	s.store.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{OrganizationID: "org_1", UserID: "user_id"}, nil)
+	s.store.EXPECT().GetOrgCodeAgentHarness(gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode).Return(&types.OrgCodeAgentHarness{
+		OrganizationID: "org_1", Runtime: types.CodeAgentRuntimeClaudeCode, Enabled: true, ProviderRefs: []string{"pe_anthropic"},
+	}, nil)
+	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{
+		{ID: "pe_anthropic", Name: "user/anthropic", EndpointType: types.ProviderEndpointTypeOrg},
+		{ID: "pe_openai", Name: "openai", EndpointType: types.ProviderEndpointTypeOrg},
+	}, nil)
+	s.manager.EXPECT().ListProviders(gomock.Any(), "").Return([]types.Provider{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider-endpoints?org_id=org_1&code_agent_runtime=claude_code", nil).WithContext(s.authCtx)
+	rr := httptest.NewRecorder()
+	s.server.listProviderEndpoints(rr, req)
+
+	var endpoints []*types.ProviderEndpoint
+	s.Require().Equal(http.StatusOK, rr.Code)
+	s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &endpoints))
+	s.Require().Len(endpoints, 1)
+	s.Equal("pe_anthropic", endpoints[0].ID)
+}
+
+func (s *ProviderHandlersSuite) TestListProvidersRejectsInvalidCodeAgentRuntimeQuery() {
+	tests := []string{
+		"/v1/provider-endpoints?code_agent_runtime=opencode",
+		"/v1/provider-endpoints?org_id=org_1&code_agent_runtime=not_a_runtime",
+	}
+	for _, target := range tests {
+		req := httptest.NewRequest(http.MethodGet, target, nil).WithContext(s.authCtx)
+		rr := httptest.NewRecorder()
+		s.server.listProviderEndpoints(rr, req)
+		s.Equal(http.StatusBadRequest, rr.Code, target)
+	}
+}
+
 func (s *ProviderHandlersSuite) TestListProviders_NoModelInfo() {
 	s.store.EXPECT().ListProviderEndpoints(gomock.Any(), gomock.Any()).Return([]*types.ProviderEndpoint{
 		{


### PR DESCRIPTION
## Summary
- add an optional code_agent_runtime filter to the provider-endpoints API
- reuse Helix harness policy and runtime/provider compatibility filtering
- require an organization scope when filtering

## Tests
- go test ./pkg/server -run focused provider catalogue tests -count=1
- gofmt and git diff checks

## Compatibility
The query parameter is optional, so existing provider-endpoints callers are unchanged.