### PR TITLE
Display task config in embedded harness picker

### DIFF
--- a/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.test.tsx
@@ -15,6 +15,7 @@ import { CodeAgentConfigChangeSource } from '../../utils/codeAgentExecutionConfi
 
 const harnessState = vi.hoisted(() => ({ harnesses: [] as any[] }))
 const providerState = vi.hoisted(() => ({ providers: [] as any[] }))
+const routerState = vi.hoisted(() => ({ name: 'org_chat' }))
 const navigate = vi.hoisted(() => vi.fn())
 
 vi.mock('../../services/orgService', () => ({
@@ -24,7 +25,7 @@ vi.mock('../../services/providersService', () => ({
   useListProviders: () => ({ data: providerState.providers, isLoading: false }),
 }))
 vi.mock('../../hooks/useRouter', () => ({
-  default: () => ({ params: { org_id: 'test-org' }, navigate }),
+  default: () => ({ name: routerState.name, params: { org_id: 'test-org' }, navigate }),
 }))
 vi.mock('../account/ClaudeSubscriptionConnect', () => ({
   useClaudeSubscriptions: () => ({ data: [] }),
@@ -69,6 +70,7 @@ function AutoSelectingPicker({
 describe('CodeAgentConfigPicker', () => {
   beforeEach(() => {
     navigate.mockClear()
+    routerState.name = 'org_chat'
     providerState.providers = [
       {
         id: 'provider-1',
@@ -421,6 +423,28 @@ describe('CodeAgentConfigPicker', () => {
     const trigger = screen.getByRole('button', { name: 'Change coding agent' })
     expect(trigger).toHaveTextContent('Configure harness')
     expect(trigger).not.toHaveTextContent('api-model')
+  })
+
+  it('shows a task-owned config read-only on embed routes without inventory', () => {
+    routerState.name = 'embed_task'
+    harnessState.harnesses = []
+    providerState.providers = []
+    renderPicker(
+      <CodeAgentConfigPicker
+        onChange={vi.fn()}
+        value={{
+          runtime: TypesCodeAgentRuntime.CodeAgentRuntimeOpenCode,
+          credential_type: TypesCodeAgentCredentialType.CodeAgentCredentialTypeAPIKey,
+          provider_ref: 'global/openai',
+          model: 'gpt-5.6-sol',
+        }}
+      />,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Change coding agent' })
+    expect(trigger).toHaveTextContent('gpt-5.6-sol')
+    expect(trigger).not.toHaveTextContent('Configure harness')
+    expect(trigger).toBeDisabled()
   })
 
   it('does not mutate an existing task whose provider is no longer allowed', async () => {

--- a/frontend/src/components/agent/CodeAgentConfigPicker.tsx
+++ b/frontend/src/components/agent/CodeAgentConfigPicker.tsx
@@ -56,6 +56,7 @@ import {
   isLegacyNativeModel,
   nativeProviderForRuntime,
 } from '../../utils/nativeModels'
+import { isEmbedRouteName } from '../../utils/organizations'
 
 type Runtime = TypesCodeAgentRuntime
 
@@ -219,6 +220,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
 }) => {
   const router = useRouter()
   const orgName = router.params.org_id
+  const isEmbedRoute = isEmbedRouteName(router.name)
   const { data: org, isLoading: loadingOrg } = useGetOrgByName(orgName, orgName !== undefined)
   const { data: providers = [], isLoading: loadingProviders } = useListProviders({
     loadModels: true,
@@ -275,7 +277,9 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
         && (configuredRuntimeStatus?.provider_refs == null
         || configuredRuntimeStatus.provider_refs.some((ref) =>
           resolveProviderEndpointRef(runtimeProviders, ref)?.id === selectedProvider.id))))
-  const selectedConfigurationAllowed = selectedRuntimeEnabled && selectedSourceAllowed
+  const selectedConfigurationAllowed = isEmbedRoute
+    ? !!value?.runtime && !!value?.model
+    : selectedRuntimeEnabled && selectedSourceAllowed
   const unconfigured = !value?.runtime
     || !value?.model
     || (policySettled && !selectedConfigurationAllowed)
@@ -450,7 +454,7 @@ const CodeAgentConfigPicker: FC<CodeAgentConfigPickerProps> = ({
         <Box component="span" sx={{ display: 'inline-flex', minWidth: 0 }}>
           <Button
             aria-label="Change coding agent"
-            disabled={disabled}
+            disabled={disabled || isEmbedRoute}
             onClick={(event) => {
               // Nothing to pick from: explain and offer the fix rather than
               // opening an empty popover.


### PR DESCRIPTION
## Summary
- display the task-owned harness/model configuration on embed routes without revalidating against intentionally hidden organization inventory
- make the embedded harness/model picker read-only
- preserve normal policy validation and editing in signed-in Helix views
- keep embed API permissions unchanged

## Tests
- yarn test src/components/agent/CodeAgentConfigPicker.test.tsx --run (22 passed)
- git diff --check

## Known unrelated blocker
Full yarn tsc is blocked on main by the existing WorkspaceReviewMessage.ts versus workspaceReviewMessage.ts filename-case collision.