### PR TITLE
Make Helix Org the Source of Truth for HelixOS Bots

### DIFF
--- a/frontend/src/pages/EmbedSessionPage.tsx
+++ b/frontend/src/pages/EmbedSessionPage.tsx
@@ -20,7 +20,11 @@ const EmbedSessionPage: FC = () => {
   const bg = theme.palette.background.default
 
   return (
-    <Box sx={{ height: '100dvh', overflow: 'hidden', backgroundColor: bg }}>
+    // display:flex is load-bearing, not cosmetic. ExternalAgentDesktopViewer's root
+    // sizes itself with `flex: 1` (it has no height of its own), so in a plain block
+    // wrapper that flex is inert and the viewer collapses to its content height —
+    // the desktop renders small and top-aligned with dead space beneath it.
+    <Box sx={{ height: '100dvh', overflow: 'hidden', backgroundColor: bg, display: 'flex', flexDirection: 'column' }}>
       <ExternalAgentDesktopViewer
         sessionId={sessionId}
         sandboxId={sessionId}


### PR DESCRIPTION
Hey Claude, so we are looking to merge the pull request that lives here. However, I've got a bit of feedback. First of all, there's a review on the PR, which we need to absorb. And then secondly, the feedback from Luke. It's as follows, but I'll expand on what I think that means. See, I think what you're saying is there's a merge conflict before we merge to main. We're going to need to do a proper basic test inside the old mode, i.e. spec task mode. What he's asking is, did we make sure that the iframe embed works? And I think what he means is the iframe embed of the agent session for spec task mode. But I think we should expand that also to org mode. As in really what we're asking is, can we see the desktop spawned by the session within Helix OS? And finally, I didn't think about this part. Are we able to apply changes to a repository back to git from inside the org mode session? So, yeah, I think to begin with, let's just absorb the feedback from Phil on the PR. And let's go back. Let's sort of discuss what we think the plan of action would be to implement those changes. Thank you.

> If you could rebase and do a basic test inside the spectask then merge it then I'll test an org-mode bot myself. Did you make sure the iframe embed still works? And will we still have a way to merge repo changes from inside the bot?

https://github.com/helixml/helixos/pull/101

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01m0yhfby764s176ennsxtv1tv)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002959_hey-claude-so-we-are/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002959_hey-claude-so-we-are/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002959_hey-claude-so-we-are/tasks.md)

🚀 Built with [Helix](https://helix.ml)