### PR TITLE
fix(hydra): harden headless container isolation

### DIFF
--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -25,6 +25,10 @@ ARG CUDA_BASE_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04@sha256:92906d87596d63
 # upstream `download_cli.sh` install path.
 ARG GOOSE_COMMIT=ca26f01d3acd9871691fa8981f05d19aed9a3b82
 
+# Rootless BuildKit binaries used by headless sessions. Pin the multi-platform
+# image index so amd64 and arm64 builds resolve reproducibly.
+FROM moby/buildkit:v0.27.1-rootless@sha256:5616ed4e78a3552f3575864c8ab585c882b892c4e93b6a7b6ac8afbc98bd2f7a AS rootless-buildkit
+
 # ====================================================================
 # Go build stage for Helix binaries
 # ====================================================================
@@ -780,6 +784,12 @@ RUN apt-get update \
     && { grep -q '^retro:' /etc/subuid || echo 'retro:100000:65536' >> /etc/subuid; } \
     && { grep -q '^retro:' /etc/subgid || echo 'retro:100000:65536' >> /etc/subgid; } \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rootless-buildkit \
+    /usr/bin/buildkitd \
+    /usr/bin/buildctl \
+    /usr/bin/rootlesskit \
+    /usr/local/bin/
 
 # NVIDIA Container Toolkit (enables GPU passthrough in inner containers)
 # This allows the desktop's dockerd to run containers with --runtime=nvidia

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -113,8 +113,13 @@ RUN apt-get update && apt-get install -y \
     libgbm-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.87.0
+# Install Rust. Download to a file so a network failure cannot be hidden by a
+# successful shell at the end of a pipeline and cached as a valid toolchain.
+RUN curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors -fsS \
+        https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --default-toolchain 1.87.0 && \
+    rm /tmp/rustup-init.sh && \
+    /root/.cargo/bin/rustc --version
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy all plugin sources (needed for both architectures)
@@ -132,17 +137,17 @@ set -e
 if [ "${TARGETARCH}" = "arm64" ]; then
     echo "=== Building ARM64 plugins ==="
     # Build vsockenc (delegates encoding to host VideoToolbox)
-    cd /build/gst-vsockenc && \
-        meson setup builddir --prefix=/usr --libdir=lib && \
-        meson compile -C builddir && \
-        meson install -C builddir --destdir=/install
+    cd /build/gst-vsockenc
+    meson setup builddir --prefix=/usr --libdir=lib
+    meson compile -C builddir
+    meson install -C builddir --destdir=/install
     find /install -name "libgstvsockenc.so" -exec cp {} /libgstvsockenc.so \;
     echo "vsockenc built"
 
     # Build pipewirezerocopysrc (DMA-BUF passthrough for virtio-gpu)
-    cd /build/gst-pipewire-zerocopy && \
-        nice -n 19 cargo build --locked --release && \
-        cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
+    cd /build/gst-pipewire-zerocopy
+    nice -n 19 cargo build --locked --release
+    cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
     echo "pipewirezerocopysrc built"
 else
     echo "=== Building amd64 plugins ==="
@@ -153,9 +158,9 @@ else
     fi
 
     # Build pipewirezerocopysrc with CUDA support
-    cd /build/gst-pipewire-zerocopy && \
-        nice -n 19 cargo build --locked --release && \
-        cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
+    cd /build/gst-pipewire-zerocopy
+    nice -n 19 cargo build --locked --release
+    cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
     echo "pipewirezerocopysrc built (amd64)"
 
     # No vsockenc on amd64 — create placeholder
@@ -672,6 +677,22 @@ if [ "$(id -u)" = "0" ]; then
         source "${init_script}"
     done
 fi
+if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
+    if [ -f /zed-build/zed ] && [ ! -e /usr/local/bin/zed ]; then
+        ln -sf /zed-build/zed /usr/local/bin/zed
+    fi
+    if [ -n "${WORKSPACE_DIR:-}" ] && [ -d "${WORKSPACE_DIR}" ] && [ -d /home/retro/work ]; then
+        chown "${UNAME}:${UNAME}" "${WORKSPACE_DIR}" /home/retro/work
+    fi
+    if [ -n "${@:-}" ]; then
+        exec setpriv --bounding-set=-sys_admin --nnp -- \
+            gosu "${UNAME}" /bin/bash -c "$@"
+    fi
+    gow_log "Launching the container's startup script as user '${UNAME}'"
+    chmod +x /opt/gow/startup.sh 2>/dev/null || true
+    exec setpriv --bounding-set=-sys_admin --nnp -- \
+        gosu "${UNAME}" ${STARTUP_SCRIPT:-/opt/gow/startup.sh}
+fi
 if [ -n "${@:-}" ]; then
     /bin/bash -c "$@"
     exit $?
@@ -712,7 +733,11 @@ ENV LANG=en_US.UTF-8 \
 # GOW dbus init script
 COPY <<_DBUS_INIT /etc/cont-init.d/99-startdbus.sh
 #!/bin/bash
-service dbus start 2>/dev/null || true
+if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
+    setpriv --bounding-set=-sys_admin --nnp -- service dbus start 2>/dev/null || true
+else
+    service dbus start 2>/dev/null || true
+fi
 _DBUS_INIT
 RUN chmod 755 /etc/cont-init.d/99-startdbus.sh
 
@@ -751,6 +776,9 @@ RUN apt-get update \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+        podman crun uidmap fuse-overlayfs passt slirp4netns \
+    && { grep -q '^retro:' /etc/subuid || echo 'retro:100000:65536' >> /etc/subuid; } \
+    && { grep -q '^retro:' /etc/subgid || echo 'retro:100000:65536' >> /etc/subgid; } \
     && rm -rf /var/lib/apt/lists/*
 
 # NVIDIA Container Toolkit (enables GPU passthrough in inner containers)
@@ -1048,8 +1076,10 @@ RUN cd /tmp/drone-ci-mcp && npm install && npm run build && npm pack && npm inst
 ENV CHROME_DEVTOOLS_MCP_HEADLESS=true \
     CHROME_DEVTOOLS_MCP_VIEWPORT=1920x1080
 
-# Start dockerd inside desktop container if /var/lib/docker is volume-mounted
+# Start the per-session container engine: rootful Docker for desktops and
+# rootless Podman for unprivileged headless agents.
 ADD desktop/shared/17-start-dockerd.sh /etc/cont-init.d/17-start-dockerd.sh
+ADD desktop/shared/headless-containers.conf /opt/helix/headless-containers.conf
 RUN chmod 755 /etc/cont-init.d/17-start-dockerd.sh
 
 # Workspace README

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -446,41 +446,38 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		}
 	}
 
-	// Docker-in-desktop mode: the desktop container runs its own dockerd with a
-	// volume-backed /var/lib/docker. No per-session sibling dockerd or network
-	// bridging needed. This is simpler and supports arbitrary DinD nesting.
-	//
-	// The init script 17-start-dockerd.sh inside the desktop container detects
-	// the volume mount and starts dockerd automatically.
+	isolation := externalAgentIsolation(containerType)
 	log.Info().
 		Str("session_id", agent.SessionID).
-		Msg("Docker-in-desktop mode: desktop will run its own dockerd")
+		Bool("privileged", isolation.privileged).
+		Bool("rootless_container_engine", isolation.rootlessContainerEngine).
+		Msg("Configuring per-session container engine")
 
 	// Build mounts - includes Docker volume for /var/lib/docker
 	mounts := h.buildMounts(agent, workspaceDir, containerType)
 
 	// Create dev container request
 	// NOTE: GPUVendor is empty - Hydra reads it from its own GPU_VENDOR env var
-	// Privileged mode is required for the inner dockerd (overlay2 needs it)
 	req := &hydra.CreateDevContainerRequest{
-		SessionID:      agent.SessionID,
-		Image:          image,
-		ContainerName:  containerName,
-		Hostname:       containerName,
-		Env:            env,
-		Mounts:         mounts,
-		WorkspaceFiles: agent.WorkspaceFiles,
-		DisplayWidth:   agent.DisplayWidth,
-		DisplayHeight:  agent.DisplayHeight,
-		DisplayFPS:     agent.DisplayRefreshRate,
-		ContainerType:  hydra.DevContainerType(containerType),
-		UserID:         agent.UserID,
-		Network:        "bridge",
-		Privileged:     true, // Required for inner dockerd (docker-in-desktop mode)
-		ProjectID:      agent.ProjectID,
-		GoldenBuild:    agent.GoldenBuild,
-		VCPUs:          agent.VCPUs,
-		MemoryMB:       agent.MemoryMB,
+		SessionID:               agent.SessionID,
+		Image:                   image,
+		ContainerName:           containerName,
+		Hostname:                containerName,
+		Env:                     env,
+		Mounts:                  mounts,
+		WorkspaceFiles:          agent.WorkspaceFiles,
+		DisplayWidth:            agent.DisplayWidth,
+		DisplayHeight:           agent.DisplayHeight,
+		DisplayFPS:              agent.DisplayRefreshRate,
+		ContainerType:           hydra.DevContainerType(containerType),
+		UserID:                  agent.UserID,
+		Network:                 "bridge",
+		Privileged:              isolation.privileged,
+		RootlessContainerEngine: isolation.rootlessContainerEngine,
+		ProjectID:               agent.ProjectID,
+		GoldenBuild:             agent.GoldenBuild,
+		VCPUs:                   agent.VCPUs,
+		MemoryMB:                agent.MemoryMB,
 	}
 
 	// Create dev container via Hydra
@@ -1562,6 +1559,18 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 	return env
 }
 
+type containerIsolation struct {
+	privileged              bool
+	rootlessContainerEngine bool
+}
+
+func externalAgentIsolation(containerType string) containerIsolation {
+	if containerType == "headless" {
+		return containerIsolation{rootlessContainerEngine: true}
+	}
+	return containerIsolation{privileged: true}
+}
+
 func setContainerEnv(env []string, key, value string) []string {
 	prefix := key + "="
 	for i, entry := range env {
@@ -1605,13 +1614,14 @@ func (h *HydraExecutor) buildMounts(agent *types.DesktopAgent, workspaceDir stri
 		},
 	}
 
-	// Docker-in-desktop: mount a named volume for the inner dockerd's data.
-	// The desktop's 17-start-dockerd.sh init script detects this mountpoint
-	// and starts dockerd automatically. No docker.sock mount needed.
+	containerDataDestination := "/var/lib/docker"
+	if containerType == "headless" {
+		containerDataDestination = "/home/retro/.local/share/containers"
+	}
 	mounts = append(mounts, hydra.MountConfig{
 		Source:      fmt.Sprintf("docker-data-%s", agent.SessionID),
-		Destination: "/var/lib/docker",
-		Type:        "volume", // Docker named volume, backed by host ext4
+		Destination: containerDataDestination,
+		Type:        "volume",
 	})
 
 	// Shared cache for admin-pinned agent binaries (currently opencode).

--- a/api/pkg/external-agent/sandbox_metering_test.go
+++ b/api/pkg/external-agent/sandbox_metering_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -123,6 +124,35 @@ func TestBuildEnvVarsForcesHeadlessStartup(t *testing.T) {
 		require.False(t, strings.HasPrefix(entry, "NVIDIA_"), entry)
 		require.False(t, strings.HasPrefix(entry, "ZED_ALLOW_EMULATED_GPU="), entry)
 	}
+}
+
+func TestExternalAgentIsolation(t *testing.T) {
+	require.Equal(t, containerIsolation{rootlessContainerEngine: true}, externalAgentIsolation("headless"))
+	for _, containerType := range []string{"ubuntu", "sway", "zorin", "xfce", "kde"} {
+		require.Equal(t, containerIsolation{privileged: true}, externalAgentIsolation(containerType), containerType)
+	}
+}
+
+func TestBuildMountsUsesContainerEngineStorageForRuntime(t *testing.T) {
+	executor := newTestExecutor(nil)
+	agent := &types.DesktopAgent{SessionID: "ses_1"}
+
+	headlessMounts := executor.buildMounts(agent, "/workspace/ses_1", "headless")
+	require.Equal(t, "docker-data-ses_1", mountSourceForDestination(headlessMounts, "/home/retro/.local/share/containers"))
+	require.Empty(t, mountSourceForDestination(headlessMounts, "/var/lib/docker"))
+
+	desktopMounts := executor.buildMounts(agent, "/workspace/ses_1", "ubuntu")
+	require.Equal(t, "docker-data-ses_1", mountSourceForDestination(desktopMounts, "/var/lib/docker"))
+	require.Empty(t, mountSourceForDestination(desktopMounts, "/home/retro/.local/share/containers"))
+}
+
+func mountSourceForDestination(mounts []hydra.MountConfig, destination string) string {
+	for _, item := range mounts {
+		if item.Destination == destination {
+			return item.Source
+		}
+	}
+	return ""
 }
 
 func countEnvKey(env []string, key string) int {

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -851,6 +851,7 @@ func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string
 		env = overrideEnvVar(env, "DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock")
 		env = overrideEnvVar(env, "CONTAINER_HOST", "unix:///run/user/1000/podman/podman.sock")
 		env = overrideEnvVar(env, "DOCKER_BUILDKIT", "0")
+		env = overrideEnvVar(env, "BUILDX_BUILDER", "helix-rootless")
 	}
 
 	// Add display settings if this is not a headless container

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -844,6 +844,14 @@ func materializeWorkspaceFiles(mounts []MountConfig, files map[string][]byte) er
 func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string {
 	env := make([]string, len(req.Env))
 	copy(env, req.Env)
+	if req.RootlessContainerEngine {
+		env = removeEnvVar(env, "BUILDKIT_HOST")
+		env = removeEnvVar(env, "HELIX_REGISTRY")
+		env = overrideEnvVar(env, "HELIX_ROOTLESS_CONTAINER_ENGINE", "1")
+		env = overrideEnvVar(env, "DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock")
+		env = overrideEnvVar(env, "CONTAINER_HOST", "unix:///run/user/1000/podman/podman.sock")
+		env = overrideEnvVar(env, "DOCKER_BUILDKIT", "0")
+	}
 
 	// Add display settings if this is not a headless container
 	if req.ContainerType != DevContainerTypeHeadless {
@@ -972,17 +980,19 @@ func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string
 	// Dev containers mount their per-session Docker socket, but helix-buildkit runs
 	// on the sandbox's main dockerd. Pass the BuildKit endpoint directly so the
 	// 17-start-dockerd.sh init script can create the helix-shared buildx builder.
-	if buildkitHost := GetBuildKitHost(); buildkitHost != "" {
-		env = append(env, fmt.Sprintf("BUILDKIT_HOST=%s", buildkitHost))
-		log.Debug().Str("buildkit_host", buildkitHost).Msg("Added BUILDKIT_HOST to dev container env")
-	}
+	if !req.RootlessContainerEngine {
+		if buildkitHost := GetBuildKitHost(); buildkitHost != "" {
+			env = append(env, fmt.Sprintf("BUILDKIT_HOST=%s", buildkitHost))
+			log.Debug().Str("buildkit_host", buildkitHost).Msg("Added BUILDKIT_HOST to dev container env")
+		}
 
-	// Add HELIX_REGISTRY for registry-based image loading (push/pull instead of tarball --load).
-	// When a build changes only one layer in a 7.73GB image, --load transfers the entire tarball
-	// (~9.5s). Registry push/pull transfers only changed layers (~0.6s) — a 16x improvement.
-	if registryHost := GetRegistryHost(); registryHost != "" {
-		env = append(env, fmt.Sprintf("HELIX_REGISTRY=%s", registryHost))
-		log.Debug().Str("registry_host", registryHost).Msg("Added HELIX_REGISTRY to dev container env")
+		// Add HELIX_REGISTRY for registry-based image loading (push/pull instead of tarball --load).
+		// When a build changes only one layer in a 7.73GB image, --load transfers the entire tarball
+		// (~9.5s). Registry push/pull transfers only changed layers (~0.6s) — a 16x improvement.
+		if registryHost := GetRegistryHost(); registryHost != "" {
+			env = append(env, fmt.Sprintf("HELIX_REGISTRY=%s", registryHost))
+			log.Debug().Str("registry_host", registryHost).Msg("Added HELIX_REGISTRY to dev container env")
+		}
 	}
 
 	// Override API URLs with sandbox's own HELIX_API_URL
@@ -1026,8 +1036,26 @@ func overrideEnvVar(env []string, key, value string) []string {
 	return append(env, prefix+value)
 }
 
+func removeEnvVar(env []string, key string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
 // buildHostConfig builds the host configuration for the container
 func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (*container.HostConfig, error) {
+	if req.RootlessContainerEngine && req.ContainerType != DevContainerTypeHeadless {
+		return nil, fmt.Errorf("rootless container engine requires a headless container")
+	}
+	if req.RootlessContainerEngine && req.Privileged {
+		return nil, fmt.Errorf("rootless container engine cannot run in privileged mode")
+	}
+
 	// Use the network from the request if specified, otherwise default to bridge.
 	// Previously we used host network mode which caused port conflicts when running
 	// multiple desktop containers (they all shared ports 9876/9877).
@@ -1045,19 +1073,40 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 	if req.ContainerType != DevContainerTypeHeadless {
 		resources.DeviceCgroupRules = dm.getDeviceCgroupRules()
 	}
+	if req.RootlessContainerEngine {
+		resources.Devices = append(resources.Devices,
+			container.DeviceMapping{PathOnHost: "/dev/fuse", PathInContainer: "/dev/fuse", CgroupPermissions: "rwm"},
+			container.DeviceMapping{PathOnHost: "/dev/net/tun", PathInContainer: "/dev/net/tun", CgroupPermissions: "rwm"},
+		)
+	}
 	// Apply CPU and memory limits when requested. NanoCPUs uses 10^9 units per CPU.
 	resources.NanoCPUs, resources.Memory, resources.MemorySwap = sandboxResourceLimits(req.VCPUs, req.MemoryMB)
 
 	hostConfig := &container.HostConfig{
 		NetworkMode: networkMode,
-		IpcMode:     "host",
 		Privileged:  req.Privileged,
 		Resources:   resources,
 	}
 	if req.Privileged {
+		hostConfig.IpcMode = "host"
 		hostConfig.SecurityOpt = []string{"seccomp=unconfined", "apparmor=unconfined"}
 	} else {
-		hostConfig.CapDrop = []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}
+		hostConfig.CapDrop = []string{"SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}
+		if req.RootlessContainerEngine {
+			// The trusted init process needs SYS_ADMIN in its bounding set so
+			// rootless Podman can create its subordinate user namespace. Before
+			// the agent starts, the image drops SYS_ADMIN from the agent's
+			// bounding set and enables no_new_privs.
+			hostConfig.CapAdd = []string{"SYS_ADMIN"}
+			hostConfig.SecurityOpt = []string{"seccomp=unconfined"}
+			// Rootless Podman needs to mount procfs entries that Docker masks or
+			// makes read-only by default. Empty, non-nil slices explicitly
+			// override those daemon defaults through the Docker API.
+			hostConfig.MaskedPaths = []string{}
+			hostConfig.ReadonlyPaths = []string{}
+		} else {
+			hostConfig.CapDrop = append([]string{"SYS_ADMIN"}, hostConfig.CapDrop...)
+		}
 	}
 
 	// Persistent dev containers (hosted web services) must survive a host
@@ -1323,13 +1372,15 @@ func (dm *DevContainerManager) buildMounts(req *CreateDevContainerRequest) ([]mo
 	// This allows docker build cache to be shared across all sessions
 	// BuildKit uses content-addressed storage, so concurrent access is safe
 	buildkitCacheDir := filepath.Join(dm.manager.dataDir, SharedBuildKitCacheDir)
-	if _, err := os.Stat(buildkitCacheDir); err == nil {
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeBind,
-			Source: buildkitCacheDir,
-			Target: "/buildkit-cache",
-		})
-		log.Debug().Str("source", buildkitCacheDir).Msg("Added shared BuildKit cache mount")
+	if !req.RootlessContainerEngine {
+		if _, err := os.Stat(buildkitCacheDir); err == nil {
+			mounts = append(mounts, mount.Mount{
+				Type:   mount.TypeBind,
+				Source: buildkitCacheDir,
+				Target: "/buildkit-cache",
+			})
+			log.Debug().Str("source", buildkitCacheDir).Msg("Added shared BuildKit cache mount")
+		}
 	}
 
 	return mounts, nil

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1052,8 +1052,12 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 		NetworkMode: networkMode,
 		IpcMode:     "host",
 		Privileged:  req.Privileged,
-		SecurityOpt: []string{"seccomp=unconfined", "apparmor=unconfined"},
 		Resources:   resources,
+	}
+	if req.Privileged {
+		hostConfig.SecurityOpt = []string{"seccomp=unconfined", "apparmor=unconfined"}
+	} else {
+		hostConfig.CapDrop = []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}
 	}
 
 	// Persistent dev containers (hosted web services) must survive a host
@@ -1063,12 +1067,6 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 	// bypassing the slow provision-fresh-sandbox + full-rebuild recovery path.
 	if req.Persistent {
 		hostConfig.RestartPolicy = container.RestartPolicy{Name: "unless-stopped"}
-	}
-
-	// Only add explicit capabilities when not in privileged mode
-	// (privileged mode already grants all capabilities)
-	if !req.Privileged {
-		hostConfig.CapAdd = []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}
 	}
 
 	// Resolve "api"/"outer-api" via the sandbox dns-proxy instead of pinning a

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	dockertypes "github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImageTag(t *testing.T) {
@@ -94,6 +95,34 @@ func TestBuildEnvHeadlessOmitsDisplayAndGPU(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestBuildHostConfigHeadlessUsesDockerSecurityDefaults(t *testing.T) {
+	dm := &DevContainerManager{manager: &Manager{dataDir: t.TempDir()}}
+
+	hostConfig, err := dm.buildHostConfig(&CreateDevContainerRequest{
+		ContainerType: DevContainerTypeHeadless,
+		Privileged:    false,
+	})
+	require.NoError(t, err)
+	require.False(t, hostConfig.Privileged)
+	require.Empty(t, hostConfig.CapAdd)
+	require.Equal(t, []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}, []string(hostConfig.CapDrop))
+	require.Empty(t, hostConfig.SecurityOpt)
+}
+
+func TestBuildHostConfigPrivilegedPreservesDesktopSecurityOptions(t *testing.T) {
+	dm := &DevContainerManager{manager: &Manager{dataDir: t.TempDir()}}
+
+	hostConfig, err := dm.buildHostConfig(&CreateDevContainerRequest{
+		ContainerType: DevContainerTypeUbuntu,
+		Privileged:    true,
+	})
+	require.NoError(t, err)
+	require.True(t, hostConfig.Privileged)
+	require.Empty(t, hostConfig.CapAdd)
+	require.Empty(t, hostConfig.CapDrop)
+	require.Equal(t, []string{"seccomp=unconfined", "apparmor=unconfined"}, hostConfig.SecurityOpt)
 }
 
 func TestResolveRegistryImage(t *testing.T) {

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -167,6 +167,7 @@ func TestBuildEnvRootlessContainerEngine(t *testing.T) {
 			"DOCKER_HOST=tcp://attacker:2375",
 			"CONTAINER_HOST=tcp://attacker:2375",
 			"DOCKER_BUILDKIT=1",
+			"BUILDX_BUILDER=attacker",
 			"BUILDKIT_HOST=tcp://attacker:1234",
 			"HELIX_REGISTRY=attacker:5000",
 		},
@@ -180,6 +181,8 @@ func TestBuildEnvRootlessContainerEngine(t *testing.T) {
 	require.Contains(t, env, "CONTAINER_HOST=unix:///run/user/1000/podman/podman.sock")
 	require.Equal(t, 1, countEnvVar(env, "DOCKER_BUILDKIT"))
 	require.Contains(t, env, "DOCKER_BUILDKIT=0")
+	require.Equal(t, 1, countEnvVar(env, "BUILDX_BUILDER"))
+	require.Contains(t, env, "BUILDX_BUILDER=helix-rootless")
 	require.Zero(t, countEnvVar(env, "BUILDKIT_HOST"))
 	require.Zero(t, countEnvVar(env, "HELIX_REGISTRY"))
 }

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -109,6 +109,96 @@ func TestBuildHostConfigHeadlessUsesDockerSecurityDefaults(t *testing.T) {
 	require.Empty(t, hostConfig.CapAdd)
 	require.Equal(t, []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}, []string(hostConfig.CapDrop))
 	require.Empty(t, hostConfig.SecurityOpt)
+	require.Empty(t, hostConfig.IpcMode)
+	require.Empty(t, hostConfig.Resources.Devices)
+}
+
+func TestBuildHostConfigRootlessContainerEngine(t *testing.T) {
+	dm := &DevContainerManager{manager: &Manager{dataDir: t.TempDir()}}
+
+	hostConfig, err := dm.buildHostConfig(&CreateDevContainerRequest{
+		ContainerType:           DevContainerTypeHeadless,
+		RootlessContainerEngine: true,
+	})
+	require.NoError(t, err)
+	require.False(t, hostConfig.Privileged)
+	require.Equal(t, []string{"SYS_ADMIN"}, []string(hostConfig.CapAdd))
+	require.Equal(t, []string{"SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}, []string(hostConfig.CapDrop))
+	require.Equal(t, []string{"seccomp=unconfined"}, hostConfig.SecurityOpt)
+	require.NotNil(t, hostConfig.MaskedPaths)
+	require.Empty(t, hostConfig.MaskedPaths)
+	require.NotNil(t, hostConfig.ReadonlyPaths)
+	require.Empty(t, hostConfig.ReadonlyPaths)
+	require.Empty(t, hostConfig.IpcMode)
+	require.Len(t, hostConfig.Resources.Devices, 2)
+	require.Equal(t, "/dev/fuse", hostConfig.Resources.Devices[0].PathOnHost)
+	require.Equal(t, "/dev/fuse", hostConfig.Resources.Devices[0].PathInContainer)
+	require.Equal(t, "rwm", hostConfig.Resources.Devices[0].CgroupPermissions)
+	require.Equal(t, "/dev/net/tun", hostConfig.Resources.Devices[1].PathOnHost)
+	require.Equal(t, "/dev/net/tun", hostConfig.Resources.Devices[1].PathInContainer)
+	require.Equal(t, "rwm", hostConfig.Resources.Devices[1].CgroupPermissions)
+}
+
+func TestBuildHostConfigRejectsInvalidRootlessContainerEngineModes(t *testing.T) {
+	dm := &DevContainerManager{manager: &Manager{dataDir: t.TempDir()}}
+
+	_, err := dm.buildHostConfig(&CreateDevContainerRequest{
+		ContainerType:           DevContainerTypeUbuntu,
+		RootlessContainerEngine: true,
+	})
+	require.EqualError(t, err, "rootless container engine requires a headless container")
+
+	_, err = dm.buildHostConfig(&CreateDevContainerRequest{
+		ContainerType:           DevContainerTypeHeadless,
+		Privileged:              true,
+		RootlessContainerEngine: true,
+	})
+	require.EqualError(t, err, "rootless container engine cannot run in privileged mode")
+}
+
+func TestBuildEnvRootlessContainerEngine(t *testing.T) {
+	t.Setenv("BUILDKIT_HOST", "tcp://buildkit:1234")
+	t.Setenv("HELIX_REGISTRY", "registry:5000")
+
+	env := (&DevContainerManager{}).buildEnv(&CreateDevContainerRequest{
+		ContainerType:           DevContainerTypeHeadless,
+		RootlessContainerEngine: true,
+		Env: []string{
+			"DOCKER_HOST=tcp://attacker:2375",
+			"CONTAINER_HOST=tcp://attacker:2375",
+			"DOCKER_BUILDKIT=1",
+			"BUILDKIT_HOST=tcp://attacker:1234",
+			"HELIX_REGISTRY=attacker:5000",
+		},
+	})
+
+	require.Equal(t, 1, countEnvVar(env, "HELIX_ROOTLESS_CONTAINER_ENGINE"))
+	require.Contains(t, env, "HELIX_ROOTLESS_CONTAINER_ENGINE=1")
+	require.Equal(t, 1, countEnvVar(env, "DOCKER_HOST"))
+	require.Contains(t, env, "DOCKER_HOST=unix:///run/user/1000/podman/podman.sock")
+	require.Equal(t, 1, countEnvVar(env, "CONTAINER_HOST"))
+	require.Contains(t, env, "CONTAINER_HOST=unix:///run/user/1000/podman/podman.sock")
+	require.Equal(t, 1, countEnvVar(env, "DOCKER_BUILDKIT"))
+	require.Contains(t, env, "DOCKER_BUILDKIT=0")
+	require.Zero(t, countEnvVar(env, "BUILDKIT_HOST"))
+	require.Zero(t, countEnvVar(env, "HELIX_REGISTRY"))
+}
+
+func TestBuildMountsRootlessContainerEngineSkipsSharedBuildKitCache(t *testing.T) {
+	dataDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dataDir, SharedBuildKitCacheDir), 0o755))
+	dm := &DevContainerManager{manager: &Manager{dataDir: dataDir}}
+
+	mounts, err := dm.buildMounts(&CreateDevContainerRequest{RootlessContainerEngine: true})
+	require.NoError(t, err)
+	for _, item := range mounts {
+		require.NotEqual(t, "/buildkit-cache", item.Target)
+	}
+
+	mounts, err = dm.buildMounts(&CreateDevContainerRequest{})
+	require.NoError(t, err)
+	require.Len(t, mounts, 1)
+	require.Equal(t, "/buildkit-cache", mounts[0].Target)
 }
 
 func TestBuildHostConfigPrivilegedPreservesDesktopSecurityOptions(t *testing.T) {
@@ -123,6 +213,17 @@ func TestBuildHostConfigPrivilegedPreservesDesktopSecurityOptions(t *testing.T) 
 	require.Empty(t, hostConfig.CapAdd)
 	require.Empty(t, hostConfig.CapDrop)
 	require.Equal(t, []string{"seccomp=unconfined", "apparmor=unconfined"}, hostConfig.SecurityOpt)
+	require.Equal(t, "host", string(hostConfig.IpcMode))
+}
+
+func countEnvVar(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, key+"=") {
+			count++
+		}
+	}
+	return count
 }
 
 func TestResolveRegistryImage(t *testing.T) {

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -107,6 +107,12 @@ type CreateDevContainerRequest struct {
 	// Privileged mode (required for docker-in-desktop: inner dockerd needs it)
 	Privileged bool `json:"privileged,omitempty"`
 
+	// RootlessContainerEngine enables the rootless Podman service used by
+	// unprivileged headless agents. Hydra supplies only the user-namespace
+	// devices and environment required by that service; desktop dockerd keeps
+	// using Privileged instead.
+	RootlessContainerEngine bool `json:"rootless_container_engine,omitempty"`
+
 	// ProjectID for golden Docker cache lookup (per-project overlayfs)
 	ProjectID string `json:"project_id,omitempty"`
 

--- a/desktop/shared/17-start-dockerd.sh
+++ b/desktop/shared/17-start-dockerd.sh
@@ -6,6 +6,11 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
     PODMAN_DATA=/home/retro/.local/share/containers
     PODMAN_RUNTIME=/run/user/1000
     PODMAN_SOCKET=${PODMAN_RUNTIME}/podman/podman.sock
+    BUILDKIT_RUNTIME=${PODMAN_RUNTIME}/buildkit
+    BUILDKIT_SOCKET=${BUILDKIT_RUNTIME}/buildkitd.sock
+    BUILDKIT_ROOTLESSKIT_STATE=${PODMAN_RUNTIME}/buildkit-rootlesskit
+    BUILDKIT_DATA=${PODMAN_DATA}/buildkit-state
+    BUILDKIT_TMP=${PODMAN_DATA}/buildkit-tmp
 
     if ! mountpoint -q "${PODMAN_DATA}" 2>/dev/null; then
         echo "[podman] ERROR: ${PODMAN_DATA} is not a volume mount"
@@ -22,7 +27,14 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
     # The agent also stores Zed state below ~/.local/share, so hand those
     # parent directories back to the unprivileged user before it starts.
     install -d -m 0755 -o retro -g retro /home/retro/.local /home/retro/.local/share
-    install -d -m 0700 -o retro -g retro "${PODMAN_DATA}" "${PODMAN_RUNTIME}" "${PODMAN_RUNTIME}/podman"
+    install -d -m 0700 -o retro -g retro \
+        "${PODMAN_DATA}" \
+        "${PODMAN_RUNTIME}" \
+        "${PODMAN_RUNTIME}/podman" \
+        "${BUILDKIT_RUNTIME}" \
+        "${BUILDKIT_ROOTLESSKIT_STATE}" \
+        "${BUILDKIT_DATA}" \
+        "${BUILDKIT_TMP}"
     install -d -m 0755 -o retro -g retro /home/retro/.config/containers
     cp /opt/helix/headless-containers.conf /home/retro/.config/containers/containers.conf
     chown retro:retro /home/retro/.config/containers/containers.conf
@@ -48,7 +60,7 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
     for i in $(seq 1 30); do
         if DOCKER_HOST="unix://${PODMAN_SOCKET}" docker info >/dev/null 2>&1; then
             echo "[podman] Rootless container engine is ready (attempt ${i})"
-            return 0
+            break
         fi
         if [ "${i}" -eq 30 ]; then
             echo "[podman] FATAL: rootless container engine not ready after 30s"
@@ -56,6 +68,72 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
         fi
         sleep 1
     done
+
+    rm -f \
+        "${BUILDKIT_SOCKET}" \
+        "${BUILDKIT_ROOTLESSKIT_STATE}/api.sock" \
+        "${BUILDKIT_ROOTLESSKIT_STATE}/child_pid" \
+        "${BUILDKIT_ROOTLESSKIT_STATE}/lock"
+    gosu retro env \
+        HOME=/home/retro \
+        USER=retro \
+        XDG_RUNTIME_DIR="${PODMAN_RUNTIME}" \
+        TMPDIR="${BUILDKIT_TMP}" \
+        BUILDKIT_SOCKET="${BUILDKIT_SOCKET}" \
+        BUILDKIT_ROOTLESSKIT_STATE="${BUILDKIT_ROOTLESSKIT_STATE}" \
+        BUILDKIT_DATA="${BUILDKIT_DATA}" \
+        bash -c '
+        while true; do
+            echo "[$(date -Iseconds)] Starting rootless BuildKit daemon..."
+            env -u BUILDKIT_HOST rootlesskit \
+                --state-dir="${BUILDKIT_ROOTLESSKIT_STATE}" \
+                buildkitd \
+                --root="${BUILDKIT_DATA}" \
+                --addr="unix://${BUILDKIT_SOCKET}" \
+                --oci-worker-no-process-sandbox
+            EXIT_CODE=$?
+            echo "[$(date -Iseconds)] BuildKit exited with code ${EXIT_CODE}, restarting in 2s..."
+            rm -f \
+                "${BUILDKIT_SOCKET}" \
+                "${BUILDKIT_ROOTLESSKIT_STATE}/api.sock" \
+                "${BUILDKIT_ROOTLESSKIT_STATE}/child_pid" \
+                "${BUILDKIT_ROOTLESSKIT_STATE}/lock"
+            sleep 2
+        done
+    ' 2>&1 | gosu retro sed -u 's/^/[ROOTLESS-BUILDKIT] /' &
+
+    echo "[buildkit] Waiting for rootless BuildKit API..."
+    for i in $(seq 1 30); do
+        if gosu retro buildctl --addr "unix://${BUILDKIT_SOCKET}" debug workers >/dev/null 2>&1; then
+            echo "[buildkit] Rootless BuildKit is ready (attempt ${i})"
+            break
+        fi
+        if [ "${i}" -eq 30 ]; then
+            echo "[buildkit] FATAL: rootless BuildKit not ready after 30s"
+            exit 1
+        fi
+        sleep 1
+    done
+
+    if ! gosu retro env -u BUILDX_BUILDER \
+        HOME=/home/retro \
+        DOCKER_HOST="unix://${PODMAN_SOCKET}" \
+        docker buildx inspect helix-rootless >/dev/null 2>&1; then
+        gosu retro env -u BUILDX_BUILDER \
+            HOME=/home/retro \
+            DOCKER_HOST="unix://${PODMAN_SOCKET}" \
+            docker buildx create \
+                --name helix-rootless \
+                --driver remote \
+                "unix://${BUILDKIT_SOCKET}"
+    fi
+    gosu retro env -u BUILDX_BUILDER \
+        HOME=/home/retro \
+        DOCKER_HOST="unix://${PODMAN_SOCKET}" \
+        docker buildx use helix-rootless --default
+    echo "[buildkit] Configured helix-rootless as the default Buildx builder"
+
+    return 0
 fi
 
 if ! mountpoint -q /var/lib/docker 2>/dev/null; then

--- a/desktop/shared/17-start-dockerd.sh
+++ b/desktop/shared/17-start-dockerd.sh
@@ -1,6 +1,62 @@
 #!/bin/bash
-# Start dockerd inside the desktop container.
-# Each desktop container runs its own dockerd with a volume-backed /var/lib/docker.
+# Start the per-session container engine. Desktop sessions use rootful Docker;
+# unprivileged headless sessions use a rootless Podman compatibility socket.
+
+if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
+    PODMAN_DATA=/home/retro/.local/share/containers
+    PODMAN_RUNTIME=/run/user/1000
+    PODMAN_SOCKET=${PODMAN_RUNTIME}/podman/podman.sock
+
+    if ! mountpoint -q "${PODMAN_DATA}" 2>/dev/null; then
+        echo "[podman] ERROR: ${PODMAN_DATA} is not a volume mount"
+        exit 1
+    fi
+    for device in /dev/fuse /dev/net/tun; do
+        if [ ! -c "${device}" ]; then
+            echo "[podman] ERROR: required device ${device} is unavailable"
+            exit 1
+        fi
+    done
+
+    # Docker creates missing parents for the nested storage mount as root.
+    # The agent also stores Zed state below ~/.local/share, so hand those
+    # parent directories back to the unprivileged user before it starts.
+    install -d -m 0755 -o retro -g retro /home/retro/.local /home/retro/.local/share
+    install -d -m 0700 -o retro -g retro "${PODMAN_DATA}" "${PODMAN_RUNTIME}" "${PODMAN_RUNTIME}/podman"
+    install -d -m 0755 -o retro -g retro /home/retro/.config/containers
+    cp /opt/helix/headless-containers.conf /home/retro/.config/containers/containers.conf
+    chown retro:retro /home/retro/.config/containers/containers.conf
+
+    rm -f "${PODMAN_SOCKET}"
+    gosu retro env \
+        HOME=/home/retro \
+        XDG_RUNTIME_DIR="${PODMAN_RUNTIME}" \
+        CONTAINERS_CONF=/home/retro/.config/containers/containers.conf \
+        PODMAN_SOCKET="${PODMAN_SOCKET}" \
+        bash -c '
+        while true; do
+            echo "[$(date -Iseconds)] Starting rootless Podman API service..."
+            env -u CONTAINER_HOST -u DOCKER_HOST \
+                podman system service --time=0 "unix://${PODMAN_SOCKET}"
+            EXIT_CODE=$?
+            echo "[$(date -Iseconds)] Podman API service exited with code ${EXIT_CODE}, restarting in 2s..."
+            sleep 2
+        done
+    ' 2>&1 | gosu retro sed -u 's/^/[ROOTLESS-PODMAN] /' &
+
+    echo "[podman] Waiting for Docker-compatible API..."
+    for i in $(seq 1 30); do
+        if DOCKER_HOST="unix://${PODMAN_SOCKET}" docker info >/dev/null 2>&1; then
+            echo "[podman] Rootless container engine is ready (attempt ${i})"
+            return 0
+        fi
+        if [ "${i}" -eq 30 ]; then
+            echo "[podman] FATAL: rootless container engine not ready after 30s"
+            exit 1
+        fi
+        sleep 1
+    done
+fi
 
 if ! mountpoint -q /var/lib/docker 2>/dev/null; then
     echo "[dockerd] ERROR: /var/lib/docker is not a volume mount."

--- a/desktop/shared/headless-containers.conf
+++ b/desktop/shared/headless-containers.conf
@@ -1,0 +1,10 @@
+[containers]
+cgroups = "disabled"
+
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+runtime = "crun"
+
+[network]
+default_rootless_network_cmd = "pasta"

--- a/desktop/ubuntu-config/startup-app.sh
+++ b/desktop/ubuntu-config/startup-app.sh
@@ -19,6 +19,10 @@ fi
 
 # Create symlink to Zed binary if not exists
 if [ -f /zed-build/zed ] && [ ! -f /usr/local/bin/zed ]; then
+    if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
+        gow_log "[start] FATAL: rootless bootstrap did not install /usr/local/bin/zed"
+        exit 1
+    fi
     sudo ln -sf /zed-build/zed /usr/local/bin/zed
     gow_log "[start] Created symlink: /usr/local/bin/zed -> /zed-build/zed"
 fi
@@ -36,8 +40,10 @@ if [ ! -d /home/retro/work ]; then
     gow_log "[start] FATAL: /home/retro/work bind mount not present"
     exit 1
 fi
-sudo chown retro:retro "$WORKSPACE_DIR"
-sudo chown retro:retro /home/retro/work
+if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" != "1" ]; then
+    sudo chown retro:retro "$WORKSPACE_DIR"
+    sudo chown retro:retro /home/retro/work
+fi
 gow_log "[start] Workspace mounted at both $WORKSPACE_DIR and /home/retro/work"
 
 # Create Zed config symlinks


### PR DESCRIPTION
## Summary

- run headless agent Docker workflows through a per-session rootless container engine and rootless BuildKit daemon
- keep the agent process unprivileged with no effective capabilities and `no_new_privs`
- limit headless device access to FUSE/TUN, use private IPC, and remove shared BuildKit/registry access
- preserve the existing privileged, rootful Docker path for graphical desktops

## Testing

- `go test ./pkg/hydra -run 'TestBuild(Env|HostConfig|Mounts)' -count=1`
- `go test ./pkg/external-agent -run 'Test(ExternalAgentIsolation|BuildMountsUsesContainerEngineStorageForRuntime|BuildEnvVarsForcesHeadlessStartup)' -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `bash -n desktop/shared/17-start-dockerd.sh`
- `./stack build-ubuntu`; rebuilt and loaded the sandbox image after two transient upstream DNS failures
- production-equivalent headless container: rootless Podman and BuildKit startup, `docker buildx build --load`, classic build/run, Compose build/published port/curl/down
- fresh live headless spec task: Buildx remote driver v0.27.1, Buildx load/run, classic build/run, Compose build/published port/curl/down, follow-up chat, restart/follow-up
- live headless enforcement: `CapEff=0`, `NoNewPrivs=1`, no `SYS_ADMIN` in the agent bounding set; direct sudo, mount, mknod, and privileged child-container attempts denied
- fresh live Ubuntu desktop spec task: unchanged rootful Docker run/build/Compose, follow-up chat, restart/follow-up, and a native 1920x1080 desktop capture showing GNOME, Zed, and the completed agent transcript

The full package run still has the two existing host-dependent ZFS probe failures in `TestPoolFreeBytes_EmptyPoolName` and `TestPoolFreeBytes_ZFSUnavailable`; all changed-path tests pass.