### PR TITLE
fix(org): restore per-Trigger GitHub and GitLab webhook routes

### DIFF
--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -99,14 +99,14 @@ type helixOrgHandlers struct {
 	// Fans out to every github topic whose (repo, events) matches
 	// the delivery — multi-topic behaviour.
 	publicGitHubWebhook http.Handler
-	// publicGitHubWebhookForStream is the per-topic variant. Path:
-	// /api/v1/orgs/{org}/topics/{topic_id}/github/webhook —
-	// deliveries to this URL are pinned to exactly one topic so
+	// publicGitHubWebhookForTrigger is the per-Trigger variant. Path:
+	// /api/v1/orgs/{org}/triggers/{trigger_id}/github/webhook —
+	// deliveries to this URL are pinned to exactly one Trigger so
 	// operators get a 1:1 mapping between GitHub webhooks and helix
 	// Triggers. The Trigger's own (repo, events) config still applies
 	// so cross-repo or non-whitelisted-event deliveries drop with
 	// 204 (no GitHub retries).
-	publicGitHubWebhookForStream  http.Handler
+	publicGitHubWebhookForTrigger http.Handler
 	publicGitLabWebhookForTrigger http.Handler
 	// publicSlackEvents is the global inbound Slack Events API handler
 	// mounted on the INSECURE router at /api/v1/slack/events. Slack
@@ -463,20 +463,9 @@ func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRou
 			Handle("/orgs/{org}/github/webhook", orgHandlers.publicGitHubWebhook).
 			Methods(http.MethodPost)
 	}
-	// Per-stream variant — operators paste this URL into a GitHub repo's
-	// webhook config when they want a 1:1 mapping between a GitHub webhook
-	// and a helix stream. Insecure mount: GitHub deliveries authenticate
-	// via HMAC over the body, not a helix session.
-	if orgHandlers.publicGitHubWebhookForStream != nil {
-		insecureRouter.
-			Handle("/orgs/{org}/topics/{topic_id}/github/webhook", orgHandlers.publicGitHubWebhookForStream).
-			Methods(http.MethodPost)
-	}
-	if orgHandlers.publicGitLabWebhookForTrigger != nil {
-		insecureRouter.
-			Handle("/orgs/{org}/topics/{topic_id}/gitlab/webhook", orgHandlers.publicGitLabWebhookForTrigger).
-			Methods(http.MethodPost)
-	}
+	registerPublicTriggerWebhookRoutes(insecureRouter,
+		orgHandlers.publicGitHubWebhookForTrigger,
+		orgHandlers.publicGitLabWebhookForTrigger)
 	// GitHub App Manifest flow callbacks — top-level browser navigations
 	// from github.com (GET), so they must be on the insecure router (no
 	// session cookie / API key). The conversion callback authenticates
@@ -1390,7 +1379,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	// the org-level handler (HMAC over body); routes deliveries to
 	// the single Trigger named in the path so operators can hand
 	// GitHub a Trigger-specific URL.
-	publicGitHubWebhookForStream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	publicGitHubWebhookForTrigger := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		orgSlugOrID := vars["org"]
 		triggerID := vars["trigger_id"]
@@ -1480,7 +1469,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 		streamCron:                    streamCronScheduler,
 		githubDeliveryRun:             githubDeliveryReconciler.Run,
 		publicGitHubWebhook:           publicGitHubWebhook,
-		publicGitHubWebhookForStream:  publicGitHubWebhookForStream,
+		publicGitHubWebhookForTrigger: publicGitHubWebhookForTrigger,
 		publicGitLabWebhookForTrigger: publicGitLabWebhookForTrigger,
 		publicGitHubManifestCallback:  publicGitHubManifestCallback,
 		publicSlackEvents:             publicSlackEvents,
@@ -1810,4 +1799,44 @@ func openOrgStore(helixStore helixstore.Store) (*helixorgstore.Store, error) {
 		return nil, fmt.Errorf("open helix-org gorm: %w", err)
 	}
 	return st, nil
+}
+
+// publicTriggerWebhookPathPrefixes are the per-Trigger public webhook
+// path shapes, newest first.
+//
+// `triggers` is what the provisioner writes into a repo's webhook config
+// today. `topics` is the pre-#3087 shape: those URLs live in third-party
+// GitHub and GitLab configs we cannot rewrite, so the old prefix stays
+// mounted on the same handlers until every install has been migrated.
+//
+// Both declare the path variable as {trigger_id} because that is the name
+// the handlers read. gorilla/mux only populates variables named in the
+// pattern, so a pattern declaring {topic_id} silently hands the handler an
+// empty id — the #3087 regression that 400'd every delivery.
+var publicTriggerWebhookPathPrefixes = []string{
+	"/orgs/{org}/triggers/{trigger_id}",
+	"/orgs/{org}/topics/{trigger_id}",
+}
+
+// registerPublicTriggerWebhookRoutes mounts the per-Trigger GitHub and
+// GitLab webhook handlers on every supported path shape.
+//
+// INSECURE mount, deliberately: these carry an HMAC over the body
+// (X-Hub-Signature-256 / X-Gitlab-Token), verified inside the transport,
+// and no helix session cookie or API key. They must be registered BEFORE
+// authRouter's PathPrefix("/orgs/{org}/") or requireUser rejects every
+// delivery with 401 before the transport can check the signature.
+func registerPublicTriggerWebhookRoutes(insecureRouter *mux.Router, github, gitlab http.Handler) {
+	for _, prefix := range publicTriggerWebhookPathPrefixes {
+		if github != nil {
+			insecureRouter.
+				Handle(prefix+"/github/webhook", github).
+				Methods(http.MethodPost)
+		}
+		if gitlab != nil {
+			insecureRouter.
+				Handle(prefix+"/gitlab/webhook", gitlab).
+				Methods(http.MethodPost)
+		}
+	}
 }

--- a/api/pkg/server/helix_org_webhook_routes_test.go
+++ b/api/pkg/server/helix_org_webhook_routes_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHandler records the mux vars the router hands the handler, so a
+// test can assert the id actually reached it rather than only that the
+// path matched.
+type captureHandler struct {
+	called    bool
+	triggerID string
+	org       string
+}
+
+func (c *captureHandler) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	c.called = true
+	c.org = vars["org"]
+	c.triggerID = vars["trigger_id"]
+}
+
+// TestPublicTriggerWebhookRoutes pins the wiring that #3087 broke: the
+// route patterns must declare the same variable name the handlers read,
+// on every path shape a live webhook may still be pointing at.
+//
+// The pre-fix failure modes this locks out:
+//   - /topics/… matched but yielded an empty trigger_id -> 400
+//   - /triggers/… was not mounted at all -> fell through to authRouter -> 401
+func TestPublicTriggerWebhookRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"github current", "/api/v1/orgs/acme/triggers/s-github-pr/github/webhook"},
+		{"github legacy", "/api/v1/orgs/acme/topics/s-github-pr/github/webhook"},
+		{"gitlab current", "/api/v1/orgs/acme/triggers/s-github-pr/gitlab/webhook"},
+		{"gitlab legacy", "/api/v1/orgs/acme/topics/s-github-pr/gitlab/webhook"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			github, gitlab := &captureHandler{}, &captureHandler{}
+			router := mux.NewRouter()
+			insecure := router.PathPrefix(APIPrefix).Subrouter()
+			registerPublicTriggerWebhookRoutes(insecure, github, gitlab)
+			// Stand in for authRouter's catch-all. Anything the
+			// webhook routes fail to claim lands here, which is a
+			// 401 in production.
+			router.PathPrefix("/orgs/{org}/").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, tc.path, nil))
+
+			got := github
+			if gitlab.called {
+				got = gitlab
+			}
+			require.True(t, got.called, "no webhook handler ran; got status %d", rec.Code)
+			require.Equal(t, "acme", got.org)
+			require.Equal(t, "s-github-pr", got.triggerID,
+				"handler reads vars[\"trigger_id\"]; the route pattern must declare that name")
+		})
+	}
+}
+
+// TestPublicTriggerWebhookRoutesSkipNilHandlers covers the deployments
+// where a transport is unwired: no route is mounted, so the request falls
+// through rather than panicking on a nil handler.
+func TestPublicTriggerWebhookRoutesSkipNilHandlers(t *testing.T) {
+	router := mux.NewRouter()
+	registerPublicTriggerWebhookRoutes(router.PathPrefix(APIPrefix).Subrouter(), nil, nil)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost,
+		"/api/v1/orgs/acme/triggers/s-github-pr/github/webhook", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}


### PR DESCRIPTION
## Problem

Every per-Trigger GitHub and GitLab webhook delivery has been failing since 23 Aug.

The Topics→Triggers cutover (#3087) changed the handler bodies to read `vars["trigger_id"]` and changed the provisioner to install payload URLs under `/triggers/`, but left the two route patterns declaring `{topic_id}`:

```go
// pattern declares {topic_id}...
Handle("/orgs/{org}/topics/{topic_id}/github/webhook", …)

// ...but the handler reads a name the pattern never declares
triggerID := vars["trigger_id"]
if triggerID == "" {
    http.Error(w, "missing trigger_id", http.StatusBadRequest)
```

gorilla/mux only populates variables named in the pattern, so `trigger_id` is unconditionally empty. Two failure modes, depending on when a webhook was installed:

| Installed | URL in GitHub/GitLab | Result |
|---|---|---|
| Before 23 Aug | `/topics/{id}/…` | route matches, empty id → **400 missing trigger_id** |
| Since 23 Aug | `/triggers/{id}/…` | no insecure route → falls to `authRouter.PathPrefix("/orgs/{org}/")` → `requireUser` → **401** |

The 401 is worth calling out: it is not a signing-secret problem. The delivery is rejected by generic auth middleware before reaching the transport that checks the HMAC.

Reproduced against production:

```
POST /api/v1/orgs/helix/topics/s-github-pr/github/webhook    → 400 missing trigger_id
POST /api/v1/orgs/helix/topics/s-github-pr/gitlab/webhook    → 400 missing org or trigger_id
POST /api/v1/orgs/helix/triggers/s-github-pr/github/webhook  → 401 Unauthorized
```

## Fix

Mount both handlers on both path shapes, with the variable named to match what the handlers read:

```go
var publicTriggerWebhookPathPrefixes = []string{
	"/orgs/{org}/triggers/{trigger_id}",   // what the provisioner installs today
	"/orgs/{org}/topics/{trigger_id}",     // pre-#3087 URLs, still in third-party configs
}
```

The legacy `/topics/` prefix stays mounted deliberately: those URLs live in GitHub and GitLab webhook configs we cannot rewrite, so dropping it would leave every pre-cutover install broken until someone re-installed it by hand. Same handler, same behaviour — compatibility, not a second code path.

Also finishes the rename the cutover started (`publicGitHubWebhookForStream` → `…ForTrigger`) and updates doc comments that still described the topics path.

## Tests

There was no coverage on these registrations at all, which is how a mechanical rename shipped broken and stayed broken for five days. The registration is extracted into `registerPublicTriggerWebhookRoutes` so it is reachable from a test without standing up the whole server.

`TestPublicTriggerWebhookRoutes` asserts on the mux vars the handler *receives* across all four shapes — matching-but-empty is precisely the failure that shipped, so asserting only on status would not have caught it.

Verified the test fails against the pre-fix wiring, reproducing both production symptoms:

```
--- FAIL: TestPublicTriggerWebhookRoutes/github_current
        no webhook handler ran; got status 404        ← the /triggers/ case (401 in prod)
--- FAIL: TestPublicTriggerWebhookRoutes/github_legacy
        handler reads vars["trigger_id"]; the route pattern must declare that name
--- FAIL: .../gitlab_current, .../gitlab_legacy
```

Full `pkg/server` suite passes; build, gofmt and vet clean.

## Not covered

Routing only. HMAC verification and `HandleInboundForTrigger` dispatch sit downstream and were unreachable behind the 400/401, so they remain unverified — a second bug could be hiding there. The real proof is a live delivery: after deploy, hit **Redeliver** on a failed delivery in the GitHub webhook UI and confirm a 2xx.

Given this is broken org-wide, it probably wants a prompt release rather than waiting for the next batch.

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>
