### PR TITLE
fix(cli): allow chatting with app-less sessions

### DIFF
--- a/api/pkg/cli/chat/cmd.go
+++ b/api/pkg/cli/chat/cmd.go
@@ -31,8 +31,8 @@ Examples:
   # Chat with a specific agent
   helix chat --agent=a1b2c3 "hi"
   
-  # Continue an existing session
-  helix chat --agent=a1b2c3 --session=ses_123 "what did we discuss?"
+  # Continue an existing session (the session retains its agent configuration)
+  helix chat --session=ses_123 "what did we discuss?"
   
   # Use a specific model
   helix chat --agent=a1b2c3 --model=claude-3-5-sonnet "explain this code"
@@ -43,8 +43,8 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		message := args[0]
 
-		if agentID == "" {
-			return fmt.Errorf("agent ID is required (use --agent flag)")
+		if agentID == "" && sessionID == "" {
+			return fmt.Errorf("agent ID or session ID is required (use --agent or --session)")
 		}
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(timeout)*time.Second)
@@ -126,7 +126,7 @@ Examples:
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent ID to chat with (required)")
+	rootCmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent ID to start a new chat with")
 	rootCmd.Flags().StringVar(&model, "model", "", "Model to use (optional, uses agent default)")
 	rootCmd.Flags().StringVar(&sessionID, "session", "", "Session ID to continue existing conversation")
 	rootCmd.Flags().StringVar(&agentType, "agent-type", "", "Agent type override (e.g., 'zed_external')")
@@ -134,7 +134,6 @@ func init() {
 	rootCmd.Flags().BoolVar(&stream, "stream", false, "Enable streaming response")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 
-	rootCmd.MarkFlagRequired("agent")
 }
 
 func New() *cobra.Command {

--- a/api/pkg/cli/chat/cmd_test.go
+++ b/api/pkg/cli/chat/cmd_test.go
@@ -1,0 +1,69 @@
+package chat
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatContinuesSessionWithoutApp(t *testing.T) {
+	type capturedRequest struct {
+		authorization string
+		path          string
+		request       types.SessionChatRequest
+	}
+	requests := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request types.SessionChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requests <- capturedRequest{
+			authorization: r.Header.Get("Authorization"),
+			path:          r.URL.Path,
+			request:       request,
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("HELIX_URL", server.URL)
+	t.Setenv("HELIX_API_KEY", "test-key")
+
+	agentID = ""
+	sessionID = ""
+	model = ""
+	agentType = ""
+	stream = false
+	verbose = false
+	timeout = 120
+	t.Cleanup(func() {
+		agentID = ""
+		sessionID = ""
+		model = ""
+		agentType = ""
+		stream = false
+		verbose = false
+		timeout = 120
+		rootCmd.SetArgs(nil)
+	})
+
+	rootCmd.SetArgs([]string{"--session", "ses_task", "validate the task"})
+	require.NoError(t, rootCmd.Execute())
+
+	captured := <-requests
+	require.Equal(t, "/api/v1/sessions/chat", captured.path)
+	require.Equal(t, "Bearer test-key", captured.authorization)
+	require.Empty(t, captured.request.AppID)
+	require.Equal(t, "ses_task", captured.request.SessionID)
+	message, ok := captured.request.Message()
+	require.True(t, ok)
+	require.Equal(t, "validate the task", message)
+}


### PR DESCRIPTION
## Summary

- allow `helix chat --session=ses_…` without requiring an app
- preserve `--agent` for starting new chats
- let continued task sessions retain their existing agent configuration

## Testing

- `go test ./pkg/cli/... -count=1`
- `go build .`
- live app-less headless task: `helix chat --session=ses_…` reached the existing OpenCode agent, inspected the isolated Buildx builder, and ran an Alpine container successfully