### PR TITLE
fix(hydra): isolate desktop IPC namespaces

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1048,6 +1048,8 @@ func removeEnvVar(env []string, key string) []string {
 	return filtered
 }
 
+const desktopShmSizeBytes = 1 << 30
+
 // buildHostConfig builds the host configuration for the container
 func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (*container.HostConfig, error) {
 	if req.RootlessContainerEngine && req.ContainerType != DevContainerTypeHeadless {
@@ -1088,8 +1090,11 @@ func (dm *DevContainerManager) buildHostConfig(req *CreateDevContainerRequest) (
 		Privileged:  req.Privileged,
 		Resources:   resources,
 	}
+	if req.ContainerType != DevContainerTypeHeadless {
+		hostConfig.IpcMode = "private"
+		hostConfig.ShmSize = desktopShmSizeBytes
+	}
 	if req.Privileged {
-		hostConfig.IpcMode = "host"
 		hostConfig.SecurityOpt = []string{"seccomp=unconfined", "apparmor=unconfined"}
 	} else {
 		hostConfig.CapDrop = []string{"SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -110,6 +110,7 @@ func TestBuildHostConfigHeadlessUsesDockerSecurityDefaults(t *testing.T) {
 	require.Equal(t, []string{"SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"}, []string(hostConfig.CapDrop))
 	require.Empty(t, hostConfig.SecurityOpt)
 	require.Empty(t, hostConfig.IpcMode)
+	require.Zero(t, hostConfig.ShmSize)
 	require.Empty(t, hostConfig.Resources.Devices)
 }
 
@@ -130,6 +131,7 @@ func TestBuildHostConfigRootlessContainerEngine(t *testing.T) {
 	require.NotNil(t, hostConfig.ReadonlyPaths)
 	require.Empty(t, hostConfig.ReadonlyPaths)
 	require.Empty(t, hostConfig.IpcMode)
+	require.Zero(t, hostConfig.ShmSize)
 	require.Len(t, hostConfig.Resources.Devices, 2)
 	require.Equal(t, "/dev/fuse", hostConfig.Resources.Devices[0].PathOnHost)
 	require.Equal(t, "/dev/fuse", hostConfig.Resources.Devices[0].PathInContainer)
@@ -204,7 +206,7 @@ func TestBuildMountsRootlessContainerEngineSkipsSharedBuildKitCache(t *testing.T
 	require.Equal(t, "/buildkit-cache", mounts[0].Target)
 }
 
-func TestBuildHostConfigPrivilegedPreservesDesktopSecurityOptions(t *testing.T) {
+func TestBuildHostConfigDesktopUsesPrivateIPC(t *testing.T) {
 	dm := &DevContainerManager{manager: &Manager{dataDir: t.TempDir()}}
 
 	hostConfig, err := dm.buildHostConfig(&CreateDevContainerRequest{
@@ -216,7 +218,8 @@ func TestBuildHostConfigPrivilegedPreservesDesktopSecurityOptions(t *testing.T) 
 	require.Empty(t, hostConfig.CapAdd)
 	require.Empty(t, hostConfig.CapDrop)
 	require.Equal(t, []string{"seccomp=unconfined", "apparmor=unconfined"}, hostConfig.SecurityOpt)
-	require.Equal(t, "host", string(hostConfig.IpcMode))
+	require.Equal(t, "private", string(hostConfig.IpcMode))
+	require.EqualValues(t, desktopShmSizeBytes, hostConfig.ShmSize)
 }
 
 func countEnvVar(env []string, key string) int {


### PR DESCRIPTION
## Summary

- give graphical dev containers their own IPC namespace
- retain a 1 GiB `/dev/shm` allocation for browser, desktop, and GPU workloads
- keep headless container behavior unchanged

## Validation

- `./stack build-sandbox`
- `go test ./pkg/hydra -skip '^TestDiskPressureSuite$' -count=1`\n- `go test ./pkg/external-agent/... ./pkg/sandbox/... -count=1`\n- restarted the live Docker Compose sandbox and exercised existing headless and graphical tasks\n- created fresh headless and graphical tasks; verified task creation, initial chat, follow-up chat, Buildx load/run, and Compose HTTP up/curl/down\n- verified GNOME Shell, Xwayland, PipeWire, GPU visibility, screenshots, 1 GiB shared memory, and host/container IPC isolation