### PR TITLE
fix(desktop): bind bridge services to loopback

### DIFF
--- a/api/cmd/desktop-bridge/main.go
+++ b/api/cmd/desktop-bridge/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -86,16 +87,17 @@ func main() {
 	// Start RevDial client if enabled and configured
 	// This allows the API to reach this desktop container through NAT/firewalls
 	if revdialEnabled && apiURL != "" && runnerID != "" && runnerToken != "" {
+		localAddr := net.JoinHostPort("127.0.0.1", cfg.HTTPPort)
 		logger.Info("starting RevDial client",
 			"api_url", apiURL,
 			"runner_id", runnerID,
-			"local_addr", fmt.Sprintf("localhost:%s", cfg.HTTPPort))
+			"local_addr", localAddr)
 
 		revdialClient := revdial.NewClient(&revdial.ClientConfig{
 			ServerURL:          apiURL,
 			RunnerID:           runnerID,
 			RunnerToken:        runnerToken,
-			LocalAddr:          fmt.Sprintf("localhost:%s", cfg.HTTPPort),
+			LocalAddr:          localAddr,
 			InsecureSkipVerify: true, // TODO: make configurable for enterprise CAs
 		})
 

--- a/api/cmd/revdial-client/main.go
+++ b/api/cmd/revdial-client/main.go
@@ -16,7 +16,7 @@ var (
 	serverURL          = flag.String("server", "", "RevDial server URL (e.g., http://api:8080/api/v1/revdial)")
 	runnerID           = flag.String("runner-id", "", "Unique runner/sandbox ID")
 	runnerToken        = flag.String("token", "", "Runner authentication token")
-	localAddr          = flag.String("local", "localhost:9876", "Local address to proxy (e.g., localhost:9876 for TCP or unix:///path/to/socket for Unix socket)")
+	localAddr          = flag.String("local", "127.0.0.1:9876", "Local address to proxy (e.g., 127.0.0.1:9876 for TCP or unix:///path/to/socket for Unix socket)")
 	insecureSkipVerify = flag.Bool("insecure", false, "Skip TLS certificate verification (env: HELIX_INSECURE_TLS)")
 )
 

--- a/api/pkg/desktop/desktop.go
+++ b/api/pkg/desktop/desktop.go
@@ -437,7 +437,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// 9. Start HTTP server
 
 	httpServer := &http.Server{
-		Addr:    ":" + s.config.HTTPPort,
+		Addr:    desktopHTTPAddress(s.config.HTTPPort),
 		Handler: s.httpHandler(),
 	}
 
@@ -492,7 +492,7 @@ func (s *Server) runWorkspaceServer(ctx context.Context) error {
 	defer s.running.Store(false)
 
 	httpServer := &http.Server{
-		Addr:    ":" + s.config.HTTPPort,
+		Addr:    desktopHTTPAddress(s.config.HTTPPort),
 		Handler: s.workspaceHTTPHandler(),
 	}
 	errCh := make(chan error, 1)
@@ -515,6 +515,10 @@ func (s *Server) runWorkspaceServer(ctx context.Context) error {
 		return fmt.Errorf("shutdown workspace server: %w", err)
 	}
 	return ctx.Err()
+}
+
+func desktopHTTPAddress(port string) string {
+	return net.JoinHostPort("127.0.0.1", port)
 }
 
 // httpHandler returns the HTTP handler with all routes.
@@ -554,7 +558,8 @@ func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/file", s.handleFile)
 	// /exec is not desktop-specific either: git identity sync on spec approval
 	// and the Claude/Codex subscription login flows all target headless
-	// containers. Its own allowlist (see exec.go) is the security boundary.
+	// containers. The server is loopback-only and reached through authenticated
+	// RevDial API routes; the command allowlist is an additional boundary.
 	mux.HandleFunc("/exec", s.handleExec)
 	mux.HandleFunc("/workspaces", s.handleWorkspaces)
 	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)

--- a/api/pkg/desktop/exec.go
+++ b/api/pkg/desktop/exec.go
@@ -28,8 +28,8 @@ type ExecResponse struct {
 	PID      int    `json:"pid,omitempty"` // Only set for background commands
 }
 
-// handleExec executes a command in the container
-// This is used for benchmarking (e.g., starting vkcube) and debugging
+// handleExec executes a restricted command in the container. The HTTP server
+// is loopback-only; authenticated API handlers reach it through RevDial.
 //
 // POST /exec
 // Request body: {"command": ["vkcube"], "background": true}
@@ -60,7 +60,6 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 		"ls":                       true,
 		"echo":                     true,
 		"weston-simple-egl":        true,
-		"claude":                   true,
 		"cat":                      true,
 		"test":                     true,
 		"npm":                      true, // Codex login wrapper installs the Codex CLI
@@ -72,6 +71,11 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 	if !allowedCommands[cmdName] {
 		s.logger.Warn("exec: blocked disallowed command", "command", cmdName)
 		http.Error(w, fmt.Sprintf("command not allowed: %s", cmdName), http.StatusForbidden)
+		return
+	}
+	if cmdName == "cat" && !catInvocationAllowed(req.Command) {
+		s.logger.Warn("exec: blocked cat outside subscription login files", "args", req.Command)
+		http.Error(w, "cat invocation not allowed", http.StatusForbidden)
 		return
 	}
 
@@ -147,6 +151,18 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func catInvocationAllowed(cmd []string) bool {
+	if len(cmd) != 2 || cmd[0] != "cat" {
+		return false
+	}
+	switch cmd[1] {
+	case "/home/retro/.codex/auth.json", "/tmp/codex-auth-stdout.txt", "/tmp/codex-auth-error.txt":
+		return true
+	default:
+		return false
+	}
 }
 
 // gitInvocationAllowed restricts `git` invocations to the identity-writing

--- a/api/pkg/desktop/exec_test.go
+++ b/api/pkg/desktop/exec_test.go
@@ -1,6 +1,51 @@
 package desktop
 
-import "testing"
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCatInvocationAllowed(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  []string
+		want bool
+	}{
+		{"allow Codex credentials", []string{"cat", "/home/retro/.codex/auth.json"}, true},
+		{"allow Codex stdout", []string{"cat", "/tmp/codex-auth-stdout.txt"}, true},
+		{"allow Codex error", []string{"cat", "/tmp/codex-auth-error.txt"}, true},
+		{"reject process environment", []string{"cat", "/proc/1/environ"}, false},
+		{"reject traversal", []string{"cat", "/tmp/../proc/1/environ"}, false},
+		{"reject flags", []string{"cat", "--", "/home/retro/.codex/auth.json"}, false},
+		{"reject multiple files", []string{"cat", "/tmp/codex-auth-stdout.txt", "/etc/passwd"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := catInvocationAllowed(tc.cmd); got != tc.want {
+				t.Fatalf("catInvocationAllowed(%v) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecRejectsUnsafeCommands(t *testing.T) {
+	server := NewServer(Config{}, slog.Default())
+	for _, body := range []string{
+		`{"command":["cat","/proc/1/environ"]}`,
+		`{"command":["claude","--version"]}`,
+	} {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+		server.handleExec(recorder, request)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("body %s returned %d, want %d", body, recorder.Code, http.StatusForbidden)
+		}
+	}
+}
 
 func TestGitInvocationAllowed(t *testing.T) {
 	cases := []struct {

--- a/api/pkg/desktop/workspace_test.go
+++ b/api/pkg/desktop/workspace_test.go
@@ -79,6 +79,10 @@ func newDesktopTestServer(t *testing.T, workspaceDir string) *Server {
 	return &Server{}
 }
 
+func TestDesktopHTTPAddressUsesLoopback(t *testing.T) {
+	require.Equal(t, "127.0.0.1:9876", desktopHTTPAddress("9876"))
+}
+
 func TestHandleWorkspacesIncludesAgentPath(t *testing.T) {
 	workspaceDir, _, _ := setupTestRepoWithRemote(t, "testproj", false)
 	s := newDesktopTestServer(t, workspaceDir)


### PR DESCRIPTION
## Summary

- bind graphical and workspace bridge HTTP servers to IPv4 loopback
- point embedded and standalone RevDial clients at the same explicit loopback address
- remove the unused generic Claude exec command and limit `cat` to the three Codex login artifacts consumed by the API

## Validation

- `go test ./pkg/desktop ./cmd/desktop-bridge ./cmd/revdial-client -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- rebuilt and published `helix-ubuntu:2e59f5` with `./stack build-ubuntu`
- fresh and resumed graphical tasks: chat/follow-up, authenticated exec, screenshot, GNOME/Xwayland/PipeWire, GPU, Docker build, and Compose run
- fresh and resumed headless tasks: chat/follow-up, authenticated exec, Docker build, and Compose run
- verified port 9876 listens on `127.0.0.1` and is unreachable through each task container IP
- verified arbitrary file reads and the removed Claude command return HTTP 403