### PR TITLE
feat(frontend): declutter project chat navigation

### DIFF
--- a/frontend/src/components/session/NewChatProjectDialog.test.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.test.tsx
@@ -92,4 +92,28 @@ describe('NewChatProjectDialog', () => {
 
     expect(onSelect).not.toHaveBeenCalled()
   })
+
+  it('shows the keyboard legend and closes with Backspace from an empty search', () => {
+    const { onClose } = renderDialog()
+    const search = screen.getByLabelText('Search projects')
+
+    expect(screen.getByText('Navigate')).toBeInTheDocument()
+    expect(screen.getByText('Select')).toBeInTheDocument()
+    expect(screen.getByText('Back')).toBeInTheDocument()
+    expect(screen.getByText('Close')).toBeInTheDocument()
+
+    fireEvent.keyDown(search, { key: 'Backspace' })
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('keeps Backspace available for editing a non-empty search', () => {
+    const { onClose } = renderDialog()
+    const search = screen.getByLabelText('Search projects')
+
+    fireEvent.change(search, { target: { value: 'webhook' } })
+    fireEvent.keyDown(search, { key: 'Backspace' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/components/session/NewChatProjectDialog.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.tsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { useTheme } from '@mui/material/styles'
 
-import { ArrowLeft, Folder, MessagesSquare } from 'lucide-react'
+import { ArrowDown, ArrowLeft, ArrowUp, Folder, MessagesSquare } from 'lucide-react'
 
 import type { TypesProject } from '../../api/api'
 import useLightTheme from '../../hooks/useLightTheme'
@@ -115,6 +115,11 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
       choose(rows[selectedIndex])
       return
     }
+    if (event.key === 'Backspace' && query === '') {
+      event.preventDefault()
+      onClose()
+      return
+    }
     // ⌘1…⌘9 jumps straight to a row, matching the hints in the list.
     const modifier = isMacPlatform() ? event.metaKey : event.ctrlKey
     if (modifier && /^[1-9]$/.test(event.key)) {
@@ -124,7 +129,7 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
         choose(rows[index])
       }
     }
-  }, [choose, rows, selectedIndex])
+  }, [choose, onClose, query, rows, selectedIndex])
 
   const shortcutLabel = isMacPlatform() ? '⌘' : 'Ctrl+'
   const mutedColor = lightTheme.isLight ? 'rgba(113,113,122,0.9)' : 'rgba(163,163,163,0.75)'
@@ -133,8 +138,7 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
     <Dialog
       open={open}
       onClose={onClose}
-      fullWidth
-      maxWidth="sm"
+      maxWidth={false}
       fullScreen={isNarrow}
       onKeyDown={handleKeyDown}
       TransitionProps={{ onEntered: () => inputRef.current?.focus() }}
@@ -151,8 +155,12 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
               }
             : {
                 position: 'fixed',
-                top: '12%',
+                top: '10vh',
                 m: 0,
+                width: 576,
+                maxWidth: 'calc(100vw - 32px)',
+                height: 420,
+                maxHeight: 'calc(100vh - 32px)',
                 borderRadius: '14px',
               }),
           display: 'flex',
@@ -302,9 +310,10 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
           sx={{
             display: 'flex',
             alignItems: 'center',
-            gap: 2,
+            gap: 1.5,
             px: 2,
-            py: 1,
+            py: 0.75,
+            minHeight: 40,
             borderTop: '1px solid',
             borderColor: 'divider',
             fontSize: '11px',
@@ -312,9 +321,44 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
             flexShrink: 0,
           }}
         >
-          <span>↑↓ Navigate</span>
-          <span>Enter Select</span>
-          <span>Esc Close</span>
+          {[
+            {
+              keys: [<ArrowUp key="up" size={11} />, <ArrowDown key="down" size={11} />],
+              label: 'Navigate',
+            },
+            { keys: ['Enter'], label: 'Select' },
+            { keys: ['Backspace'], label: 'Back' },
+            { keys: ['Esc'], label: 'Close' },
+          ].map((hint) => (
+            <Box key={hint.label} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                {hint.keys.map((key, index) => (
+                  <Box
+                    component="kbd"
+                    key={`${hint.label}-${index}`}
+                    sx={{
+                      minWidth: 20,
+                      height: 20,
+                      px: 0.5,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderRadius: '4px',
+                      backgroundColor: lightTheme.isLight
+                        ? 'rgba(39,39,42,0.08)'
+                        : 'rgba(241,243,247,0.12)',
+                      color: 'text.primary',
+                      font: 'inherit',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {key}
+                  </Box>
+                ))}
+              </Box>
+              <span>{hint.label}</span>
+            </Box>
+          ))}
         </Box>
       )}
     </Dialog>

--- a/frontend/src/components/session/ProjectChatGroup.test.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.test.tsx
@@ -85,29 +85,31 @@ const renderEmptyProject = (collapsed = false) => render(
 )
 
 describe('ProjectChatGroup', () => {
-  it('renders an expanded project with no tasks', () => {
+  it('hides an expanded project with no visible sessions or tasks', async () => {
     mocks.emptySessions = true
     renderEmptyProject()
 
-    expect(screen.getByText('Empty project')).toBeInTheDocument()
-    expect(screen.getByText('No tasks yet')).toBeInTheDocument()
-  })
-
-  it('keeps an empty collapsed project visible without the empty-state row', () => {
-    mocks.emptySessions = true
-    renderEmptyProject(true)
-
-    expect(screen.getByText('Empty project')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Empty project')).not.toBeInTheDocument())
     expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
   })
 
-  // One group renders per project, so leaving collapsed groups enabled costs a
-  // task request per project on every poll for rows nobody can see.
-  it('does not query or poll while collapsed', () => {
+  it('hides a collapsed project after probing its visible items', async () => {
+    mocks.emptySessions = true
     renderEmptyProject(true)
 
-    expect(mocks.sessionOptions.every((options) => options.enabled === false)).toBe(true)
-    expect(mocks.taskOptions.every((options) => options.enabled === false)).toBe(true)
+    await waitFor(() => expect(screen.queryByText('Empty project')).not.toBeInTheDocument())
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
+    expect(mocks.sessionOptions.at(-1)?.enabled).toBe(true)
+    expect(mocks.taskOptions.at(-1)?.enabled).toBe(true)
+  })
+
+  it('stops querying after a collapsed group proves it has visible items', async () => {
+    renderEmptyProject(true)
+
+    expect(mocks.sessionOptions.some((options) => options.enabled === true)).toBe(true)
+    expect(mocks.taskOptions.some((options) => options.enabled === true)).toBe(true)
+    await waitFor(() => expect(mocks.sessionOptions.at(-1)?.enabled).toBe(false))
+    expect(mocks.taskOptions.at(-1)?.enabled).toBe(false)
   })
 
   it('queries once expanded', () => {

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -121,7 +121,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
   const visibleCount = visibleThreadCount + additionalVisibleCount
   const projectId = project?.id
   const groupId = projectId || 'default'
-  const groupName = project?.name || 'None'
+  const groupName = project?.name || 'No project'
   const requestCount = visibleCount + 1
   // A collapsed group renders nothing, so it must not fetch — and above all must
   // not keep polling. One sidebar renders a group per project, so leaving these

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, MutableRefObject, ReactElement, useState } from 'react'
+import { FC, MouseEvent, MutableRefObject, ReactElement, useEffect, useState } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -44,6 +44,8 @@ import { GitBranch } from 'lucide-react'
 import { getProjectChatItemDetails, resolveProjectChatItemBranch } from './projectChatItemDetails'
 
 const SHOW_MORE_COUNT = 20
+
+type GroupVisibility = 'unknown' | 'visible' | 'empty'
 
 const activeStatusDotPulse = keyframes`
   0%, 100% {
@@ -118,16 +120,16 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
   // row itself. That makes the row two lines, and taller.
   const isPhone = useIsPhone()
   const [additionalVisibleCount, setAdditionalVisibleCount] = useState(0)
+  const [visibility, setVisibility] = useState<GroupVisibility>('unknown')
   const visibleCount = visibleThreadCount + additionalVisibleCount
   const projectId = project?.id
   const groupId = projectId || 'default'
   const groupName = project?.name || 'No project'
   const requestCount = visibleCount + 1
-  // A collapsed group renders nothing, so it must not fetch — and above all must
-  // not keep polling. One sidebar renders a group per project, so leaving these
-  // enabled costs a task request per project every refetch interval, for rows
-  // the user cannot see.
-  const queriesEnabled = enabled && !collapsed
+  // A collapsed group probes once to determine whether the current participant
+  // filter can see anything. Visible collapsed groups then stop querying; empty
+  // ones keep watching so a newly assigned task can make the project reappear.
+  const queriesEnabled = enabled && (!collapsed || visibility !== 'visible')
 
   const sessionsQuery = useListSessions(
     orgId,
@@ -214,7 +216,11 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
   const tasksMayHaveMore = !!projectId && tasks.length === requestCount
   const hasMore = filteredItems.length > visibleCount || sessionsHaveMore || tasksMayHaveMore
   const canShowLess = additionalVisibleCount > 0
-  const isLoading = queriesEnabled && (sessionsQuery.isLoading || (!!projectId && tasksQuery.isLoading))
+  const isLoading = queriesEnabled && (
+    sessionsQuery.isLoading
+    || (!!projectId && tasksQuery.isLoading)
+    || pinnedQueries.some((pinnedQuery) => pinnedQuery.isLoading)
+  )
   const isFetchingMore = sessionsQuery.isFetching || tasksQuery.isFetching
   const hasError = sessionsQuery.isError || tasksQuery.isError
   const archiveVerb = archived ? 'Unarchive' : 'Archive'
@@ -234,6 +240,21 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
       color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
       backgroundColor: lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)',
     },
+  }
+
+  const participantScope = participantIds.join('\u0000')
+  useEffect(() => {
+    setVisibility('unknown')
+  }, [archived, participantScope])
+
+  const hasVisibleItems = items.length > 0 || hasMore
+  useEffect(() => {
+    if (!projectId || isLoading || hasError) return
+    setVisibility(hasVisibleItems ? 'visible' : 'empty')
+  }, [hasError, hasVisibleItems, isLoading, projectId])
+
+  if (projectId && !isLoading && !hasError && !hasVisibleItems) {
+    return null
   }
 
   if (query && !isLoading && !hasError && !hasMore && filteredItems.length === 0) {
@@ -405,22 +426,6 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
           {hasError && (
             <Typography color="error" sx={{ px: 1, py: 0.75, fontSize: '0.7rem' }}>
               Failed to load chats
-            </Typography>
-          )}
-          {!isLoading && !hasError && renderedItems.length === 0 && !!projectId && (
-            <Typography
-              sx={{
-                height: 28,
-                px: 1,
-                display: 'flex',
-                alignItems: 'center',
-                color: lightTheme.isLight
-                  ? 'rgba(113,113,122,0.65)'
-                  : 'rgba(163,163,163,0.55)',
-                fontSize: '11px',
-              }}
-            >
-              {archived ? 'Nothing archived' : 'No tasks yet'}
             </Typography>
           )}
           {renderedItems.map((item) => {

--- a/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
@@ -10,6 +10,7 @@ import {
   compactRelativeTime,
   DEFAULT_PROJECT_CHAT_SIDEBAR_PREFERENCES,
   filterProjectChatGroups,
+  filterSidebarProjectsWithActivity,
   filterSidebarMembers,
   getSidebarPullRequestIcon,
   getSidebarMemberResults,
@@ -66,7 +67,7 @@ describe('ProjectChatSidebar logic', () => {
     }, true, true)).toBe(4)
   })
 
-  it('groups tasks and project-linked chats by project, and puts direct chats in None', () => {
+  it('groups tasks and project-linked chats by project, and puts direct chats in No project', () => {
     const tasks: SpecTask[] = [{
       id: 'task-one',
       project_id: 'project-one',
@@ -107,7 +108,7 @@ describe('ProjectChatSidebar logic', () => {
 
     const groups = buildProjectChatGroups(projects, tasks, sessions)
 
-    expect(groups.map((group) => group.name)).toEqual(['None', 'Project One', 'Project Two'])
+    expect(groups.map((group) => group.name)).toEqual(['No project', 'Project One', 'Project Two'])
     expect(groups[0]?.items.map((item) => item.id)).toEqual(['direct-session'])
     expect(groups[1]?.items.map((item) => item.id)).toEqual(['task-one', 'worker-session'])
     expect(groups[1]?.items[0]?.session).toEqual(expect.objectContaining({
@@ -297,6 +298,16 @@ describe('ProjectChatSidebar logic', () => {
     }).map((project) => project.id)).toEqual(['project-two', 'project-one'])
     expect(reorderProjectIds(['project-one', 'project-two'], 'project-one', 'project-two'))
       .toEqual(['project-two', 'project-one'])
+  })
+
+  it('removes projects without chat activity from the active sidebar', () => {
+    const projectsWithEmpty: TypesProject[] = [
+      { id: 'project-active', name: 'Active', last_activity_at: '2026-08-31T10:00:00Z' },
+      { id: 'project-empty', name: 'Empty' },
+    ]
+
+    expect(filterSidebarProjectsWithActivity(projectsWithEmpty).map((project) => project.id))
+      .toEqual(['project-active'])
   })
 
   it('uses AND matching across multiple search tokens', () => {

--- a/frontend/src/components/session/ProjectChatSidebar.logic.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.ts
@@ -78,6 +78,10 @@ export const resolveSidebarProjectFilter = (
     : ALL_PROJECTS_FILTER
 )
 
+export const filterSidebarProjectsWithActivity = (
+  projects: TypesProject[],
+): TypesProject[] => projects.filter((project) => !!project.last_activity_at)
+
 export const parseSidebarParticipantIds = (storedValue: string | null): string[] | null => {
   if (storedValue === null) return null
   try {
@@ -450,7 +454,7 @@ export const buildProjectChatGroups = (
   sortOrder: SidebarThreadSortOrder = 'updated_at',
   pinnedAtByItemKey: ReadonlyMap<string, string> = new Map(),
 ): SidebarGroup[] => {
-  const defaultGroup: SidebarGroup = { id: 'default', name: 'None', items: [] }
+  const defaultGroup: SidebarGroup = { id: 'default', name: 'No project', items: [] }
   const groupsByProjectId = new Map<string, SidebarGroup>()
   projects.forEach((project) => {
     if (!project.id) return

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -37,6 +37,7 @@ import SimpleConfirmWindow from '../widgets/SimpleConfirmWindow'
 import {
   ALL_PROJECTS_FILTER,
   collapsedGroupsStorageKey,
+  filterSidebarProjectsWithActivity,
   getChatShortcutNumber,
   isChatShortcutModifier,
   isNewThreadShortcut,
@@ -161,12 +162,16 @@ const ProjectChatSidebar: FC<{
     setVisibleThreadCount,
     setManualProjectOrder,
   } = useProjectChatSidebarPreferences(preferencesStorageKey, projects)
+  const activeProjects = filterSidebarProjectsWithActivity(projects)
+  const sidebarProjects = showArchived ? projects : activeProjects
   const focusedProject = projectFilter === ALL_PROJECTS_FILTER
     ? undefined
-    : projects.find((project) => project.id === projectFilter)
-  const resolvedProjectFilter = resolveSidebarProjectFilter(projectFilter, projects)
+    : sidebarProjects.find((project) => project.id === projectFilter)
+  const resolvedProjectFilter = resolveSidebarProjectFilter(projectFilter, sidebarProjects)
   const focusMode = projectFilter !== ALL_PROJECTS_FILTER && !!focusedProject
-  const displayedProjects = focusMode && focusedProject ? [focusedProject] : sortedProjects
+  const displayedProjects = focusMode && focusedProject
+    ? [focusedProject]
+    : sortedProjects.filter((project) => showArchived || !!project.last_activity_at)
 
   useEffect(() => {
     if (projectsLoading || resolvedProjectFilter === projectFilter) return
@@ -496,7 +501,7 @@ const ProjectChatSidebar: FC<{
   const filterControls = (
     <>
         <ProjectChatSidebarProjectFilter
-          projects={projects}
+          projects={sidebarProjects}
           selectedProjectId={projectFilter}
           archived={showArchived}
           onChange={selectProjectFilter}
@@ -641,7 +646,7 @@ const ProjectChatSidebar: FC<{
         </Box>
         <Box sx={{ pl: 0.75, pr: 0.75, pt: 1.25, pb: 0.5, display: 'flex', alignItems: 'center' }}>
           <ProjectChatSidebarProjectFilter
-            projects={projects}
+            projects={sidebarProjects}
             selectedProjectId={projectFilter}
             archived={showArchived}
             onChange={selectProjectFilter}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -429,7 +429,7 @@ const Home: FC = () => {
   if (projectsLoading) {
     return (
       <Page
-        breadcrumbs={[{ title: 'None' }]}
+        breadcrumbs={[{ title: 'No project' }]}
         breadcrumbTitle="New thread"
         breadcrumbShowHome={false}
         disableContentScroll
@@ -510,7 +510,7 @@ const Home: FC = () => {
 
   return (
     <Page
-      breadcrumbs={[{ title: selectedProject?.name || 'None' }]}
+      breadcrumbs={[{ title: selectedProject?.name || 'No project' }]}
       breadcrumbTitle={isProjectContext ? 'New Task' : 'New thread'}
       breadcrumbShowHome={false}
       disableContentScroll
@@ -589,7 +589,7 @@ const Home: FC = () => {
               onClick={(event) => setProjectMenuAnchor(event.currentTarget)}
               sx={{ ...selectorButtonSx, fontSize: isPhone ? '0.8rem' : '0.7rem' }}
             >
-              {selectedProject?.name || 'None'}
+              {selectedProject?.name || 'No project'}
             </Button>
             <Menu
               anchorEl={projectMenuAnchor}


### PR DESCRIPTION
## Summary

- hide projects with no active chat or task activity from the active chat sidebar and its filter while keeping every project available in the new-thread picker
- resolve project visibility from the current sidebar participant filter, so projects whose activity belongs only to other users do not render an empty group
- probe collapsed groups once and stop their polling after visible items are confirmed
- resize the desktop new-thread project picker to the T3 Code command-palette dimensions (576 x 420) with a scrollable result area and keyboard keycap footer
- support Backspace to leave the picker when search is empty
- rename the standalone chat context from None to No project across the sidebar, breadcrumb, selector, and picker

Reference: https://github.com/pingdotgg/t3code

## Testing

- yarn vitest run src/components/session/ProjectChatGroup.test.tsx src/components/session/ProjectChatSidebar.logic.test.ts src/components/session/NewChatProjectDialog.test.tsx src/pages/Home.test.tsx (56 tests passed)
- yarn build
- live inner-Helix browser verification at 1280 x 800: dialog measured 576 x 420 and the keyboard footer rendered
- reproduced the participant-filter mismatch from mr-tester-org1: the false-positive project disappeared after deselecting its task owner and reappeared after reselecting that owner