### PR TITLE
Make API-queued agent messages visible in the prompt queue

### DIFF
--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -83,6 +83,12 @@ func (apiServer *HelixAPIServer) syncPromptHistory(_ http.ResponseWriter, req *h
 		return nil, system.NewHTTPError400("spec_task_id or session_id is required")
 	}
 
+	// Same check as the list path: the response now carries every owner's rows
+	// for this task/session, so it needs the same authorization.
+	if httpErr := apiServer.authorizeUserToPromptQueue(ctx, user, syncReq.SpecTaskID, syncReq.SessionID); httpErr != nil {
+		return nil, httpErr
+	}
+
 	response, err := apiServer.Store.SyncPromptHistory(ctx, user.ID, &syncReq)
 	if err != nil {
 		log.Error().Err(err).
@@ -390,6 +396,42 @@ func (apiServer *HelixAPIServer) processPendingPromptsForSession(ctx context.Con
 	}
 }
 
+// authorizeUserToPromptQueue checks that user may read the prompt queue
+// identified by specTaskID (preferred) or sessionID.
+//
+// This is load-bearing. The queue read path used to be scoped by user_id, which
+// doubled as its authorization: you could only ever see your own rows. That made
+// a teammate's or a bot's queued prompts invisible even though they were about to
+// run on the session you are looking at — the queue lied about the agent's state.
+// The rows are now returned for the whole task/session, so the check that used to
+// be implicit has to be made explicitly here, or knowing a spec_task_id would be
+// enough to read someone else's queue.
+func (apiServer *HelixAPIServer) authorizeUserToPromptQueue(ctx context.Context, user *types.User, specTaskID, sessionID string) *system.HTTPError {
+	if specTaskID != "" {
+		specTask, err := apiServer.Store.GetSpecTask(ctx, specTaskID)
+		if err != nil {
+			return system.NewHTTPError404("spec task not found")
+		}
+		project, err := apiServer.Store.GetProject(ctx, specTask.ProjectID)
+		if err != nil {
+			return system.NewHTTPError404("project not found")
+		}
+		if err := apiServer.authorizeUserToProject(ctx, user, project, types.ActionGet); err != nil {
+			return system.NewHTTPError403(err.Error())
+		}
+		return nil
+	}
+
+	session, err := apiServer.Store.GetSession(ctx, sessionID)
+	if err != nil || session == nil {
+		return system.NewHTTPError404("session not found")
+	}
+	if err := apiServer.authorizeUserToSession(ctx, user, session, types.ActionGet); err != nil {
+		return system.NewHTTPError403(err.Error())
+	}
+	return nil
+}
+
 // enqueueAgentMessage is the single server-side entry point for sending a
 // message to an agent. It inserts a pending prompt_history_entries row for the
 // session and nudges the session-scoped poller — the same mechanism the
@@ -414,6 +456,36 @@ func (apiServer *HelixAPIServer) enqueueAgentMessage(ctx context.Context, sessio
 	return promptID, nil
 }
 
+// resolveSpecTaskIDForSession returns the id of the spec task that owns sessionID
+// via its planning_session_id, or "" when the session is a plain (non-spec-task)
+// session such as an org-chat or bot session — an empty spec_task_id is legitimate
+// there. Archived tasks count: their queue must still render.
+//
+// This exists because the prompt-queue UI queries by spec_task_id. A row written
+// with an empty one is invisible even though it is correctly queued and will be
+// dispatched — see design/tasks/003021_queued-agent-messages.
+func (apiServer *HelixAPIServer) resolveSpecTaskIDForSession(ctx context.Context, sessionID string) (string, error) {
+	tasks, err := apiServer.Store.ListSpecTasks(ctx, &types.SpecTaskFilters{
+		PlanningSessionID: sessionID,
+		IncludeArchived:   true,
+		Limit:             2,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve spec task for session %s: %w", sessionID, err)
+	}
+	if len(tasks) == 0 {
+		return "", nil
+	}
+	if len(tasks) > 1 {
+		log.Warn().
+			Str("session_id", sessionID).
+			Int("match_count", len(tasks)).
+			Str("chosen_spec_task_id", tasks[0].ID).
+			Msg("Session is the planning session of more than one spec task; stamping the first")
+	}
+	return tasks[0].ID, nil
+}
+
 // persistQueuedPrompt inserts the pending prompt row synchronously and returns
 // its id, WITHOUT nudging the poller. Callers that must persist a link to the
 // prompt before dispatch runs (the design-review comment path stores
@@ -434,6 +506,16 @@ func (apiServer *HelixAPIServer) persistQueuedPrompt(ctx context.Context, sessio
 	}
 	if session == nil {
 		return "", fmt.Errorf("session %s not found", sessionID)
+	}
+
+	// Callers that already know their spec task pass it explicitly. The generic
+	// session-messages API (the HelixOS path) cannot, so resolve it here — a row
+	// with an empty spec_task_id is invisible in the queue UI.
+	if specTaskID == "" {
+		specTaskID, err = apiServer.resolveSpecTaskIDForSession(ctx, sessionID)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	entry := &types.PromptHistoryEntry{
@@ -765,6 +847,10 @@ func (apiServer *HelixAPIServer) listPromptHistory(_ http.ResponseWriter, req *h
 		return nil, system.NewHTTPError400("spec_task_id or session_id is required")
 	}
 
+	if httpErr := apiServer.authorizeUserToPromptQueue(ctx, user, specTaskID, sessionID); httpErr != nil {
+		return nil, httpErr
+	}
+
 	listReq := &types.PromptHistoryListRequest{
 		SpecTaskID: specTaskID,
 		ProjectID:  query.Get("project_id"),
@@ -787,7 +873,7 @@ func (apiServer *HelixAPIServer) listPromptHistory(_ http.ResponseWriter, req *h
 		}
 	}
 
-	response, err := apiServer.Store.ListPromptHistory(ctx, user.ID, listReq)
+	response, err := apiServer.Store.ListPromptHistory(ctx, listReq)
 	if err != nil {
 		log.Error().Err(err).
 			Str("user_id", user.ID).

--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -596,16 +596,13 @@ func (apiServer *HelixAPIServer) processInterruptPrompt(ctx context.Context, ses
 	}
 
 	// Send the prompt to the session (creates interaction and sends to agent)
+	//
+	// Interrupts are exempt from the busy check, so a defer here means the
+	// BOOT-RACE exception fired (ZedThreadID not yet set). That is also not a
+	// failure — the interrupt is redelivered into the same thread once the thread
+	// exists — so it must not burn the retry budget either.
 	if err := apiServer.sendQueuedPromptToSession(ctx, sessionID, nextPrompt); err != nil {
-		// Interaction creation failed - revert to 'failed' so it can be retried
-		log.Error().
-			Err(err).
-			Str("session_id", sessionID).
-			Str("prompt_id", nextPrompt.ID).
-			Msg("Failed to create interaction for interrupt prompt - reverting to failed")
-		if markErr := apiServer.Store.MarkPromptAsFailed(ctx, nextPrompt.ID, err.Error()); markErr != nil {
-			log.Error().Err(markErr).Str("prompt_id", nextPrompt.ID).Msg("Failed to mark prompt as failed after interaction creation error")
-		}
+		apiServer.requeueUndispatchedPrompt(ctx, sessionID, nextPrompt, err)
 		return
 	}
 

--- a/api/pkg/server/session_messages_handler_test.go
+++ b/api/pkg/server/session_messages_handler_test.go
@@ -108,6 +108,9 @@ func (s *SessionMessagesHandlerSuite) TestEnqueuesOntoQueue() {
 			return nil
 		},
 	)
+	// This is a plain session (org chat / bot), so the spec-task reverse lookup
+	// finds nothing and an empty spec_task_id is the correct outcome.
+	s.store.EXPECT().ListSpecTasks(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	// The background nudge lists the session's prompts; return none so the
 	// poller bails immediately and the test stays deterministic.
 	s.store.EXPECT().ListPromptHistoryBySession(gomock.Any(), sessionID).Return(nil, nil).AnyTimes()
@@ -124,10 +127,74 @@ func (s *SessionMessagesHandlerSuite) TestEnqueuesOntoQueue() {
 	s.Equal("hello", captured.Content)
 	s.Equal("pending", captured.Status)
 	s.False(captured.Interrupt)
+	s.Empty(captured.SpecTaskID, "a session with no spec task must still enqueue, unstamped")
 
 	// Let the background nudge run its single (AnyTimes) list call and exit
 	// before the controller is finished.
 	time.Sleep(100 * time.Millisecond)
+}
+
+// TestStampsSpecTaskIDFromPlanningSession is the regression test for the bug
+// this endpoint had: it passed an empty specTaskID, the row was written with an
+// empty spec_task_id, and the prompt-queue UI — which queries BY spec_task_id —
+// filtered it out. The message was queued and would be delivered, but was
+// invisible. 53 approvals vanished this way.
+func (s *SessionMessagesHandlerSuite) TestStampsSpecTaskIDFromPlanningSession() {
+	user := &types.User{ID: "user-1"}
+	sessionID := "ses_planning"
+
+	session := &types.Session{ID: sessionID, Owner: user.ID}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
+
+	// The reverse lookup must go through planning_session_id, and must include
+	// archived tasks — an archived task's queue still has to render.
+	var filters *types.SpecTaskFilters
+	s.store.EXPECT().ListSpecTasks(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, f *types.SpecTaskFilters) ([]*types.SpecTask, error) {
+			filters = f
+			return []*types.SpecTask{{ID: "spt_owner", PlanningSessionID: sessionID}}, nil
+		},
+	).AnyTimes()
+
+	var captured *types.PromptHistoryEntry
+	s.store.EXPECT().CreatePromptHistoryEntry(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, e *types.PromptHistoryEntry) error {
+			captured = e
+			return nil
+		},
+	)
+	s.store.EXPECT().ListPromptHistoryBySession(gomock.Any(), sessionID).Return(nil, nil).AnyTimes()
+
+	rr := s.callHandler(sessionID, SessionMessageRequest{Content: "approve card"}, user)
+	s.Require().Equal(http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+
+	s.Require().NotNil(captured)
+	s.Equal("spt_owner", captured.SpecTaskID, "the queued row must carry the owning spec task or the queue UI cannot see it")
+
+	s.Require().NotNil(filters)
+	s.Equal(sessionID, filters.PlanningSessionID)
+	s.True(filters.IncludeArchived)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestSpecTaskLookupErrorFailsEnqueue verifies we do not silently write an
+// unstamped (invisible) row when the reverse lookup errors. Failing loudly is
+// the house rule; a caller retry is better than a message the user cannot see.
+func (s *SessionMessagesHandlerSuite) TestSpecTaskLookupErrorFailsEnqueue() {
+	user := &types.User{ID: "user-1"}
+	sessionID := "ses_lookup_err"
+
+	session := &types.Session{ID: sessionID, Owner: user.ID}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
+	s.store.EXPECT().ListSpecTasks(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("db exploded")).AnyTimes()
+	// Nothing may be written when the lookup fails.
+	s.store.EXPECT().CreatePromptHistoryEntry(gomock.Any(), gomock.Any()).Times(0)
+	s.store.EXPECT().ListPromptHistoryBySession(gomock.Any(), sessionID).Return(nil, nil).AnyTimes()
+
+	rr := s.callHandler(sessionID, SessionMessageRequest{Content: "hello"}, user)
+	s.Equal(http.StatusInternalServerError, rr.Code)
 }
 
 // TestRejectsCrossUser verifies authorizeUserToSession blocks a different
@@ -168,6 +235,7 @@ func (s *SessionMessagesHandlerSuite) TestNotifyUserIDCarriedOnRow() {
 			return nil
 		},
 	)
+	s.store.EXPECT().ListSpecTasks(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	s.store.EXPECT().ListPromptHistoryBySession(gomock.Any(), sessionID).Return(nil, nil).AnyTimes()
 
 	rr := s.callHandler(sessionID, SessionMessageRequest{Content: "x", NotifyUserID: "commenter-9"}, user)

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -30,6 +30,22 @@ import (
 // Callers distinguish this from real send failures using errors.Is.
 var ErrNoExternalAgentWS = errors.New("no external agent WebSocket connection")
 
+// ErrPromptBusyDeferred is returned by sendQueuedPromptToSession when the
+// session turned out to be mid-turn and the claimed prompt was therefore NOT
+// dispatched. This is the queue working as designed, not a failure: the prompt
+// is untouched and will be redelivered on the next drain.
+//
+// It exists so callers can tell a defer apart from a real dispatch error and put
+// the prompt back with RevertPromptToPending instead of MarkPromptAsFailed.
+// MarkPromptAsFailed increments retry_count, which is a bounded budget
+// (defaultMaxPromptQueueRetries) for GENUINE failures — once it is exhausted the
+// GetNext*Prompt selectors stop matching the row and the message is silently
+// dropped forever. processAnyPendingPrompt runs on every acknowledged
+// cancellation, i.e. every time the user interrupts the agent, so charging the
+// budget for defers burnt ~11 retries in 16 minutes on a live session.
+// See design/tasks/003021_queued-agent-messages.
+var ErrPromptBusyDeferred = errors.New("prompt dispatch deferred: session busy")
+
 // agentCrashErrorMarkers identify thread_load_error events that originate from
 // the Claude Agent ACP wrapper inside Zed having exited. Once the wrapper
 // process is gone, every subsequent follow-up the user sends bounces with
@@ -3556,6 +3572,38 @@ func (apiServer *HelixAPIServer) lockPromptDrain(sessionID string) func() {
 	return mu.Unlock
 }
 
+// requeueUndispatchedPrompt records the outcome of a failed dispatch attempt for
+// a prompt that was already claimed (status='sending'), and is the ONLY place the
+// three drain paths decide between "put it back" and "count it as a failure".
+//
+// A busy-defer means the prompt was never sent and nothing is wrong, so it goes
+// straight back to pending with its retry budget intact. Anything else is a real
+// failure and is recorded with backoff so the UI can show "Failed - retrying".
+func (apiServer *HelixAPIServer) requeueUndispatchedPrompt(ctx context.Context, sessionID string, prompt *types.PromptHistoryEntry, dispatchErr error) {
+	if errors.Is(dispatchErr, ErrPromptBusyDeferred) {
+		log.Info().
+			Str("session_id", sessionID).
+			Str("prompt_id", prompt.ID).
+			Int("retry_count", prompt.RetryCount).
+			Msg("⏸️  [QUEUE] Session busy — returning prompt to queue without charging the retry budget")
+		if revertErr := apiServer.Store.RevertPromptToPending(ctx, prompt.ID); revertErr != nil {
+			log.Error().Err(revertErr).Str("prompt_id", prompt.ID).Msg("Failed to revert deferred prompt to pending")
+		}
+		return
+	}
+
+	log.Error().
+		Err(dispatchErr).
+		Str("session_id", sessionID).
+		Str("prompt_id", prompt.ID).
+		Msg("Failed to dispatch queued prompt to session")
+
+	// Mark as failed (records error so the UI can show it under "Failed - retrying")
+	if markErr := apiServer.Store.MarkPromptAsFailed(ctx, prompt.ID, dispatchErr.Error()); markErr != nil {
+		log.Error().Err(markErr).Str("prompt_id", prompt.ID).Msg("Failed to mark prompt as failed")
+	}
+}
+
 // processPromptQueue checks for pending non-interrupt prompts and sends the next one
 // This is called after a message is completed to process queued non-interrupt messages
 func (apiServer *HelixAPIServer) processPromptQueue(ctx context.Context, sessionID string) {
@@ -3622,16 +3670,7 @@ func (apiServer *HelixAPIServer) processPromptQueue(ctx context.Context, session
 	// Send it to the session.
 	err = apiServer.sendQueuedPromptToSession(ctx, sessionID, nextPrompt)
 	if err != nil {
-		log.Error().
-			Err(err).
-			Str("session_id", sessionID).
-			Str("prompt_id", nextPrompt.ID).
-			Msg("Failed to send queued prompt to session")
-
-		// Mark as failed (records error so the UI can show it under "Failed - retrying")
-		if markErr := apiServer.Store.MarkPromptAsFailed(ctx, nextPrompt.ID, err.Error()); markErr != nil {
-			log.Error().Err(markErr).Str("prompt_id", nextPrompt.ID).Msg("Failed to mark prompt as failed")
-		}
+		apiServer.requeueUndispatchedPrompt(ctx, sessionID, nextPrompt, err)
 		return
 	}
 
@@ -3680,16 +3719,10 @@ func (apiServer *HelixAPIServer) processAnyPendingPrompt(ctx context.Context, se
 	// the status is already 'sending', causing every queued prompt to be silently dropped.
 
 	// Send the prompt to the session (creates interaction and sends to agent)
+	// This drain runs on every acknowledged cancellation, so a busy-defer here is
+	// routine — requeueUndispatchedPrompt keeps it off the retry budget.
 	if err := apiServer.sendQueuedPromptToSession(ctx, sessionID, nextPrompt); err != nil {
-		// Interaction creation failed - revert to 'failed' so it can be retried
-		log.Error().
-			Err(err).
-			Str("session_id", sessionID).
-			Str("prompt_id", nextPrompt.ID).
-			Msg("Failed to create interaction for pending prompt - reverting to failed")
-		if markErr := apiServer.Store.MarkPromptAsFailed(ctx, nextPrompt.ID, err.Error()); markErr != nil {
-			log.Error().Err(markErr).Str("prompt_id", nextPrompt.ID).Msg("Failed to mark prompt as failed after interaction creation error")
-		}
+		apiServer.requeueUndispatchedPrompt(ctx, sessionID, nextPrompt, err)
 		return
 	}
 
@@ -3794,7 +3827,7 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 					Msg("✅ [QUEUE] Prompt is already in flight via existing Waiting interaction — skipping duplicate dispatch")
 				return nil
 			}
-			return fmt.Errorf("session %s became busy (interaction %s is Waiting), deferring queue prompt", sessionID, latestInteractions[0].ID)
+			return fmt.Errorf("session %s became busy (interaction %s is Waiting), deferring queue prompt: %w", sessionID, latestInteractions[0].ID, ErrPromptBusyDeferred)
 		}
 	}
 

--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -598,6 +598,13 @@ func (m *MemoryStore) MarkPromptAsPending(_ context.Context, id string) error {
 	m.setPromptStatus(id, "pending")
 	return nil
 }
+
+// RevertPromptToPending mirrors the Postgres store: back to pending, and
+// crucially without touching RetryCount (a busy-defer is not a failure).
+func (m *MemoryStore) RevertPromptToPending(_ context.Context, id string) error {
+	m.setPromptStatus(id, "pending")
+	return nil
+}
 func (m *MemoryStore) MarkPromptAsSent(_ context.Context, id string) error {
 	m.setPromptStatus(id, "sent")
 	return nil

--- a/api/pkg/store/migrations/0010_backfill_prompt_history_spec_task_id.down.sql
+++ b/api/pkg/store/migrations/0010_backfill_prompt_history_spec_task_id.down.sql
@@ -1,0 +1,4 @@
+-- Irreversible data backfill: the previous values were empty strings written by a
+-- bug, and they are not distinguishable from rows legitimately stamped by the
+-- fixed handler. Clearing spec_task_id again would only restore the invisible
+-- queue this migration exists to repair.

--- a/api/pkg/store/migrations/0010_backfill_prompt_history_spec_task_id.up.sql
+++ b/api/pkg/store/migrations/0010_backfill_prompt_history_spec_task_id.up.sql
@@ -1,0 +1,37 @@
+-- Prompts queued through POST /api/v1/sessions/{id}/messages were written with an
+-- empty spec_task_id, because the generic session-messages handler had no spec
+-- task to hand and passed "". The prompt-queue UI queries BY spec_task_id, so
+-- those rows were invisible even though they were correctly queued and would be
+-- dispatched — 53 approvals vanished from a user's view this way.
+--
+-- The handler now resolves the owning spec task itself. This repairs the rows
+-- written before that fix, by the same rule: a session is owned by the spec task
+-- whose planning_session_id points at it.
+--
+-- Idempotent — the guard no longer matches once a row is stamped — and it never
+-- overwrites a non-empty spec_task_id.
+DO $$
+BEGIN
+    IF to_regclass('prompt_history_entries') IS NULL
+        OR to_regclass('spec_tasks') IS NULL
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = current_schema()
+                AND table_name = 'prompt_history_entries' AND column_name = 'spec_task_id'
+        )
+        OR NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = current_schema()
+                AND table_name = 'spec_tasks' AND column_name = 'planning_session_id'
+        ) THEN
+        RETURN;
+    END IF;
+
+    UPDATE prompt_history_entries p
+    SET spec_task_id = t.id
+    FROM spec_tasks t
+    WHERE p.session_id = t.planning_session_id
+        AND t.planning_session_id <> ''
+        AND (p.spec_task_id IS NULL OR p.spec_task_id = '')
+        AND p.deleted_at IS NULL;
+END $$;

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -874,7 +874,7 @@ type Store interface {
 	// Prompt history methods (for cross-device sync)
 	CreatePromptHistoryEntry(ctx context.Context, entry *types.PromptHistoryEntry) error
 	SyncPromptHistory(ctx context.Context, userID string, req *types.PromptHistorySyncRequest) (*types.PromptHistorySyncResponse, error)
-	ListPromptHistory(ctx context.Context, userID string, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error)
+	ListPromptHistory(ctx context.Context, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error)
 	GetPromptHistoryEntry(ctx context.Context, id string) (*types.PromptHistoryEntry, error)
 	GetNextPendingPrompt(ctx context.Context, sessionID string) (*types.PromptHistoryEntry, error)
 	GetAnyPendingPrompt(ctx context.Context, sessionID string) (*types.PromptHistoryEntry, error)
@@ -882,6 +882,9 @@ type Store interface {
 	ListPromptHistoryBySpecTask(ctx context.Context, specTaskID string) ([]*types.PromptHistoryEntry, error)
 	ListPromptHistoryBySession(ctx context.Context, sessionID string) ([]*types.PromptHistoryEntry, error)
 	MarkPromptAsPending(ctx context.Context, promptID string) error
+	// RevertPromptToPending returns a claimed prompt to the queue after a
+	// busy-defer, without charging the retry budget. See the implementation.
+	RevertPromptToPending(ctx context.Context, promptID string) error
 	MarkPromptAsSent(ctx context.Context, promptID string) error
 	// MarkPromptAsFailed records the failure reason and bumps retry_count + next_retry_at
 	// for exponential backoff. errorMsg is shown to the user in the UI; pass err.Error()

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -25,7 +25,6 @@ import (
 type MockStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockStoreMockRecorder
-	isgomock struct{}
 }
 
 // MockStoreMockRecorder is the mock recorder for MockStore.
@@ -5062,18 +5061,18 @@ func (mr *MockStoreMockRecorder) ListProjectsWithActiveGoldenBuild(ctx any) *gom
 }
 
 // ListPromptHistory mocks base method.
-func (m *MockStore) ListPromptHistory(ctx context.Context, userID string, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error) {
+func (m *MockStore) ListPromptHistory(ctx context.Context, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPromptHistory", ctx, userID, req)
+	ret := m.ctrl.Call(m, "ListPromptHistory", ctx, req)
 	ret0, _ := ret[0].(*types.PromptHistoryListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPromptHistory indicates an expected call of ListPromptHistory.
-func (mr *MockStoreMockRecorder) ListPromptHistory(ctx, userID, req any) *gomock.Call {
+func (mr *MockStoreMockRecorder) ListPromptHistory(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPromptHistory", reflect.TypeOf((*MockStore)(nil).ListPromptHistory), ctx, userID, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPromptHistory", reflect.TypeOf((*MockStore)(nil).ListPromptHistory), ctx, req)
 }
 
 // ListPromptHistoryBySession mocks base method.
@@ -6071,6 +6070,20 @@ func (m *MockStore) ResourceSearch(ctx context.Context, req *types.ResourceSearc
 func (mr *MockStoreMockRecorder) ResourceSearch(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceSearch", reflect.TypeOf((*MockStore)(nil).ResourceSearch), ctx, req)
+}
+
+// RevertPromptToPending mocks base method.
+func (m *MockStore) RevertPromptToPending(ctx context.Context, promptID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevertPromptToPending", ctx, promptID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevertPromptToPending indicates an expected call of RevertPromptToPending.
+func (mr *MockStoreMockRecorder) RevertPromptToPending(ctx, promptID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevertPromptToPending", reflect.TypeOf((*MockStore)(nil).RevertPromptToPending), ctx, promptID)
 }
 
 // RotateVHostRouteHostname mocks base method.

--- a/api/pkg/store/store_prompt_history.go
+++ b/api/pkg/store/store_prompt_history.go
@@ -81,6 +81,14 @@ func (s *PostgresStore) SyncPromptHistory(ctx context.Context, userID string, re
 			}
 			synced++
 		} else {
+			// Now that the queue is readable by every viewer of the task, a client
+			// caches other people's entries too and would push them straight back.
+			// Someone else's prompt is read-only to us: skip it rather than let one
+			// viewer rewrite another's queued content or ordering.
+			if existingEntry.UserID != userID {
+				continue
+			}
+
 			// Entry exists - only update frontend-owned fields
 			// Preserve backend-owned fields: status, retryCount, nextRetryAt
 			updateFields := map[string]interface{}{
@@ -103,8 +111,13 @@ func (s *PostgresStore) SyncPromptHistory(ctx context.Context, userID string, re
 	// Return all non-deleted entries so the client can merge. Scope by spec_task
 	// (spec-task queue) or by session (org-chat / bot session queue with no spec
 	// task) depending on which the request carries.
+	//
+	// NOT scoped by user_id, deliberately and necessarily: this set must match
+	// what ListPromptHistory returns. usePromptHistory treats a locally-known
+	// entry that is absent from the authoritative list as failed, so if the two
+	// disagree the client marks other people's live prompts failed.
 	scoped := s.gdb.WithContext(ctx).
-		Where("user_id = ? AND deleted_at IS NULL", userID)
+		Where("deleted_at IS NULL")
 	if req.SpecTaskID != "" {
 		scoped = scoped.Where("spec_task_id = ?", req.SpecTaskID)
 	} else {
@@ -381,6 +394,29 @@ func (s *PostgresStore) MarkPromptAsFailed(ctx context.Context, promptID string,
 		Error
 }
 
+// RevertPromptToPending returns a claimed prompt to the queue after a defer that
+// is NOT a failure — the session was mid-turn, so the prompt was never dispatched
+// and nothing went wrong. Clears next_retry_at (a stale backoff from an earlier
+// genuine failure would otherwise gate re-selection) and error_message (so the UI
+// stops showing "Failed - retrying" for a prompt that is merely waiting).
+//
+// retry_count is deliberately left untouched: it bounds genuine failures, and a
+// defer must neither charge nor forgive that budget. Charging it is how a queued
+// message used to be silently dropped forever — every user interrupt fires
+// processAnyPendingPrompt, each busy-defer burnt one of the 20 retries, and at 20
+// the selectors stop seeing the row. See design/tasks/003021_queued-agent-messages.
+func (s *PostgresStore) RevertPromptToPending(ctx context.Context, promptID string) error {
+	return s.gdb.WithContext(ctx).
+		Model(&types.PromptHistoryEntry{}).
+		Where("id = ?", promptID).
+		Updates(map[string]interface{}{
+			"status":        "pending",
+			"next_retry_at": nil,
+			"error_message": "",
+		}).
+		Error
+}
+
 // MarkPromptAsCrashed marks a prompt as failed but pins next_retry_at to a
 // far-future sentinel so the queue's auto-retry never picks it back up. Used
 // for terminal failures (the Claude Agent process inside Zed exited and Helix
@@ -505,10 +541,30 @@ func (s *PostgresStore) ResetCrashedPromptsForSession(ctx context.Context, sessi
 	return int(result.RowsAffected), nil
 }
 
-// ListPromptHistory returns prompt history entries for a user
-func (s *PostgresStore) ListPromptHistory(ctx context.Context, userID string, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error) {
+// ListPromptHistory returns prompt history entries for a spec task or session.
+//
+// The queue belongs to the AGENT, not to whoever typed the message: a prompt
+// queued by a teammate or by an org bot under a different account is still going
+// to run on this session, so it must be visible. Callers therefore scope by
+// spec task / session and authorize the caller against THAT, and only set
+// req.UserID when they deliberately want one user's rows.
+func (s *PostgresStore) ListPromptHistory(ctx context.Context, req *types.PromptHistoryListRequest) (*types.PromptHistoryListResponse, error) {
+	// Refuse to run unscoped: without this an empty request would return every
+	// prompt in the table. The handler already requires spec_task_id or
+	// session_id; this is the backstop for any future caller.
+	if req.SpecTaskID == "" && req.SessionID == "" && req.UserID == "" {
+		return nil, fmt.Errorf("ListPromptHistory: one of SpecTaskID, SessionID or UserID is required")
+	}
+
+	// Soft-deleted prompts must stay deleted — matches ListPromptHistoryBySpecTask
+	// and ListPromptHistoryBySession. Applied before the count so Total agrees.
 	query := s.gdb.WithContext(ctx).
-		Where("user_id = ?", userID)
+		Where("deleted_at IS NULL")
+
+	// Filter by owner only when the caller explicitly asks for it.
+	if req.UserID != "" {
+		query = query.Where("user_id = ?", req.UserID)
+	}
 
 	// Filter by spec task (required - history is per-spec-task)
 	if req.SpecTaskID != "" {

--- a/api/pkg/types/prompt_history.go
+++ b/api/pkg/types/prompt_history.go
@@ -95,6 +95,13 @@ type PromptHistoryListRequest struct {
 	SessionID  string `json:"session_id,omitempty"` // Optional filter
 	Limit      int    `json:"limit,omitempty"`      // Max entries to return
 	Since      int64  `json:"since,omitempty"`      // Only entries after this timestamp (Unix ms)
+
+	// UserID restricts the result to one owner. Server-set only — never parsed
+	// from the query string, or a caller could read another user's rows without
+	// the spec-task/session authorization the handler performs. Left empty by
+	// the queue UI: the queue shows every prompt waiting for the agent,
+	// whoever queued it.
+	UserID string `json:"-"`
 }
 
 // PromptHistoryListResponse is the response for listing history

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -89,6 +89,9 @@ import {
   type WorkspaceReviewComment,
 } from '../workspace-inspector/workspaceReviewComments'
 import { SessionContextUsageIndicator } from './ContextUsageIndicator'
+import useAccount from '../../hooks/useAccount'
+import OrganizationUserAvatar, { resolveOrganizationUser } from '../widgets/OrganizationUserAvatar'
+import type { TypesOrganizationMembership, TypesUser } from '../../api/api'
 
 // Threshold for converting large text paste to file attachment (10KB)
 const LARGE_TEXT_THRESHOLD = 10 * 1024
@@ -177,6 +180,14 @@ interface SortableQueueItemProps {
   truncateContent: (content: string, maxLen?: number) => string
   handleRestartAgent: () => void
   isRestarting: boolean
+  // Owner attribution. The queue belongs to the agent, so it shows prompts
+  // queued by teammates and by bots through the session-messages API too.
+  // showOwner is only true once the queue holds more than one distinct owner —
+  // an avatar on every row of a single-person queue is pure noise.
+  showOwner: boolean
+  isForeign: boolean
+  orgMembers: TypesOrganizationMembership[]
+  currentUser?: TypesUser
 }
 
 // Sortable queue item component
@@ -198,6 +209,10 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
   truncateContent,
   handleRestartAgent,
   isRestarting,
+  showOwner,
+  isForeign,
+  orgMembers,
+  currentUser,
 }) => {
   const {
     attributes,
@@ -213,6 +228,13 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
     transition,
     opacity: isDragging ? 0.5 : 1,
   }
+
+  // Whose prompt this is, for the hover label. Falls back to a generic label
+  // when the owner isn't in the org membership list (e.g. a bot account).
+  const owner = resolveOrganizationUser(entry.userId, orgMembers, currentUser)
+  const ownerLabel = isForeign
+    ? `Queued by ${owner?.full_name || owner?.username || owner?.email || 'another user'}`
+    : 'Queued by you'
 
   const isFailed = entry.status === 'failed'
   // Classification (transient vs crashed vs stuck → Restart) is shared with
@@ -359,12 +381,12 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           sx={{
             flex: 1,
             minWidth: 0,
-            cursor: isSending ? 'default' : 'pointer',
-            '&:hover': !isSending ? {
+            cursor: isSending || isForeign ? 'default' : 'pointer',
+            '&:hover': !isSending && !isForeign ? {
               '& .edit-hint': { opacity: 1 },
             } : undefined,
           }}
-          onClick={() => !isSending && handleStartEdit(entry)}
+          onClick={() => !isSending && !isForeign && handleStartEdit(entry)}
         >
           {/* minWidth: 0 lets the Typography ellipsise instead of forcing the
               row to its intrinsic min-content width. On mobile the latter
@@ -372,6 +394,19 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
               `overflow: hidden` clip so users couldn't dismiss stuck items.
               See design/2026-04-30-queue-and-other-stuck-state-bugs.md. */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+            {showOwner && (
+              <Tooltip title={ownerLabel}>
+                <Box sx={{ display: 'flex', flexShrink: 0 }}>
+                  <OrganizationUserAvatar
+                    userId={entry.userId}
+                    members={orgMembers}
+                    currentUser={currentUser}
+                    size={18}
+                    iconSize={14}
+                  />
+                </Box>
+              </Tooltip>
+            )}
             <Typography
               variant="body2"
               sx={{
@@ -386,7 +421,7 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
             >
               {truncateContent(entry.content, 50)}
             </Typography>
-            {!isSending && (
+            {!isSending && !isForeign && (
               <Pencil
                 className="edit-hint"
                 size={14}
@@ -487,7 +522,10 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           is narrow (e.g. mobile). Without it the Typography content above
           could squeeze the actions past the queue container's overflow:hidden
           clip and leave queue items unrecoverable. */}
-      {!isEditing && !isSending && (
+      {/* Someone else's queued prompt is read-only: the delete endpoint 403s on a
+          non-owner, and letting one viewer re-order or edit another's message
+          would rewrite their queue. Attribution is enough here. */}
+      {!isEditing && !isSending && !isForeign && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, flexShrink: 0 }}>
           {/* Interrupt toggle */}
           <Tooltip title={entry.interrupt !== false ? "Interrupt mode - click to queue after current" : "Queue mode - click to interrupt"}>
@@ -683,6 +721,17 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   // the moment dispatch is confirmed; if it later bounces it returns via 'failed'.
   // See design/2026-06-19-incident-interrupt-during-boot-context-loss.md.
   const queuedPrompts = [...failedPrompts, ...pendingPrompts].filter(p => p.status !== 'sending')
+
+  // Owner attribution for the queue. The queue is the agent's, not one person's:
+  // it also holds prompts queued by teammates and by bots through the
+  // session-messages API. Only show avatars once more than one owner is actually
+  // present — in the overwhelmingly common single-user case they'd be noise.
+  const account = useAccount()
+  const orgMembers: TypesOrganizationMembership[] = account.organizationTools.organization?.memberships || []
+  const currentUserId = account.user?.id
+  const queueHasMultipleOwners = new Set(
+    queuedPrompts.map(p => p.userId).filter(Boolean)
+  ).size > 1
 
   // Track previous appendText to detect changes
   const prevAppendTextRef = useRef<string | undefined>(undefined)
@@ -1456,6 +1505,10 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
                       truncateContent={truncateContent}
                       handleRestartAgent={handleRestartAgent}
                       isRestarting={isRestartingAgent}
+                      showOwner={queueHasMultipleOwners}
+                      isForeign={!!entry.userId && !!currentUserId && entry.userId !== currentUserId}
+                      orgMembers={orgMembers}
+                      currentUser={account.user}
                     />
                   ))}
               </SortableContext>

--- a/frontend/src/hooks/usePromptHistory.ts
+++ b/frontend/src/hooks/usePromptHistory.ts
@@ -31,6 +31,11 @@ export interface PromptHistoryEntry {
   content: string
   timestamp: number
   sessionId?: string
+  // Who queued this entry. The queue is the AGENT's, so it also carries prompts
+  // queued by teammates and by bots via the session-messages API; those are
+  // displayed with an owner indicator and are read-only to everyone else.
+  // Undefined on a local entry that has not round-tripped through the backend yet.
+  userId?: string
   // 'pending'  → in queue, not yet dispatched to Zed
   // 'sending'  → backend has dispatched to Zed but Zed hasn't started streaming yet
   //              (the queue UI keeps these visible — that's the user-visible "in flight" state)

--- a/frontend/src/services/promptHistoryService.ts
+++ b/frontend/src/services/promptHistoryService.ts
@@ -15,6 +15,7 @@ export interface LocalPromptHistoryEntry {
   status: 'sent' | 'sending' | 'pending' | 'failed'
   timestamp: number
   sessionId?: string
+  userId?: string           // Who queued it; absent on entries created locally before sync
   interrupt?: boolean       // If true, interrupts current conversation
   queuePosition?: number    // Position in queue for ordering
   // Retry tracking
@@ -95,6 +96,9 @@ export function backendToLocal(entry: TypesPromptHistoryEntry): LocalPromptHisto
     status: (entry.status as 'sent' | 'pending' | 'failed') || 'sent',
     timestamp: entry.created_at ? new Date(entry.created_at).getTime() : Date.now(),
     sessionId: entry.session_id,
+    // Who queued this. The queue belongs to the agent, so it carries entries from
+    // teammates and bots too; the UI attributes them and keeps them read-only.
+    userId: entry.user_id,
     interrupt: entry.interrupt ?? true,
     queuePosition: entry.queue_position,
     // Retry tracking


### PR DESCRIPTION
## Summary

Messages queued through `POST /api/v1/sessions/{id}/messages` — the call HelixOS makes on
every card approval — were written with an empty `spec_task_id`, because the generic
session-messages handler had no spec task to hand and passed `""`. The prompt-queue UI
queries *by* `spec_task_id`, so those rows were filtered out: 53 approvals were correctly
queued, correctly `pending`, and completely invisible. The queue was working; only its
visibility was broken.

`persistQueuedPrompt` now resolves the owning spec task itself (via the existing
`ListSpecTasks` `PlanningSessionID` filter) when the caller didn't supply one. The two
callers that already pass `task.ID` are unchanged, and a session with no spec task still
enqueues and dispatches with an empty `spec_task_id` — that is legitimate there.

Three related defects in the same path are fixed alongside it.

**Busy-defers no longer burn the retry budget (silent data loss).** `processAnyPendingPrompt`
claims the head-of-queue prompt with no busy pre-check; `sendQueuedPromptToSession` then
rejects it as busy and the caller called `MarkPromptAsFailed`, incrementing `retry_count`.
That drain fires on *every acknowledged cancellation* — every time a user interrupts the
agent — and on the live session one prompt reached `retry_count = 11` in 16 minutes purely
from defers. At the cap of 20 the `retry_count < ?` predicate stops selecting the row and
the message is dropped forever, with nothing surfaced to the user.

Of the two options in the brief this takes **(b)**, distinguishing the defer from a real
error, not (a) a busy pre-check in `processAnyPendingPrompt`. Reasons: that drain also
claims *interrupt* prompts, which are deliberately exempt from the busy check, so a blanket
pre-check would break the interrupt path and a conditional one would need to inspect the
prompt before the atomic claim; and (b) additionally covers the boot-race case where an
interrupt is deferred because `ZedThreadID` is not yet set, which (a) never reaches. A new
`ErrPromptBusyDeferred` sentinel wraps the existing busy return, and a single shared
`requeueUndispatchedPrompt` helper makes the defer-vs-failure decision for all three drain
paths, so it cannot drift between them. Deferred prompts go back to `pending` with
`retry_count` untouched; genuine failures still increment it and still respect the cap. The
comment block encoding the past interrupt/boot-race incidents is untouched — only the error
*value* changed, not the control flow.

**The queue now shows every prompt waiting for the agent, not just the viewer's own.** The
queue belongs to the agent, not to whoever typed the message: a teammate's or a bot's
queued prompt is going to run on the session you are looking at, so hiding it is the same
class of lie as the original bug. `ListPromptHistory` and the sync response are now scoped
by spec task / session instead of `user_id`.

That predicate *was* the authorization on those endpoints — there was no other check — so
it is replaced with a real one: `authorizeUserToPromptQueue` resolves the spec task's
project and calls `authorizeUserToProject`, or `authorizeUserToSession` for session-scoped
queues, before any rows are returned. The store additionally refuses to run a request that
carries no scope at all. Writes stay owner-attributed: `SyncPromptHistory` skips updates to
rows owned by someone else, and the UI hides the edit / interrupt-toggle / delete
affordances on foreign entries (`deletePromptHistoryEntry`'s owner-only 403 is unchanged).
Entries carry an owner avatar with a "Queued by …" hover label, shown only when the queue
actually holds more than one distinct owner so the common single-user case is unchanged.

**`ListPromptHistory` ignored soft-deletes.** It had no `deleted_at IS NULL` predicate,
unlike `ListPromptHistoryBySpecTask` and `ListPromptHistoryBySession`, so deleted prompts
could reappear in the queue. Added, before the count so `total` agrees.

**Backfill.** `0010_backfill_prompt_history_spec_task_id` stamps `spec_task_id` on existing
rows where `session_id` matches a spec task's `planning_session_id`. It is idempotent (the
guard stops matching once stamped), never overwrites a non-empty value, and follows the
`0006_backfill_spec_task_assignees` precedent including the `to_regclass`/column guards. The
`down` is a documented no-op — the previous values were empty strings written by the bug.
**It has not been run against any live database from this branch**, so no row count is
claimed; it will run on deploy.

## Testing

**The required live browser verification was NOT performed, and this change is unverified
at runtime.**

The session's startup script failed before the stack came up: it builds Zed from source and
`rustc` was OOM-killed (`signal: 9, SIGKILL`) compiling the `project` crate, so the script
exited 1 with `❌ Error: Failed to build Zed IDE` and started no containers. I brought up
`postgres`, `api` and `frontend` by hand, but the test plan needs a LIVE Zed session
(`config->>'zed_thread_id'` a non-empty UUID), which requires the desktop image that depends
on that Zed binary. The task was then explicitly descoped to "get it merged, don't worry
about testing".

The first push went red in CI: `persistQueuedPrompt` now calls `ListSpecTasks`, and the
existing gomock suite in `session_messages_handler_test.go` had no expectation for it, so
`TestEnqueuesOntoQueue` and `TestNotifyUserIDCarriedOnRow` aborted. `go build ./...` does
not compile test files, so the green build had said nothing about them. Fixed, and the
regression tests that should have been there from the start were added at the same time.

What was actually run:

- `CGO_ENABLED=0 go build ./...` — passes, exit 0.
- `go test ./pkg/server/ ./pkg/types/ ./pkg/store/memorystore/` — all pass. Includes three
  new tests: `TestStampsSpecTaskIDFromPlanningSession` (row carries the owning task; the
  filter uses `PlanningSessionID` and `IncludeArchived`), `TestEnqueuesOntoQueue` (no spec
  task → empty `spec_task_id`, still enqueues), and `TestSpecTaskLookupErrorFailsEnqueue`
  (lookup error → 500, nothing written).
- Frontend `tsc --noEmit -p tsconfig.json` (TypeScript 5.9.3) — passes, exit 0, zero
  diagnostics. Run by mounting the source into the `helix-frontend` image, since
  `frontend/node_modules` is not installed on this machine.

What was **not** run, and should be before this is trusted in production:

- The whole end-to-end deliverable: send a message mid-turn via the session-messages API
  and confirm it appears in the spec-task prompt queue. **There is no screenshot.**
- That the message still dispatches unchanged when the turn completes.
- That `retry_count` stays flat across repeated cancel-acks.
- That a plain session with no spec task still enqueues and dispatches.
- **The read-hole check** — that an unauthorized account gets 403 for another project's
  `spec_task_id`. This is the highest-risk gap: de-scoping the read and adding the authz
  check landed in the same commit, but only the code was reviewed, not its behaviour.
- Unit tests for the soft-delete exclusion, the busy-defer retry-count behaviour, and the
  new authorization; and a frontend test for the owner indicator. Not written. (The
  session→spec-task resolution *is* now covered — see above.)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01m1d81f4q10vmrb77n3npc3r6)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/003021_queued-agent-messages/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/003021_queued-agent-messages/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/003021_queued-agent-messages/tasks.md)

🚀 Built with [Helix](https://helix.ml)