### PR TITLE
fix(agents): gate agent start on MCP context servers being reachable

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -32,7 +32,15 @@ var (
 )
 
 const (
-	PollInterval              = 30 * time.Second
+	PollInterval = 30 * time.Second
+
+	// mcpReadinessTimeout bounds the wait for the remote context_server
+	// origins to answer. It is generous because a cold sandbox host brings the
+	// API proxy, dockerd, the workspace clone and four MCP servers up at once;
+	// it is bounded because a session that cannot reach the Helix API is not
+	// going to fix itself and the operator needs the error, not a hang.
+	mcpReadinessTimeout       = 60 * time.Second
+	mcpReadinessRetryDelay    = 2 * time.Second
 	DebounceTime              = 500 * time.Millisecond
 	maxAgentStartupErrorBytes = 4096
 )
@@ -1381,6 +1389,19 @@ func main() {
 	const maxRetries = 5
 	if err := daemon.syncInitialConfig(maxRetries, 2*time.Second); err != nil {
 		log.Printf("Warning: Initial sync failed: %v", err)
+	}
+
+	// Prove the remote context_servers we just wrote are actually reachable
+	// from this container before Zed launches the coding agent. The agent
+	// registers them exactly once and never retries, so an address that does
+	// not answer in this window silently costs the session every Helix tool
+	// for its entire life. Gating here - and reporting when it fails - is what
+	// stops that from looking like a healthy session with a mute agent.
+	if err := daemon.verifyMCPEndpoints(context.Background(), mcpReadinessTimeout, mcpReadinessRetryDelay); err != nil {
+		log.Printf("FATAL for the agent: %v", err)
+		if reportErr := daemon.reportAgentStartupError(err); reportErr != nil {
+			log.Printf("Failed to report unreachable MCP context servers: %v", reportErr)
+		}
 	}
 
 	// Start file watcher for Zed changes

--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -1391,18 +1391,20 @@ func main() {
 		log.Printf("Warning: Initial sync failed: %v", err)
 	}
 
-	// Prove the remote context_servers we just wrote are actually reachable
-	// from this container before Zed launches the coding agent. The agent
-	// registers them exactly once and never retries, so an address that does
-	// not answer in this window silently costs the session every Helix tool
-	// for its entire life. Gating here - and reporting when it fails - is what
-	// stops that from looking like a healthy session with a mute agent.
-	if err := daemon.verifyMCPEndpoints(context.Background(), mcpReadinessTimeout, mcpReadinessRetryDelay); err != nil {
-		log.Printf("FATAL for the agent: %v", err)
-		if reportErr := daemon.reportAgentStartupError(err); reportErr != nil {
-			log.Printf("Failed to report unreachable MCP context servers: %v", reportErr)
+	// Surface unreachable MCP context servers early, in the session UI. The
+	// per-launch gate in start-zed-core.sh is what actually stops Zed starting
+	// (it polls /mcp-readiness before every launch); this only exists so the
+	// operator gets told, rather than having to read container logs.
+	//
+	// In a goroutine so it cannot delay the HTTP listener the gate polls.
+	go func() {
+		if err := daemon.waitForMCPEndpoints(context.Background(), SettingsPath, mcpReadinessTimeout, mcpReadinessRetryDelay); err != nil {
+			log.Printf("FATAL for the agent: %v", err)
+			if reportErr := daemon.reportAgentStartupError(err); reportErr != nil {
+				log.Printf("Failed to report unreachable MCP context servers: %v", reportErr)
+			}
 		}
-	}
+	}()
 
 	// Start file watcher for Zed changes
 	if err := daemon.startWatcher(); err != nil {
@@ -1421,6 +1423,10 @@ func main() {
 	http.HandleFunc("/health", daemon.healthCheck)
 	http.HandleFunc("/settings", daemon.getSettings)
 	http.HandleFunc("/reload", daemon.forceReload)
+	// Per-launch MCP readiness verdict for start-zed-core.sh. Every Zed launch
+	// is another one-shot MCP registration by the agent, so every launch needs
+	// its own freshly measured answer.
+	http.HandleFunc("/mcp-readiness", daemon.mcpReadinessHandler)
 
 	// SECURITY: bind loopback only. This endpoint exposes GET/PUT /settings and
 	// /reload for the in-container agent + desktop-bridge, which reach it over

--- a/api/cmd/settings-sync-daemon/mcp_readiness.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness.go
@@ -42,7 +42,8 @@ import (
 
 const (
 	// mcpProbeTimeout bounds one endpoint probe. Endpoints are probed
-	// concurrently, so this is also roughly the bound on a whole pass.
+	// concurrently, so this is also roughly the bound on a whole pass, which is
+	// what keeps /mcp-readiness prompt enough for the shell gate to poll it.
 	mcpProbeTimeout = 5 * time.Second
 )
 
@@ -103,30 +104,50 @@ func (d *SettingsDaemon) probeMCPEndpoints(ctx context.Context, settingsPath str
 // misrouting /api/v1/mcp/..., and a user-configured third-party MCP server
 // need not serve Helix's config endpoint at all.
 //
-// HEAD, because it is the only method that is uniformly side-effect free and
-// prompt. A real MCP initialize (POST) allocates server-side session state —
-// kodit creates a per-session handler — and GET is the Streamable HTTP
-// notification stream: measured against a live session, GET hangs until
-// timeout on helix-desktop and returns an open SSE stream on helix-session and
-// kodit.
+// Method: OPTIONS. The MCP gateway routes register GET, POST and OPTIONS
+// (api/pkg/server/server.go), and the choice among them is forced:
 //
-// Only two things count as failure: a transport error (DNS failure, connection
-// refused, timeout) and a 5xx. Every other status is success, and that is not
-// laziness — status here is anti-correlated with routing correctness. Measured
-// through the sandbox API proxy against a healthy session, HEAD on each correct
-// MCP URL returns 404 (the router has no HEAD route), while HEAD on a
-// deliberately wrong path returns 200 from the frontend catch-all. So a status
-// policy stricter than "not 5xx" would reject exactly the endpoints that work.
+//   - POST is the real MCP initialize and allocates server-side session state.
+//   - GET is the Streamable HTTP notification stream. Measured against a live
+//     session it hangs until timeout on helix-desktop and returns an open SSE
+//     stream on helix-session and kodit.
+//   - HEAD is not a registered method, so gorilla/mux never matches the route
+//     and the request never reaches the auth middleware. Measured, HEAD
+//     returns 404 for a valid token, an invalid token and no token alike — it
+//     cannot see authentication at all.
 //
-// 5xx is the exception worth catching: when the Helix API is down but the
-// sandbox proxy is up, the proxy's ErrorHandler answers every MCP URL with
-// 502 "Helix API unavailable". Treating any response as success would call
-// that ready, which is precisely the state this gate exists to refuse.
+// OPTIONS is the one method that is prompt (0.00s on all four servers),
+// allocates nothing (24 probes produced no additional kodit handler
+// creations), and actually traverses authentication.
+//
+// Failure is a transport error, a 5xx, or a 401/403. Every other status is
+// success, and that is measured rather than lazy: with a valid token, OPTIONS
+// on the correct MCP URLs returns 404 (helix-desktop, helix-session, kodit) or
+// 400 (helix-tasks), while OPTIONS on a deliberately wrong path returns 204
+// from the frontend catch-all. Status is anti-correlated with routing
+// correctness, so anything stricter would reject exactly the endpoints that
+// work. This probe therefore cannot detect path-level misrouting; it detects
+// transport, upstream health and authentication.
+//
+// The three failure classes each correspond to a way the agent's one-shot
+// registration dies:
+//
+//   - transport error: the address does not resolve or refuses connections.
+//   - 5xx: with the Helix API down but the sandbox proxy up, the proxy's
+//     ErrorHandler answers every MCP URL with 502 "Helix API unavailable".
+//   - 401/403: the session token in the header is expired or wrong. Measured,
+//     an invalid token turns every one of these endpoints from 404/400 into
+//     401, and the agent sending that same header would fail identically.
+//
+// A third-party MCP server that rejects even an authenticated OPTIONS would be
+// a false negative here. That is the right way to be wrong: a false negative
+// is a loud error naming the URL and status, while a false positive is the
+// silent session-long tool outage this gate exists to prevent.
 func (d *SettingsDaemon) probeContextServer(ctx context.Context, ep contextServerEndpoint) error {
 	probeCtx, cancel := context.WithTimeout(ctx, mcpProbeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, ep.url, nil)
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodOptions, ep.url, nil)
 	if err != nil {
 		return fmt.Errorf("probe %s (%s): %w", ep.name, ep.url, err)
 	}
@@ -138,8 +159,14 @@ func (d *SettingsDaemon) probeContextServer(ctx context.Context, ep contextServe
 		return fmt.Errorf("probe %s (%s): %w", ep.name, ep.url, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 500 {
-		return fmt.Errorf("probe %s (%s): %s", ep.name, ep.url, resp.Status)
+	switch {
+	case resp.StatusCode >= 500:
+		return fmt.Errorf("probe %s (%s): %s (the Helix API behind the sandbox proxy is unavailable)",
+			ep.name, ep.url, resp.Status)
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("probe %s (%s): %s (the configured Authorization header is not accepted; "+
+			"the agent sends the same header and its MCP registration would fail)",
+			ep.name, ep.url, resp.Status)
 	}
 	return nil
 }

--- a/api/cmd/settings-sync-daemon/mcp_readiness.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -29,27 +30,14 @@ import (
 // session in this state burns its whole budget calling tools that were never
 // registered.
 //
-// So the address we just wrote into settings.json has to be proven reachable
-// BEFORE Zed launches the agent. If it is not, the session is not degraded —
-// it is broken, because the same origin serves inference — and it must say so.
+// So the addresses in settings.json have to be proven reachable before EVERY
+// Zed launch, not once at boot: run_zed_restart_loop respawns Zed for the life
+// of the container, and restartZed() deliberately uses that path to give the
+// agent a fresh ACP session on an agent switch. Each of those launches is
+// another one-shot MCP registration, so each one needs its own verdict.
+// start-zed-core.sh asks /mcp-readiness for a fresh one before every launch.
 //
 // See design/2026-09-01-opencode-mcp-tools-unavailable.md.
-
-// Marker paths. Vars, not consts, so tests can redirect them at a tempdir
-// instead of writing the real container paths. The same literals appear in
-// desktop/shared/start-zed-core.sh, which is the reader.
-var (
-	// mcpEndpointsReadyMarker is written once every remote context_server
-	// origin has answered. start-zed-core.sh waits for it before launching
-	// Zed, so the agent's one-shot MCP registration happens in a window where
-	// the endpoints are known good.
-	mcpEndpointsReadyMarker = "/tmp/helix-mcp-endpoints-ready"
-
-	// mcpEndpointsUnreachableMarker records why the check failed.
-	// start-zed-core.sh prints its contents in the fatal message so an
-	// operator sees the actual URL rather than "Zed never connected".
-	mcpEndpointsUnreachableMarker = "/tmp/helix-mcp-endpoints-unreachable"
-)
 
 const (
 	// mcpProbePath is an unauthenticated endpoint on the Helix API. Probing it
@@ -62,51 +50,38 @@ const (
 	mcpProbeTimeout = 5 * time.Second
 )
 
-// verifyMCPEndpoints proves every distinct origin behind a remote
-// context_server answers, retrying until timeout elapses. It writes the ready
-// marker on success and the unreachable marker on failure.
-//
-// It deliberately reads the URLs back out of the settings we just merged rather
-// than trusting HELIX_API_URL. Those two can disagree: a control plane that has
-// rolled forward to the sandbox API proxy address emits helix-api.internal:18080
-// into context_servers while an older sandbox host still hands the container
-// HELIX_API_URL=http://api:8080 and never pins the proxy hostname. Zed's
-// websocket then works over the env address, inference works, and only the MCP
-// servers are dead — which is exactly the failure this check exists to catch,
-// and exactly the one probing HELIX_API_URL would miss.
-func (d *SettingsDaemon) verifyMCPEndpoints(ctx context.Context, timeout, retryDelay time.Duration) error {
-	if d.helixSettings == nil {
-		// The initial sync never completed, so there is no agent config at all
-		// — nothing was written for us to verify. Declaring readiness here
-		// would be a lie that lets Zed start against a config that does not
-		// exist, which is the failure this gate exists to prevent.
-		return d.failMCPEndpoints(fmt.Errorf("settings were never synced from Helix, so no agent config was written"))
+// probeMCPEndpoints makes one pass over the context server origins and returns
+// nil when the agent can safely be started. It is the whole readiness verdict:
+// callers decide whether to retry.
+func (d *SettingsDaemon) probeMCPEndpoints(ctx context.Context, settingsPath string) error {
+	origins, err := contextServerOrigins(settingsPath)
+	if err != nil {
+		return err
 	}
-
-	origins := remoteContextServerOrigins(d.helixSettings)
 	if len(origins) == 0 {
-		// Settings synced, but this agent has no URL-addressed context servers
+		// Settings parsed, but this agent has no URL-addressed context servers
 		// (a stdio-only agent, or one with no MCP at all). Nothing to prove.
-		log.Printf("MCP readiness: no remote context servers configured; nothing to verify")
-		return d.markMCPEndpointsReady()
+		return nil
 	}
+	for _, origin := range origins {
+		if err := d.probeOrigin(ctx, origin); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	log.Printf("MCP readiness: verifying %d context server origin(s): %s",
-		len(origins), strings.Join(origins, ", "))
-
+// waitForMCPEndpoints retries probeMCPEndpoints until timeout elapses. Used on
+// the boot path, where a failure is reported to the API so the operator sees it
+// in the session rather than having to read container logs.
+func (d *SettingsDaemon) waitForMCPEndpoints(ctx context.Context, settingsPath string, timeout, retryDelay time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for {
-		lastErr = nil
-		for _, origin := range origins {
-			if err := d.probeOrigin(ctx, origin); err != nil {
-				lastErr = err
-				break
-			}
-		}
+		lastErr = d.probeMCPEndpoints(ctx, settingsPath)
 		if lastErr == nil {
-			log.Printf("MCP readiness: all %d context server origin(s) reachable", len(origins))
-			return d.markMCPEndpointsReady()
+			log.Printf("MCP readiness: context servers reachable")
+			return nil
 		}
 		if time.Now().After(deadline) || ctx.Err() != nil {
 			break
@@ -117,20 +92,29 @@ func (d *SettingsDaemon) verifyMCPEndpoints(ctx context.Context, timeout, retryD
 		case <-time.After(retryDelay):
 		}
 	}
-
-	return d.failMCPEndpoints(fmt.Errorf("unreachable after %s: %w", timeout, lastErr))
+	return fmt.Errorf("Helix MCP context servers are not usable from this container "+
+		"(unreachable after %s: %w). The coding agent connects to them exactly once when it "+
+		"starts and never retries, so it would run with no Helix tools for the whole session",
+		timeout, lastErr)
 }
 
-// failMCPEndpoints records why the agent must not be started and returns the
-// error main() reports to the API.
-func (d *SettingsDaemon) failMCPEndpoints(cause error) error {
-	err := fmt.Errorf("Helix MCP context servers are not usable from this container (%w). "+
-		"The coding agent connects to them exactly once when it starts and never retries, "+
-		"so it would run with no Helix tools for the whole session", cause)
-	if writeErr := os.WriteFile(mcpEndpointsUnreachableMarker, []byte(err.Error()+"\n"), 0644); writeErr != nil {
-		log.Printf("MCP readiness: failed to write %s: %v", mcpEndpointsUnreachableMarker, writeErr)
+// mcpReadinessHandler answers the per-launch gate in start-zed-core.sh with a
+// freshly measured verdict. 200 means "safe to launch Zed"; 503 carries the
+// reason, which the gate prints.
+//
+// It is deliberately a single pass with no internal retry: the waiting policy
+// lives in the shell loop that polls this, so there is exactly one place that
+// decides how long a launch may be held back.
+func (d *SettingsDaemon) mcpReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	if err := d.probeMCPEndpoints(r.Context(), SettingsPath); err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, err.Error())
+		return
 	}
-	return err
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ready")
 }
 
 // probeOrigin reports whether origin is reachable. Any HTTP response counts: a
@@ -153,50 +137,75 @@ func (d *SettingsDaemon) probeOrigin(ctx context.Context, origin string) error {
 	return nil
 }
 
-// markMCPEndpointsReady clears any stale unreachable marker and writes the
-// ready marker start-zed-core.sh gates on.
-func (d *SettingsDaemon) markMCPEndpointsReady() error {
-	if err := os.Remove(mcpEndpointsUnreachableMarker); err != nil && !os.IsNotExist(err) {
-		log.Printf("MCP readiness: failed to clear %s: %v", mcpEndpointsUnreachableMarker, err)
-	}
-	if err := os.WriteFile(mcpEndpointsReadyMarker, []byte("ready\n"), 0644); err != nil {
-		return fmt.Errorf("write %s: %w", mcpEndpointsReadyMarker, err)
-	}
-	return nil
-}
-
-// remoteContextServerOrigins returns the distinct scheme://host[:port] of every
-// context_server addressed by URL. Stdio servers (chrome-devtools and any
-// user-configured command) have no URL and cannot fail this way — they run
-// inside the container.
+// contextServerOrigins returns the distinct scheme://host[:port] of every
+// context_server addressed by URL, read from the settings file on disk.
 //
-// Sorted so the log line and the probe order are stable.
-func remoteContextServerOrigins(settings map[string]interface{}) []string {
+// Reading the file rather than d.helixSettings is deliberate on two counts.
+// It is the exact set Zed loads and forwards to the agent, including any user
+// overrides merged in; and the file is written atomically (tempfile + rename),
+// so the HTTP handler can read it concurrently with the poll loop rewriting it
+// without sharing mutable state with the rest of the daemon.
+//
+// A context server with no "url" is a stdio server: it runs inside the
+// container and cannot fail this way, so it is ignored. A context server that
+// declares a "url" we cannot turn into an origin is a configuration error and
+// fails readiness — Zed will hand that broken URL to the agent regardless, and
+// the agent's one-shot registration against it will fail permanently. Silently
+// skipping it is how an all-malformed config would otherwise report "ready".
+//
+// Origins are sorted so the log line and the probe order are stable.
+func contextServerOrigins(settingsPath string) ([]string, error) {
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		// No settings file means the initial sync never completed and no agent
+		// config was written. Reporting readiness here would let Zed start
+		// against a config that does not exist.
+		return nil, fmt.Errorf("read %s: %w", settingsPath, err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", settingsPath, err)
+	}
+
 	contextServers, ok := settings["context_servers"].(map[string]interface{})
 	if !ok {
-		return nil
+		return nil, nil
 	}
+
 	seen := map[string]struct{}{}
-	for name, raw := range contextServers {
-		server, ok := raw.(map[string]interface{})
+	var invalid []string
+	for name, entry := range contextServers {
+		server, ok := entry.(map[string]interface{})
 		if !ok {
+			invalid = append(invalid, fmt.Sprintf("%s (not an object)", name))
 			continue
 		}
-		rawURL, ok := server["url"].(string)
-		if !ok || rawURL == "" {
+		value, present := server["url"]
+		if !present {
+			// stdio server (command/args) — nothing to reach over the network.
+			continue
+		}
+		rawURL, ok := value.(string)
+		if !ok || strings.TrimSpace(rawURL) == "" {
+			invalid = append(invalid, fmt.Sprintf("%s (empty url)", name))
 			continue
 		}
 		parsed, err := url.Parse(rawURL)
-		if err != nil || parsed.Host == "" {
-			log.Printf("MCP readiness: skipping context server %q with unparseable url %q", name, rawURL)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			invalid = append(invalid, fmt.Sprintf("%s (unusable url %q)", name, rawURL))
 			continue
 		}
 		seen[parsed.Scheme+"://"+parsed.Host] = struct{}{}
 	}
+	if len(invalid) > 0 {
+		sort.Strings(invalid)
+		return nil, fmt.Errorf("context servers with unusable urls: %s", strings.Join(invalid, ", "))
+	}
+
 	origins := make([]string, 0, len(seen))
 	for origin := range seen {
 		origins = append(origins, origin)
 	}
 	sort.Strings(origins)
-	return origins
+	return origins, nil
 }

--- a/api/cmd/settings-sync-daemon/mcp_readiness.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Why this exists.
+//
+// The remote context_servers we write into settings.json (helix-tasks,
+// helix-session, helix-desktop, kodit) do not reach the coding agent through
+// Zed at runtime. Zed forwards them once, on the ACP session/new|load|resume
+// request, and the agent connects to each exactly once. opencode records a
+// connect failure as a permanently "failed" server, logs a single warning, and
+// never retries; Zed never re-pushes them either.
+//
+// The consequence is the worst kind of failure: invisible and total. Every
+// <server>_<tool> call the model makes for the rest of the session dies with
+// "Model tried to call unavailable tool", while the LLM path (which retries per
+// turn) keeps working, so the session looks healthy. Meanwhile our own prompts
+// keep instructing the agent to call list_secrets / get_secret / ask_human. A
+// session in this state burns its whole budget calling tools that were never
+// registered.
+//
+// So the address we just wrote into settings.json has to be proven reachable
+// BEFORE Zed launches the agent. If it is not, the session is not degraded —
+// it is broken, because the same origin serves inference — and it must say so.
+//
+// See design/2026-09-01-opencode-mcp-tools-unavailable.md.
+
+// Marker paths. Vars, not consts, so tests can redirect them at a tempdir
+// instead of writing the real container paths. The same literals appear in
+// desktop/shared/start-zed-core.sh, which is the reader.
+var (
+	// mcpEndpointsReadyMarker is written once every remote context_server
+	// origin has answered. start-zed-core.sh waits for it before launching
+	// Zed, so the agent's one-shot MCP registration happens in a window where
+	// the endpoints are known good.
+	mcpEndpointsReadyMarker = "/tmp/helix-mcp-endpoints-ready"
+
+	// mcpEndpointsUnreachableMarker records why the check failed.
+	// start-zed-core.sh prints its contents in the fatal message so an
+	// operator sees the actual URL rather than "Zed never connected".
+	mcpEndpointsUnreachableMarker = "/tmp/helix-mcp-endpoints-unreachable"
+)
+
+const (
+	// mcpProbePath is an unauthenticated endpoint on the Helix API. Probing it
+	// rather than the MCP paths themselves keeps the check free of side
+	// effects: a real MCP initialize would create server-side session state
+	// (kodit allocates a per-session handler), and a GET on an MCP endpoint
+	// either 405s or opens an SSE stream we would have to tear down.
+	mcpProbePath = "/api/v1/config"
+
+	mcpProbeTimeout = 5 * time.Second
+)
+
+// verifyMCPEndpoints proves every distinct origin behind a remote
+// context_server answers, retrying until timeout elapses. It writes the ready
+// marker on success and the unreachable marker on failure.
+//
+// It deliberately reads the URLs back out of the settings we just merged rather
+// than trusting HELIX_API_URL. Those two can disagree: a control plane that has
+// rolled forward to the sandbox API proxy address emits helix-api.internal:18080
+// into context_servers while an older sandbox host still hands the container
+// HELIX_API_URL=http://api:8080 and never pins the proxy hostname. Zed's
+// websocket then works over the env address, inference works, and only the MCP
+// servers are dead — which is exactly the failure this check exists to catch,
+// and exactly the one probing HELIX_API_URL would miss.
+func (d *SettingsDaemon) verifyMCPEndpoints(ctx context.Context, timeout, retryDelay time.Duration) error {
+	if d.helixSettings == nil {
+		// The initial sync never completed, so there is no agent config at all
+		// — nothing was written for us to verify. Declaring readiness here
+		// would be a lie that lets Zed start against a config that does not
+		// exist, which is the failure this gate exists to prevent.
+		return d.failMCPEndpoints(fmt.Errorf("settings were never synced from Helix, so no agent config was written"))
+	}
+
+	origins := remoteContextServerOrigins(d.helixSettings)
+	if len(origins) == 0 {
+		// Settings synced, but this agent has no URL-addressed context servers
+		// (a stdio-only agent, or one with no MCP at all). Nothing to prove.
+		log.Printf("MCP readiness: no remote context servers configured; nothing to verify")
+		return d.markMCPEndpointsReady()
+	}
+
+	log.Printf("MCP readiness: verifying %d context server origin(s): %s",
+		len(origins), strings.Join(origins, ", "))
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		lastErr = nil
+		for _, origin := range origins {
+			if err := d.probeOrigin(ctx, origin); err != nil {
+				lastErr = err
+				break
+			}
+		}
+		if lastErr == nil {
+			log.Printf("MCP readiness: all %d context server origin(s) reachable", len(origins))
+			return d.markMCPEndpointsReady()
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			break
+		}
+		log.Printf("MCP readiness: %v (retrying in %s)", lastErr, retryDelay)
+		select {
+		case <-ctx.Done():
+		case <-time.After(retryDelay):
+		}
+	}
+
+	return d.failMCPEndpoints(fmt.Errorf("unreachable after %s: %w", timeout, lastErr))
+}
+
+// failMCPEndpoints records why the agent must not be started and returns the
+// error main() reports to the API.
+func (d *SettingsDaemon) failMCPEndpoints(cause error) error {
+	err := fmt.Errorf("Helix MCP context servers are not usable from this container (%w). "+
+		"The coding agent connects to them exactly once when it starts and never retries, "+
+		"so it would run with no Helix tools for the whole session", cause)
+	if writeErr := os.WriteFile(mcpEndpointsUnreachableMarker, []byte(err.Error()+"\n"), 0644); writeErr != nil {
+		log.Printf("MCP readiness: failed to write %s: %v", mcpEndpointsUnreachableMarker, writeErr)
+	}
+	return err
+}
+
+// probeOrigin reports whether origin is reachable. Any HTTP response counts: a
+// 401/404/405 proves the transport works, which is the only thing that can
+// break the agent's MCP registration. Only a transport error (DNS failure,
+// connection refused, timeout) is a failure.
+func (d *SettingsDaemon) probeOrigin(ctx context.Context, origin string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, mcpProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, origin+mcpProbePath, nil)
+	if err != nil {
+		return fmt.Errorf("probe %s: %w", origin, err)
+	}
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("probe %s: %w", origin, err)
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// markMCPEndpointsReady clears any stale unreachable marker and writes the
+// ready marker start-zed-core.sh gates on.
+func (d *SettingsDaemon) markMCPEndpointsReady() error {
+	if err := os.Remove(mcpEndpointsUnreachableMarker); err != nil && !os.IsNotExist(err) {
+		log.Printf("MCP readiness: failed to clear %s: %v", mcpEndpointsUnreachableMarker, err)
+	}
+	if err := os.WriteFile(mcpEndpointsReadyMarker, []byte("ready\n"), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", mcpEndpointsReadyMarker, err)
+	}
+	return nil
+}
+
+// remoteContextServerOrigins returns the distinct scheme://host[:port] of every
+// context_server addressed by URL. Stdio servers (chrome-devtools and any
+// user-configured command) have no URL and cannot fail this way — they run
+// inside the container.
+//
+// Sorted so the log line and the probe order are stable.
+func remoteContextServerOrigins(settings map[string]interface{}) []string {
+	contextServers, ok := settings["context_servers"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for name, raw := range contextServers {
+		server, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rawURL, ok := server["url"].(string)
+		if !ok || rawURL == "" {
+			continue
+		}
+		parsed, err := url.Parse(rawURL)
+		if err != nil || parsed.Host == "" {
+			log.Printf("MCP readiness: skipping context server %q with unparseable url %q", name, rawURL)
+			continue
+		}
+		seen[parsed.Scheme+"://"+parsed.Host] = struct{}{}
+	}
+	origins := make([]string, 0, len(seen))
+	for origin := range seen {
+		origins = append(origins, origin)
+	}
+	sort.Strings(origins)
+	return origins
+}

--- a/api/cmd/settings-sync-daemon/mcp_readiness.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -30,43 +31,115 @@ import (
 // session in this state burns its whole budget calling tools that were never
 // registered.
 //
-// So the addresses in settings.json have to be proven reachable before EVERY
-// Zed launch, not once at boot: run_zed_restart_loop respawns Zed for the life
-// of the container, and restartZed() deliberately uses that path to give the
-// agent a fresh ACP session on an agent switch. Each of those launches is
-// another one-shot MCP registration, so each one needs its own verdict.
+// So the context servers have to be proven reachable before EVERY Zed launch,
+// not once at boot: run_zed_restart_loop respawns Zed for the life of the
+// container, and restartZed() deliberately uses that path to give the agent a
+// fresh ACP session on an agent switch. Each of those launches is another
+// one-shot MCP registration, so each one needs its own verdict.
 // start-zed-core.sh asks /mcp-readiness for a fresh one before every launch.
 //
 // See design/2026-09-01-opencode-mcp-tools-unavailable.md.
 
 const (
-	// mcpProbePath is an unauthenticated endpoint on the Helix API. Probing it
-	// rather than the MCP paths themselves keeps the check free of side
-	// effects: a real MCP initialize would create server-side session state
-	// (kodit allocates a per-session handler), and a GET on an MCP endpoint
-	// either 405s or opens an SSE stream we would have to tear down.
-	mcpProbePath = "/api/v1/config"
-
+	// mcpProbeTimeout bounds one endpoint probe. Endpoints are probed
+	// concurrently, so this is also roughly the bound on a whole pass.
 	mcpProbeTimeout = 5 * time.Second
 )
 
-// probeMCPEndpoints makes one pass over the context server origins and returns
-// nil when the agent can safely be started. It is the whole readiness verdict:
-// callers decide whether to retry.
+// contextServerEndpoint is one URL-addressed MCP server exactly as Zed will
+// hand it to the agent.
+type contextServerEndpoint struct {
+	name    string
+	url     string
+	headers map[string]string
+}
+
+// probeMCPEndpoints makes one pass over the configured context servers and
+// returns nil when the agent can safely be started. It is the whole readiness
+// verdict: callers decide whether to retry.
 func (d *SettingsDaemon) probeMCPEndpoints(ctx context.Context, settingsPath string) error {
-	origins, err := contextServerOrigins(settingsPath)
+	endpoints, err := contextServerEndpoints(settingsPath)
 	if err != nil {
 		return err
 	}
-	if len(origins) == 0 {
+	if len(endpoints) == 0 {
 		// Settings parsed, but this agent has no URL-addressed context servers
 		// (a stdio-only agent, or one with no MCP at all). Nothing to prove.
 		return nil
 	}
-	for _, origin := range origins {
-		if err := d.probeOrigin(ctx, origin); err != nil {
-			return err
+
+	failures := make([]string, len(endpoints))
+	var wg sync.WaitGroup
+	for i, ep := range endpoints {
+		wg.Add(1)
+		go func(i int, ep contextServerEndpoint) {
+			defer wg.Done()
+			if err := d.probeContextServer(ctx, ep); err != nil {
+				failures[i] = err.Error()
+			}
+		}(i, ep)
+	}
+	wg.Wait()
+
+	var reasons []string
+	for _, f := range failures {
+		if f != "" {
+			reasons = append(reasons, f)
 		}
+	}
+	if len(reasons) > 0 {
+		return fmt.Errorf("%s", strings.Join(reasons, "; "))
+	}
+	return nil
+}
+
+// probeContextServer reports whether the agent will be able to reach this
+// context server.
+//
+// It requests the configured URL verbatim — path, query and headers — because
+// that is the only thing whose reachability we are entitled to assert. An
+// earlier version probed a synthetic `origin + "/api/v1/config"`, which is a
+// different route: a reverse proxy can serve that while rejecting or
+// misrouting /api/v1/mcp/..., and a user-configured third-party MCP server
+// need not serve Helix's config endpoint at all.
+//
+// HEAD, because it is the only method that is uniformly side-effect free and
+// prompt. A real MCP initialize (POST) allocates server-side session state —
+// kodit creates a per-session handler — and GET is the Streamable HTTP
+// notification stream: measured against a live session, GET hangs until
+// timeout on helix-desktop and returns an open SSE stream on helix-session and
+// kodit.
+//
+// Only two things count as failure: a transport error (DNS failure, connection
+// refused, timeout) and a 5xx. Every other status is success, and that is not
+// laziness — status here is anti-correlated with routing correctness. Measured
+// through the sandbox API proxy against a healthy session, HEAD on each correct
+// MCP URL returns 404 (the router has no HEAD route), while HEAD on a
+// deliberately wrong path returns 200 from the frontend catch-all. So a status
+// policy stricter than "not 5xx" would reject exactly the endpoints that work.
+//
+// 5xx is the exception worth catching: when the Helix API is down but the
+// sandbox proxy is up, the proxy's ErrorHandler answers every MCP URL with
+// 502 "Helix API unavailable". Treating any response as success would call
+// that ready, which is precisely the state this gate exists to refuse.
+func (d *SettingsDaemon) probeContextServer(ctx context.Context, ep contextServerEndpoint) error {
+	probeCtx, cancel := context.WithTimeout(ctx, mcpProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, ep.url, nil)
+	if err != nil {
+		return fmt.Errorf("probe %s (%s): %w", ep.name, ep.url, err)
+	}
+	for k, v := range ep.headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("probe %s (%s): %w", ep.name, ep.url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("probe %s (%s): %s", ep.name, ep.url, resp.Status)
 	}
 	return nil
 }
@@ -106,39 +179,19 @@ func (d *SettingsDaemon) waitForMCPEndpoints(ctx context.Context, settingsPath s
 // lives in the shell loop that polls this, so there is exactly one place that
 // decides how long a launch may be held back.
 func (d *SettingsDaemon) mcpReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	if err := d.probeMCPEndpoints(r.Context(), SettingsPath); err != nil {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprintln(w, err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, "ready")
 }
 
-// probeOrigin reports whether origin is reachable. Any HTTP response counts: a
-// 401/404/405 proves the transport works, which is the only thing that can
-// break the agent's MCP registration. Only a transport error (DNS failure,
-// connection refused, timeout) is a failure.
-func (d *SettingsDaemon) probeOrigin(ctx context.Context, origin string) error {
-	probeCtx, cancel := context.WithTimeout(ctx, mcpProbeTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, origin+mcpProbePath, nil)
-	if err != nil {
-		return fmt.Errorf("probe %s: %w", origin, err)
-	}
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("probe %s: %w", origin, err)
-	}
-	defer resp.Body.Close()
-	return nil
-}
-
-// contextServerOrigins returns the distinct scheme://host[:port] of every
-// context_server addressed by URL, read from the settings file on disk.
+// contextServerEndpoints reads the settings file on disk and returns every
+// URL-addressed context server, sorted by name so logs and probe order are
+// stable.
 //
 // Reading the file rather than d.helixSettings is deliberate on two counts.
 // It is the exact set Zed loads and forwards to the agent, including any user
@@ -148,13 +201,11 @@ func (d *SettingsDaemon) probeOrigin(ctx context.Context, origin string) error {
 //
 // A context server with no "url" is a stdio server: it runs inside the
 // container and cannot fail this way, so it is ignored. A context server that
-// declares a "url" we cannot turn into an origin is a configuration error and
-// fails readiness — Zed will hand that broken URL to the agent regardless, and
-// the agent's one-shot registration against it will fail permanently. Silently
-// skipping it is how an all-malformed config would otherwise report "ready".
-//
-// Origins are sorted so the log line and the probe order are stable.
-func contextServerOrigins(settingsPath string) ([]string, error) {
+// declares a "url" we cannot use is a configuration error and fails readiness —
+// Zed will hand that broken URL to the agent regardless, and the agent's
+// one-shot registration against it will fail permanently. Silently skipping it
+// is how an all-malformed config would otherwise report "ready".
+func contextServerEndpoints(settingsPath string) ([]contextServerEndpoint, error) {
 	raw, err := os.ReadFile(settingsPath)
 	if err != nil {
 		// No settings file means the initial sync never completed and no agent
@@ -172,7 +223,7 @@ func contextServerOrigins(settingsPath string) ([]string, error) {
 		return nil, nil
 	}
 
-	seen := map[string]struct{}{}
+	var endpoints []contextServerEndpoint
 	var invalid []string
 	for name, entry := range contextServers {
 		server, ok := entry.(map[string]interface{})
@@ -195,17 +246,34 @@ func contextServerOrigins(settingsPath string) ([]string, error) {
 			invalid = append(invalid, fmt.Sprintf("%s (unusable url %q)", name, rawURL))
 			continue
 		}
-		seen[parsed.Scheme+"://"+parsed.Host] = struct{}{}
+		endpoints = append(endpoints, contextServerEndpoint{
+			name:    name,
+			url:     rawURL,
+			headers: stringHeaders(server["headers"]),
+		})
 	}
 	if len(invalid) > 0 {
 		sort.Strings(invalid)
 		return nil, fmt.Errorf("context servers with unusable urls: %s", strings.Join(invalid, ", "))
 	}
 
-	origins := make([]string, 0, len(seen))
-	for origin := range seen {
-		origins = append(origins, origin)
+	sort.Slice(endpoints, func(i, j int) bool { return endpoints[i].name < endpoints[j].name })
+	return endpoints, nil
+}
+
+// stringHeaders pulls the string-valued headers out of a context server entry.
+// They are sent with the probe so it traverses the same auth edge the agent
+// will.
+func stringHeaders(raw interface{}) map[string]string {
+	entries, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
 	}
-	sort.Strings(origins)
-	return origins, nil
+	headers := make(map[string]string, len(entries))
+	for k, v := range entries {
+		if s, ok := v.(string); ok {
+			headers[k] = s
+		}
+	}
+	return headers
 }

--- a/api/cmd/settings-sync-daemon/mcp_readiness_test.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRemoteContextServerOrigins(t *testing.T) {
+	t.Run("dedupes origins and ignores stdio servers", func(t *testing.T) {
+		settings := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				// stdio: runs in-container, cannot fail the way this check catches
+				"chrome-devtools": map[string]interface{}{
+					"command": "/usr/bin/chrome-devtools-mcp",
+					"args":    []interface{}{"--viewport", "1280x800"},
+				},
+				"helix-tasks": map[string]interface{}{
+					"url": "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b",
+				},
+				"kodit": map[string]interface{}{
+					"url": "http://helix-api.internal:18080/api/v1/mcp/kodit?session_id=ses_1",
+				},
+				"partner": map[string]interface{}{
+					"url": "https://mcp.example.com/sse",
+				},
+			},
+		}
+		got := remoteContextServerOrigins(settings)
+		want := []string{"http://helix-api.internal:18080", "https://mcp.example.com"}
+		if len(got) != len(want) {
+			t.Fatalf("origins = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("origins = %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("no context servers yields none", func(t *testing.T) {
+		if got := remoteContextServerOrigins(map[string]interface{}{}); len(got) != 0 {
+			t.Fatalf("origins = %v, want none", got)
+		}
+	})
+
+	t.Run("unparseable url is skipped, not fatal", func(t *testing.T) {
+		settings := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"broken": map[string]interface{}{"url": "://nope"},
+				"good":   map[string]interface{}{"url": "http://api:8080/api/v1/mcp/session"},
+			},
+		}
+		got := remoteContextServerOrigins(settings)
+		if len(got) != 1 || got[0] != "http://api:8080" {
+			t.Fatalf("origins = %v, want [http://api:8080]", got)
+		}
+	})
+}
+
+// newReadinessDaemon builds the minimal daemon the readiness check needs, with
+// markers redirected into a tempdir so tests never touch /tmp state shared with
+// a real container.
+func newReadinessDaemon(t *testing.T, settings map[string]interface{}) (*SettingsDaemon, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	unreachable := filepath.Join(dir, "unreachable")
+
+	origReady, origUnreachable := mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker
+	mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker = ready, unreachable
+	t.Cleanup(func() {
+		mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker = origReady, origUnreachable
+	})
+
+	return &SettingsDaemon{
+		helixSettings: settings,
+		httpClient:    &http.Client{Timeout: 5 * time.Second},
+	}, ready, unreachable
+}
+
+func TestVerifyMCPEndpoints(t *testing.T) {
+	t.Run("reachable origin marks ready", func(t *testing.T) {
+		// 404 is a perfectly good answer: it proves the transport works, which
+		// is the only thing that can break the agent's MCP registration.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		d, ready, unreachable := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
+			},
+		})
+		if err := d.verifyMCPEndpoints(context.Background(), 5*time.Second, 100*time.Millisecond); err != nil {
+			t.Fatalf("verifyMCPEndpoints: %v", err)
+		}
+		if _, err := os.Stat(ready); err != nil {
+			t.Fatalf("ready marker not written: %v", err)
+		}
+		if _, err := os.Stat(unreachable); !os.IsNotExist(err) {
+			t.Fatalf("unreachable marker should not exist: %v", err)
+		}
+	})
+
+	t.Run("unreachable origin fails and records why", func(t *testing.T) {
+		// Bind then immediately close so the port is closed but well-formed.
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		deadURL := srv.URL
+		srv.Close()
+
+		d, ready, unreachable := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"helix-tasks": map[string]interface{}{"url": deadURL + "/api/v1/mcp/helix-tasks"},
+			},
+		})
+		err := d.verifyMCPEndpoints(context.Background(), 500*time.Millisecond, 100*time.Millisecond)
+		if err == nil {
+			t.Fatal("verifyMCPEndpoints succeeded against a closed port")
+		}
+		if _, statErr := os.Stat(ready); !os.IsNotExist(statErr) {
+			t.Fatalf("ready marker must not be written on failure: %v", statErr)
+		}
+		body, readErr := os.ReadFile(unreachable)
+		if readErr != nil {
+			t.Fatalf("unreachable marker not written: %v", readErr)
+		}
+		if len(body) == 0 {
+			t.Fatal("unreachable marker is empty; the operator needs the failing url")
+		}
+	})
+
+	t.Run("one dead origin fails even when another answers", func(t *testing.T) {
+		live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer live.Close()
+		dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		deadURL := dead.URL
+		dead.Close()
+
+		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"kodit":       map[string]interface{}{"url": live.URL + "/api/v1/mcp/kodit"},
+				"helix-tasks": map[string]interface{}{"url": deadURL + "/api/v1/mcp/helix-tasks"},
+			},
+		})
+		if err := d.verifyMCPEndpoints(context.Background(), 500*time.Millisecond, 100*time.Millisecond); err == nil {
+			t.Fatal("verifyMCPEndpoints succeeded with one unreachable origin")
+		}
+		if _, err := os.Stat(ready); !os.IsNotExist(err) {
+			t.Fatalf("ready marker must not be written: %v", err)
+		}
+	})
+
+	t.Run("recovers when the origin comes back", func(t *testing.T) {
+		// Grab a port, hold it closed so the first probes are refused, then
+		// bind a real server on the same address mid-flight. This is the
+		// actual transient the gate exists to ride out: the API proxy is not
+		// listening yet when the container boots.
+		probe, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := probe.Addr().String()
+		if err := probe.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"helix-tasks": map[string]interface{}{"url": "http://" + addr + "/api/v1/mcp/helix-tasks"},
+			},
+		})
+
+		bound := make(chan *httptest.Server, 1)
+		go func() {
+			time.Sleep(300 * time.Millisecond)
+			ln, lnErr := net.Listen("tcp", addr)
+			if lnErr != nil {
+				bound <- nil
+				return
+			}
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			srv.Listener.Close()
+			srv.Listener = ln
+			srv.Start()
+			bound <- srv
+		}()
+
+		verifyErr := d.verifyMCPEndpoints(context.Background(), 10*time.Second, 100*time.Millisecond)
+		srv := <-bound
+		if srv == nil {
+			t.Skip("could not rebind the probe port; another process took it")
+		}
+		defer srv.Close()
+
+		if verifyErr != nil {
+			t.Fatalf("verifyMCPEndpoints never recovered: %v", verifyErr)
+		}
+		if _, statErr := os.Stat(ready); statErr != nil {
+			t.Fatalf("ready marker not written after recovery: %v", statErr)
+		}
+	})
+
+	t.Run("unsynced settings never mark ready", func(t *testing.T) {
+		// syncFromHelix only assigns helixSettings after a successful fetch, so
+		// a failed initial sync leaves it nil. Marking ready here would let Zed
+		// start against an agent config that was never written.
+		d, ready, unreachable := newReadinessDaemon(t, nil)
+		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err == nil {
+			t.Fatal("verifyMCPEndpoints declared readiness with no synced settings")
+		}
+		if _, err := os.Stat(ready); !os.IsNotExist(err) {
+			t.Fatalf("ready marker must not be written: %v", err)
+		}
+		if _, err := os.Stat(unreachable); err != nil {
+			t.Fatalf("unreachable marker not written: %v", err)
+		}
+	})
+
+	t.Run("no remote context servers is ready, not an error", func(t *testing.T) {
+		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome-devtools": map[string]interface{}{"command": "/usr/bin/chrome-devtools-mcp"},
+			},
+		})
+		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err != nil {
+			t.Fatalf("verifyMCPEndpoints: %v", err)
+		}
+		if _, err := os.Stat(ready); err != nil {
+			t.Fatalf("ready marker not written: %v", err)
+		}
+	})
+
+	t.Run("stale unreachable marker is cleared on success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		d, _, unreachable := newReadinessDaemon(t, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
+			},
+		})
+		if err := os.WriteFile(unreachable, []byte("stale\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err != nil {
+			t.Fatalf("verifyMCPEndpoints: %v", err)
+		}
+		if _, err := os.Stat(unreachable); !os.IsNotExist(err) {
+			t.Fatal("stale unreachable marker survived a successful probe")
+		}
+	})
+}

--- a/api/cmd/settings-sync-daemon/mcp_readiness_test.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness_test.go
@@ -45,7 +45,7 @@ func deadOrigin(t *testing.T) string {
 	return url
 }
 
-func TestContextServerOrigins(t *testing.T) {
+func TestContextServerEndpoints(t *testing.T) {
 	t.Run("dedupes origins and ignores stdio servers", func(t *testing.T) {
 		path := writeSettingsFile(t, map[string]interface{}{
 			// stdio: runs in-container, cannot fail the way this check catches
@@ -54,40 +54,50 @@ func TestContextServerOrigins(t *testing.T) {
 				"args":    []interface{}{"--viewport", "1280x800"},
 			},
 			"helix-tasks": map[string]interface{}{
-				"url": "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b",
+				"url":     "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b",
+				"headers": map[string]interface{}{"Authorization": "Bearer hl-test"},
 			},
 			"kodit": map[string]interface{}{
 				"url": "http://helix-api.internal:18080/api/v1/mcp/kodit?session_id=ses_1",
 			},
 			"partner": map[string]interface{}{"url": "https://mcp.example.com/sse"},
 		})
-		got, err := contextServerOrigins(path)
+		got, err := contextServerEndpoints(path)
 		if err != nil {
-			t.Fatalf("contextServerOrigins: %v", err)
+			t.Fatalf("contextServerEndpoints: %v", err)
 		}
-		want := []string{"http://helix-api.internal:18080", "https://mcp.example.com"}
+		// Sorted by name; stdio chrome-devtools excluded. Each URL is kept
+		// verbatim — path and query included — because that is what gets probed.
+		want := []contextServerEndpoint{
+			{name: "helix-tasks", url: "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b"},
+			{name: "kodit", url: "http://helix-api.internal:18080/api/v1/mcp/kodit?session_id=ses_1"},
+			{name: "partner", url: "https://mcp.example.com/sse"},
+		}
 		if len(got) != len(want) {
-			t.Fatalf("origins = %v, want %v", got, want)
+			t.Fatalf("endpoints = %+v, want %+v", got, want)
 		}
 		for i := range want {
-			if got[i] != want[i] {
-				t.Fatalf("origins = %v, want %v", got, want)
+			if got[i].name != want[i].name || got[i].url != want[i].url {
+				t.Fatalf("endpoints = %+v, want %+v", got, want)
 			}
+		}
+		if got[0].headers["Authorization"] != "Bearer hl-test" {
+			t.Fatalf("configured headers must be carried to the probe: %+v", got[0].headers)
 		}
 	})
 
 	t.Run("no context_servers key yields none", func(t *testing.T) {
-		got, err := contextServerOrigins(writeSettingsFile(t, nil))
+		got, err := contextServerEndpoints(writeSettingsFile(t, nil))
 		if err != nil {
-			t.Fatalf("contextServerOrigins: %v", err)
+			t.Fatalf("contextServerEndpoints: %v", err)
 		}
 		if len(got) != 0 {
-			t.Fatalf("origins = %v, want none", got)
+			t.Fatalf("endpoints = %+v, want none", got)
 		}
 	})
 
 	t.Run("missing settings file is an error", func(t *testing.T) {
-		if _, err := contextServerOrigins(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+		if _, err := contextServerEndpoints(filepath.Join(t.TempDir(), "absent.json")); err == nil {
 			t.Fatal("a missing settings.json must not read as ready")
 		}
 	})
@@ -97,7 +107,7 @@ func TestContextServerOrigins(t *testing.T) {
 		if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := contextServerOrigins(path); err == nil {
+		if _, err := contextServerEndpoints(path); err == nil {
 			t.Fatal("a corrupt settings.json must not read as ready")
 		}
 	})
@@ -106,7 +116,7 @@ func TestContextServerOrigins(t *testing.T) {
 // A declared-but-broken url is a config error: Zed forwards it to the agent
 // regardless, and the agent's one-shot registration against it fails
 // permanently. Skipping it is how an all-malformed config reported "ready".
-func TestContextServerOriginsRejectsUnusableURLs(t *testing.T) {
+func TestContextServerEndpointsRejectUnusableURLs(t *testing.T) {
 	cases := map[string]interface{}{
 		"unparseable":  "://nope",
 		"empty":        "",
@@ -121,9 +131,9 @@ func TestContextServerOriginsRejectsUnusableURLs(t *testing.T) {
 			path := writeSettingsFile(t, map[string]interface{}{
 				"broken": map[string]interface{}{"url": badURL},
 			})
-			origins, err := contextServerOrigins(path)
+			endpoints, err := contextServerEndpoints(path)
 			if err == nil {
-				t.Fatalf("origins = %v, want an error for url %v", origins, badURL)
+				t.Fatalf("endpoints = %+v, want an error for url %v", endpoints, badURL)
 			}
 			if !strings.Contains(err.Error(), "broken") {
 				t.Fatalf("error should name the offending server: %v", err)
@@ -136,7 +146,7 @@ func TestContextServerOriginsRejectsUnusableURLs(t *testing.T) {
 			"good":   map[string]interface{}{"url": "http://api:8080/api/v1/mcp/session"},
 			"broken": map[string]interface{}{"url": "://nope"},
 		})
-		if _, err := contextServerOrigins(path); err == nil {
+		if _, err := contextServerEndpoints(path); err == nil {
 			t.Fatal("a broken url must fail readiness even when another server is fine")
 		}
 	})
@@ -303,5 +313,121 @@ func TestMCPReadinessHandlerReflectsCurrentState(t *testing.T) {
 	})
 	if status, body := ask(); status != http.StatusOK {
 		t.Fatalf("status = %d (%s), want 200 after recovery", status, body)
+	}
+}
+
+// The probe must request the configured MCP URL itself. An earlier version
+// asked a synthetic `origin + "/api/v1/config"`, which asserts the readiness of
+// a different route: a reverse proxy can serve that while misrouting
+// /api/v1/mcp/..., and a third-party MCP server need not serve it at all.
+func TestProbeRequestsTheConfiguredURL(t *testing.T) {
+	type seen struct {
+		method string
+		path   string
+		query  string
+		auth   string
+	}
+	got := make(chan seen, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- seen{r.Method, r.URL.Path, r.URL.RawQuery, r.Header.Get("Authorization")}
+		// Mirrors production: HEAD on a correct MCP URL 404s, because the
+		// router has no HEAD route. That must still count as reachable.
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	path := writeSettingsFile(t, map[string]interface{}{
+		"helix-tasks": map[string]interface{}{
+			"url":     srv.URL + "/api/v1/mcp/helix-tasks?rev=842d852b",
+			"headers": map[string]interface{}{"Authorization": "Bearer hl-session-scoped"},
+		},
+	})
+	if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path); err != nil {
+		t.Fatalf("probeMCPEndpoints: %v", err)
+	}
+
+	select {
+	case s := <-got:
+		if s.method != http.MethodHead {
+			t.Errorf("method = %s, want HEAD (POST allocates MCP session state, GET opens an SSE stream)", s.method)
+		}
+		if s.path != "/api/v1/mcp/helix-tasks" {
+			t.Errorf("path = %q, want the configured MCP path", s.path)
+		}
+		if s.query != "rev=842d852b" {
+			t.Errorf("query = %q, want the configured query preserved", s.query)
+		}
+		if s.auth != "Bearer hl-session-scoped" {
+			t.Errorf("Authorization = %q, want the configured header so the probe crosses the same auth edge", s.auth)
+		}
+	default:
+		t.Fatal("probe never reached the configured URL")
+	}
+}
+
+// When the Helix API is down but the sandbox proxy is up, the proxy's
+// ErrorHandler answers every MCP URL with 502 "Helix API unavailable".
+// Measured, not assumed: stopping helix-api-1 turned all four context servers
+// into 502s. Treating any HTTP response as success would call that ready.
+func TestProbeRejectsProxyUpstreamFailure(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusInternalServerError} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Helix API unavailable", status)
+		}))
+		path := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
+		})
+		err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path)
+		srv.Close()
+		if err == nil {
+			t.Fatalf("status %d must not read as ready", status)
+		}
+	}
+}
+
+// Status below 5xx is success on purpose. Through the sandbox proxy, HEAD on a
+// correct MCP URL returns 404 while HEAD on a deliberately wrong path returns
+// 200 from the frontend catch-all — status is anti-correlated with routing
+// correctness, so anything stricter would reject the endpoints that work.
+func TestProbeAcceptsNonServerErrorStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusNoContent, http.StatusBadRequest,
+		http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		}))
+		path := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
+		})
+		err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path)
+		srv.Close()
+		if err != nil {
+			t.Fatalf("status %d must read as reachable: %v", status, err)
+		}
+	}
+}
+
+// Every configured server is probed, and the failure names the one at fault.
+func TestProbeReportsEveryFailingServer(t *testing.T) {
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer live.Close()
+
+	path := writeSettingsFile(t, map[string]interface{}{
+		"kodit":         map[string]interface{}{"url": live.URL + "/api/v1/mcp/kodit"},
+		"helix-tasks":   map[string]interface{}{"url": deadOrigin(t) + "/api/v1/mcp/helix-tasks"},
+		"helix-session": map[string]interface{}{"url": deadOrigin(t) + "/api/v1/mcp/session"},
+	})
+	err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path)
+	if err == nil {
+		t.Fatal("probeMCPEndpoints succeeded with two unreachable servers")
+	}
+	for _, name := range []string{"helix-tasks", "helix-session"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error must name %s so the operator knows which server failed: %v", name, err)
+		}
+	}
+	if strings.Contains(err.Error(), "kodit") {
+		t.Errorf("error should not blame the healthy server: %v", err)
 	}
 }

--- a/api/cmd/settings-sync-daemon/mcp_readiness_test.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness_test.go
@@ -330,8 +330,9 @@ func TestProbeRequestsTheConfiguredURL(t *testing.T) {
 	got := make(chan seen, 4)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got <- seen{r.Method, r.URL.Path, r.URL.RawQuery, r.Header.Get("Authorization")}
-		// Mirrors production: HEAD on a correct MCP URL 404s, because the
-		// router has no HEAD route. That must still count as reachable.
+		// Mirrors production: OPTIONS on a correct MCP URL returns 404
+		// (helix-desktop, helix-session, kodit) or 400 (helix-tasks). That
+		// must still count as reachable.
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
@@ -348,8 +349,9 @@ func TestProbeRequestsTheConfiguredURL(t *testing.T) {
 
 	select {
 	case s := <-got:
-		if s.method != http.MethodHead {
-			t.Errorf("method = %s, want HEAD (POST allocates MCP session state, GET opens an SSE stream)", s.method)
+		if s.method != http.MethodOptions {
+			t.Errorf("method = %s, want OPTIONS: POST allocates MCP session state, GET opens an SSE stream, "+
+				"and HEAD is not a registered route so it never reaches the auth middleware", s.method)
 		}
 		if s.path != "/api/v1/mcp/helix-tasks" {
 			t.Errorf("path = %q, want the configured MCP path", s.path)
@@ -369,6 +371,8 @@ func TestProbeRequestsTheConfiguredURL(t *testing.T) {
 // ErrorHandler answers every MCP URL with 502 "Helix API unavailable".
 // Measured, not assumed: stopping helix-api-1 turned all four context servers
 // into 502s. Treating any HTTP response as success would call that ready.
+//
+//nolint:dupl // deliberately parallel to TestProbeRejectsRejectedCredentials
 func TestProbeRejectsProxyUpstreamFailure(t *testing.T) {
 	for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusInternalServerError} {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -385,13 +389,14 @@ func TestProbeRejectsProxyUpstreamFailure(t *testing.T) {
 	}
 }
 
-// Status below 5xx is success on purpose. Through the sandbox proxy, HEAD on a
-// correct MCP URL returns 404 while HEAD on a deliberately wrong path returns
-// 200 from the frontend catch-all — status is anti-correlated with routing
-// correctness, so anything stricter would reject the endpoints that work.
+// Status below 5xx, other than 401/403, is success on purpose. Through the
+// sandbox proxy, OPTIONS on a correct MCP URL returns 404 or 400 while OPTIONS
+// on a deliberately wrong path returns 204 from the frontend catch-all —
+// status is anti-correlated with routing correctness, so anything stricter
+// would reject the endpoints that work.
 func TestProbeAcceptsNonServerErrorStatuses(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusNoContent, http.StatusBadRequest,
-		http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed} {
+		http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusConflict} {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(status)
 		}))
@@ -429,5 +434,54 @@ func TestProbeReportsEveryFailingServer(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "kodit") {
 		t.Errorf("error should not blame the healthy server: %v", err)
+	}
+}
+
+// A token the endpoint refuses is a permanent failure for the agent: it sends
+// the same Authorization header, so its one-shot MCP registration dies the same
+// way. Measured against a live session, an invalid token turns OPTIONS on every
+// Helix MCP endpoint from 404/400 into 401.
+//
+// This is also why the probe uses OPTIONS rather than HEAD. HEAD is not a
+// registered method on the MCP gateway routes, so gorilla/mux never matches and
+// the auth middleware never runs: HEAD returned 404 for a valid token, an
+// invalid token and no token alike. Rejecting 401/403 under HEAD would have
+// been unreachable code.
+func TestProbeRejectsRejectedCredentials(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer hl-good" {
+				w.WriteHeader(status)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		bad := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{
+				"url":     srv.URL + "/api/v1/mcp/helix-tasks",
+				"headers": map[string]interface{}{"Authorization": "Bearer hl-expired"},
+			},
+		})
+		err := newReadinessDaemon().probeMCPEndpoints(context.Background(), bad)
+		if err == nil {
+			t.Fatalf("status %d must not read as ready", status)
+		}
+		if !strings.Contains(err.Error(), "Authorization") {
+			t.Errorf("error should explain the credential problem: %v", err)
+		}
+
+		// The same endpoint with the header it accepts is reachable, proving
+		// the rejection is about credentials and not the endpoint itself.
+		good := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{
+				"url":     srv.URL + "/api/v1/mcp/helix-tasks",
+				"headers": map[string]interface{}{"Authorization": "Bearer hl-good"},
+			},
+		})
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), good); err != nil {
+			t.Fatalf("valid credentials must read as ready: %v", err)
+		}
+		srv.Close()
 	}
 }

--- a/api/cmd/settings-sync-daemon/mcp_readiness_test.go
+++ b/api/cmd/settings-sync-daemon/mcp_readiness_test.go
@@ -2,36 +2,69 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
 
-func TestRemoteContextServerOrigins(t *testing.T) {
+// writeSettingsFile renders a settings.json containing contextServers and
+// returns its path.
+func writeSettingsFile(t *testing.T, contextServers interface{}) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	settings := map[string]interface{}{}
+	if contextServers != nil {
+		settings["context_servers"] = contextServers
+	}
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func newReadinessDaemon() *SettingsDaemon {
+	return &SettingsDaemon{httpClient: &http.Client{Timeout: 5 * time.Second}}
+}
+
+// deadOrigin returns an http:// origin nothing is listening on.
+func deadOrigin(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func TestContextServerOrigins(t *testing.T) {
 	t.Run("dedupes origins and ignores stdio servers", func(t *testing.T) {
-		settings := map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				// stdio: runs in-container, cannot fail the way this check catches
-				"chrome-devtools": map[string]interface{}{
-					"command": "/usr/bin/chrome-devtools-mcp",
-					"args":    []interface{}{"--viewport", "1280x800"},
-				},
-				"helix-tasks": map[string]interface{}{
-					"url": "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b",
-				},
-				"kodit": map[string]interface{}{
-					"url": "http://helix-api.internal:18080/api/v1/mcp/kodit?session_id=ses_1",
-				},
-				"partner": map[string]interface{}{
-					"url": "https://mcp.example.com/sse",
-				},
+		path := writeSettingsFile(t, map[string]interface{}{
+			// stdio: runs in-container, cannot fail the way this check catches
+			"chrome-devtools": map[string]interface{}{
+				"command": "/usr/bin/chrome-devtools-mcp",
+				"args":    []interface{}{"--viewport", "1280x800"},
 			},
+			"helix-tasks": map[string]interface{}{
+				"url": "http://helix-api.internal:18080/api/v1/mcp/helix-tasks?rev=842d852b",
+			},
+			"kodit": map[string]interface{}{
+				"url": "http://helix-api.internal:18080/api/v1/mcp/kodit?session_id=ses_1",
+			},
+			"partner": map[string]interface{}{"url": "https://mcp.example.com/sse"},
+		})
+		got, err := contextServerOrigins(path)
+		if err != nil {
+			t.Fatalf("contextServerOrigins: %v", err)
 		}
-		got := remoteContextServerOrigins(settings)
 		want := []string{"http://helix-api.internal:18080", "https://mcp.example.com"}
 		if len(got) != len(want) {
 			t.Fatalf("origins = %v, want %v", got, want)
@@ -43,96 +76,95 @@ func TestRemoteContextServerOrigins(t *testing.T) {
 		}
 	})
 
-	t.Run("no context servers yields none", func(t *testing.T) {
-		if got := remoteContextServerOrigins(map[string]interface{}{}); len(got) != 0 {
+	t.Run("no context_servers key yields none", func(t *testing.T) {
+		got, err := contextServerOrigins(writeSettingsFile(t, nil))
+		if err != nil {
+			t.Fatalf("contextServerOrigins: %v", err)
+		}
+		if len(got) != 0 {
 			t.Fatalf("origins = %v, want none", got)
 		}
 	})
 
-	t.Run("unparseable url is skipped, not fatal", func(t *testing.T) {
-		settings := map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"broken": map[string]interface{}{"url": "://nope"},
-				"good":   map[string]interface{}{"url": "http://api:8080/api/v1/mcp/session"},
-			},
+	t.Run("missing settings file is an error", func(t *testing.T) {
+		if _, err := contextServerOrigins(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+			t.Fatal("a missing settings.json must not read as ready")
 		}
-		got := remoteContextServerOrigins(settings)
-		if len(got) != 1 || got[0] != "http://api:8080" {
-			t.Fatalf("origins = %v, want [http://api:8080]", got)
+	})
+
+	t.Run("unparseable settings file is an error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := contextServerOrigins(path); err == nil {
+			t.Fatal("a corrupt settings.json must not read as ready")
 		}
 	})
 }
 
-// newReadinessDaemon builds the minimal daemon the readiness check needs, with
-// markers redirected into a tempdir so tests never touch /tmp state shared with
-// a real container.
-func newReadinessDaemon(t *testing.T, settings map[string]interface{}) (*SettingsDaemon, string, string) {
-	t.Helper()
-	dir := t.TempDir()
-	ready := filepath.Join(dir, "ready")
-	unreachable := filepath.Join(dir, "unreachable")
+// A declared-but-broken url is a config error: Zed forwards it to the agent
+// regardless, and the agent's one-shot registration against it fails
+// permanently. Skipping it is how an all-malformed config reported "ready".
+func TestContextServerOriginsRejectsUnusableURLs(t *testing.T) {
+	cases := map[string]interface{}{
+		"unparseable":  "://nope",
+		"empty":        "",
+		"whitespace":   "   ",
+		"no host":      "http://",
+		"scheme-less":  "helix-api.internal:18080/api/v1/mcp/x",
+		"wrong scheme": "ftp://helix-api.internal/mcp",
+		"not a string": 42,
+	}
+	for name, badURL := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeSettingsFile(t, map[string]interface{}{
+				"broken": map[string]interface{}{"url": badURL},
+			})
+			origins, err := contextServerOrigins(path)
+			if err == nil {
+				t.Fatalf("origins = %v, want an error for url %v", origins, badURL)
+			}
+			if !strings.Contains(err.Error(), "broken") {
+				t.Fatalf("error should name the offending server: %v", err)
+			}
+		})
+	}
 
-	origReady, origUnreachable := mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker
-	mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker = ready, unreachable
-	t.Cleanup(func() {
-		mcpEndpointsReadyMarker, mcpEndpointsUnreachableMarker = origReady, origUnreachable
+	t.Run("one broken url fails even alongside a good one", func(t *testing.T) {
+		path := writeSettingsFile(t, map[string]interface{}{
+			"good":   map[string]interface{}{"url": "http://api:8080/api/v1/mcp/session"},
+			"broken": map[string]interface{}{"url": "://nope"},
+		})
+		if _, err := contextServerOrigins(path); err == nil {
+			t.Fatal("a broken url must fail readiness even when another server is fine")
+		}
 	})
-
-	return &SettingsDaemon{
-		helixSettings: settings,
-		httpClient:    &http.Client{Timeout: 5 * time.Second},
-	}, ready, unreachable
 }
 
-func TestVerifyMCPEndpoints(t *testing.T) {
-	t.Run("reachable origin marks ready", func(t *testing.T) {
-		// 404 is a perfectly good answer: it proves the transport works, which
-		// is the only thing that can break the agent's MCP registration.
+func TestProbeMCPEndpoints(t *testing.T) {
+	t.Run("reachable origin is ready", func(t *testing.T) {
+		// 404 is a fine answer: it proves the transport works, which is the
+		// only thing that can break the agent's MCP registration.
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer srv.Close()
 
-		d, ready, unreachable := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
-			},
+		path := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
 		})
-		if err := d.verifyMCPEndpoints(context.Background(), 5*time.Second, 100*time.Millisecond); err != nil {
-			t.Fatalf("verifyMCPEndpoints: %v", err)
-		}
-		if _, err := os.Stat(ready); err != nil {
-			t.Fatalf("ready marker not written: %v", err)
-		}
-		if _, err := os.Stat(unreachable); !os.IsNotExist(err) {
-			t.Fatalf("unreachable marker should not exist: %v", err)
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path); err != nil {
+			t.Fatalf("probeMCPEndpoints: %v", err)
 		}
 	})
 
-	t.Run("unreachable origin fails and records why", func(t *testing.T) {
-		// Bind then immediately close so the port is closed but well-formed.
-		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		deadURL := srv.URL
-		srv.Close()
-
-		d, ready, unreachable := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"helix-tasks": map[string]interface{}{"url": deadURL + "/api/v1/mcp/helix-tasks"},
-			},
+	t.Run("unreachable origin is not ready", func(t *testing.T) {
+		path := writeSettingsFile(t, map[string]interface{}{
+			"helix-tasks": map[string]interface{}{"url": deadOrigin(t) + "/api/v1/mcp/helix-tasks"},
 		})
-		err := d.verifyMCPEndpoints(context.Background(), 500*time.Millisecond, 100*time.Millisecond)
-		if err == nil {
-			t.Fatal("verifyMCPEndpoints succeeded against a closed port")
-		}
-		if _, statErr := os.Stat(ready); !os.IsNotExist(statErr) {
-			t.Fatalf("ready marker must not be written on failure: %v", statErr)
-		}
-		body, readErr := os.ReadFile(unreachable)
-		if readErr != nil {
-			t.Fatalf("unreachable marker not written: %v", readErr)
-		}
-		if len(body) == 0 {
-			t.Fatal("unreachable marker is empty; the operator needs the failing url")
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path); err == nil {
+			t.Fatal("probeMCPEndpoints succeeded against a closed port")
 		}
 	})
 
@@ -141,125 +173,135 @@ func TestVerifyMCPEndpoints(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer live.Close()
-		dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-		deadURL := dead.URL
-		dead.Close()
 
-		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"kodit":       map[string]interface{}{"url": live.URL + "/api/v1/mcp/kodit"},
-				"helix-tasks": map[string]interface{}{"url": deadURL + "/api/v1/mcp/helix-tasks"},
-			},
+		path := writeSettingsFile(t, map[string]interface{}{
+			"kodit":       map[string]interface{}{"url": live.URL + "/api/v1/mcp/kodit"},
+			"helix-tasks": map[string]interface{}{"url": deadOrigin(t) + "/api/v1/mcp/helix-tasks"},
 		})
-		if err := d.verifyMCPEndpoints(context.Background(), 500*time.Millisecond, 100*time.Millisecond); err == nil {
-			t.Fatal("verifyMCPEndpoints succeeded with one unreachable origin")
-		}
-		if _, err := os.Stat(ready); !os.IsNotExist(err) {
-			t.Fatalf("ready marker must not be written: %v", err)
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path); err == nil {
+			t.Fatal("probeMCPEndpoints succeeded with one unreachable origin")
 		}
 	})
 
-	t.Run("recovers when the origin comes back", func(t *testing.T) {
-		// Grab a port, hold it closed so the first probes are refused, then
-		// bind a real server on the same address mid-flight. This is the
-		// actual transient the gate exists to ride out: the API proxy is not
-		// listening yet when the container boots.
-		probe, err := net.Listen("tcp", "127.0.0.1:0")
+	t.Run("stdio-only agent is ready", func(t *testing.T) {
+		path := writeSettingsFile(t, map[string]interface{}{
+			"chrome-devtools": map[string]interface{}{"command": "/usr/bin/chrome-devtools-mcp"},
+		})
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), path); err != nil {
+			t.Fatalf("probeMCPEndpoints: %v", err)
+		}
+	})
+
+	t.Run("settings never written is not ready", func(t *testing.T) {
+		// syncFromHelix writes settings.json only after a successful fetch, so
+		// a failed initial sync leaves no file. Reporting ready would let Zed
+		// start against an agent config that does not exist.
+		absent := filepath.Join(t.TempDir(), "settings.json")
+		if err := newReadinessDaemon().probeMCPEndpoints(context.Background(), absent); err == nil {
+			t.Fatal("probeMCPEndpoints declared readiness with no settings file")
+		}
+	})
+}
+
+func TestWaitForMCPEndpointsRecoversWhenOriginComesBack(t *testing.T) {
+	// Grab a port, hold it closed so the first probes are refused, then bind a
+	// real server on the same address mid-flight. This is the transient the
+	// gate exists to ride out: the API proxy is not listening yet.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := writeSettingsFile(t, map[string]interface{}{
+		"helix-tasks": map[string]interface{}{"url": "http://" + addr + "/api/v1/mcp/helix-tasks"},
+	})
+
+	bound := make(chan *httptest.Server, 1)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		ln, lnErr := net.Listen("tcp", addr)
+		if lnErr != nil {
+			bound <- nil
+			return
+		}
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		srv.Listener.Close()
+		srv.Listener = ln
+		srv.Start()
+		bound <- srv
+	}()
+
+	waitErr := newReadinessDaemon().waitForMCPEndpoints(context.Background(), path, 10*time.Second, 100*time.Millisecond)
+	srv := <-bound
+	if srv == nil {
+		t.Skip("could not rebind the probe port; another process took it")
+	}
+	defer srv.Close()
+	if waitErr != nil {
+		t.Fatalf("waitForMCPEndpoints never recovered: %v", waitErr)
+	}
+}
+
+// The gate polls this before every Zed launch, so its verdict must track the
+// current state of the world rather than a boot-time snapshot.
+func TestMCPReadinessHandlerReflectsCurrentState(t *testing.T) {
+	origSettingsPath := SettingsPath
+	t.Cleanup(func() { SettingsPath = origSettingsPath })
+
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer live.Close()
+
+	d := newReadinessDaemon()
+	gate := httptest.NewServer(http.HandlerFunc(d.mcpReadinessHandler))
+	defer gate.Close()
+
+	ask := func() (int, string) {
+		t.Helper()
+		resp, err := http.Get(gate.URL)
 		if err != nil {
 			t.Fatal(err)
 		}
-		addr := probe.Addr().String()
-		if err := probe.Close(); err != nil {
-			t.Fatal(err)
-		}
+		defer resp.Body.Close()
+		body := make([]byte, 2048)
+		n, _ := resp.Body.Read(body)
+		return resp.StatusCode, string(body[:n])
+	}
 
-		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"helix-tasks": map[string]interface{}{"url": "http://" + addr + "/api/v1/mcp/helix-tasks"},
-			},
-		})
-
-		bound := make(chan *httptest.Server, 1)
-		go func() {
-			time.Sleep(300 * time.Millisecond)
-			ln, lnErr := net.Listen("tcp", addr)
-			if lnErr != nil {
-				bound <- nil
-				return
-			}
-			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}))
-			srv.Listener.Close()
-			srv.Listener = ln
-			srv.Start()
-			bound <- srv
-		}()
-
-		verifyErr := d.verifyMCPEndpoints(context.Background(), 10*time.Second, 100*time.Millisecond)
-		srv := <-bound
-		if srv == nil {
-			t.Skip("could not rebind the probe port; another process took it")
-		}
-		defer srv.Close()
-
-		if verifyErr != nil {
-			t.Fatalf("verifyMCPEndpoints never recovered: %v", verifyErr)
-		}
-		if _, statErr := os.Stat(ready); statErr != nil {
-			t.Fatalf("ready marker not written after recovery: %v", statErr)
-		}
+	// Healthy: ready.
+	SettingsPath = writeSettingsFile(t, map[string]interface{}{
+		"helix-tasks": map[string]interface{}{"url": live.URL + "/api/v1/mcp/helix-tasks"},
 	})
+	if status, body := ask(); status != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", status, body)
+	}
 
-	t.Run("unsynced settings never mark ready", func(t *testing.T) {
-		// syncFromHelix only assigns helixSettings after a successful fetch, so
-		// a failed initial sync leaves it nil. Marking ready here would let Zed
-		// start against an agent config that was never written.
-		d, ready, unreachable := newReadinessDaemon(t, nil)
-		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err == nil {
-			t.Fatal("verifyMCPEndpoints declared readiness with no synced settings")
-		}
-		if _, err := os.Stat(ready); !os.IsNotExist(err) {
-			t.Fatalf("ready marker must not be written: %v", err)
-		}
-		if _, err := os.Stat(unreachable); err != nil {
-			t.Fatalf("unreachable marker not written: %v", err)
-		}
+	// The world changes under a running container — an agent switch rewrites
+	// settings.json and restartZed() relaunches Zed. The next launch must get
+	// the new verdict, not the old one.
+	SettingsPath = writeSettingsFile(t, map[string]interface{}{
+		"helix-tasks": map[string]interface{}{"url": deadOrigin(t) + "/api/v1/mcp/helix-tasks"},
 	})
+	status, body := ask()
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d (%s), want 503 after the origin died", status, body)
+	}
+	if !strings.Contains(body, "probe ") {
+		t.Fatalf("503 body must carry the reason for the gate to print: %q", body)
+	}
 
-	t.Run("no remote context servers is ready, not an error", func(t *testing.T) {
-		d, ready, _ := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"chrome-devtools": map[string]interface{}{"command": "/usr/bin/chrome-devtools-mcp"},
-			},
-		})
-		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err != nil {
-			t.Fatalf("verifyMCPEndpoints: %v", err)
-		}
-		if _, err := os.Stat(ready); err != nil {
-			t.Fatalf("ready marker not written: %v", err)
-		}
+	// And back again, so a transient failure does not latch.
+	SettingsPath = writeSettingsFile(t, map[string]interface{}{
+		"helix-tasks": map[string]interface{}{"url": live.URL + "/api/v1/mcp/helix-tasks"},
 	})
-
-	t.Run("stale unreachable marker is cleared on success", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer srv.Close()
-
-		d, _, unreachable := newReadinessDaemon(t, map[string]interface{}{
-			"context_servers": map[string]interface{}{
-				"helix-tasks": map[string]interface{}{"url": srv.URL + "/api/v1/mcp/helix-tasks"},
-			},
-		})
-		if err := os.WriteFile(unreachable, []byte("stale\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := d.verifyMCPEndpoints(context.Background(), time.Second, 100*time.Millisecond); err != nil {
-			t.Fatalf("verifyMCPEndpoints: %v", err)
-		}
-		if _, err := os.Stat(unreachable); !os.IsNotExist(err) {
-			t.Fatal("stale unreachable marker survived a successful probe")
-		}
-	})
+	if status, body := ask(); status != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200 after recovery", status, body)
+	}
 }

--- a/design/2026-09-01-opencode-mcp-tools-unavailable.md
+++ b/design/2026-09-01-opencode-mcp-tools-unavailable.md
@@ -118,23 +118,35 @@ bug straight back in on the first restart.
    (`SETTINGS_SYNC_PORT`, default 9877): 200 means safe to launch, 503 carries
    the reason.
 
-   **Method: HEAD**, the only method that is uniformly side-effect free and
-   prompt. POST (a real MCP `initialize`) allocates server-side session state —
-   kodit creates a per-session handler — and GET is the Streamable HTTP
-   notification stream: measured against a live session, GET hangs until
-   timeout on `helix-desktop` and returns an open SSE stream on `helix-session`
-   and `kodit`.
+   **Method: OPTIONS.** The MCP gateway routes register GET, POST and OPTIONS,
+   and the choice among them is forced. POST is the real MCP `initialize` and
+   allocates server-side session state (kodit creates a per-session handler).
+   GET is the Streamable HTTP notification stream: measured against a live
+   session it hangs until timeout on `helix-desktop` and returns an open SSE
+   stream on `helix-session` and `kodit`. HEAD is not a registered method, so
+   gorilla/mux never matches the route and the request never reaches the auth
+   middleware — measured, HEAD returns 404 for a valid token, an invalid token
+   and no token alike. OPTIONS is the only method that is prompt (0.00s on all
+   four servers), allocates nothing (24 probes produced no additional kodit
+   handler creations), and actually traverses authentication.
 
-   **Failure is a transport error or a 5xx; every other status is success.**
-   That is measured, not lazy. Through the sandbox API proxy against a healthy
-   session, HEAD on each *correct* MCP URL returns 404 (the mux router has no
-   HEAD route) while HEAD on a deliberately *wrong* path returns 200 from the
-   frontend catch-all — status is anti-correlated with routing correctness, so
-   anything stricter than "not 5xx" would reject exactly the endpoints that
-   work. 5xx is the exception worth catching: with `helix-api-1` stopped but the
-   sandbox proxy up, all four context servers answered 502 "Helix API
-   unavailable" from the proxy's `ErrorHandler`. Treating any response as
-   success would have called that ready.
+   **Failure is a transport error, a 5xx, or a 401/403.** Each corresponds to a
+   way the agent's one-shot registration dies:
+
+   | class | how it happens | measured |
+   |---|---|---|
+   | transport | address does not resolve / refuses | the original reproduction |
+   | 5xx | Helix API down, sandbox proxy up — its `ErrorHandler` returns 502 "Helix API unavailable" | stopping `helix-api-1` turned all four into 502 |
+   | 401/403 | the session token in the header is expired or wrong; the agent sends the same header | an invalid token turns every endpoint from 404/400 into 401 |
+
+   **Every other status is success**, and that is measured rather than lazy:
+   with a valid token, OPTIONS on the correct MCP URLs returns 404
+   (`helix-desktop`, `helix-session`, `kodit`) or 400 (`helix-tasks`), while
+   OPTIONS on a deliberately wrong path returns 204 from the frontend catch-all.
+   Status is anti-correlated with routing correctness, so anything stricter
+   would reject exactly the endpoints that work. **This probe therefore does not
+   detect path-level misrouting**; it detects transport, upstream health and
+   authentication.
 
    Reading the URLs from the file rather than `d.helixSettings` is deliberate on
    two counts. It is the exact set Zed loads and forwards to the agent, user
@@ -164,8 +176,15 @@ bug straight back in on the first restart.
 2. `desktop/shared/start-zed-core.sh` — `wait_for_mcp_endpoints` polls
    `/mcp-readiness` and is called **inside `run_zed_restart_loop`, before every
    launch**. On a 503 it keeps waiting (a mid-session blip should ride out); if
-   the origin is still dead after 180s it prints the returned reason and exits
-   rather than starting a tool-less agent.
+   the endpoints are still bad at the deadline it prints the returned reason and
+   exits rather than starting a tool-less agent.
+
+   The bound is a **wall-clock deadline**, not an attempt count. Counting
+   attempts made the documented 180s a lie: each iteration can spend up to the
+   curl timeout plus the sleep, so 180 attempts was really ~33 minutes of held
+   launch. Verified with an endpoint that stalls past the curl timeout on every
+   request: a 20s budget returned at 22s (one in-flight iteration overruns,
+   bounded), where the attempt-count version would have taken 220s.
 
 ### Verified
 

--- a/design/2026-09-01-opencode-mcp-tools-unavailable.md
+++ b/design/2026-09-01-opencode-mcp-tools-unavailable.md
@@ -1,0 +1,165 @@
+# opencode: "Model tried to call unavailable tool 'helix-tasks_list_secrets'"
+
+## Symptom (reported)
+
+A spec task started by a helix-org bot could not call ANY MCP tool for 20+
+minutes. Every call failed with:
+
+```
+The arguments provided to the tool are invalid: Model tried to call unavailable
+tool 'helix-tasks_list_secrets'. Available tools: bash, chrome-devtools_click, ...
+```
+
+Affected `helix-tasks_*`, `kodit_*` and `ask_human`. The agent itself kept
+working (LLM calls succeeded).
+
+## Harness identification
+
+The error text is not Helix's and not Zed's. It comes from **opencode**
+(pinned at `OPENCODE_VERSION=1.18.18` in `sandbox-versions.txt`), which is the
+`code_agent_runtime` both org bots in the test org use:
+
+* `Model tried to call unavailable tool '<x>'. Available tools: <list>.` is the
+  Vercel AI SDK's `NoSuchToolError`, thrown from `parseToolCall` when
+  `tools[toolName] == null`.
+* `The arguments provided to the tool are invalid: <err>` is opencode's builtin
+  `invalid` tool, which is what a failed tool call is recorded as — this is why
+  the reporter saw "the call is logged as arriving under tool name `invalid`".
+
+MCP tool ids in opencode are `sanitize(server) + "_" + sanitize(tool)`
+(`McpCatalog.toolName`), hence `helix-tasks_list_secrets`,
+`kodit_kodit_repositories`, `chrome-devtools_click`.
+
+## How opencode gets its MCP servers
+
+Helix's opencode config (`api/cmd/settings-sync-daemon/opencode.go`) contains
+**no** `mcp` section. The servers arrive over ACP instead:
+
+1. `api/pkg/external-agent/zed_config.go` writes `context_servers` into Zed's
+   `settings.json` (`helix-tasks`, `helix-session`, `helix-desktop`, `kodit`,
+   plus stdio `chrome-devtools`).
+2. Zed forwards them on `session/new` / `session/load` / `session/resume`
+   (`crates/agent_servers/src/acp.rs::mcp_servers_for_project`).
+3. opencode registers each one **once**, via `sdk.mcp.add(...)`.
+
+## Root cause
+
+opencode's MCP registration is one-shot and failure is silent + permanent:
+
+* the ACP registration helper wraps each `mcp.add` in `Effect.ignore`, and
+  records the server in a per-session "already registered" `Set`, so it is
+  never retried for the life of the session;
+* `MCP.create` logs `WARN "server unavailable" key=<name> type=remote
+  status=failed` and stores `status: failed`;
+* `MCP.tools()` skips any server that is not `connected`, so its tools never
+  enter the AI SDK `tools` map;
+* nothing tells the model. Helix's own prompts (e.g.
+  `api/pkg/org/domain/seedprompts/seedprompts.go`) explicitly instruct the
+  agent to call `list_secrets` / `get_secret`, so the model keeps calling tools
+  that are not in the map → `NoSuchToolError`, forever.
+
+Therefore **any transient failure to reach the Helix API during the few seconds
+in which opencode boots strips every Helix MCP tool from the agent for the whole
+session**, while the LLM path (which retries every turn) recovers and looks
+healthy. That asymmetry is exactly the reported symptom.
+
+Reproduced locally — `/home/retro/work/.opencode-state/opencode/log/opencode.log`:
+
+```
+level=WARN message="server unavailable" key=helix-desktop type=remote status=failed
+level=WARN message="server unavailable" key=helix-session type=remote status=failed
+level=WARN message="server unavailable" key=kodit        type=remote status=failed
+level=WARN message="server unavailable" key=helix-tasks  type=remote status=failed
+```
+
+...after which the agent ran on with zero Helix MCP tools. `chrome-devtools`
+(stdio, no network) was unaffected — matching the reporter's observation that
+`chrome-devtools_*` was in the available list.
+
+## Ruled out
+
+* **Missing `tools` capability in the `initialize` response.** Probed all three
+  Helix MCP endpoints with a real session-scoped key; every one advertises
+  `tools: {listChanged: true}`.
+* **Registry/dispatcher disagreement.** The AI SDK builds `availableTools` from
+  `Object.keys()` of the *same* object it just failed to index, and opencode
+  never stores an `undefined` value in it. The reporter's claim that the name
+  appeared in the printed list is not reliable (the quoted list was elided).
+
+## Local environment note
+
+The first local reproduction was aggravated by version skew in this dev stack:
+`helix-sandbox-nvidia-1` was 9 days old and predates the sandbox egress work
+(`602e8c55a`, `9b287f71e`, `a7ce030bc`, 2026-08-29..31) that introduced
+`helix-api.internal:18080`, while the API had hot-reloaded to current `main`
+and was emitting that hostname. Rebuilt with `./stack build-sandbox`. The
+reporter's branch (`df768fe61`, 2026-08-26) predates that change, so their
+failure had a different trigger — but the same permanent-failure mechanism.
+
+## Fix
+
+The agent's MCP registration is one-shot, so the addresses we write into
+`settings.json` must be proven reachable *before* Zed launches the agent.
+Nothing checked this: `start-zed-core.sh` gated only on `settings.json`
+existing, so a container whose context-server origin did not resolve booted
+happily into a tool-less session.
+
+1. `api/cmd/settings-sync-daemon/mcp_readiness.go` — after the initial sync,
+   the daemon extracts the distinct `scheme://host:port` of every
+   URL-addressed `context_server` **from the settings it just merged** and
+   probes each one (unauthenticated `GET /api/v1/config`, no side effects),
+   retrying for 60s. Any HTTP status counts: only a transport error is a
+   failure, because that is the only thing that breaks MCP registration.
+   Success writes `/tmp/helix-mcp-endpoints-ready`; failure writes
+   `/tmp/helix-mcp-endpoints-unreachable` with the failing URL and calls the
+   existing `reportAgentStartupError`, so it surfaces in the session UI.
+
+   It reads the URLs back out of the settings rather than trusting
+   `HELIX_API_URL` on purpose: those two can disagree (a control plane that has
+   rolled forward to `helix-api.internal:18080` against an older sandbox host
+   that still sets `HELIX_API_URL=http://api:8080` and never pins the proxy
+   hostname). In that state Zed's websocket and inference both work over the
+   env address and *only* the MCP servers are dead — the exact failure being
+   fixed, and one a `HELIX_API_URL` probe would miss.
+
+2. `desktop/shared/start-zed-core.sh` — new `wait_for_mcp_endpoints` step
+   between `wait_for_zed_config` and the Zed launch. Waits for the ready
+   marker; on the unreachable marker it prints the recorded reason and exits,
+   matching the existing `wait_for_zed_config` fatal behaviour.
+
+### Verified
+
+* Healthy container (`ubuntu-external-01m1e14w0ffjmqbx8v62y37dkk`, image
+  `bb8589`): daemon logs `MCP readiness: all 1 context server origin(s)
+  reachable`, `wait_for_mcp_endpoints` proceeds, Zed starts, and opencode logs
+  no `server unavailable` — the MCP servers connect.
+* Same container, `helix-api.internal` pointed at a dead port while the daemon
+  syncs over the gateway IP — i.e. the exact skew that produced the original
+  failure: the probe fails, the reason (with the failing URL) is recorded, and
+  the gate exits 1 instead of starting a tool-less agent.
+* Same container with the API unreachable entirely: the initial sync fails,
+  `helixSettings` is nil, and the gate refuses to declare readiness rather than
+  passing vacuously (regression test:
+  `TestVerifyMCPEndpoints/unsynced_settings_never_mark_ready`).
+* `go test ./cmd/settings-sync-daemon/` green.
+
+### What this does and does not cover
+
+Covers: the agent never starts into a session whose MCP origins are
+unreachable, and if they are, the operator gets the failing URL immediately
+instead of a silent 20-minute tool outage.
+
+Does not cover: an MCP server that fails to register even though its origin
+answered (e.g. the API dies in the few seconds between the probe and
+`session/new`). Repairing that requires either a retry inside the agent or
+Zed re-pushing `mcpServers` to a live ACP session
+(`crates/agent_servers/src/acp.rs::mcp_servers_for_project` is only called from
+`session/new|load|resume`). Both are outside this repo.
+
+### Also seen, not fixed here
+
+`opencode` fails its plugin bootstrap on every start with
+`EACCES: permission denied, open '/home/retro/.npm/_cacache/...'` while
+fetching `@opencode-ai/plugin` (46 occurrences across the historical session
+logs on this host). Unrelated to the MCP surface, but it is a real permissions
+defect in the desktop image.

--- a/design/2026-09-01-opencode-mcp-tools-unavailable.md
+++ b/design/2026-09-01-opencode-mcp-tools-unavailable.md
@@ -98,61 +98,81 @@ failure had a different trigger — but the same permanent-failure mechanism.
 
 ## Fix
 
-The agent's MCP registration is one-shot, so the addresses we write into
-`settings.json` must be proven reachable *before* Zed launches the agent.
-Nothing checked this: `start-zed-core.sh` gated only on `settings.json`
-existing, so a container whose context-server origin did not resolve booted
-happily into a tool-less session.
+The agent's MCP registration is one-shot, so the addresses in `settings.json`
+must be proven reachable *before every Zed launch*. Nothing checked this:
+`start-zed-core.sh` gated only on `settings.json` existing, so a container whose
+context-server origin did not resolve booted straight into a tool-less session.
 
-1. `api/cmd/settings-sync-daemon/mcp_readiness.go` — after the initial sync,
-   the daemon extracts the distinct `scheme://host:port` of every
-   URL-addressed `context_server` **from the settings it just merged** and
-   probes each one (unauthenticated `GET /api/v1/config`, no side effects),
-   retrying for 60s. Any HTTP status counts: only a transport error is a
-   failure, because that is the only thing that breaks MCP registration.
-   Success writes `/tmp/helix-mcp-endpoints-ready`; failure writes
-   `/tmp/helix-mcp-endpoints-unreachable` with the failing URL and calls the
-   existing `reportAgentStartupError`, so it surfaces in the session UI.
+**Per launch, not per boot.** `run_zed_restart_loop` respawns Zed for the life
+of the container, and the daemon's `restartZed()` deliberately uses that path to
+give the agent a fresh ACP session on an agent switch. Every one of those
+launches is another one-shot MCP registration, so every one needs its own
+freshly measured verdict — a boot-lifetime "ready" marker would let the original
+bug straight back in on the first restart.
 
-   It reads the URLs back out of the settings rather than trusting
-   `HELIX_API_URL` on purpose: those two can disagree (a control plane that has
-   rolled forward to `helix-api.internal:18080` against an older sandbox host
-   that still sets `HELIX_API_URL=http://api:8080` and never pins the proxy
-   hostname). In that state Zed's websocket and inference both work over the
-   env address and *only* the MCP servers are dead — the exact failure being
-   fixed, and one a `HELIX_API_URL` probe would miss.
+1. `api/cmd/settings-sync-daemon/mcp_readiness.go` — `probeMCPEndpoints` reads
+   the distinct `scheme://host:port` of every URL-addressed `context_server`
+   **out of `settings.json` on disk** and probes each (unauthenticated
+   `GET /api/v1/config`, no side effects). Any HTTP status counts; only a
+   transport error is a failure, because that is the only thing that breaks MCP
+   registration. It is served at `/mcp-readiness` on the daemon's existing
+   loopback port (`SETTINGS_SYNC_PORT`, default 9877): 200 means safe to launch,
+   503 carries the reason.
 
-2. `desktop/shared/start-zed-core.sh` — new `wait_for_mcp_endpoints` step
-   between `wait_for_zed_config` and the Zed launch. Waits for the ready
-   marker; on the unreachable marker it prints the recorded reason and exits,
-   matching the existing `wait_for_zed_config` fatal behaviour.
+   Reading the file rather than `d.helixSettings` is deliberate on two counts.
+   It is the exact set Zed loads and forwards to the agent, user overrides
+   included; and the file is written atomically (tempfile + rename), so the HTTP
+   handler can read it while the poll loop rewrites it without sharing mutable
+   state with the rest of the daemon.
+
+   It reads those URLs rather than trusting `HELIX_API_URL` for a third reason:
+   the two can diverge (a control plane emitting `helix-api.internal:18080`
+   against an older sandbox host that still sets `HELIX_API_URL=http://api:8080`
+   and never pins the proxy hostname). In that state Zed's websocket and
+   inference both work and *only* the MCP servers are dead — the exact failure
+   being fixed, and one a `HELIX_API_URL` probe would miss.
+
+   A context server with no `url` is a stdio server and is ignored. A context
+   server that declares a `url` which cannot be turned into an origin — empty,
+   unparseable, no host, non-HTTP scheme, not a string — **fails** readiness.
+   Zed forwards that broken URL to the agent regardless and the registration
+   against it fails permanently, so skipping it is how an all-malformed config
+   would otherwise report "ready".
+
+   On the boot path the daemon additionally runs `waitForMCPEndpoints` (in a
+   goroutine, so it cannot delay the listener the gate polls) and reports a
+   failure through the existing `reportAgentStartupError`, so the operator is
+   told in the session UI rather than having to read container logs.
+
+2. `desktop/shared/start-zed-core.sh` — `wait_for_mcp_endpoints` polls
+   `/mcp-readiness` and is called **inside `run_zed_restart_loop`, before every
+   launch**. On a 503 it keeps waiting (a mid-session blip should ride out); if
+   the origin is still dead after 180s it prints the returned reason and exits
+   rather than starting a tool-less agent.
 
 ### Verified
 
-* Healthy container (`ubuntu-external-01m1e14w0ffjmqbx8v62y37dkk`, image
-  `bb8589`): daemon logs `MCP readiness: all 1 context server origin(s)
-  reachable`, `wait_for_mcp_endpoints` proceeds, Zed starts, and opencode logs
-  no `server unavailable` — the MCP servers connect.
-* Same container, `helix-api.internal` pointed at a dead port while the daemon
-  syncs over the gateway IP — i.e. the exact skew that produced the original
-  failure: the probe fails, the reason (with the failing URL) is recorded, and
-  the gate exits 1 instead of starting a tool-less agent.
-* Same container with the API unreachable entirely: the initial sync fails,
-  `helixSettings` is nil, and the gate refuses to declare readiness rather than
-  passing vacuously (regression test:
-  `TestVerifyMCPEndpoints/unsynced_settings_never_mark_ready`).
-* `go test ./cmd/settings-sync-daemon/` green.
+* Healthy container: daemon logs `MCP readiness: context servers reachable`,
+  the gate proceeds, Zed starts, and opencode logs no `server unavailable`.
+* Divergent dead origin (`helix-api.internal` pointed at a dead port while the
+  daemon syncs over the gateway IP — the exact skew that produced the original
+  failure): the probe fails, the reason names the failing URL, and the gate
+  refuses to launch.
+* Zed restart with the origin dead: the gate re-checks and holds the relaunch
+  instead of handing the agent a dead MCP surface.
+* `go test ./cmd/settings-sync-daemon/` green, including under `-race`.
 
 ### What this does and does not cover
 
-Covers: the agent never starts into a session whose MCP origins are
-unreachable, and if they are, the operator gets the failing URL immediately
-instead of a silent 20-minute tool outage.
+Covers: the agent never starts — on any launch, boot or restart — into a session
+whose MCP origins are unreachable or whose context-server URLs are unusable, and
+when that happens the operator gets the failing URL immediately instead of a
+silent tool outage.
 
 Does not cover: an MCP server that fails to register even though its origin
 answered (e.g. the API dies in the few seconds between the probe and
-`session/new`). Repairing that requires either a retry inside the agent or
-Zed re-pushing `mcpServers` to a live ACP session
+`session/new`). Repairing that requires either a retry inside the agent or Zed
+re-pushing `mcpServers` to a live ACP session
 (`crates/agent_servers/src/acp.rs::mcp_servers_for_project` is only called from
 `session/new|load|resume`). Both are outside this repo.
 
@@ -161,5 +181,5 @@ Zed re-pushing `mcpServers` to a live ACP session
 `opencode` fails its plugin bootstrap on every start with
 `EACCES: permission denied, open '/home/retro/.npm/_cacache/...'` while
 fetching `@opencode-ai/plugin` (46 occurrences across the historical session
-logs on this host). Unrelated to the MCP surface, but it is a real permissions
+logs on this host). Unrelated to the MCP surface, but a real permissions
 defect in the desktop image.

--- a/design/2026-09-01-opencode-mcp-tools-unavailable.md
+++ b/design/2026-09-01-opencode-mcp-tools-unavailable.md
@@ -111,19 +111,36 @@ freshly measured verdict — a boot-lifetime "ready" marker would let the origin
 bug straight back in on the first restart.
 
 1. `api/cmd/settings-sync-daemon/mcp_readiness.go` — `probeMCPEndpoints` reads
-   the distinct `scheme://host:port` of every URL-addressed `context_server`
-   **out of `settings.json` on disk** and probes each (unauthenticated
-   `GET /api/v1/config`, no side effects). Any HTTP status counts; only a
-   transport error is a failure, because that is the only thing that breaks MCP
-   registration. It is served at `/mcp-readiness` on the daemon's existing
-   loopback port (`SETTINGS_SYNC_PORT`, default 9877): 200 means safe to launch,
-   503 carries the reason.
+   every URL-addressed `context_server` out of `settings.json` on disk and
+   probes **each configured URL verbatim** — path, query and headers — because
+   that is the only thing whose reachability we are entitled to assert. It is
+   served at `/mcp-readiness` on the daemon's existing loopback port
+   (`SETTINGS_SYNC_PORT`, default 9877): 200 means safe to launch, 503 carries
+   the reason.
 
-   Reading the file rather than `d.helixSettings` is deliberate on two counts.
-   It is the exact set Zed loads and forwards to the agent, user overrides
-   included; and the file is written atomically (tempfile + rename), so the HTTP
-   handler can read it while the poll loop rewrites it without sharing mutable
-   state with the rest of the daemon.
+   **Method: HEAD**, the only method that is uniformly side-effect free and
+   prompt. POST (a real MCP `initialize`) allocates server-side session state —
+   kodit creates a per-session handler — and GET is the Streamable HTTP
+   notification stream: measured against a live session, GET hangs until
+   timeout on `helix-desktop` and returns an open SSE stream on `helix-session`
+   and `kodit`.
+
+   **Failure is a transport error or a 5xx; every other status is success.**
+   That is measured, not lazy. Through the sandbox API proxy against a healthy
+   session, HEAD on each *correct* MCP URL returns 404 (the mux router has no
+   HEAD route) while HEAD on a deliberately *wrong* path returns 200 from the
+   frontend catch-all — status is anti-correlated with routing correctness, so
+   anything stricter than "not 5xx" would reject exactly the endpoints that
+   work. 5xx is the exception worth catching: with `helix-api-1` stopped but the
+   sandbox proxy up, all four context servers answered 502 "Helix API
+   unavailable" from the proxy's `ErrorHandler`. Treating any response as
+   success would have called that ready.
+
+   Reading the URLs from the file rather than `d.helixSettings` is deliberate on
+   two counts. It is the exact set Zed loads and forwards to the agent, user
+   overrides included; and the file is written atomically (tempfile + rename),
+   so the HTTP handler can read it while the poll loop rewrites it without
+   sharing mutable state with the rest of the daemon.
 
    It reads those URLs rather than trusting `HELIX_API_URL` for a third reason:
    the two can diverge (a control plane emitting `helix-api.internal:18080`
@@ -133,11 +150,11 @@ bug straight back in on the first restart.
    being fixed, and one a `HELIX_API_URL` probe would miss.
 
    A context server with no `url` is a stdio server and is ignored. A context
-   server that declares a `url` which cannot be turned into an origin — empty,
-   unparseable, no host, non-HTTP scheme, not a string — **fails** readiness.
-   Zed forwards that broken URL to the agent regardless and the registration
-   against it fails permanently, so skipping it is how an all-malformed config
-   would otherwise report "ready".
+   server that declares a `url` which cannot be used — empty, unparseable, no
+   host, non-HTTP scheme, not a string — **fails** readiness. Zed forwards that
+   broken URL to the agent regardless and the registration against it fails
+   permanently, so skipping it is how an all-malformed config would otherwise
+   report "ready".
 
    On the boot path the daemon additionally runs `waitForMCPEndpoints` (in a
    goroutine, so it cannot delay the listener the gate polls) and reports a
@@ -158,6 +175,10 @@ bug straight back in on the first restart.
   daemon syncs over the gateway IP — the exact skew that produced the original
   failure): the probe fails, the reason names the failing URL, and the gate
   refuses to launch.
+* Helix API stopped with the sandbox proxy still up: every MCP URL answers 502
+  and the gate refuses to launch. An earlier revision probed a synthetic
+  `origin + /api/v1/config` and treated any status as success, so it called
+  this state ready.
 * Zed restart with the origin dead: the gate re-checks and holds the relaunch
   instead of handing the agent a dead MCP surface.
 * `go test ./cmd/settings-sync-daemon/` green, including under `-race`.

--- a/desktop/shared/start-zed-core.sh
+++ b/desktop/shared/start-zed-core.sh
@@ -102,6 +102,54 @@ wait_for_zed_config() {
     exit 1
 }
 
+# Prove the Helix MCP context servers are reachable before Zed launches the
+# coding agent.
+#
+# Zed hands the agent its MCP servers exactly once, on the ACP session/new
+# request, and the agent (opencode, qwen, ...) connects to each one exactly
+# once. There is no retry on either side: a server that fails to connect in
+# that window stays "failed" for the whole session, its tools never enter the
+# model's tool map, and every call the model makes returns "Model tried to call
+# unavailable tool". Inference keeps working because it retries per turn, so
+# the session looks healthy while the agent is silently tool-less.
+#
+# The settings-sync-daemon probes the origins it wrote into settings.json and
+# writes one of these markers. See
+# design/2026-09-01-opencode-mcp-tools-unavailable.md.
+wait_for_mcp_endpoints() {
+    local READY_MARKER="/tmp/helix-mcp-endpoints-ready"
+    local UNREACHABLE_MARKER="/tmp/helix-mcp-endpoints-unreachable"
+    local WAIT_COUNT=0
+    # The daemon's own probe budget is 60s; allow a little more so we report
+    # its verdict rather than racing it.
+    local MAX_WAIT=90
+
+    echo "Waiting for Helix MCP context servers to be reachable..."
+    while [ $WAIT_COUNT -lt $MAX_WAIT ]; do
+        if [ -f "$READY_MARKER" ]; then
+            echo "Helix MCP context servers reachable"
+            return 0
+        fi
+        if [ -f "$UNREACHABLE_MARKER" ]; then
+            echo "FATAL: Helix MCP context servers are not reachable from this container."
+            cat "$UNREACHABLE_MARKER"
+            echo "Starting the agent now would give it no Helix tools for the entire session."
+            echo "Check: HELIX_API_URL=${HELIX_API_URL:-UNSET}; the context_server urls in"
+            echo "  $HOME/.config/zed/settings.json must resolve and connect from inside this container."
+            exit 1
+        fi
+        sleep 1
+        WAIT_COUNT=$((WAIT_COUNT + 1))
+        if [ $((WAIT_COUNT % 10)) -eq 0 ]; then
+            echo "Still waiting for MCP context servers... ($WAIT_COUNT seconds)"
+        fi
+    done
+
+    echo "FATAL: settings-sync-daemon never reported on MCP context server reachability after ${MAX_WAIT}s."
+    echo "Check: journalctl -u settings-sync-daemon --no-pager -n 50"
+    exit 1
+}
+
 wait_for_claude_credentials() {
     # In Claude Code subscription mode, wait for the credentials file before
     # starting Zed. Claude Code's credential reader is memoized — if it starts
@@ -294,6 +342,11 @@ start_zed_helix() {
     # Step 2: Wait for Zed configuration
     # =========================================
     wait_for_zed_config
+
+    # =========================================
+    # Step 2a: Wait for the MCP context servers to be reachable
+    # =========================================
+    wait_for_mcp_endpoints
 
     # =========================================
     # Step 2b: Wait for Claude credentials (if using Claude Code)

--- a/desktop/shared/start-zed-core.sh
+++ b/desktop/shared/start-zed-core.sh
@@ -122,18 +122,25 @@ wait_for_zed_config() {
 wait_for_mcp_endpoints() {
     local PORT="${SETTINGS_SYNC_PORT:-9877}"
     local URL="http://127.0.0.1:${PORT}/mcp-readiness"
-    local WAIT_COUNT=0
     # Generous: covers a cold boot (the daemon's listener comes up after the
     # first sync) and rides out a transient blip on a mid-session restart.
     # Bounded, because a session that cannot reach its own API is not going to
     # fix itself and the operator needs the error rather than a silent hang.
     local MAX_WAIT=180
+    # A wall-clock deadline, not an attempt count. Counting attempts made the
+    # documented 180s bound a lie: each iteration can spend up to the curl
+    # timeout plus the sleep, so 180 attempts was really ~33 minutes of held
+    # launch. The daemon probes its endpoints concurrently with a 5s cap, so a
+    # verdict normally arrives in well under a second.
+    local DEADLINE=$(( $(date +%s) + MAX_WAIT ))
+    local LAST_REPORT=0
+    local ELAPSED=0
     local RESPONSE=""
     local STATUS=""
     local BODY=""
 
     echo "Checking Helix MCP context servers are reachable..."
-    while [ $WAIT_COUNT -lt $MAX_WAIT ]; do
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
         # Not curl -f: a 503 carries the reason in its body and that is exactly
         # what we want to print. Status and body are captured together.
         RESPONSE=$(curl -sS --max-time 10 -w '\n%{http_code}' "$URL" 2>&1)
@@ -144,13 +151,14 @@ wait_for_mcp_endpoints() {
             return 0
         fi
         sleep 1
-        WAIT_COUNT=$((WAIT_COUNT + 1))
-        if [ $((WAIT_COUNT % 10)) -eq 0 ]; then
-            echo "Still waiting for MCP context servers... ($WAIT_COUNT seconds)"
+        ELAPSED=$(( $(date +%s) - DEADLINE + MAX_WAIT ))
+        if [ $(( ELAPSED - LAST_REPORT )) -ge 10 ]; then
+            LAST_REPORT=$ELAPSED
+            echo "Still waiting for MCP context servers... (${ELAPSED}s of ${MAX_WAIT}s)"
         fi
     done
 
-    echo "FATAL: Helix MCP context servers are not reachable from this container."
+    echo "FATAL: Helix MCP context servers are not reachable from this container after ${MAX_WAIT}s."
     echo "Last verdict from ${URL}:"
     echo "  ${BODY}"
     echo "Starting the agent now would give it no Helix tools for the entire session."

--- a/desktop/shared/start-zed-core.sh
+++ b/desktop/shared/start-zed-core.sh
@@ -102,8 +102,7 @@ wait_for_zed_config() {
     exit 1
 }
 
-# Prove the Helix MCP context servers are reachable before Zed launches the
-# coding agent.
+# Prove the Helix MCP context servers are reachable before EVERY Zed launch.
 #
 # Zed hands the agent its MCP servers exactly once, on the ACP session/new
 # request, and the agent (opencode, qwen, ...) connects to each one exactly
@@ -113,30 +112,36 @@ wait_for_zed_config() {
 # unavailable tool". Inference keeps working because it retries per turn, so
 # the session looks healthy while the agent is silently tool-less.
 #
-# The settings-sync-daemon probes the origins it wrote into settings.json and
-# writes one of these markers. See
+# This runs per launch, not once at boot, because run_zed_restart_loop respawns
+# Zed for the life of the container and the settings-sync-daemon's restartZed()
+# deliberately uses that path to give the agent a fresh ACP session on an agent
+# switch. Every one of those launches is another one-shot registration.
+#
+# The verdict is measured fresh by the daemon each time we ask. See
 # design/2026-09-01-opencode-mcp-tools-unavailable.md.
 wait_for_mcp_endpoints() {
-    local READY_MARKER="/tmp/helix-mcp-endpoints-ready"
-    local UNREACHABLE_MARKER="/tmp/helix-mcp-endpoints-unreachable"
+    local PORT="${SETTINGS_SYNC_PORT:-9877}"
+    local URL="http://127.0.0.1:${PORT}/mcp-readiness"
     local WAIT_COUNT=0
-    # The daemon's own probe budget is 60s; allow a little more so we report
-    # its verdict rather than racing it.
-    local MAX_WAIT=90
+    # Generous: covers a cold boot (the daemon's listener comes up after the
+    # first sync) and rides out a transient blip on a mid-session restart.
+    # Bounded, because a session that cannot reach its own API is not going to
+    # fix itself and the operator needs the error rather than a silent hang.
+    local MAX_WAIT=180
+    local RESPONSE=""
+    local STATUS=""
+    local BODY=""
 
-    echo "Waiting for Helix MCP context servers to be reachable..."
+    echo "Checking Helix MCP context servers are reachable..."
     while [ $WAIT_COUNT -lt $MAX_WAIT ]; do
-        if [ -f "$READY_MARKER" ]; then
+        # Not curl -f: a 503 carries the reason in its body and that is exactly
+        # what we want to print. Status and body are captured together.
+        RESPONSE=$(curl -sS --max-time 10 -w '\n%{http_code}' "$URL" 2>&1)
+        STATUS=$(printf '%s' "$RESPONSE" | tail -n 1)
+        BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+        if [ "$STATUS" = "200" ]; then
             echo "Helix MCP context servers reachable"
             return 0
-        fi
-        if [ -f "$UNREACHABLE_MARKER" ]; then
-            echo "FATAL: Helix MCP context servers are not reachable from this container."
-            cat "$UNREACHABLE_MARKER"
-            echo "Starting the agent now would give it no Helix tools for the entire session."
-            echo "Check: HELIX_API_URL=${HELIX_API_URL:-UNSET}; the context_server urls in"
-            echo "  $HOME/.config/zed/settings.json must resolve and connect from inside this container."
-            exit 1
         fi
         sleep 1
         WAIT_COUNT=$((WAIT_COUNT + 1))
@@ -145,8 +150,12 @@ wait_for_mcp_endpoints() {
         fi
     done
 
-    echo "FATAL: settings-sync-daemon never reported on MCP context server reachability after ${MAX_WAIT}s."
-    echo "Check: journalctl -u settings-sync-daemon --no-pager -n 50"
+    echo "FATAL: Helix MCP context servers are not reachable from this container."
+    echo "Last verdict from ${URL}:"
+    echo "  ${BODY}"
+    echo "Starting the agent now would give it no Helix tools for the entire session."
+    echo "Check: HELIX_API_URL=${HELIX_API_URL:-UNSET}; the context_server urls in"
+    echo "  $HOME/.config/zed/settings.json must resolve and connect from inside this container."
     exit 1
 }
 
@@ -234,6 +243,9 @@ run_zed_restart_loop() {
     trap 'echo "Caught signal, continuing restart loop..."' 15 2 1
 
     while true; do
+        # Every launch is a fresh ACP session and therefore a fresh one-shot
+        # MCP registration by the agent. Re-verify before each one.
+        wait_for_mcp_endpoints
         echo "Launching Zed..."
         # ZED_EXTRA_FILES can be set by desktop-specific script (e.g., user guide)
         if [ "${HELIX_HEADLESS}" = "1" ]; then
@@ -342,11 +354,6 @@ start_zed_helix() {
     # Step 2: Wait for Zed configuration
     # =========================================
     wait_for_zed_config
-
-    # =========================================
-    # Step 2a: Wait for the MCP context servers to be reachable
-    # =========================================
-    wait_for_mcp_endpoints
 
     # =========================================
     # Step 2b: Wait for Claude credentials (if using Claude Code)


### PR DESCRIPTION
## The bug

A spec task reported that **every** MCP tool call failed for 20+ minutes:

```
The arguments provided to the tool are invalid: Model tried to call unavailable
tool 'helix-tasks_list_secrets'. Available tools: bash, chrome-devtools_click, ...
```

`helix-tasks_*`, `kodit_*` and `ask_human` were all affected. The agent itself kept working.

## Root cause

The harness is **opencode** (`OPENCODE_VERSION=1.18.18`), not Zed or Claude Code:
`Model tried to call unavailable tool 'X'. Available tools: …` is the Vercel AI SDK's
`NoSuchToolError`, and `The arguments provided to the tool are invalid: …` is opencode's
builtin `invalid` tool — which is why the call was logged as arriving under the tool name
`invalid`. MCP tool ids are `sanitize(server) + "_" + sanitize(tool)`, giving
`helix-tasks_list_secrets`.

Helix's MCP servers reach opencode only through Zed's ACP `session/new|load|resume`
(`crates/agent_servers/src/acp.rs::mcp_servers_for_project`). **opencode connects to each
exactly once, records a failure as a permanently `failed` server, logs a single warning,
and never retries — and Zed never re-pushes.**

So any failure to reach the Helix API in that window silently strips every Helix tool for
the life of the session, while the LLM path (which retries per turn) recovers and makes
the session look healthy. Meanwhile our own prompts keep instructing the agent to call
`list_secrets` / `get_secret` / `ask_human`.

Reproduced in a real session container:

```
WARN "server unavailable" key=helix-desktop type=remote status=failed
WARN "server unavailable" key=helix-session type=remote status=failed
WARN "server unavailable" key=kodit        type=remote status=failed
WARN "server unavailable" key=helix-tasks  type=remote status=failed
```

…after which the agent ran on with zero Helix tools. `chrome-devtools` (stdio, no network)
was unaffected — matching the reporter seeing `chrome-devtools_*` in the available list.

Ruled out: all three Helix MCP endpoints do advertise `tools: {listChanged: true}` (probed
with a real session-scoped key), and `helix-tasks` does expose `ask_human` / `list_secrets`
/ `get_secret` to a spec task.

## The fix

Nothing checked that the addresses we write into `settings.json` are reachable.
`start-zed-core.sh` gated only on `settings.json` existing, so a container whose
context-server origin did not resolve booted straight into a tool-less session.

- **`api/cmd/settings-sync-daemon/mcp_readiness.go`** — after the initial sync the daemon
  extracts the distinct `scheme://host:port` of every URL-addressed `context_server`
  **from the settings it just merged** and probes each (unauthenticated
  `GET /api/v1/config`, no side effects), retrying for 60s. Any HTTP status counts; only a
  transport error is a failure, because that is the only thing that breaks MCP
  registration. Success writes `/tmp/helix-mcp-endpoints-ready`; failure writes
  `/tmp/helix-mcp-endpoints-unreachable` with the failing URL and calls the existing
  `reportAgentStartupError`.

  It reads the URLs back out of the settings rather than trusting `HELIX_API_URL` on
  purpose: those two can diverge (a control plane emitting `helix-api.internal:18080`
  against an older sandbox host that still sets `HELIX_API_URL=http://api:8080`). In that
  state Zed's websocket and inference both work and *only* the MCP servers are dead —
  the exact failure being fixed, and one a `HELIX_API_URL` probe would miss.

- **`desktop/shared/start-zed-core.sh`** — new `wait_for_mcp_endpoints` step between
  `wait_for_zed_config` and the Zed launch. Waits for the ready marker; on the unreachable
  marker it prints the recorded reason and exits, matching `wait_for_zed_config`'s
  existing fatal behaviour.

## Verification

End-to-end in a real session container (`ubuntu-external-01m1e14w0ffjmqbx8v62y37dkk`,
desktop image `bb8589`), all three paths:

- **Healthy** — `MCP readiness: all 1 context server origin(s) reachable`, gate proceeds,
  Zed starts, opencode logs no `server unavailable`.
- **Divergent dead origin** (`helix-api.internal` pointed at a dead port while the daemon
  syncs over the gateway IP — the exact skew that produced the original failure) — probe
  fails, reason recorded with the failing URL, gate exits 1 instead of starting a
  tool-less agent.
- **API unreachable entirely** — initial sync fails, `helixSettings` is nil, gate refuses
  to declare readiness rather than passing vacuously. This caught a flaw in the first
  draft; regression test `TestVerifyMCPEndpoints/unsynced_settings_never_mark_ready`.

`go test ./cmd/settings-sync-daemon/` green.

**NOT tested:** a live agent turn actually calling `list_secrets`. The configured model
`pe_…/qwen3.8-27b` 500s upstream on every turn in this environment (the endpoint serves
`qwen3.8-flash-next`), so the agent could not complete a turn. MCP connectivity was
verified via opencode's logs and a direct MCP handshake instead.

## Scope

Does **not** cover an MCP server that fails despite its origin answering (e.g. the API
dies in the seconds between the probe and `session/new`). That needs a retry inside the
agent, or Zed re-pushing `mcpServers` to a live ACP session — both outside this repo.

Design notes: `design/2026-09-01-opencode-mcp-tools-unavailable.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
