### PR TITLE
feat: add board archive automation and fix API keys

### DIFF
--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -43,7 +43,7 @@ func newCreateCommand() *cobra.Command {
 	flags := uploadFlags{}
 	cmd := &cobra.Command{
 		Use:   "create <file-or-directory>",
-		Short: "Create an artifact from HTML, a compiled SPA, PDF, or image",
+		Short: "Create an artifact from HTML, Markdown, a compiled SPA, PDF, or image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			projectID := firstNonEmpty(flags.projectID, os.Getenv("HELIX_PROJECT_ID"))

--- a/api/pkg/cli/spectask/files_cmd.go
+++ b/api/pkg/cli/spectask/files_cmd.go
@@ -1,0 +1,157 @@
+package spectask
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// newFilesCommand lists the files in a running session's workspace — the same
+// view the web UI's "Files" panel shows. Read-only; complements `copy` (upload
+// into the container) and `download` (pull a file out).
+func newFilesCommand() *cobra.Command {
+	var (
+		workspace  string
+		jsonOutput bool
+	)
+	cmd := &cobra.Command{
+		Use:   "files <session-id>",
+		Short: "List files in a session's workspace",
+		Long: `List the files in a running session container's workspace (the same
+listing the web UI Files browser shows).
+
+Examples:
+  helix spectask files ses_01xxx
+  helix spectask files ses_01xxx --workspace keel --json
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionID := args[0]
+			apiURL, token := getAPIURL(), getToken()
+			if apiURL == "" || token == "" {
+				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+			}
+			u := fmt.Sprintf("%s/api/v1/external-agents/%s/workspace-files", apiURL, sessionID)
+			if workspace != "" {
+				u += "?workspace=" + url.QueryEscape(workspace)
+			}
+			body, err := workspaceGET(u, token)
+			if err != nil {
+				return err
+			}
+			var resp types.WorkspaceFilesResponse
+			if err := json.Unmarshal(body, &resp); err != nil {
+				return fmt.Errorf("decode workspace files: %w", err)
+			}
+			if jsonOutput {
+				out, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Fprintln(cmd.OutOrStdout(), string(out))
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "workspace: %s\n", resp.Workspace)
+			for _, e := range resp.Entries {
+				marker := " "
+				if e.Kind == "dir" {
+					marker = "/"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %10d  %s%s\n", e.Size, e.Path, marker)
+			}
+			if resp.Truncated {
+				fmt.Fprintln(cmd.OutOrStdout(), "  … (listing truncated)")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "", "Workspace/repo name (default: primary)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print JSON")
+	return cmd
+}
+
+// newDownloadCommand pulls one file out of a running session's workspace to the
+// local filesystem — the inverse of `copy`. Use it to collect a sub-agent's
+// output (findings.json, a rendered report, logs) into the driving session.
+func newDownloadCommand() *cobra.Command {
+	var (
+		workspace string
+		outPath   string
+	)
+	cmd := &cobra.Command{
+		Use:   "download <session-id> <remote-path>",
+		Short: "Download a file from a session's workspace",
+		Long: `Download a file from a running session container's workspace.
+
+<remote-path> is relative to the workspace root. By default the file is written
+to the current directory under its base name; use -o to choose a path, or -o -
+to stream to stdout.
+
+Examples:
+  helix spectask download ses_01xxx engagement/findings.json
+  helix spectask download ses_01xxx out/report.pdf -o ./report.pdf
+  helix spectask download ses_01xxx notes.md -o -           # to stdout
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionID, remotePath := args[0], args[1]
+			apiURL, token := getAPIURL(), getToken()
+			if apiURL == "" || token == "" {
+				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+			}
+			q := url.Values{}
+			q.Set("path", remotePath)
+			if workspace != "" {
+				q.Set("workspace", workspace)
+			}
+			u := fmt.Sprintf("%s/api/v1/external-agents/%s/workspace-file/download?%s", apiURL, sessionID, q.Encode())
+			body, err := workspaceGET(u, token)
+			if err != nil {
+				return err
+			}
+			if outPath == "-" {
+				_, err := cmd.OutOrStdout().Write(body)
+				return err
+			}
+			dest := outPath
+			if dest == "" {
+				dest = filepath.Base(remotePath)
+			}
+			if err := os.WriteFile(dest, body, 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", dest, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Downloaded %s (%d bytes) from session %s\n", dest, len(body), sessionID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "", "Workspace/repo name (default: primary)")
+	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Local output path (default: base name; '-' for stdout)")
+	return cmd
+}
+
+func workspaceGET(u, token string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("workspace API returned %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -68,6 +68,8 @@ func New() *cobra.Command {
 	cmd.AddCommand(newLatencyCommand())
 	cmd.AddCommand(newExecCommand())
 	cmd.AddCommand(newCopyCommand())
+	cmd.AddCommand(newFilesCommand())
+	cmd.AddCommand(newDownloadCommand())
 
 	return cmd
 }

--- a/api/pkg/server/api_key_handlers_test.go
+++ b/api/pkg/server/api_key_handlers_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/controller"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetAPIKeysReturnsStableLatestPersonalKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	user := &types.User{ID: "user_1", Type: types.OwnerTypeUser}
+	older := &types.ApiKey{
+		Created:   time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		Owner:     user.ID,
+		OwnerType: user.Type,
+		Key:       "hl-older",
+		Name:      "API Key",
+		Type:      types.APIkeytypeAPI,
+	}
+	newer := &types.ApiKey{
+		Created:   time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		Owner:     user.ID,
+		OwnerType: user.Type,
+		Key:       "hl-newer",
+		Name:      "API Key",
+		Type:      types.APIkeytypeAPI,
+	}
+	organizationKey := &types.ApiKey{
+		Created:        time.Date(2026, 9, 2, 0, 0, 0, 0, time.UTC),
+		Owner:          user.ID,
+		OwnerType:      user.Type,
+		Key:            "hl-organization",
+		Name:           "Organization Key",
+		Type:           types.APIkeytypeAPI,
+		OrganizationID: "org_1",
+	}
+	allKeys := []*types.ApiKey{older, organizationKey, newer}
+
+	mockStore.EXPECT().ListAPIKeys(gomock.Any(), &store.ListAPIKeysQuery{
+		Owner: user.ID, OwnerType: user.Type, Type: types.APIkeytypeAPI,
+	}).Return(allKeys, nil).Times(2)
+	mockStore.EXPECT().ListAPIKeys(gomock.Any(), &store.ListAPIKeysQuery{
+		Owner: user.ID, OwnerType: user.Type,
+	}).Return(allKeys, nil).Times(2)
+
+	server := &HelixAPIServer{
+		Controller: &controller.Controller{Options: controller.Options{Store: mockStore}},
+	}
+
+	for range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/api_keys", nil)
+		req = req.WithContext(setRequestUser(context.Background(), *user))
+		keys, err := server.getAPIKeys(nil, req)
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		require.Equal(t, newer.Key, keys[0].Key)
+	}
+}
+
+func TestPersonalAPIKeyRejectsScopedKeys(t *testing.T) {
+	base := types.ApiKey{Type: types.APIkeytypeAPI}
+	require.True(t, isPersonalAPIKey(&base))
+
+	for name, mutate := range map[string]func(*types.ApiKey){
+		"organization": func(key *types.ApiKey) { key.OrganizationID = "org_1" },
+		"project":      func(key *types.ApiKey) { key.ProjectID = "prj_1" },
+		"spec task":    func(key *types.ApiKey) { key.SpecTaskID = "spt_1" },
+		"session":      func(key *types.ApiKey) { key.SessionID = "ses_1" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			key := base
+			mutate(&key)
+			require.False(t, isPersonalAPIKey(&key))
+		})
+	}
+}

--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -80,7 +80,7 @@ func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Req
 
 // createProjectArtifact godoc
 // @Summary Create a project artifact
-// @Description Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.
+// @Description Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.
 // @Tags Artifacts
 // @Accept multipart/form-data
 // @Produce json
@@ -90,7 +90,7 @@ func (s *HelixAPIServer) listProjectArtifacts(w http.ResponseWriter, r *http.Req
 // @Param entrypoint formData string false "HTML entrypoint (default index.html)"
 // @Param visibility formData string false "project or public"
 // @Param with_subdomain formData bool false "Deprecated: public artifacts always receive a share subdomain"
-// @Param artifact formData file true "HTML, PDF, image, or ZIP bundle"
+// @Param artifact formData file true "HTML, Markdown, PDF, image, or ZIP bundle"
 // @Success 201 {object} types.Artifact
 // @Router /api/v1/projects/{id}/artifacts [post]
 // @Security BearerAuth
@@ -259,7 +259,7 @@ func (s *HelixAPIServer) getArtifactViewer(w http.ResponseWriter, r *http.Reques
 
 // updateArtifact godoc
 // @Summary Update an artifact
-// @Description Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.
+// @Description Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.
 // @Tags Artifacts
 // @Accept multipart/form-data
 // @Produce json
@@ -269,7 +269,7 @@ func (s *HelixAPIServer) getArtifactViewer(w http.ResponseWriter, r *http.Reques
 // @Param entrypoint formData string false "HTML entrypoint"
 // @Param visibility formData string false "project or public"
 // @Param with_subdomain formData bool false "Allocate or retain a public default subdomain"
-// @Param artifact formData file false "Replacement HTML, PDF, image, or ZIP content"
+// @Param artifact formData file false "Replacement HTML, Markdown, PDF, or ZIP content"
 // @Success 200 {object} types.Artifact
 // @Router /api/v1/artifacts/{artifact_id} [put]
 // @Security BearerAuth
@@ -673,7 +673,7 @@ func validateArtifactEntrypoint(files []types.ArtifactFile, requested string) (s
 	}
 	if len(files) == 1 {
 		switch artifactKindFromFiles(files) {
-		case types.ArtifactKindPDF, types.ArtifactKindImage:
+		case types.ArtifactKindPDF, types.ArtifactKindImage, types.ArtifactKindMarkdown:
 			return entrypoint, nil
 		case types.ArtifactKindSingleFile:
 			if artifactFileIsHTML(*entrypointFile) {
@@ -681,7 +681,7 @@ func validateArtifactEntrypoint(files []types.ArtifactFile, requested string) (s
 			}
 			fallthrough
 		default:
-			return "", errors.New("single-file artifact must be HTML, PDF, or an image")
+			return "", errors.New("single-file artifact must be HTML, Markdown, PDF, or an image")
 		}
 	}
 	if !artifactFileIsHTML(*entrypointFile) {
@@ -719,6 +719,8 @@ func artifactKindFromFiles(files []types.ArtifactFile) types.ArtifactKind {
 		return types.ArtifactKindPDF
 	case strings.HasPrefix(contentType, "image/"):
 		return types.ArtifactKindImage
+	case artifactFileIsMarkdown(files[0]):
+		return types.ArtifactKindMarkdown
 	default:
 		return types.ArtifactKindSingleFile
 	}
@@ -727,6 +729,15 @@ func artifactKindFromFiles(files []types.ArtifactFile) types.ArtifactKind {
 func artifactFileIsHTML(file types.ArtifactFile) bool {
 	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(file.ContentType, ";", 2)[0]))
 	return contentType == "text/html" && (strings.EqualFold(path.Ext(file.Path), ".html") || strings.EqualFold(path.Ext(file.Path), ".htm"))
+}
+
+func artifactFileIsMarkdown(file types.ArtifactFile) bool {
+	if strings.EqualFold(path.Ext(file.Path), ".html") || strings.EqualFold(path.Ext(file.Path), ".htm") {
+		return false
+	}
+	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(file.ContentType, ";", 2)[0]))
+	return contentType == "text/markdown" || contentType == "text/x-markdown" ||
+		strings.EqualFold(path.Ext(file.Path), ".md") || strings.EqualFold(path.Ext(file.Path), ".markdown")
 }
 
 func artifactVersionFromUpload(r *http.Request, artifactID, versionID, storagePrefix string, versionNumber int, userID string, upload *artifactUpload) *types.ArtifactVersion {
@@ -1021,11 +1032,12 @@ func activePrivateArtifactRouteUser(route *types.VHostRoute, now time.Time) (str
 // serveArtifactDocument delivers non-HTML documents on the trusted viewer
 // origin. Chrome blocks its extension-backed PDF viewer inside a cross-origin
 // iframe, so PDFs use this permission-checked, MIME-locked route instead of an
-// artifact vhost.
+// artifact vhost. Markdown artifacts use the same route so the viewer can
+// fetch the raw source same-origin.
 func (s *HelixAPIServer) serveArtifactDocument(w http.ResponseWriter, r *http.Request) {
 	artifactID := mux.Vars(r)["artifact_id"]
 	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
-	if err != nil || artifact.Kind != types.ArtifactKindPDF {
+	if err != nil || (artifact.Kind != types.ArtifactKindPDF && artifact.Kind != types.ArtifactKindMarkdown) {
 		http.NotFound(w, r)
 		return
 	}

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -102,6 +102,8 @@ func TestValidateArtifactEntrypointSupportsDocuments(t *testing.T) {
 		{name: "PDF", file: types.ArtifactFile{Path: "report.pdf", ContentType: "application/pdf"}, expectedKind: types.ArtifactKindPDF},
 		{name: "image", file: types.ArtifactFile{Path: "diagram.png", ContentType: "image/png"}, expectedKind: types.ArtifactKindImage},
 		{name: "HTML", file: types.ArtifactFile{Path: "page.html", ContentType: "text/html; charset=utf-8"}, expectedKind: types.ArtifactKindSingleFile},
+		{name: "markdown extension", file: types.ArtifactFile{Path: "notes.md", ContentType: "text/plain; charset=utf-8"}, expectedKind: types.ArtifactKindMarkdown},
+		{name: "markdown content type", file: types.ArtifactFile{Path: "notes.txt", ContentType: "text/markdown; charset=utf-8"}, expectedKind: types.ArtifactKindMarkdown},
 	}
 
 	for _, test := range tests {
@@ -116,7 +118,7 @@ func TestValidateArtifactEntrypointSupportsDocuments(t *testing.T) {
 
 func TestValidateArtifactEntrypointRejectsUnsupportedSingleFile(t *testing.T) {
 	_, err := validateArtifactEntrypoint([]types.ArtifactFile{{Path: "script.js", ContentType: "text/javascript"}}, "script.js")
-	require.ErrorContains(t, err, "must be HTML, PDF, or an image")
+	require.ErrorContains(t, err, "must be HTML, Markdown, PDF, or an image")
 }
 
 func TestValidateArtifactEntrypointRequiresHTMLForBundle(t *testing.T) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -15436,6 +15436,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by organization code-agent harness policy",
+                        "name": "code_agent_runtime",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "Include all endpoints (system admin only)",
                         "name": "all",
@@ -28498,24 +28504,24 @@ const docTemplate = `{
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "gitlab",
-                "github",
-                "local",
-                "slack",
-                "helix_events",
                 "webhook",
+                "gitlab",
+                "slack",
+                "email",
+                "local",
+                "helix_events",
                 "cron",
-                "email"
+                "github"
             ],
             "x-enum-varnames": [
-                "KindGitLab",
-                "KindGitHub",
-                "KindLocal",
-                "KindSlack",
-                "KindHelixEvents",
                 "KindWebhook",
+                "KindGitLab",
+                "KindSlack",
+                "KindEmail",
+                "KindLocal",
+                "KindHelixEvents",
                 "KindCron",
-                "KindEmail"
+                "KindGitHub"
             ]
         },
         "transport.ResolvedActivation": {
@@ -35060,6 +35066,18 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive automation, reconciled by the spec task orchestrator",
+                    "type": "boolean"
+                },
                 "auto_start_backlog_tasks": {
                     "description": "Automation settings",
                     "type": "boolean"
@@ -35633,6 +35651,18 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived (1-365)",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive tasks immediately when they enter Done",
+                    "type": "boolean"
                 },
                 "auto_start_backlog_tasks": {
                     "type": "boolean"

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -2767,7 +2767,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2818,7 +2818,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML, PDF, image, or ZIP content",
+                        "description": "Replacement HTML, Markdown, PDF, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13338,7 +13338,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13390,7 +13390,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "file",
-                        "description": "HTML, PDF, image, or ZIP bundle",
+                        "description": "HTML, Markdown, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -28504,23 +28504,23 @@ const docTemplate = `{
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "gitlab",
                 "slack",
-                "email",
-                "local",
-                "helix_events",
                 "cron",
+                "gitlab",
+                "local",
+                "email",
+                "webhook",
+                "helix_events",
                 "github"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindGitLab",
                 "KindSlack",
-                "KindEmail",
-                "KindLocal",
-                "KindHelixEvents",
                 "KindCron",
+                "KindGitLab",
+                "KindLocal",
+                "KindEmail",
+                "KindWebhook",
+                "KindHelixEvents",
                 "KindGitHub"
             ]
         },
@@ -29147,13 +29147,15 @@ const docTemplate = `{
                 "single_file",
                 "spa",
                 "pdf",
-                "image"
+                "image",
+                "markdown"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
                 "ArtifactKindSPA",
                 "ArtifactKindPDF",
-                "ArtifactKindImage"
+                "ArtifactKindImage",
+                "ArtifactKindMarkdown"
             ]
         },
         "types.ArtifactVersion": {

--- a/api/pkg/server/ensure_pull_request_test.go
+++ b/api/pkg/server/ensure_pull_request_test.go
@@ -85,6 +85,9 @@ func (f *fakeGitRepoService) CreateRepository(_ context.Context, _ *types.GitRep
 func (f *fakeGitRepoService) GetRepository(_ context.Context, _ string) (*types.GitRepository, error) {
 	panic("GetRepository unexpected")
 }
+func (f *fakeGitRepoService) GetRepositoryMetadata(_ context.Context, _ string) (*types.GitRepository, error) {
+	panic("GetRepositoryMetadata unexpected")
+}
 func (f *fakeGitRepoService) UpdateRepository(_ context.Context, _ string, _ *types.GitRepositoryUpdateRequest, _ string) (*types.GitRepository, error) {
 	panic("UpdateRepository unexpected")
 }

--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -1730,9 +1730,10 @@ func (s *HelixAPIServer) getOrCreateUserAPIKey(ctx context.Context, user *types.
 		return "", fmt.Errorf("failed to get API keys: %w", err)
 	}
 
-	// Filter for personal API keys (not app-scoped)
+	// Filter for a user-level key rather than an app, organization, project,
+	// spec-task, or session-scoped key.
 	for _, key := range apiKeys {
-		if key.AppID == nil || !key.AppID.Valid || key.AppID.String == "" {
+		if isPersonalAPIKey(key) {
 			return key.Key, nil
 		}
 	}

--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -230,8 +230,9 @@ func (s *HelixAPIServer) updateGitRepository(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Get existing one
-	existing, err := s.gitRepositoryService.GetRepository(r.Context(), repoID)
+	// Get existing metadata only — a failed external clone (e.g. bad
+	// credentials) must not block fixing those credentials via this endpoint.
+	existing, err := s.gitRepositoryService.GetRepositoryMetadata(r.Context(), repoID)
 	if err != nil {
 		log.Error().Err(err).Str("repo_id", repoID).Msg("Failed to get existing git repository")
 		http.Error(w, fmt.Sprintf("Failed to get existing repository: %s", err.Error()), http.StatusInternalServerError)
@@ -292,8 +293,9 @@ func (s *HelixAPIServer) deleteGitRepository(w http.ResponseWriter, r *http.Requ
 
 	user := getRequestUser(r)
 
-	// Get existing one
-	existing, err := s.gitRepositoryService.GetRepository(r.Context(), repoID)
+	// Metadata only — deletion must work even when the external clone failed
+	// (e.g. authentication error), otherwise the repository is undeletable.
+	existing, err := s.gitRepositoryService.GetRepositoryMetadata(r.Context(), repoID)
 	if err != nil {
 		log.Error().Err(err).Str("repo_id", repoID).Msg("Failed to get existing git repository")
 		http.Error(w, fmt.Sprintf("Failed to get existing repository: %s", err.Error()), http.StatusInternalServerError)

--- a/api/pkg/server/git_repository_servicer.go
+++ b/api/pkg/server/git_repository_servicer.go
@@ -17,6 +17,7 @@ type gitRepositoryServicer interface {
 	ValidateUserOAuth(ctx context.Context, repo *types.GitRepository, userID string) error
 	CreateRepository(ctx context.Context, request *types.GitRepositoryCreateRequest) (*types.GitRepository, error)
 	GetRepository(ctx context.Context, repoID string) (*types.GitRepository, error)
+	GetRepositoryMetadata(ctx context.Context, repoID string) (*types.GitRepository, error)
 	UpdateRepository(ctx context.Context, repoID string, request *types.GitRepositoryUpdateRequest, koditAPIKey string) (*types.GitRepository, error)
 	DeleteRepository(ctx context.Context, repoID string) error
 	CreateSampleRepository(ctx context.Context, request *types.CreateSampleRepositoryRequest) (*types.GitRepository, error)

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/helixml/helix/api/pkg/config"
@@ -1284,6 +1283,16 @@ func containsType(keyType string, typesParam string) bool {
 	return false
 }
 
+func isPersonalAPIKey(key *types.ApiKey) bool {
+	if key == nil || key.Type != types.APIkeytypeAPI {
+		return false
+	}
+	if key.AppID != nil && key.AppID.Valid && key.AppID.String != "" {
+		return false
+	}
+	return key.OrganizationID == "" && key.ProjectID == "" && key.SpecTaskID == "" && key.SessionID == ""
+}
+
 // getAPIKeys godoc
 // @Summary Get API keys
 // @Description Get API keys
@@ -1304,6 +1313,26 @@ func (apiServer *HelixAPIServer) getAPIKeys(_ http.ResponseWriter, req *http.Req
 
 	typesParam := req.URL.Query().Get("types")
 	appIDParam := req.URL.Query().Get("app_id")
+	if typesParam == "" && appIDParam == "" {
+		var latest *types.ApiKey
+		for _, key := range apiKeys {
+			if isPersonalAPIKey(key) && (latest == nil || key.Created.After(latest.Created)) {
+				latest = key
+			}
+		}
+		if latest != nil {
+			return []*types.ApiKey{latest}, nil
+		}
+
+		createdKey, err := apiServer.Controller.CreateAPIKey(ctx, user, &types.ApiKey{
+			Name: "API Key",
+			Type: types.APIkeytypeAPI,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return []*types.ApiKey{createdKey}, nil
+	}
 
 	includeAllTypes := false
 	if typesParam == "all" {
@@ -1321,22 +1350,6 @@ func (apiServer *HelixAPIServer) getAPIKeys(_ http.ResponseWriter, req *http.Req
 		filteredAPIKeys = append(filteredAPIKeys, key)
 	}
 	apiKeys = filteredAPIKeys
-
-	// If filter is missing, we are getting user keys. If we haven't got any. create a new one.
-	if typesParam == "" && appIDParam == "" && len(apiKeys) == 0 {
-		createdKey, err := apiServer.Controller.CreateAPIKey(ctx, user, &types.ApiKey{
-			Created: time.Now(),
-			Key:     uuid.New().String(),
-			Name:    "API Key",
-			Type:    types.APIkeytypeAPI,
-			Owner:   user.ID,
-		})
-		if err != nil {
-			return nil, err
-		}
-		apiKeys = append(apiKeys, createdKey)
-		return apiKeys, nil
-	}
 
 	return apiKeys, nil
 }

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -736,6 +736,18 @@ func (s *HelixAPIServer) updateProject(_ http.ResponseWriter, r *http.Request) (
 	if req.AutoStartBacklogTasks != nil {
 		project.AutoStartBacklogTasks = *req.AutoStartBacklogTasks
 	}
+	if req.AutoArchiveCompletedTasks != nil {
+		project.AutoArchiveCompletedTasks = *req.AutoArchiveCompletedTasks
+	}
+	if req.ArchiveStaleTasksEnabled != nil {
+		project.ArchiveStaleTasksEnabled = *req.ArchiveStaleTasksEnabled
+	}
+	if req.ArchiveStaleTasksDays != nil {
+		if *req.ArchiveStaleTasksDays < 1 || *req.ArchiveStaleTasksDays > 365 {
+			return nil, system.NewHTTPError400("archive_stale_tasks_days must be between 1 and 365")
+		}
+		project.ArchiveStaleTasksDays = *req.ArchiveStaleTasksDays
+	}
 	if req.AgentTools != nil {
 		project.AgentTools = sanitizeAgentTools(*req.AgentTools)
 	}
@@ -913,6 +925,15 @@ func (s *HelixAPIServer) updateProject(_ http.ResponseWriter, r *http.Request) (
 		}
 		if req.AutoStartBacklogTasks != nil {
 			changedFields = append(changedFields, "auto_start_backlog_tasks")
+		}
+		if req.AutoArchiveCompletedTasks != nil {
+			changedFields = append(changedFields, "auto_archive_completed_tasks")
+		}
+		if req.ArchiveStaleTasksEnabled != nil {
+			changedFields = append(changedFields, "archive_stale_tasks_enabled")
+		}
+		if req.ArchiveStaleTasksDays != nil {
+			changedFields = append(changedFields, "archive_stale_tasks_days")
 		}
 		if req.DefaultHelixAppID != nil {
 			changedFields = append(changedFields, "default_helix_app_id")

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -15432,6 +15432,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by organization code-agent harness policy",
+                        "name": "code_agent_runtime",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "Include all endpoints (system admin only)",
                         "name": "all",
@@ -28494,24 +28500,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "gitlab",
-                "github",
-                "local",
-                "slack",
-                "helix_events",
                 "webhook",
+                "gitlab",
+                "slack",
+                "email",
+                "local",
+                "helix_events",
                 "cron",
-                "email"
+                "github"
             ],
             "x-enum-varnames": [
-                "KindGitLab",
-                "KindGitHub",
-                "KindLocal",
-                "KindSlack",
-                "KindHelixEvents",
                 "KindWebhook",
+                "KindGitLab",
+                "KindSlack",
+                "KindEmail",
+                "KindLocal",
+                "KindHelixEvents",
                 "KindCron",
-                "KindEmail"
+                "KindGitHub"
             ]
         },
         "transport.ResolvedActivation": {
@@ -35056,6 +35062,18 @@
                         "type": "string"
                     }
                 },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive automation, reconciled by the spec task orchestrator",
+                    "type": "boolean"
+                },
                 "auto_start_backlog_tasks": {
                     "description": "Automation settings",
                     "type": "boolean"
@@ -35629,6 +35647,18 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived (1-365)",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive tasks immediately when they enter Done",
+                    "type": "boolean"
                 },
                 "auto_start_backlog_tasks": {
                     "type": "boolean"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -2763,7 +2763,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2814,7 +2814,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML, PDF, image, or ZIP content",
+                        "description": "Replacement HTML, Markdown, PDF, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13334,7 +13334,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13386,7 +13386,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "HTML, PDF, image, or ZIP bundle",
+                        "description": "HTML, Markdown, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -28500,23 +28500,23 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "gitlab",
                 "slack",
-                "email",
-                "local",
-                "helix_events",
                 "cron",
+                "gitlab",
+                "local",
+                "email",
+                "webhook",
+                "helix_events",
                 "github"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindGitLab",
                 "KindSlack",
-                "KindEmail",
-                "KindLocal",
-                "KindHelixEvents",
                 "KindCron",
+                "KindGitLab",
+                "KindLocal",
+                "KindEmail",
+                "KindWebhook",
+                "KindHelixEvents",
                 "KindGitHub"
             ]
         },
@@ -29143,13 +29143,15 @@
                 "single_file",
                 "spa",
                 "pdf",
-                "image"
+                "image",
+                "markdown"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
                 "ArtifactKindSPA",
                 "ArtifactKindPDF",
-                "ArtifactKindImage"
+                "ArtifactKindImage",
+                "ArtifactKindMarkdown"
             ]
         },
         "types.ArtifactVersion": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3593,24 +3593,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - gitlab
-    - github
-    - local
-    - slack
-    - helix_events
     - webhook
-    - cron
+    - gitlab
+    - slack
     - email
+    - local
+    - helix_events
+    - cron
+    - github
     type: string
     x-enum-varnames:
-    - KindGitLab
-    - KindGitHub
-    - KindLocal
-    - KindSlack
-    - KindHelixEvents
     - KindWebhook
-    - KindCron
+    - KindGitLab
+    - KindSlack
     - KindEmail
+    - KindLocal
+    - KindHelixEvents
+    - KindCron
+    - KindGitHub
   transport.ResolvedActivation:
     properties:
       address:
@@ -8416,6 +8416,15 @@ definitions:
         items:
           type: string
         type: array
+      archive_stale_tasks_days:
+        description: Idle days before a stale task is archived
+        type: integer
+      archive_stale_tasks_enabled:
+        description: Archive tasks idle for ArchiveStaleTasksDays
+        type: boolean
+      auto_archive_completed_tasks:
+        description: Archive automation, reconciled by the spec task orchestrator
+        type: boolean
       auto_start_backlog_tasks:
         description: Automation settings
         type: boolean
@@ -8814,6 +8823,15 @@ definitions:
         items:
           type: string
         type: array
+      archive_stale_tasks_days:
+        description: Idle days before a stale task is archived (1-365)
+        type: integer
+      archive_stale_tasks_enabled:
+        description: Archive tasks idle for ArchiveStaleTasksDays
+        type: boolean
+      auto_archive_completed_tasks:
+        description: Archive tasks immediately when they enter Done
+        type: boolean
       auto_start_backlog_tasks:
         type: boolean
       code_agent_config:
@@ -23820,6 +23838,10 @@ paths:
       - description: Organization ID
         in: query
         name: org_id
+        type: string
+      - description: Filter by organization code-agent harness policy
+        in: query
+        name: code_agent_runtime
         type: string
       - description: Include all endpoints (system admin only)
         in: query

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3593,23 +3593,23 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - webhook
-    - gitlab
     - slack
-    - email
-    - local
-    - helix_events
     - cron
+    - gitlab
+    - local
+    - email
+    - webhook
+    - helix_events
     - github
     type: string
     x-enum-varnames:
-    - KindWebhook
-    - KindGitLab
     - KindSlack
-    - KindEmail
-    - KindLocal
-    - KindHelixEvents
     - KindCron
+    - KindGitLab
+    - KindLocal
+    - KindEmail
+    - KindWebhook
+    - KindHelixEvents
     - KindGitHub
   transport.ResolvedActivation:
     properties:
@@ -4041,12 +4041,14 @@ definitions:
     - spa
     - pdf
     - image
+    - markdown
     type: string
     x-enum-varnames:
     - ArtifactKindSingleFile
     - ArtifactKindSPA
     - ArtifactKindPDF
     - ArtifactKindImage
+    - ArtifactKindMarkdown
   types.ArtifactVersion:
     properties:
       artifact_id:
@@ -15712,8 +15714,8 @@ paths:
     put:
       consumes:
       - multipart/form-data
-      description: Patch metadata and optionally upload replacement HTML, PDF, image,
-        or ZIP content as a new version.
+      description: Patch metadata and optionally upload replacement HTML, Markdown,
+        PDF, or ZIP content as a new version.
       parameters:
       - description: Artifact ID
         in: path
@@ -15740,7 +15742,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: Replacement HTML, PDF, image, or ZIP content
+      - description: Replacement HTML, Markdown, PDF, or ZIP content
         in: formData
         name: artifact
         type: file
@@ -22406,8 +22408,8 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: Upload one HTML, PDF, or image file, or a ZIP containing a compiled
-        static SPA.
+      description: Upload one HTML, Markdown, PDF, or image file, or a ZIP containing
+        a compiled static SPA.
       parameters:
       - description: Project ID
         in: path
@@ -22435,7 +22437,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: HTML, PDF, image, or ZIP bundle
+      - description: HTML, Markdown, PDF, image, or ZIP bundle
         in: formData
         name: artifact
         required: true

--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -754,6 +754,27 @@ func (s *GitRepositoryService) GetRepository(ctx context.Context, repoID string)
 	return &gitRepo, nil
 }
 
+// GetRepositoryMetadata reads repository metadata from the store without
+// touching git on disk. Unlike GetRepository it never clones or syncs, so a
+// broken external clone (e.g. failed authentication) cannot block
+// metadata-level operations such as updating credentials or deleting the
+// repository.
+func (s *GitRepositoryService) GetRepositoryMetadata(ctx context.Context, repoID string) (*types.GitRepository, error) {
+	storedRepo, err := s.store.GetGitRepository(ctx, repoID)
+	if err != nil {
+		return nil, fmt.Errorf("repository %s not found: %w", repoID, err)
+	}
+
+	// Make a defensive copy to avoid race conditions with callers mutating fields.
+	gitRepo := *storedRepo
+	if storedRepo.Branches != nil {
+		gitRepo.Branches = make([]string, len(storedRepo.Branches))
+		copy(gitRepo.Branches, storedRepo.Branches)
+	}
+
+	return &gitRepo, nil
+}
+
 // GetExternalRepoStatus returns the status of the local repo compared to the external remote.
 // Uses gitea/git module for native git operations.
 func (s *GitRepositoryService) GetExternalRepoStatus(ctx context.Context, repoID string, branchName string) (*types.ExternalStatus, error) {
@@ -850,8 +871,9 @@ func (s *GitRepositoryService) UpdateRepository(
 		}
 	}
 
-	// Get existing repository
-	existing, err := s.GetRepository(ctx, repoID)
+	// Get existing repository metadata (no git sync — a broken external clone
+	// must not block metadata updates such as fixing credentials)
+	existing, err := s.GetRepositoryMetadata(ctx, repoID)
 	if err != nil {
 		return nil, fmt.Errorf("repository not found: %w", err)
 	}
@@ -903,6 +925,19 @@ func (s *GitRepositoryService) UpdateRepository(
 		existing.KoditIndexing = *request.KoditIndexing
 	}
 
+	// Kodit clones through Helix's git server, so the repository must exist on
+	// disk before registration. Sync now (with any credentials just applied) so
+	// a failure aborts the whole update instead of persisting a half-enabled
+	// Kodit state.
+	if shouldRegisterKodit {
+		if koditAPIKey == "" {
+			return nil, fmt.Errorf("cannot register repository with Kodit without API key")
+		}
+		if err := s.updateRepositoryFromGit(ctx, existing); err != nil {
+			return nil, fmt.Errorf("failed to sync repository before Kodit registration: %w", err)
+		}
+	}
+
 	existing.UpdatedAt = time.Now()
 
 	// Update in store
@@ -913,11 +948,6 @@ func (s *GitRepositoryService) UpdateRepository(
 
 	// Register with Kodit if indexing was just enabled
 	if shouldRegisterKodit {
-		// Always use the internal URL - Kodit clones through Helix's git server
-		// GetRepository was called earlier, so external repos are already cloned to disk
-		if koditAPIKey == "" {
-			return nil, fmt.Errorf("cannot register repository with Kodit without API key")
-		}
 		koditCloneURL := s.BuildAuthenticatedCloneURL(repoID, koditAPIKey)
 
 		koditRepoID, _, err := s.koditService.RegisterRepository(ctx, &RegisterRepositoryParams{

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -56,6 +56,13 @@ const (
 	recentPRPollingInterval = 30 * time.Second
 	stalePRPollingInterval  = 5 * time.Minute
 	oldPRPollingInterval    = time.Hour
+
+	// staleArchiveSweepInterval controls how often inactive tasks are evaluated.
+	// Completed-task archiving is event-driven in handleDone instead.
+	staleArchiveSweepInterval = time.Hour
+	// defaultArchiveStaleTasksDays is used when a project enabled stale
+	// archiving without a configured day count.
+	defaultArchiveStaleTasksDays = 6
 )
 
 // ContainerExecutor defines the interface for container lifecycle management
@@ -138,6 +145,10 @@ func (o *SpecTaskOrchestrator) Start(ctx context.Context) error {
 	o.wg.Add(1)
 	go o.prPollLoop(ctx)
 
+	// Start the hourly reconciler for stale-task archive automation.
+	o.wg.Add(1)
+	go o.staleArchiveLoop(ctx)
+
 	return nil
 }
 
@@ -164,7 +175,7 @@ func (o *SpecTaskOrchestrator) orchestrationLoop(ctx context.Context) {
 			types.TaskStatusBacklog,
 			types.TaskStatusQueuedSpecGeneration,
 			types.TaskStatusQueuedImplementation,
-			types.TaskStatusDone, // For shutdown
+			types.TaskStatusDone, // For shutdown and immediate auto-archive
 		},
 	}, func(task *types.SpecTask) error {
 		taskCh <- task
@@ -1690,24 +1701,225 @@ func (o *SpecTaskOrchestrator) buildPlanningPrompt(task *types.SpecTask, app *ty
 }
 
 func (o *SpecTaskOrchestrator) handleDone(ctx context.Context, task *types.SpecTask) error {
+	if task.Archived {
+		return nil
+	}
+
+	var stopErr error
 	if task.KeepAlive {
 		log.Info().
 			Str("task_id", task.ID).
 			Msg("Task in done status but keep_alive is set - leaving desktop running")
-		return nil
+	} else if task.PlanningSessionID != "" {
+		if err := o.containerExecutor.StopDesktop(ctx, task.PlanningSessionID); err != nil {
+			stopErr = fmt.Errorf("failed to stop desktop: %w", err)
+		} else {
+			log.Info().
+				Str("task_id", task.ID).
+				Msg("Task in done status - stopping desktop")
+		}
 	}
-	if task.PlanningSessionID == "" {
+
+	if err := o.archiveCompletedTask(ctx, task); err != nil {
+		return err
+	}
+	return stopErr
+}
+
+func (o *SpecTaskOrchestrator) archiveCompletedTask(ctx context.Context, task *types.SpecTask) error {
+	if task.ProjectID == "" {
 		return nil
 	}
 
-	err := o.containerExecutor.StopDesktop(ctx, task.PlanningSessionID)
+	project, err := o.store.GetProject(ctx, task.ProjectID)
 	if err != nil {
-		return fmt.Errorf("failed to stop desktop: %w", err)
+		return fmt.Errorf("failed to get project for completed-task archive automation: %w", err)
+	}
+	if !project.AutoArchiveCompletedTasks {
+		return nil
+	}
+
+	latest, err := o.store.GetSpecTask(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("failed to reload completed task for archive automation: %w", err)
+	}
+	if latest.Archived || latest.Status != types.TaskStatusDone {
+		return nil
+	}
+
+	latest.Archived = true
+	if err := o.store.UpdateSpecTask(ctx, latest); err != nil {
+		return fmt.Errorf("failed to auto-archive completed task: %w", err)
 	}
 
 	log.Info().
-		Str("task_id", task.ID).
-		Msg("Task in done status - stopping desktop")
-
+		Str("task_id", latest.ID).
+		Str("project_id", latest.ProjectID).
+		Msg("Auto-archived completed task")
 	return nil
+}
+
+// staleArchiveLoop reconciles stale-task automation once per hour.
+func (o *SpecTaskOrchestrator) staleArchiveLoop(ctx context.Context) {
+	defer o.wg.Done()
+
+	ticker := time.NewTicker(staleArchiveSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-o.stopChan:
+			return
+		case <-ticker.C:
+			o.staleArchiveSweep(ctx)
+		}
+	}
+}
+
+// staleArchiveSweep evaluates non-archived tasks against their project's
+// inactivity policy and archives the ones that qualify.
+func (o *SpecTaskOrchestrator) staleArchiveSweep(ctx context.Context) {
+	// SortBy "last_message" makes the store compute LastMessageAt per task
+	// (COALESCE'd to created_at when the task has no session interactions) —
+	// exactly the idle signal the stale check needs. Default filtering
+	// excludes already-archived tasks.
+	tasks, err := o.store.ListSpecTasks(ctx, &types.SpecTaskFilters{
+		SortBy: "last_message",
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to list tasks for archive sweep")
+		return
+	}
+	if len(tasks) == 0 {
+		return
+	}
+
+	now := time.Now()
+	projectCache := make(map[string]*types.Project)
+
+	for _, task := range tasks {
+		project, cached := projectCache[task.ProjectID]
+		if !cached {
+			project, err = o.store.GetProject(ctx, task.ProjectID)
+			if err != nil {
+				if !isDeletedProjectError(err) {
+					log.Warn().Err(err).
+						Str("task_id", task.ID).
+						Str("project_id", task.ProjectID).
+						Msg("Failed to load project during archive sweep")
+				}
+				projectCache[task.ProjectID] = nil
+				continue
+			}
+			projectCache[task.ProjectID] = project
+		}
+		if project == nil {
+			continue
+		}
+
+		if !shouldArchiveStaleTask(project, task, now) {
+			continue
+		}
+
+		// Reload the task so a concurrent status change or manual archive
+		// between list and write is never clobbered.
+		latest, err := o.store.GetSpecTask(ctx, task.ID)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("task_id", task.ID).
+				Msg("Failed to reload task during archive sweep")
+			continue
+		}
+		if latest.Archived {
+			continue
+		}
+
+		o.stopTaskAgentsBeforeArchive(ctx, latest)
+
+		latest.Archived = true
+		if err := o.store.UpdateSpecTask(ctx, latest); err != nil {
+			log.Warn().Err(err).
+				Str("task_id", task.ID).
+				Msg("Failed to archive task during archive sweep")
+			continue
+		}
+
+		log.Info().
+			Str("task_id", task.ID).
+			Str("project_id", task.ProjectID).
+			Str("status", latest.Status.String()).
+			Msg("Auto-archived stale task")
+	}
+}
+
+// shouldArchiveStaleTask reports whether an inactive task is old enough to be
+// archived by the hourly stale-task cleanup.
+func shouldArchiveStaleTask(project *types.Project, task *types.SpecTask, now time.Time) bool {
+	if !project.ArchiveStaleTasksEnabled {
+		return false
+	}
+
+	// Never archive tasks with agent work in flight or an open PR awaiting
+	// merge — those are waiting on agents/CI, not abandoned by people.
+	switch task.Status {
+	case types.TaskStatusSpecGeneration,
+		types.TaskStatusImplementationQueued,
+		types.TaskStatusImplementation,
+		types.TaskStatusPullRequest,
+		types.TaskStatusDone:
+		return false
+	}
+
+	staleDays := project.ArchiveStaleTasksDays
+	if staleDays < 1 {
+		staleDays = defaultArchiveStaleTasksDays
+	}
+	idleSince := now.Add(-time.Duration(staleDays) * 24 * time.Hour)
+
+	lastActivity := task.CreatedAt
+	if task.LastMessageAt != nil && task.LastMessageAt.After(lastActivity) {
+		lastActivity = *task.LastMessageAt
+	}
+	if task.StatusUpdatedAt != nil && task.StatusUpdatedAt.After(lastActivity) {
+		lastActivity = *task.StatusUpdatedAt
+	}
+	if lastActivity.Before(idleSince) {
+		return true
+	}
+	return false
+}
+
+// stopTaskAgentsBeforeArchive mirrors the manual archive handler: any running
+// agent for the task is stopped before the task disappears from the board.
+func (o *SpecTaskOrchestrator) stopTaskAgentsBeforeArchive(ctx context.Context, task *types.SpecTask) {
+	if o.containerExecutor == nil {
+		return
+	}
+
+	if task.PlanningSessionID != "" {
+		session, err := o.store.GetSession(ctx, task.PlanningSessionID)
+		if err == nil && session.Metadata.AgentType == "zed_external" {
+			if err := o.containerExecutor.StopDesktop(ctx, task.PlanningSessionID); err != nil {
+				log.Warn().Err(err).
+					Str("task_id", task.ID).
+					Str("session_id", task.PlanningSessionID).
+					Msg("Failed to stop agent session when auto-archiving (continuing anyway)")
+			}
+		}
+	}
+
+	externalAgent, err := o.store.GetSpecTaskExternalAgent(ctx, task.ID)
+	if err == nil && externalAgent != nil && externalAgent.Status == "running" {
+		if err := o.containerExecutor.StopDesktop(ctx, externalAgent.ID); err != nil {
+			log.Warn().Err(err).
+				Str("task_id", task.ID).
+				Str("agent_id", externalAgent.ID).
+				Msg("Failed to stop external agent when auto-archiving (continuing anyway)")
+		} else {
+			externalAgent.Status = "stopped"
+			_ = o.store.UpdateSpecTaskExternalAgent(ctx, externalAgent)
+		}
+	}
 }

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -79,6 +79,86 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_EmptyPlanningSessionSkips
 	s.Require().NoError(err)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_AutoArchivesImmediately() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:        "task-completed",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusDone,
+	}
+	latest := *task
+
+	s.store.EXPECT().GetProject(ctx, task.ProjectID).Return(&types.Project{
+		ID:                        task.ProjectID,
+		AutoArchiveCompletedTasks: true,
+	}, nil)
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(&latest, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			s.True(updated.Archived)
+			return nil
+		},
+	)
+
+	err := s.orchestrator.processTask(ctx, task)
+	s.Require().NoError(err)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_LeavesTaskVisibleWhenAutoArchiveDisabled() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:        "task-completed",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusDone,
+	}
+
+	s.store.EXPECT().GetProject(ctx, task.ProjectID).Return(&types.Project{
+		ID:                        task.ProjectID,
+		AutoArchiveCompletedTasks: false,
+	}, nil)
+
+	err := s.orchestrator.processTask(ctx, task)
+	s.Require().NoError(err)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestStaleArchiveSweepArchivesOnlyInactiveTasks() {
+	ctx := context.Background()
+	now := time.Now()
+	staleTask := &types.SpecTask{
+		ID:        "task-stale",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusBacklog,
+		CreatedAt: now.Add(-10 * 24 * time.Hour),
+	}
+	doneTask := &types.SpecTask{
+		ID:        "task-done",
+		ProjectID: staleTask.ProjectID,
+		Status:    types.TaskStatusDone,
+		CreatedAt: now.Add(-10 * 24 * time.Hour),
+	}
+	latest := *staleTask
+	s.orchestrator.containerExecutor = nil
+
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{
+		SortBy: "last_message",
+	}).Return([]*types.SpecTask{staleTask, doneTask}, nil)
+	s.store.EXPECT().GetProject(ctx, staleTask.ProjectID).Return(&types.Project{
+		ID:                       staleTask.ProjectID,
+		ArchiveStaleTasksEnabled: true,
+		ArchiveStaleTasksDays:    6,
+	}, nil)
+	s.store.EXPECT().GetSpecTask(ctx, staleTask.ID).Return(&latest, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, updated *types.SpecTask) error {
+			s.Equal(staleTask.ID, updated.ID)
+			s.True(updated.Archived)
+			return nil
+		},
+	)
+
+	s.orchestrator.staleArchiveSweep(ctx)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_SkipsWhenStaleEvent() {
 	ctx := context.Background()
 	eventTask := &types.SpecTask{
@@ -1245,4 +1325,106 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_Mer
 	assert.Equal(s.T(), types.TaskStatusPullRequest, task.Status,
 		"task must stay in pull_request when at least one PR errors")
 	assert.False(s.T(), task.MergedToMain)
+}
+
+func TestShouldArchiveStaleTask(t *testing.T) {
+	assert.Equal(t, time.Hour, staleArchiveSweepInterval)
+
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	ago := func(d time.Duration) *time.Time {
+		t := now.Add(-d)
+		return &t
+	}
+	proj := func(enabled bool, staleDays int) *types.Project {
+		return &types.Project{
+			ArchiveStaleTasksEnabled: enabled,
+			ArchiveStaleTasksDays:    staleDays,
+		}
+	}
+
+	tests := []struct {
+		name string
+		proj *types.Project
+		task *types.SpecTask
+		want bool
+	}{
+		{
+			name: "stale archiving disabled leaves idle backlog",
+			proj: proj(false, 6),
+			task: &types.SpecTask{Status: types.TaskStatusBacklog, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+			want: false,
+		},
+		{
+			name: "idle backlog past stale window archives",
+			proj: proj(true, 6),
+			task: &types.SpecTask{Status: types.TaskStatusBacklog, CreatedAt: now.Add(-10 * 24 * time.Hour)},
+			want: true,
+		},
+		{
+			name: "recent backlog stays",
+			proj: proj(true, 6),
+			task: &types.SpecTask{Status: types.TaskStatusBacklog, CreatedAt: now.Add(-3 * 24 * time.Hour)},
+			want: false,
+		},
+		{
+			name: "recent message resets stale clock",
+			proj: proj(true, 6),
+			task: &types.SpecTask{
+				Status:        types.TaskStatusSpecReview,
+				CreatedAt:     now.Add(-30 * 24 * time.Hour),
+				LastMessageAt: ago(24 * time.Hour),
+			},
+			want: false,
+		},
+		{
+			name: "status update resets stale clock",
+			proj: proj(true, 6),
+			task: &types.SpecTask{
+				Status:          types.TaskStatusSpecReview,
+				CreatedAt:       now.Add(-30 * 24 * time.Hour),
+				StatusUpdatedAt: ago(2 * 24 * time.Hour),
+			},
+			want: false,
+		},
+		{
+			name: "active agent work never stale",
+			proj: proj(true, 6),
+			task: &types.SpecTask{Status: types.TaskStatusImplementation, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+			want: false,
+		},
+		{
+			name: "open pull request never stale",
+			proj: proj(true, 6),
+			task: &types.SpecTask{Status: types.TaskStatusPullRequest, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+			want: false,
+		},
+		{
+			name: "completed task is handled by event automation",
+			proj: proj(true, 6),
+			task: &types.SpecTask{Status: types.TaskStatusDone, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+			want: false,
+		},
+		{
+			name: "zero day count falls back to default of six",
+			proj: proj(true, 0),
+			task: &types.SpecTask{Status: types.TaskStatusBacklog, CreatedAt: now.Add(-8 * 24 * time.Hour)},
+			want: true,
+		},
+		{
+			name: "zero day count default does not archive seven-day-old idle with recent message",
+			proj: proj(true, 0),
+			task: &types.SpecTask{
+				Status:        types.TaskStatusBacklog,
+				CreatedAt:     now.Add(-8 * 24 * time.Hour),
+				LastMessageAt: ago(5 * 24 * time.Hour),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shouldArchiveStaleTask(tc.proj, tc.task, now))
+		})
+	}
 }

--- a/api/pkg/types/artifact.go
+++ b/api/pkg/types/artifact.go
@@ -13,6 +13,7 @@ const (
 	ArtifactKindSPA        ArtifactKind = "spa"
 	ArtifactKindPDF        ArtifactKind = "pdf"
 	ArtifactKindImage      ArtifactKind = "image"
+	ArtifactKindMarkdown   ArtifactKind = "markdown"
 )
 
 type ArtifactVisibility string

--- a/api/pkg/types/project.go
+++ b/api/pkg/types/project.go
@@ -228,6 +228,10 @@ type Project struct {
 
 	// Automation settings
 	AutoStartBacklogTasks bool `json:"auto_start_backlog_tasks"` // Automatically move backlog tasks to planning when capacity available
+	// Archive automation, reconciled by the spec task orchestrator
+	AutoArchiveCompletedTasks bool `json:"auto_archive_completed_tasks" gorm:"default:false"` // Archive tasks immediately when they enter Done
+	ArchiveStaleTasksEnabled  bool `json:"archive_stale_tasks_enabled" gorm:"default:false"`  // Archive tasks idle for ArchiveStaleTasksDays
+	ArchiveStaleTasksDays     int  `json:"archive_stale_tasks_days" gorm:"default:6"`         // Idle days before a stale task is archived
 
 	// StartupScriptFromYAML indicates the startup script was set via project YAML
 	// When true, the UI should show the script as read-only
@@ -404,7 +408,10 @@ type ProjectUpdateRequest struct {
 	DefaultRepoID                   *string                   `json:"default_repo_id,omitempty"`
 	StartupScript                   *string                   `json:"startup_script,omitempty"`
 	AutoStartBacklogTasks           *bool                     `json:"auto_start_backlog_tasks,omitempty"`
-	DefaultHelixAppID               *string                   `json:"default_helix_app_id,omitempty"` // Org-agent identity only; coding projects use CodeAgentConfig
+	AutoArchiveCompletedTasks       *bool                     `json:"auto_archive_completed_tasks,omitempty"` // Archive tasks immediately when they enter Done
+	ArchiveStaleTasksEnabled        *bool                     `json:"archive_stale_tasks_enabled,omitempty"`  // Archive tasks idle for ArchiveStaleTasksDays
+	ArchiveStaleTasksDays           *int                      `json:"archive_stale_tasks_days,omitempty"`     // Idle days before a stale task is archived (1-365)
+	DefaultHelixAppID               *string                   `json:"default_helix_app_id,omitempty"`         // Org-agent identity only; coding projects use CodeAgentConfig
 	CodeAgentConfig                 *CodeAgentExecutionConfig `json:"code_agent_config,omitempty"`
 	DefaultSandboxRuntime           *SandboxRuntime           `json:"default_sandbox_runtime,omitempty"`            // Default sandbox environment for spec tasks
 	DefaultSandboxResourceOverrides *SandboxResourceOverrides `json:"default_sandbox_resource_overrides,omitempty"` // Default sandbox resources for spec tasks

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2318,13 +2318,13 @@ export enum TransportFieldType {
 }
 
 export enum TransportKind {
-  KindWebhook = "webhook",
-  KindGitLab = "gitlab",
   KindSlack = "slack",
-  KindEmail = "email",
-  KindLocal = "local",
-  KindHelixEvents = "helix_events",
   KindCron = "cron",
+  KindGitLab = "gitlab",
+  KindLocal = "local",
+  KindEmail = "email",
+  KindWebhook = "webhook",
+  KindHelixEvents = "helix_events",
   KindGitHub = "github",
 }
 
@@ -2585,6 +2585,7 @@ export enum TypesArtifactKind {
   ArtifactKindSPA = "spa",
   ArtifactKindPDF = "pdf",
   ArtifactKindImage = "image",
+  ArtifactKindMarkdown = "markdown",
 }
 
 export interface TypesArtifactVersion {
@@ -10200,7 +10201,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.
+     * @description Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.
      *
      * @tags Artifacts
      * @name V1ArtifactsUpdate
@@ -10221,7 +10222,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         visibility?: string;
         /** Allocate or retain a public default subdomain */
         with_subdomain?: boolean;
-        /** Replacement HTML, PDF, image, or ZIP content */
+        /** Replacement HTML, Markdown, PDF, or ZIP content */
         artifact?: File;
       },
       params: RequestParams = {},
@@ -15356,7 +15357,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.
+     * @description Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.
      *
      * @tags Artifacts
      * @name V1ProjectsArtifactsCreate
@@ -15377,7 +15378,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         visibility?: string;
         /** Deprecated: public artifacts always receive a share subdomain */
         with_subdomain?: boolean;
-        /** HTML, PDF, image, or ZIP bundle */
+        /** HTML, Markdown, PDF, image, or ZIP bundle */
         artifact: File;
       },
       params: RequestParams = {},

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2318,14 +2318,14 @@ export enum TransportFieldType {
 }
 
 export enum TransportKind {
-  KindGitLab = "gitlab",
-  KindGitHub = "github",
-  KindLocal = "local",
-  KindSlack = "slack",
-  KindHelixEvents = "helix_events",
   KindWebhook = "webhook",
-  KindCron = "cron",
+  KindGitLab = "gitlab",
+  KindSlack = "slack",
   KindEmail = "email",
+  KindLocal = "local",
+  KindHelixEvents = "helix_events",
+  KindCron = "cron",
+  KindGitHub = "github",
 }
 
 export interface TransportResolvedActivation {
@@ -5300,6 +5300,12 @@ export interface TypesProject {
    * project inherits. Empty means no Helix MCP surface at all.
    */
   agent_tools?: string[];
+  /** Idle days before a stale task is archived */
+  archive_stale_tasks_days?: number;
+  /** Archive tasks idle for ArchiveStaleTasksDays */
+  archive_stale_tasks_enabled?: boolean;
+  /** Archive automation, reconciled by the spec task orchestrator */
+  auto_archive_completed_tasks?: boolean;
   /** Automation settings */
   auto_start_backlog_tasks?: boolean;
   /** CodeAgentConfig is the project default copied into each new SpecTask. */
@@ -5555,6 +5561,12 @@ export interface TypesProjectTaskSpec {
 export interface TypesProjectUpdateRequest {
   /** Helix MCP tools granted to every spec task */
   agent_tools?: string[];
+  /** Idle days before a stale task is archived (1-365) */
+  archive_stale_tasks_days?: number;
+  /** Archive tasks idle for ArchiveStaleTasksDays */
+  archive_stale_tasks_enabled?: boolean;
+  /** Archive tasks immediately when they enter Done */
+  auto_archive_completed_tasks?: boolean;
   auto_start_backlog_tasks?: boolean;
   code_agent_config?: TypesCodeAgentExecutionConfig;
   default_branch?: string;
@@ -16185,6 +16197,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         with_models?: boolean;
         /** Organization ID */
         org_id?: string;
+        /** Filter by organization code-agent harness policy */
+        code_agent_runtime?: string;
         /** Include all endpoints (system admin only) */
         all?: boolean;
       },

--- a/frontend/src/components/account/ApiKeysSettings.test.tsx
+++ b/frontend/src/components/account/ApiKeysSettings.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import ApiKeysSettings from './ApiKeysSettings'
+
+vi.mock('../../services/userService', () => ({
+  useGetUserAPIKeys: () => ({ data: [{ key: 'hl-personal-key' }] }),
+  useRegenerateUserAPIKey: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('./SettingsPanel', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../session/MarkdownCodeBlock', () => ({
+  default: ({ children }: { children: string }) => <pre>{children}</pre>,
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+const originalSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+
+describe('ApiKeysSettings', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalSecureContext) {
+      Object.defineProperty(window, 'isSecureContext', originalSecureContext)
+    } else {
+      Reflect.deleteProperty(window, 'isSecureContext')
+    }
+  })
+
+  it('copies a personal key on an insecure HTTP origin', async () => {
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    })
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    })
+
+    render(<ApiKeysSettings />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy API key' }))
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'))
+  })
+})

--- a/frontend/src/components/account/ApiKeysSettings.tsx
+++ b/frontend/src/components/account/ApiKeysSettings.tsx
@@ -16,6 +16,7 @@ import { Copy, Eye, EyeOff, RefreshCcw } from 'lucide-react'
 import MarkdownCodeBlock from '../session/MarkdownCodeBlock'
 import SettingsPanel from './SettingsPanel'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import {
   useGetUserAPIKeys,
   useRegenerateUserAPIKey,
@@ -32,7 +33,7 @@ const ApiKeysSettings: FC = () => {
   const [keyToRegenerate, setKeyToRegenerate] = useState<string>('')
 
   const handleCopy = useCallback((text: string) => {
-    navigator.clipboard.writeText(text)
+    copyTextToClipboard(text)
       .then(() => {
         snackbar.success('Copied to clipboard')
       })

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -33,6 +33,7 @@ import ClaudeConnectMethodPicker, { ClaudeConnectMethod } from './ClaudeConnectM
 import { SELECT_MENU_PROPS } from '../../contexts/theme'
 import useAccount from '../../hooks/useAccount'
 import { formatClaudeAccountDetail, formatClaudeOrganizationRef } from './claudeSubscriptionUtils'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import SubscriptionIdentity from './SubscriptionIdentity'
 import { matchesAllTokens } from '../../utils/searchUtils'
 import { APP_MONO_FONT_FAMILY } from '../../styles/typography'
@@ -567,8 +568,9 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   }
 
   const handleCopyCommand = () => {
-    navigator.clipboard.writeText(SETUP_TOKEN_COMMAND)
-    snackbar.success('Command copied to clipboard')
+    void copyTextToClipboard(SETUP_TOKEN_COMMAND)
+      .then(() => snackbar.success('Command copied to clipboard'))
+      .catch(() => snackbar.error('Failed to copy command'))
   }
 
   const handleDeleteClick = (id: string) => {
@@ -824,8 +826,9 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                   <IconButton
                     size="small"
                     onClick={() => {
-                      navigator.clipboard.writeText(CREDENTIALS_FILE_COMMAND)
-                      snackbar.success('Command copied')
+                      void copyTextToClipboard(CREDENTIALS_FILE_COMMAND)
+                        .then(() => snackbar.success('Command copied'))
+                        .catch(() => snackbar.error('Failed to copy command'))
                     }}
                     aria-label="Copy command"
                   >

--- a/frontend/src/components/account/CodexSubscriptionConnect.tsx
+++ b/frontend/src/components/account/CodexSubscriptionConnect.tsx
@@ -288,7 +288,11 @@ export default function CodexSubscriptionConnect({ orgId, enableForOrgId }: Prop
                       <IconButton
                         size="small"
                         aria-label="Copy device code"
-                        onClick={() => copyTextToClipboard(deviceCode)}
+                        onClick={() => {
+                          void copyTextToClipboard(deviceCode).catch((error) => {
+                            console.error('Failed to copy device code', error)
+                          })
+                        }}
                       >
                         <Copy size={14} />
                       </IconButton>

--- a/frontend/src/components/account/GeneralSettings.tsx
+++ b/frontend/src/components/account/GeneralSettings.tsx
@@ -37,6 +37,7 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ onOpenPasswordDialog }) => 
   const updateAccount = useUpdateAccount()
 
   const savedFullName = currentUser?.name || account.user?.name || ''
+  const email = currentUser?.email || account.user?.email || ''
 
   const [fullName, setFullName] = useState<string>(savedFullName)
 
@@ -82,6 +83,23 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ onOpenPasswordDialog }) => 
             display: 'flex',
             // Side by side there is no room for a usable text field on a
             // phone, so the label and input stack instead.
+            flexDirection: { xs: 'column', sm: 'row' },
+            justifyContent: 'space-between',
+            alignItems: { xs: 'stretch', sm: 'center' },
+            gap: { xs: 1, sm: 2 },
+          }}
+        >
+          <Typography variant="h6">Email</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-all' }}>
+            {email}
+          </Typography>
+        </Box>
+      </SettingsPanel>
+
+      <SettingsPanel>
+        <Box
+          sx={{
+            display: 'flex',
             flexDirection: { xs: 'column', sm: 'row' },
             justifyContent: 'space-between',
             alignItems: { xs: 'stretch', sm: 'center' },

--- a/frontend/src/components/app/CodeExamples.tsx
+++ b/frontend/src/components/app/CodeExamples.tsx
@@ -9,6 +9,7 @@ import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { Eye, EyeOff } from 'lucide-react';
 import { CODE_EXAMPLES } from '../../data/codeExamples';
+import { copyTextToClipboard } from '../../utils/clipboard';
 import { Prism as SyntaxHighlighterPrism } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -61,7 +62,7 @@ const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
   // Always copy with the real key, regardless of reveal state
   const handleCopyCode = async () => {
     try {
-      await navigator.clipboard.writeText(CODE_EXAMPLES[selectedTab].code(address, apiKey));
+      await copyTextToClipboard(CODE_EXAMPLES[selectedTab].code(address, apiKey));
     } catch (err) {
       console.error('Failed to copy code:', err);
     }

--- a/frontend/src/components/app/DevelopersSection.tsx
+++ b/frontend/src/components/app/DevelopersSection.tsx
@@ -12,6 +12,7 @@ import MonacoEditor from '../widgets/MonacoEditor';
 import { generateYamlFilename } from '../../utils/format';
 import useSnackbar from '../../hooks/useSnackbar';
 import { useSettingsDialog } from '../../contexts/settingsDialog';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface DevelopersSectionProps {
   schema: string;
@@ -47,7 +48,7 @@ const DevelopersSection: React.FC<DevelopersSectionProps> = ({
   };
 
   const handleCopyCommand = (command: string, setCopied: (value: boolean) => void) => {
-    navigator.clipboard.writeText(command)
+    copyTextToClipboard(command)
       .then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);

--- a/frontend/src/components/app/IdeIntegrationSection.tsx
+++ b/frontend/src/components/app/IdeIntegrationSection.tsx
@@ -13,6 +13,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import useSnackbar from '../../hooks/useSnackbar';
 import useAccount from '../../hooks/useAccount'
 import { useGetUserAPIKeys } from '../../services/userService'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 interface IdeIntegrationSectionProps {
   appId: string;
@@ -24,7 +25,7 @@ const IdeIntegrationSection: React.FC<IdeIntegrationSectionProps> = ({
   const account = useAccount()
 
   const [selectedIde, setSelectedIde] = useState<string>('cline');
-  const { success: snackbarSuccess } = useSnackbar();
+  const { success: snackbarSuccess, error: snackbarError } = useSnackbar();
 
   const { data: apiKeys, isLoading: isLoadingApiKeys } = useGetUserAPIKeys()
 
@@ -78,8 +79,9 @@ const IdeIntegrationSection: React.FC<IdeIntegrationSectionProps> = ({
             size="small"
             startIcon={<ContentCopyIcon />}
             onClick={() => {
-              navigator.clipboard.writeText("curl -Ls -O https://get.helixml.tech/install.sh && bash install.sh --cli");
-              snackbarSuccess('Command copied to clipboard');
+              void copyTextToClipboard("curl -Ls -O https://get.helixml.tech/install.sh && bash install.sh --cli")
+                .then(() => snackbarSuccess('Command copied to clipboard'))
+                .catch(() => snackbarError('Failed to copy command'));
             }}
             sx={{ textTransform: 'none', flexShrink: 0 }}
           >
@@ -117,8 +119,9 @@ const IdeIntegrationSection: React.FC<IdeIntegrationSectionProps> = ({
                 size="small"
                 startIcon={<ContentCopyIcon />}
                 onClick={() => {
-                  navigator.clipboard.writeText(getGenericMCPConfig());
-                  snackbarSuccess('Configuration copied to clipboard');
+                  void copyTextToClipboard(getGenericMCPConfig())
+                    .then(() => snackbarSuccess('Configuration copied to clipboard'))
+                    .catch(() => snackbarError('Failed to copy configuration'));
                 }}
                 sx={{ textTransform: 'none' }}
               >
@@ -161,8 +164,9 @@ const IdeIntegrationSection: React.FC<IdeIntegrationSectionProps> = ({
                 size="small"
                 startIcon={<ContentCopyIcon />}
                 onClick={() => {
-                  navigator.clipboard.writeText(getGenericMCPConfig());
-                  snackbarSuccess('Configuration copied to clipboard');
+                  void copyTextToClipboard(getGenericMCPConfig())
+                    .then(() => snackbarSuccess('Configuration copied to clipboard'))
+                    .catch(() => snackbarError('Failed to copy configuration'));
                 }}
                 sx={{ textTransform: 'none' }}
               >
@@ -200,8 +204,9 @@ const IdeIntegrationSection: React.FC<IdeIntegrationSectionProps> = ({
                 size="small"
                 startIcon={<ContentCopyIcon />}
                 onClick={() => {
-                  navigator.clipboard.writeText(getGenericMCPConfig());
-                  snackbarSuccess('Configuration copied to clipboard');
+                  void copyTextToClipboard(getGenericMCPConfig())
+                    .then(() => snackbarSuccess('Configuration copied to clipboard'))
+                    .catch(() => snackbarError('Failed to copy configuration'));
                 }}
                 sx={{ textTransform: 'none' }}
               >

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../utils/apps';
 
 import { TypesInteractionState, TypesSession } from '../../api/api';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface PreviewPanelProps {
   appId: string;
@@ -287,8 +288,9 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
 
   const handleCopyContent = () => {
     if (selectedChunk) {
-      navigator.clipboard.writeText(selectedChunk.content);
-      snackbar.success('Content copied to clipboard');
+      void copyTextToClipboard(selectedChunk.content)
+        .then(() => snackbar.success('Content copied to clipboard'))
+        .catch(() => snackbar.error('Failed to copy content'));
     }
   };
 

--- a/frontend/src/components/app/TestsEditor.tsx
+++ b/frontend/src/components/app/TestsEditor.tsx
@@ -22,6 +22,7 @@ import { generateYamlFilename } from '../../utils/format';
 import useSnackbar from '../../hooks/useSnackbar';
 import useLightTheme from '../../hooks/useLightTheme';
 import { useSettingsDialog } from '../../contexts/settingsDialog';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface TestsEditorProps {
   app: IAppFlatState;
@@ -97,7 +98,7 @@ const TestsEditor: React.FC<TestsEditorProps> = ({
   };
 
   const handleCopyCommand = (command: string) => {
-    navigator.clipboard.writeText(command)
+    copyTextToClipboard(command)
       .then(() => {
         setTestCopied(true);
         setTimeout(() => setTestCopied(false), 2000);
@@ -110,7 +111,7 @@ const TestsEditor: React.FC<TestsEditorProps> = ({
   };
 
   const handleCopyConfig = (config: string, setCopied: (value: boolean) => void, configType: string) => {
-    navigator.clipboard.writeText(config)
+    copyTextToClipboard(config)
       .then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -477,4 +478,4 @@ comment_job:
   );
 };
 
-export default TestsEditor; 
+export default TestsEditor;

--- a/frontend/src/components/app/TriggerCrispSetup.tsx
+++ b/frontend/src/components/app/TriggerCrispSetup.tsx
@@ -22,6 +22,7 @@ import InputAdornment from '@mui/material/InputAdornment'
 import { CrispLogo } from '../icons/ProviderIcons'
 import DarkDialog from '../dialog/DarkDialog'
 import { IAppFlatState } from '../../types'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 import crispMarketplace from '../../../assets/img/crisp/marketplace.png'
 import crispProductionToken from '../../../assets/img/crisp/production_token.png'
@@ -97,7 +98,7 @@ const TriggerCrispSetup: FC<TriggerCrispSetupProps> = ({
   const handleCopyScopes = async () => {
     const scopesText = requiredScopes.join(', ')
     try {
-      await navigator.clipboard.writeText(scopesText)
+      await copyTextToClipboard(scopesText)
     } catch (err) {
       console.error('Failed to copy scopes:', err)
     }

--- a/frontend/src/components/app/TriggerTeamsSetup.tsx
+++ b/frontend/src/components/app/TriggerTeamsSetup.tsx
@@ -20,6 +20,7 @@ import Alert from '@mui/material/Alert'
 import { TeamsLogo } from '../icons/ProviderIcons'
 import DarkDialog from '../dialog/DarkDialog'
 import { IAppFlatState } from '../../types'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 interface SetupStep {
   step: number
@@ -124,7 +125,7 @@ const TriggerTeamsSetup: FC<TriggerTeamsSetupProps> = ({
 
   const handleCopyWebhookUrl = async () => {
     try {
-      await navigator.clipboard.writeText(webhookUrl)
+      await copyTextToClipboard(webhookUrl)
     } catch (err) {
       console.error('Failed to copy webhook URL:', err)
     }

--- a/frontend/src/components/artifacts/ArtifactDialog.test.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.test.tsx
@@ -39,11 +39,30 @@ describe('ArtifactDialog', () => {
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
     expect(input.accept).toContain('.pdf')
     expect(input.accept).toContain('image/*')
+    expect(input.accept).toContain('.md')
     expect(screen.getByLabelText('Entrypoint')).toBeInTheDocument()
 
     fireEvent.change(input, { target: { files: [new File(['pdf'], 'report.pdf', { type: 'application/pdf' })] } })
 
     expect(screen.getByText('report.pdf')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Entrypoint')).not.toBeInTheDocument()
+  })
+
+  it('accepts markdown uploads without asking for an entrypoint', () => {
+    render(
+      <ArtifactDialog
+        open
+        projectName="Example project"
+        saving={false}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [new File(['# hi'], 'notes.md', { type: 'text/markdown' })] } })
+
+    expect(screen.getByText('notes.md')).toBeInTheDocument()
     expect(screen.queryByLabelText('Entrypoint')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/artifacts/ArtifactDialog.tsx
+++ b/frontend/src/components/artifacts/ArtifactDialog.tsx
@@ -51,9 +51,14 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, projectName, saving, error,
   const selectedDocument = !!file && (
     file.type === 'application/pdf' ||
     file.type.startsWith('image/') ||
-    ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif'].includes(fileExtension ?? '')
+    file.type === 'text/markdown' ||
+    file.type === 'text/x-markdown' ||
+    ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif'].includes(fileExtension ?? '') ||
+    ['md', 'markdown'].includes(fileExtension ?? '')
   )
-  const documentArtifact = artifact?.kind === TypesArtifactKind.ArtifactKindPDF || artifact?.kind === TypesArtifactKind.ArtifactKindImage
+  const documentArtifact = artifact?.kind === TypesArtifactKind.ArtifactKindPDF ||
+    artifact?.kind === TypesArtifactKind.ArtifactKindImage ||
+    artifact?.kind === TypesArtifactKind.ArtifactKindMarkdown
   const showEntrypoint = file ? !selectedDocument : !documentArtifact
   const agentPrompt = projectName
     ? `Create and upload an artifact to the Helix project "${projectName}".`
@@ -76,7 +81,7 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, projectName, saving, error,
               <Box>
                 <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>Upload manually</Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Upload HTML, a compiled app ZIP, a PDF, or an image.
+                  Upload HTML, Markdown, a compiled app ZIP, a PDF, or an image.
                 </Typography>
               </Box>
             )}
@@ -104,7 +109,7 @@ const ArtifactDialog: FC<Props> = ({ open, artifact, projectName, saving, error,
             )}
             <Button component="label" variant="outlined" startIcon={<Upload size={18} />} sx={{ alignSelf: 'flex-start' }}>
               {artifact ? 'Publish new version' : 'Choose artifact file'}
-              <input hidden type="file" accept=".html,.htm,.zip,.pdf,image/*,text/html,application/zip,application/pdf" onChange={handleFile} />
+              <input hidden type="file" accept=".html,.htm,.md,.markdown,.zip,.pdf,image/*,text/html,text/markdown,application/zip,application/pdf" onChange={handleFile} />
             </Button>
             <Typography variant="body2" color="text.secondary">
               {file?.name ?? (artifact ? 'Keep the current content version' : 'No file selected')}

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -33,6 +33,7 @@ const artifactKindLabel = (artifact: TypesArtifact) => {
     case TypesArtifactKind.ArtifactKindSPA: return 'Static SPA'
     case TypesArtifactKind.ArtifactKindPDF: return 'PDF document'
     case TypesArtifactKind.ArtifactKindImage: return 'Image'
+    case TypesArtifactKind.ArtifactKindMarkdown: return 'Markdown document'
     default: return 'HTML page'
   }
 }

--- a/frontend/src/components/common/CopyButton.tsx
+++ b/frontend/src/components/common/CopyButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { IconButton, Tooltip, useTheme, Box } from '@mui/material';
 import { Copy, Check } from 'lucide-react';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface CopyButtonProps {
   content: string;
@@ -25,7 +26,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(content);
+      await copyTextToClipboard(content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -76,4 +77,4 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   );
 };
 
-export default CopyButton; 
+export default CopyButton;

--- a/frontend/src/components/dashboard/LLMCallDrawer.tsx
+++ b/frontend/src/components/dashboard/LLMCallDrawer.tsx
@@ -19,6 +19,7 @@ import { X, Copy } from 'lucide-react'
 import { TypesLLMCall } from '../../api/api'
 import JsonView from '../widgets/JsonView'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 export const formatTokenCount = (n?: number): string => {
   if (n === undefined || n === null) return '-'
@@ -121,8 +122,9 @@ const MetaRow: FC<{ label: string, value?: React.ReactNode, copyValue?: string }
             aria-label={`Copy ${label}`}
             sx={{ p: 0.25 }}
             onClick={() => {
-              navigator.clipboard.writeText(copyValue)
-              snackbar.success('Copied to clipboard')
+              void copyTextToClipboard(copyValue)
+                .then(() => snackbar.success('Copied to clipboard'))
+                .catch(() => snackbar.error('Failed to copy'))
             }}
           >
             <Copy size={13} />

--- a/frontend/src/components/dashboard/LLMCallsTable.tsx
+++ b/frontend/src/components/dashboard/LLMCallsTable.tsx
@@ -15,6 +15,7 @@ import { useListLLMCalls } from '../../services/llmCallsService';
 import SimpleTable from '../widgets/SimpleTable';
 import LLMCallDrawer, { formatTokenCount } from './LLMCallDrawer';
 import useSnackbar from '../../hooks/useSnackbar';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface LLMCallsTableProps {
   sessionFilter: string;
@@ -42,8 +43,9 @@ const IdCell: FC<{ id?: string, label: string }> = ({ id, label }) => {
           sx={{ p: 0.25 }}
           onClick={(e) => {
             e.stopPropagation();
-            navigator.clipboard.writeText(id);
-            snackbar.success('Copied to clipboard');
+            void copyTextToClipboard(id)
+              .then(() => snackbar.success('Copied to clipboard'))
+              .catch(() => snackbar.error('Failed to copy'));
           }}
         >
           <Copy size={12} />

--- a/frontend/src/components/datagrid/AppAPIKeys.tsx
+++ b/frontend/src/components/datagrid/AppAPIKeys.tsx
@@ -11,6 +11,7 @@ import {
   IApiKey,
 } from '../../types'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 const AppAPIKeysDataGrid: FC<React.PropsWithChildren<{
   data: IApiKey[],
@@ -22,7 +23,7 @@ const AppAPIKeysDataGrid: FC<React.PropsWithChildren<{
   const snackbar = useSnackbar()
 
   const handleCopy = useCallback((text: string, successMessage: string) => {
-    navigator.clipboard.writeText(text)
+    copyTextToClipboard(text)
       .then(() => {
         snackbar.success(successMessage)
       })

--- a/frontend/src/components/external-agent/InsecureContextWarning.tsx
+++ b/frontend/src/components/external-agent/InsecureContextWarning.tsx
@@ -9,6 +9,7 @@
 import React, { useState } from 'react';
 import { Box, Typography, Alert, Collapse, IconButton } from '@mui/material';
 import { ExpandMore, ExpandLess, Warning, ContentCopy, Check } from '@mui/icons-material';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface BrowserInstructions {
   name: string;
@@ -96,21 +97,11 @@ const InsecureContextWarning: React.FC = () => {
 
   const handleCopy = async (value: string) => {
     try {
-      await navigator.clipboard.writeText(value);
+      await copyTextToClipboard(value);
       setCopiedValue(value);
       setTimeout(() => setCopiedValue(null), 2000);
-    } catch {
-      // Fallback for when clipboard API fails (we're in insecure context after all!)
-      const textArea = document.createElement('textarea');
-      textArea.value = value;
-      textArea.style.position = 'fixed';
-      textArea.style.left = '-9999px';
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-      setCopiedValue(value);
-      setTimeout(() => setCopiedValue(null), 2000);
+    } catch (error) {
+      console.error('Failed to copy text', error);
     }
   };
 

--- a/frontend/src/components/external-agent/StatsOverlay.tsx
+++ b/frontend/src/components/external-agent/StatsOverlay.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { StreamStats, ActiveConnection, QualityMode } from './DesktopStreamViewer.types';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 // An inter-frame interval below this (ms) is physically impossible as a freshly
 // rendered 60Hz frame — it means a queue piled up and then drained (a "burst").
@@ -207,24 +208,10 @@ const StatsOverlay: React.FC<StatsOverlayProps> = ({
       shouldPollScreenshots,
     );
     try {
-      await navigator.clipboard.writeText(text);
+      await copyTextToClipboard(text);
       setCopyState('copied');
     } catch {
-      // Clipboard API is unavailable on insecure (http) origins; fall back to a
-      // hidden textarea + execCommand so localhost still works.
-      const ta = document.createElement('textarea');
-      ta.value = text;
-      ta.style.position = 'fixed';
-      ta.style.opacity = '0';
-      document.body.appendChild(ta);
-      ta.select();
-      try {
-        document.execCommand('copy');
-        setCopyState('copied');
-      } catch {
-        setCopyState('failed');
-      }
-      document.body.removeChild(ta);
+      setCopyState('failed');
     }
     setTimeout(() => setCopyState('idle'), 1500);
   };

--- a/frontend/src/components/git/CodeIntelligenceTab.tsx
+++ b/frontend/src/components/git/CodeIntelligenceTab.tsx
@@ -70,6 +70,7 @@ import {
 import useDebounce from '../../hooks/useDebounce'
 import useSnackbar from '../../hooks/useSnackbar'
 import { useGetUserAPIKeys } from '../../services/userService'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import KoditStatusPill from './KoditStatusPill'
 
 interface CodeIntelligenceTabProps {
@@ -1235,8 +1236,9 @@ const ConnectSubTab: FC = () => {
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
 
   const handleCopy = (text: string, label: string) => {
-    navigator.clipboard.writeText(text)
-    snackbar.success(`${label} copied to clipboard`)
+    void copyTextToClipboard(text)
+      .then(() => snackbar.success(`${label} copied to clipboard`))
+      .catch(() => snackbar.error(`Failed to copy ${label.toLowerCase()}`))
   }
 
   return (

--- a/frontend/src/components/helix-org/AssetConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/AssetConfigDrawer.tsx
@@ -19,6 +19,7 @@ import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined'
 
 import { AssetAuthType, AssetKind } from '../../api/api'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import {
   AssetDTO,
   AssetHealthDTO,
@@ -175,8 +176,12 @@ const AssetConfigDrawer: FC<AssetConfigDrawerProps> = ({ open, asset, health, ag
 
   const copyPublicKey = async () => {
     if (!currentPublicKey) return
-    await navigator.clipboard.writeText(currentPublicKey)
-    snackbar.success('Public key copied')
+    try {
+      await copyTextToClipboard(currentPublicKey)
+      snackbar.success('Public key copied')
+    } catch {
+      snackbar.error('Failed to copy public key')
+    }
   }
 
   const toggleEnabled = async (nextEnabled: boolean) => {

--- a/frontend/src/components/orgs/CreatedOrgApiKeyDialog.tsx
+++ b/frontend/src/components/orgs/CreatedOrgApiKeyDialog.tsx
@@ -1,0 +1,81 @@
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Typography from '@mui/material/Typography'
+
+import MarkdownCodeBlock from '../session/MarkdownCodeBlock'
+
+interface CreatedOrgApiKeyDialogProps {
+  apiKey: string
+  open: boolean
+  onClose: () => void
+}
+
+const cliInstall = 'curl -Ls -O https://get.helixml.tech/install.sh && bash install.sh --cli'
+
+const CreatedOrgApiKeyDialog = ({ apiKey, open, onClose }: CreatedOrgApiKeyDialogProps) => {
+  const helixURL = window.location.origin
+  const cliAuthentication = `export HELIX_URL='${helixURL}'
+export HELIX_API_KEY='${apiKey}'
+
+# Verify authentication
+helix organization list`
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>API key created</DialogTitle>
+      <DialogContent>
+        <Alert severity="success" sx={{ mb: 2 }}>
+          Your organization API key is ready. Treat it like a password and store it securely.
+        </Alert>
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" fontWeight={600}>
+            Copy your API key
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Use the copy button in this code block, then paste the key into your application or secret manager.
+          </Typography>
+          <MarkdownCodeBlock language="text" defaultWrapped>
+            {apiKey}
+          </MarkdownCodeBlock>
+        </Box>
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" fontWeight={600}>
+            Install the Helix CLI
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Skip this step if the <code>helix</code> command is already installed.
+          </Typography>
+          <MarkdownCodeBlock language="bash" defaultWrapped>
+            {cliInstall}
+          </MarkdownCodeBlock>
+        </Box>
+
+        <Box>
+          <Typography variant="subtitle1" fontWeight={600}>
+            Authenticate the Helix CLI
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            The CLI reads these environment variables; there is no separate login command. Copy and run this block in your terminal.
+          </Typography>
+          <MarkdownCodeBlock language="bash" defaultWrapped>
+            {cliAuthentication}
+          </MarkdownCodeBlock>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default CreatedOrgApiKeyDialog

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -25,6 +25,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import useApi from '../../hooks/useApi'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 import {
   ServerProjectWebServiceResponse,
   ServerProjectWebServiceLogsResponse,
@@ -263,8 +264,9 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
               cnameTarget={cnameTarget}
               onDelete={(id) => deleteDomainMutation.mutate(id)}
               onCopy={(text, label) => {
-                navigator.clipboard.writeText(text)
-                snackbar.success(`${label} copied`)
+                void copyTextToClipboard(text)
+                  .then(() => snackbar.success(`${label} copied`))
+                  .catch(() => snackbar.error(`Failed to copy ${label.toLowerCase()}`))
               }}
             />
 
@@ -324,8 +326,9 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
                     <IconButton
                       size="small"
                       onClick={() => {
-                        navigator.clipboard.writeText(cnameTarget)
-                        snackbar.success('CNAME target copied')
+                        void copyTextToClipboard(cnameTarget)
+                          .then(() => snackbar.success('CNAME target copied'))
+                          .catch(() => snackbar.error('Failed to copy CNAME target'))
                       }}
                     >
                       <ContentCopyIcon fontSize="small" />
@@ -366,8 +369,9 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
                         <IconButton
                           size="small"
                           onClick={() => {
-                            navigator.clipboard.writeText('_acme-challenge.app.yourcompany.com')
-                            snackbar.success('Record name copied')
+                            void copyTextToClipboard('_acme-challenge.app.yourcompany.com')
+                              .then(() => snackbar.success('Record name copied'))
+                              .catch(() => snackbar.error('Failed to copy record name'))
                           }}
                         >
                           <ContentCopyIcon fontSize="small" />
@@ -381,8 +385,9 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
                         <IconButton
                           size="small"
                           onClick={() => {
-                            navigator.clipboard.writeText(acmeChallengeTarget)
-                            snackbar.success('ACME challenge target copied')
+                            void copyTextToClipboard(acmeChallengeTarget)
+                              .then(() => snackbar.success('ACME challenge target copied'))
+                              .catch(() => snackbar.error('Failed to copy ACME challenge target'))
                           }}
                         >
                           <ContentCopyIcon fontSize="small" />

--- a/frontend/src/components/sandboxes/SandboxApiExamples.tsx
+++ b/frontend/src/components/sandboxes/SandboxApiExamples.tsx
@@ -17,6 +17,7 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { Check, Copy } from 'lucide-react'
 
 import useLightTheme from '../../hooks/useLightTheme'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 const SyntaxHighlighter = SyntaxHighlighterPrism as unknown as React.FC<any>
 
@@ -251,7 +252,7 @@ const CodeBlock: FC<{ code: string; lang: Lang }> = ({ code, lang }) => {
   const [copied, setCopied] = useState(false)
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code)
+      await copyTextToClipboard(code)
       setCopied(true)
       setTimeout(() => setCopied(false), 1200)
     } catch {

--- a/frontend/src/components/session/ChatStatsOverlay.tsx
+++ b/frontend/src/components/session/ChatStatsOverlay.tsx
@@ -13,6 +13,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Box, Typography, IconButton, Tooltip } from '@mui/material';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 // Stats data structure
 export interface ChatStats {
@@ -326,10 +327,10 @@ Streaming:
   Throttle: ${stats.throttleMs}ms
 `;
 
-    navigator.clipboard.writeText(statsText).then(() => {
+    copyTextToClipboard(statsText).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    }).catch((error) => console.error('Failed to copy chat stats', error));
   }, [stats]);
 
   return (

--- a/frontend/src/components/session/CopyButtonWithCheck.tsx
+++ b/frontend/src/components/session/CopyButtonWithCheck.tsx
@@ -3,6 +3,7 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 const CopyButtonWithCheck: FC<{ text: string, alwaysVisible?: boolean }> = ({ text }) => {
   const [copied, setCopied] = useState(false)
@@ -12,28 +13,10 @@ const CopyButtonWithCheck: FC<{ text: string, alwaysVisible?: boolean }> = ({ te
     
     const textToCopy = sanitizeTextForCopy(text)
 
-    // Fallback method for older browsers or when navigator.clipboard is not available/permission denied
-    const fallbackCopy = () => {
-      const textArea = document.createElement('textarea')
-      textArea.value = textToCopy
-      textArea.style.position = 'fixed'
-      textArea.style.left = '-9999px'
-      document.body.appendChild(textArea)
-      textArea.select()
-      document.execCommand('copy')
-      document.body.removeChild(textArea)
+    copyTextToClipboard(textToCopy).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    }
-
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(textToCopy).then(() => {
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
-      }).catch(fallbackCopy)
-    } else {
-      fallbackCopy()
-    }
+    }).catch((error) => console.error('Failed to copy text', error))
   }
   return (
     <Tooltip title={copied ? 'Copied!' : 'Copy'} placement="bottom">

--- a/frontend/src/components/session/InteractionDebugCopyButton.tsx
+++ b/frontend/src/components/session/InteractionDebugCopyButton.tsx
@@ -10,6 +10,7 @@ import {
   TypesSession,
 } from "../../api/api";
 import { useStreaming } from "../../contexts/streaming";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import { buildInteractionDebugContext } from "./interactionDebugContext";
 
 interface InteractionDebugCopyButtonProps {
@@ -18,17 +19,6 @@ interface InteractionDebugCopyButtonProps {
   sessionSteps: unknown[];
   serverConfig: TypesServerConfigForFrontend;
 }
-
-const fallbackCopy = (text: string) => {
-  const textArea = document.createElement("textarea");
-  textArea.value = text;
-  textArea.style.position = "fixed";
-  textArea.style.left = "-9999px";
-  document.body.appendChild(textArea);
-  textArea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textArea);
-};
 
 const InteractionDebugCopyButton: FC<InteractionDebugCopyButtonProps> = ({
   interaction,
@@ -67,12 +57,7 @@ const InteractionDebugCopyButton: FC<InteractionDebugCopyButtonProps> = ({
       },
     );
 
-    try {
-      if (!navigator.clipboard?.writeText) throw new Error("Clipboard API unavailable");
-      await navigator.clipboard.writeText(context);
-    } catch {
-      fallbackCopy(context);
-    }
+    await copyTextToClipboard(context);
 
     setCopied(true);
     window.setTimeout(() => setCopied(false), 2000);

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -478,98 +478,7 @@ export class MessageProcessor {
   }
 
   private sanitizeHtml(message: string): string {
-    // Temporarily replace code blocks to protect them from sanitization
-    const codeBlocks: string[] = [];
-    let processedMessage = message.replace(
-      /```(?:[\w]*)\n([\s\S]*?)```/g,
-      (match, codeContent) => {
-        codeBlocks.push(match);
-        return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
-      },
-    );
-
-    // Also protect inline code spans
-    const inlineCode: string[] = [];
-    processedMessage = processedMessage.replace(/`([^`]+)`/g, (match) => {
-      inlineCode.push(match);
-      return `__INLINE_CODE_${inlineCode.length - 1}__`;
-    });
-
-    // Escape HTML-like tags that aren't in our allowlist BEFORE DOMPurify
-    // This prevents malformed tags like <svg xmlns="... from breaking rendering
-    const ALLOWED_TAG_NAMES = [
-      "a",
-      "p",
-      "br",
-      "strong",
-      "em",
-      "div",
-      "span",
-      "h1",
-      "h2",
-      "h3",
-      "h4",
-      "h5",
-      "h6",
-      "ul",
-      "ol",
-      "li",
-      "code",
-      "pre",
-      "blockquote",
-      "details",
-      "summary",
-      "table",
-      "thead",
-      "tbody",
-      "tr",
-      "th",
-      "td",
-    ];
-    processedMessage = processedMessage.replace(
-      /<(\/?)([\w-]+)/g,
-      (match, slash, tagName) => {
-        if (ALLOWED_TAG_NAMES.includes(tagName.toLowerCase())) {
-          return match; // Keep allowed tags
-        }
-        return `&lt;${slash}${tagName}`; // Escape disallowed tags
-      },
-    );
-
-    // Use DOMPurify to sanitize HTML while preserving safe tags and attributes
-    processedMessage = DOMPurify.sanitize(processedMessage, {
-      ALLOWED_TAGS: ALLOWED_TAG_NAMES,
-      ALLOWED_ATTR: [
-        "href",
-        "target",
-        "class",
-        "style",
-        "title",
-        "id",
-        "aria-hidden",
-        "aria-label",
-        "role",
-      ],
-      ADD_ATTR: ["target"],
-    });
-
-    // Restore inline code
-    inlineCode.forEach((code, index) => {
-      processedMessage = processedMessage.replace(
-        `__INLINE_CODE_${index}__`,
-        code,
-      );
-    });
-
-    // Restore code blocks
-    codeBlocks.forEach((codeBlock, index) => {
-      processedMessage = processedMessage.replace(
-        `__CODE_BLOCK_${index}__`,
-        codeBlock,
-      );
-    });
-
-    return processedMessage;
+    return sanitizeChatMarkdown(message);
   }
 
   private addCitationData(message: string): string {
@@ -754,10 +663,10 @@ export class MessageProcessor {
 
 export interface InteractionMarkdownProps {
   text: string;
-  session: TypesSession;
-  getFileURL: (filename: string) => string;
+  session?: TypesSession | null;
+  getFileURL?: (filename: string) => string;
   showBlinker?: boolean;
-  isStreaming: boolean;
+  isStreaming?: boolean;
   onFilterDocument?: (docId: string) => void;
   compactThinking?: boolean;
   renderThinkingWidget?: boolean;
@@ -1267,9 +1176,106 @@ const WorkspaceFileReference: FC<{ path: string; label: string }> = ({ path, lab
   );
 };
 
+// Shared HTML sanitization for chat markdown. Applied both by the
+// MessageProcessor (session messages) and the no-session rendering path used
+// by standalone surfaces such as markdown artifacts.
+export function sanitizeChatMarkdown(message: string): string {
+  // Temporarily replace code blocks to protect them from sanitization
+  const codeBlocks: string[] = [];
+  let processedMessage = message.replace(
+    /```(?:[\w]*)\n([\s\S]*?)```/g,
+    (match, codeContent) => {
+      codeBlocks.push(match);
+      return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+    },
+  );
+
+  // Also protect inline code spans
+  const inlineCode: string[] = [];
+  processedMessage = processedMessage.replace(/`([^`]+)`/g, (match) => {
+    inlineCode.push(match);
+    return `__INLINE_CODE_${inlineCode.length - 1}__`;
+  });
+
+  // Escape HTML-like tags that aren't in our allowlist BEFORE DOMPurify
+  // This prevents malformed tags like <svg xmlns="... from breaking rendering
+  const ALLOWED_TAG_NAMES = [
+    "a",
+    "p",
+    "br",
+    "strong",
+    "em",
+    "div",
+    "span",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "ul",
+    "ol",
+    "li",
+    "code",
+    "pre",
+    "blockquote",
+    "details",
+    "summary",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+  ];
+  processedMessage = processedMessage.replace(
+    /<(\/?)([\w-]+)/g,
+    (match, slash, tagName) => {
+      if (ALLOWED_TAG_NAMES.includes(tagName.toLowerCase())) {
+        return match; // Keep allowed tags
+      }
+      return `&lt;${slash}${tagName}`; // Escape disallowed tags
+    },
+  );
+
+  // Use DOMPurify to sanitize HTML while preserving safe tags and attributes
+  processedMessage = DOMPurify.sanitize(processedMessage, {
+    ALLOWED_TAGS: ALLOWED_TAG_NAMES,
+    ALLOWED_ATTR: [
+      "href",
+      "target",
+      "class",
+      "style",
+      "title",
+      "id",
+      "aria-hidden",
+      "aria-label",
+      "role",
+    ],
+    ADD_ATTR: ["target"],
+  });
+
+  // Restore inline code
+  inlineCode.forEach((code, index) => {
+    processedMessage = processedMessage.replace(
+      `__INLINE_CODE_${index}__`,
+      code,
+    );
+  });
+
+  // Restore code blocks
+  codeBlocks.forEach((codeBlock, index) => {
+    processedMessage = processedMessage.replace(
+      `__CODE_BLOCK_${index}__`,
+      codeBlock,
+    );
+  });
+
+  return processedMessage;
+}
+
 function processBasicContent(text: string): string {
-  // Implement basic processing logic here
-  return text;
+  return sanitizeChatMarkdown(text);
 }
 
 // Export with React.memo to prevent unnecessary re-renders

--- a/frontend/src/components/session/MarkdownCodeBlock.test.tsx
+++ b/frontend/src/components/session/MarkdownCodeBlock.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import MarkdownCodeBlock from "./MarkdownCodeBlock";
 
 const theme = createTheme({ palette: { mode: "dark" } });
 const writeText = vi.fn().mockResolvedValue(undefined);
+const originalSecureContext = Object.getOwnPropertyDescriptor(window, "isSecureContext");
 
 function renderCodeBlock() {
   return render(
@@ -18,6 +19,10 @@ function renderCodeBlock() {
 describe("MarkdownCodeBlock", () => {
   beforeEach(() => {
     writeText.mockClear();
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -68,4 +73,30 @@ describe("MarkdownCodeBlock", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('fmt.Println("hello")'));
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
   });
+
+  it("copies through the HTTP fallback when the Clipboard API is unavailable", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    renderCodeBlock();
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+});
+
+afterAll(() => {
+  if (originalSecureContext) {
+    Object.defineProperty(window, "isSecureContext", originalSecureContext);
+  } else {
+    Reflect.deleteProperty(window, "isSecureContext");
+  }
 });

--- a/frontend/src/components/session/MarkdownCodeBlock.tsx
+++ b/frontend/src/components/session/MarkdownCodeBlock.tsx
@@ -8,6 +8,7 @@ import { Prism as SyntaxHighlighterTS } from "react-syntax-highlighter";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 import { APP_MONO_FONT_FAMILY, TYPOGRAPHY } from "../../styles/typography";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import { getChatColors } from "./chatStyles";
 
 const SyntaxHighlighter = SyntaxHighlighterTS as any;
@@ -30,7 +31,7 @@ const MarkdownCodeBlock: FC<MarkdownCodeBlockProps> = React.memo(
 
     const handleCopy = useCallback(async () => {
       try {
-        await navigator.clipboard.writeText(code);
+        await copyTextToClipboard(code);
         if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
         setCopied(true);
         copiedTimerRef.current = setTimeout(() => {

--- a/frontend/src/components/session/MarkdownTable.tsx
+++ b/frontend/src/components/session/MarkdownTable.tsx
@@ -6,6 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Tooltip from "@mui/material/Tooltip";
 import { useTheme } from "@mui/material/styles";
 import { Check, Copy, Maximize2, Minimize2 } from "lucide-react";
+import { copyTextToClipboard } from "../../utils/clipboard";
 
 function wrapInlineCode(code: string): string {
   const longestRun = [...(code.match(/`+/g) ?? [])].reduce(
@@ -124,14 +125,14 @@ export default function MarkdownTable({
   const copyTable = async (format: "markdown" | "csv") => {
     setMenuAnchor(null);
     const table = tableRef.current;
-    if (!table || !navigator.clipboard) return;
+    if (!table) return;
 
     const text =
       format === "markdown"
         ? serializeTableToMarkdown(table)
         : serializeTableToCsv(table);
     try {
-      await navigator.clipboard.writeText(text);
+      await copyTextToClipboard(text);
       setCopied(true);
       if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
       copiedTimerRef.current = setTimeout(() => setCopied(false), 1200);

--- a/frontend/src/components/slack/SlackSetupScaffold.tsx
+++ b/frontend/src/components/slack/SlackSetupScaffold.tsx
@@ -22,6 +22,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import CloseIcon from '@mui/icons-material/Close'
 import DarkDialog from '../dialog/DarkDialog'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 // SetupStep is one numbered instruction. `image` is a screenshot shown
 // under the step (click to enlarge); `below` is any other indented
@@ -69,7 +70,7 @@ export const StepNumber: FC<{ n: number }> = ({ n }) => (
 function useCopied(): [boolean, (text: string) => void] {
   const [copied, setCopied] = useState(false)
   const copy = (text: string) => {
-    navigator.clipboard.writeText(text).then(
+    copyTextToClipboard(text).then(
       () => { setCopied(true); setTimeout(() => setCopied(false), 1500) },
       () => { /* ignore */ },
     )

--- a/frontend/src/components/system/ErrorBoundary.tsx
+++ b/frontend/src/components/system/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { isMobileOrTablet } from '../../utils/isMobileOrTablet'
 import { logErrorToSession, getRecentErrors, clearErrorLog } from '../../utils/errorSessionLog'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 interface Props {
   children: React.ReactNode
@@ -89,7 +90,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
       })
     }
     text += `\nURL: ${window.location.href}\nUA: ${navigator.userAgent}\nTime: ${new Date().toISOString()}`
-    navigator.clipboard.writeText(text).catch(() => {
+    copyTextToClipboard(text).catch(() => {
       // fallback: select text for manual copy
     })
   }

--- a/frontend/src/components/tasks/AgentKanbanBoard.tsx
+++ b/frontend/src/components/tasks/AgentKanbanBoard.tsx
@@ -75,6 +75,7 @@ import { useTheme } from '@mui/material/styles'
 import useApi from '../../hooks/useApi'
 import useAccount from '../../hooks/useAccount'
 import { IApp } from '../../types'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 // Task types
 type TaskPriority = 'low' | 'medium' | 'high' | 'critical'
@@ -706,7 +707,9 @@ const AgentKanbanBoard: FC<AgentKanbanBoardProps> = ({ projectId, apps }) => {
         </MenuItem>
         <MenuItem onClick={() => {
           if (selectedTask) {
-            navigator.clipboard.writeText(selectedTask.id)
+            void copyTextToClipboard(selectedTask.id).catch((error) => {
+              console.error('Failed to copy task ID', error)
+            })
           }
           setTaskMenuAnchor(null)
         }}>

--- a/frontend/src/components/tasks/TaskCard.sandbox.test.tsx
+++ b/frontend/src/components/tasks/TaskCard.sandbox.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TypesSandboxRuntime } from "../../api/api";
+import TaskCard, { SpecTaskWithExtras } from "./TaskCard";
+
+vi.mock("../../hooks/useAccount", () => ({
+  default: () => ({
+    user: { id: "usr_1", fullName: "Test User", email: "test@example.com" },
+    organizationTools: { organization: { memberships: [] } },
+  }),
+}));
+
+vi.mock("../external-agent/ExternalAgentDesktopViewer", () => ({
+  default: () => <div data-testid="desktop-viewer" />,
+}));
+
+vi.mock("../../services/specTaskWorkflowService", () => ({
+  useApproveImplementation: () => ({ mutate: vi.fn(), isPending: false }),
+  useStopAgent: () => ({ mutate: vi.fn(), isPending: false }),
+  useMoveToBacklog: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../../services/specTaskService", () => ({
+  useUpdateSpecTask: () => ({ mutate: vi.fn() }),
+  useDeleteSpecTask: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("../../hooks/useAttentionEvents", () => ({
+  useAttentionEvents: () => ({ acknowledge: vi.fn() }),
+}));
+
+vi.mock("../specTask/CloneTaskDialog", () => ({ default: () => null }));
+vi.mock("../specTask/CloneGroupProgress", () => ({ default: () => null }));
+vi.mock("./UsagePulseChart", () => ({ default: () => null }));
+vi.mock("./CIStatusIcon", () => ({ default: () => null }));
+vi.mock("./SpecTaskActionButtons", () => ({ default: () => null }));
+vi.mock("./AssigneeSelector", () => ({ default: () => null }));
+
+function baseTask(overrides: Partial<SpecTaskWithExtras> = {}): SpecTaskWithExtras {
+  return {
+    id: "spt_1",
+    name: "web-pentest: recon",
+    status: "implementation",
+    phase: "implementation",
+    planning_session_id: "ses_1",
+    sandbox_state: "running",
+    ...overrides,
+  };
+}
+
+function renderCard(task: SpecTaskWithExtras) {
+  return render(
+    <TaskCard
+      task={task}
+      index={0}
+      columns={[]}
+      projectId="prj_1"
+    />,
+  );
+}
+
+describe("TaskCard sandbox screenshot", () => {
+  it("mounts the desktop viewer for a live desktop-runtime task", () => {
+    renderCard(baseTask());
+    expect(screen.getByTestId("desktop-viewer")).toBeInTheDocument();
+  });
+
+  it("does not mount the desktop viewer for a headless-runtime task", () => {
+    renderCard(
+      baseTask({ sandbox_runtime: TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu }),
+    );
+    expect(screen.queryByTestId("desktop-viewer")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -54,6 +54,7 @@ import {
 } from "../../services/specTaskService";
 import {
   ServerTaskProgressResponse,
+  TypesSandboxRuntime,
   TypesSpecTaskStatus,
   ServerBatchTaskUsageMetric,
 } from "../../api/api";
@@ -155,6 +156,7 @@ export interface SpecTaskWithExtras {
   // Sandbox state — populated by the listTasks backend handler, avoids per-card session polling
   sandbox_state?: string; // "absent" | "running" | "starting"
   sandbox_status_message?: string; // Transient startup message
+  sandbox_runtime?: TypesSandboxRuntime; // "ubuntu-desktop" (default) | "headless-ubuntu" — headless has no desktop to screenshot
   queue_reason?: string; // Why a queued task hasn't started yet (WIP/dependency); recomputed each read
   // Status tracking
   status_updated_at?: string;
@@ -597,6 +599,13 @@ function TaskCardInner({
   const orgMembers = account.organizationTools.organization?.memberships || [];
 
   const assignedUser = resolveOrganizationUser(task.assignee_id, orgMembers, account.user)
+
+  // Headless sandbox tasks run the agent without a compositor or video
+  // encoder, so a desktop screenshot can never load. Skip the viewer (and its
+  // per-card poll loop) entirely instead of showing a stuck "Loading
+  // desktop..." panel.
+  const isHeadlessSandbox =
+    task.sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu;
 
   // Handle assignee change
   const handleAssigneeChange = (userId: string | null) => {
@@ -1190,23 +1199,25 @@ function TaskCardInner({
                 px: 0.5,
               }}
             >
-              <CircularProgress size={10} thickness={5} />
-              <Typography
-                variant="caption"
-                sx={{ color: "text.secondary", fontSize: "0.7rem" }}
-              >
-                Starting desktop...
-              </Typography>
+                <CircularProgress size={10} thickness={5} />
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.secondary", fontSize: "0.7rem" }}
+                >
+                  {isHeadlessSandbox ? "Starting sandbox..." : "Starting desktop..."}
+                </Typography>
             </Box>
           )
         )}
 
         {/* Live screenshot for active sessions - click opens desktop viewer.
-            Only render when the sandbox is actually live ("running"/"starting").
-            Polling absent sandboxes burns API requests and dumps a fleet of
-            503s in the logs every time the page loads, since each card spins
-            up its own poll loop until it hits one. */}
-        {task.planning_session_id &&
+            Only render when the sandbox is actually live ("running"/"starting")
+            and the task runs a desktop sandbox - headless tasks have no
+            compositor to capture. Polling absent sandboxes burns API requests
+            and dumps a fleet of 503s in the logs every time the page loads,
+            since each card spins up its own poll loop until it hits one. */}
+        {!isHeadlessSandbox &&
+          task.planning_session_id &&
           task.phase !== "completed" &&
           !task.merged_to_main &&
           !taskError &&

--- a/frontend/src/components/widgets/ApiCodeExamples.tsx
+++ b/frontend/src/components/widgets/ApiCodeExamples.tsx
@@ -9,6 +9,7 @@ import { API_CODE_EXAMPLES } from '../../data/apiCodeExamples';
 import { Prism as SyntaxHighlighterPrism } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { AdvancedModelPicker } from '../create/AdvancedModelPicker';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface ApiCodeExamplesProps {
   apiKey: string;
@@ -40,7 +41,7 @@ const ApiCodeExamples: FC<ApiCodeExamplesProps> = ({ apiKey, model }) => {
 
   const handleCopyCode = async () => {
     try {
-      await navigator.clipboard.writeText(API_CODE_EXAMPLES[selectedTab].code(url, apiKey, effectiveModel));
+      await copyTextToClipboard(API_CODE_EXAMPLES[selectedTab].code(url, apiKey, effectiveModel));
     } catch (err) {
       console.error('Failed to copy code:', err);
     }

--- a/frontend/src/components/widgets/JsonView.tsx
+++ b/frontend/src/components/widgets/JsonView.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Switch, FormControlLabel, IconButton, Tooltip } from '
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckIcon from '@mui/icons-material/Check'
 import useSnackbar from '../../hooks/useSnackbar'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 interface JsonViewProps {
   data: any,
@@ -81,7 +82,7 @@ const JsonView: FC<React.PropsWithChildren<JsonViewProps>> = ({
 
   const handleCopy = () => {
     const textToCopy = typeof(data) === 'string' ? data : JSON.stringify(data, null, 2);
-    navigator.clipboard.writeText(textToCopy)
+    copyTextToClipboard(textToCopy)
       .then(() => {
         setShowCopied(true);
         setTimeout(() => setShowCopied(false), 2000);

--- a/frontend/src/components/widgets/JsonWindow.tsx
+++ b/frontend/src/components/widgets/JsonWindow.tsx
@@ -12,6 +12,7 @@ import useTheme from '@mui/material/styles/useTheme'
 import useThemeConfig from '../../hooks/useThemeConfig'
 import useLightTheme from '../../hooks/useLightTheme'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import { copyTextToClipboard } from '../../utils/clipboard'
 
 interface JsonWindowProps {
   data: any,
@@ -35,7 +36,7 @@ const JsonWindow: FC<React.PropsWithChildren<JsonWindowProps>> = ({
 
   const handleCopy = () => {
     const textToCopy = typeof(data) === 'string' ? data : JSON.stringify(data, null, 4)
-    navigator.clipboard.writeText(textToCopy)
+    copyTextToClipboard(textToCopy)
       .then(() => {
         snackbar.success('Copied to clipboard')
       })
@@ -139,4 +140,3 @@ const JsonWindow: FC<React.PropsWithChildren<JsonWindowProps>> = ({
 }
 
 export default JsonWindow
-

--- a/frontend/src/components/widgets/MaskedSecret.tsx
+++ b/frontend/src/components/widgets/MaskedSecret.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { Copy, Check, Eye, EyeOff } from 'lucide-react';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 const MASK = '•'.repeat(16); // 16 bullets, fixed width — does not encode key length
 const DEFAULT_AUTO_HIDE_MS = 30_000;
@@ -76,7 +77,7 @@ const MaskedSecret: FC<MaskedSecretProps> = ({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(value);
+      await copyTextToClipboard(value);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import App from './App'
 import ErrorBoundary from './components/system/ErrorBoundary'
 import { isMobileOrTablet } from './utils/isMobileOrTablet'
 import { logErrorToSession, getRecentErrors, clearErrorLog } from './utils/errorSessionLog'
+import { copyTextToClipboard } from './utils/clipboard'
 
 const win = (window as any)
 win.setUserFunctions = []
@@ -99,7 +100,7 @@ if (isMobileOrTablet()) {
         previousErrors.forEach(e => { text += `[${e.timestamp}] ${e.message}\n` })
       }
       text += `\nURL: ${window.location.href}\nUA: ${navigator.userAgent}\nTime: ${new Date().toISOString()}`
-      navigator.clipboard.writeText(text).catch(() => {})
+      copyTextToClipboard(text).catch(() => {})
     })
   }
 

--- a/frontend/src/pages/ArtifactViewer.test.tsx
+++ b/frontend/src/pages/ArtifactViewer.test.tsx
@@ -51,6 +51,19 @@ vi.mock('../services/artifactService', () => ({
     mutateAsync: mocks.mutateAsync,
     isPending: false,
   }),
+  useGetArtifactMarkdownSource: (_artifactId: string, enabled: boolean) => ({
+    data: enabled ? '# Hello artifact' : undefined,
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+vi.mock('../components/session/Markdown', () => ({
+  default: ({ text }: { text: string }) => <div data-testid="markdown-rendered">{text}</div>,
+}))
+
+vi.mock('../components/session/MarkdownCodeBlock', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown-raw">{children}</div>,
 }))
 
 vi.mock('../components/system/Page', () => ({
@@ -114,6 +127,20 @@ describe('ArtifactViewer', () => {
 
     expect(screen.getByRole('img', { name: 'Public artifact' })).toHaveAttribute('src', 'http://artifact.example.test/')
     expect(screen.queryByTitle('Public artifact')).not.toBeInTheDocument()
+  })
+
+  it('renders markdown artifacts without an iframe and toggles to raw source', () => {
+    mocks.artifactKind = 'markdown'
+    render(<ArtifactViewer />)
+
+    expect(screen.getByTestId('markdown-rendered')).toHaveTextContent('# Hello artifact')
+    expect(screen.queryByTitle('Public artifact')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View raw markdown' }))
+    expect(screen.getByTestId('markdown-raw')).toHaveTextContent('# Hello artifact')
+
+    fireEvent.click(screen.getByRole('button', { name: 'View rendered markdown' }))
+    expect(screen.getByTestId('markdown-rendered')).toHaveTextContent('# Hello artifact')
   })
 
   it('renders PDF artifacts in the browser frame', () => {

--- a/frontend/src/pages/ArtifactViewer.tsx
+++ b/frontend/src/pages/ArtifactViewer.tsx
@@ -17,6 +17,7 @@ import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import { useGetArtifactViewer, useSetArtifactVisibility } from '../services/artifactService'
+import { copyTextToClipboard } from '../utils/clipboard'
 
 const ArtifactViewer: FC = () => {
   const account = useAccount()
@@ -51,9 +52,13 @@ const ArtifactViewer: FC = () => {
 
   const copyShareLink = async () => {
     if (!artifact?.subdomain_url) return
-    await navigator.clipboard.writeText(artifact.subdomain_url)
-    snackbar.success('Public link copied')
-    setShareAnchor(null)
+    try {
+      await copyTextToClipboard(artifact.subdomain_url)
+      snackbar.success('Public link copied')
+      setShareAnchor(null)
+    } catch {
+      snackbar.error('Failed to copy public link')
+    }
   }
 
   const openShareMenu = (event: MouseEvent<HTMLElement>) => setShareAnchor(event.currentTarget)

--- a/frontend/src/pages/ArtifactViewer.tsx
+++ b/frontend/src/pages/ArtifactViewer.tsx
@@ -1,22 +1,26 @@
-import { FC, MouseEvent, useState } from 'react'
+import { FC, MouseEvent, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import { Copy, ExternalLink, Globe2, LockKeyhole } from 'lucide-react'
+import { CodeXml, Copy, ExternalLink, Eye, Globe2, LockKeyhole } from 'lucide-react'
 
 import { TypesArtifactKind } from '../api/api'
 import ArtifactVisibilityBadge from '../components/artifacts/ArtifactVisibilityBadge'
+import Markdown from '../components/session/Markdown'
+import MarkdownCodeBlock from '../components/session/MarkdownCodeBlock'
 import Page from '../components/system/Page'
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
-import { useGetArtifactViewer, useSetArtifactVisibility } from '../services/artifactService'
+import { useGetArtifactMarkdownSource, useGetArtifactViewer, useSetArtifactVisibility } from '../services/artifactService'
 import { copyTextToClipboard } from '../utils/clipboard'
 
 const ArtifactViewer: FC = () => {
@@ -27,6 +31,7 @@ const ArtifactViewer: FC = () => {
   const { data: artifact, isLoading, error } = useGetArtifactViewer(artifactId)
   const visibilityMutation = useSetArtifactVisibility(artifactId)
   const [shareAnchor, setShareAnchor] = useState<HTMLElement | null>(null)
+  const [showRawMarkdown, setShowRawMarkdown] = useState(false)
 
   const organizationSlug = artifact?.organization_name || artifact?.organization_id || ''
   const organizationTitle = artifact?.organization_name || 'Organization'
@@ -34,11 +39,19 @@ const ArtifactViewer: FC = () => {
   const isPublic = artifact?.visibility === 'public'
   const isImage = artifact?.kind === TypesArtifactKind.ArtifactKindImage
   const isPDF = artifact?.kind === TypesArtifactKind.ArtifactKindPDF
-  const frameURL = isPDF
-    ? `/artifacts/${artifact.id}/document`
-    : isPublic
-      ? artifact?.subdomain_url
-      : artifact ? `/artifacts/${artifact.id}/embed` : undefined
+  const isMarkdown = artifact?.kind === TypesArtifactKind.ArtifactKindMarkdown
+  const markdownSource = useGetArtifactMarkdownSource(artifactId, isMarkdown)
+  const frameURL = isMarkdown
+    ? undefined
+    : isPDF
+      ? `/artifacts/${artifact.id}/document`
+      : isPublic
+        ? artifact?.subdomain_url
+        : artifact ? `/artifacts/${artifact.id}/embed` : undefined
+
+  useEffect(() => {
+    setShowRawMarkdown(false)
+  }, [artifactId])
 
   const setVisibility = async (visibility: 'project' | 'public') => {
     try {
@@ -113,6 +126,18 @@ const ArtifactViewer: FC = () => {
       topbarContent={(
         <Stack direction="row" spacing={1} alignItems="center">
           <ArtifactVisibilityBadge visibility={artifact.visibility} privateLabel="Private" />
+          {isMarkdown && (
+            <Tooltip title={showRawMarkdown ? 'View rendered markdown' : 'View and copy raw markdown'}>
+              <IconButton
+                aria-label={showRawMarkdown ? 'View rendered markdown' : 'View raw markdown'}
+                size="small"
+                color={showRawMarkdown ? 'primary' : 'default'}
+                onClick={() => setShowRawMarkdown((current) => !current)}
+              >
+                {showRawMarkdown ? <Eye size={18} /> : <CodeXml size={18} />}
+              </IconButton>
+            </Tooltip>
+          )}
           {account.initialized && !account.user ? (
             <Button size="small" onClick={login} sx={{ textTransform: 'none', fontWeight: 500, minWidth: 'auto' }}>
               Login
@@ -131,7 +156,25 @@ const ArtifactViewer: FC = () => {
       )}
     >
       <Box sx={{ flex: 1, minHeight: 0, p: 1, bgcolor: 'background.default' }}>
-        {frameURL && isImage ? (
+        {isMarkdown ? (
+          markdownSource.isLoading ? (
+            <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}><CircularProgress /></Box>
+          ) : markdownSource.isError || markdownSource.data === undefined ? (
+            <Box sx={{ height: '100%', display: 'grid', placeItems: 'center' }}>
+              <Typography color="text.secondary">The markdown source is unavailable.</Typography>
+            </Box>
+          ) : showRawMarkdown ? (
+            <Box sx={{ height: '100%', overflow: 'auto', p: 1 }}>
+              <MarkdownCodeBlock language="markdown" defaultWrapped>{markdownSource.data}</MarkdownCodeBlock>
+            </Box>
+          ) : (
+            <Box sx={{ height: '100%', overflow: 'auto' }}>
+              <Box sx={{ maxWidth: 900, mx: 'auto', px: { xs: 2, md: 4 }, py: 3 }}>
+                <Markdown text={markdownSource.data} session={null} renderThinkingWidget={false} />
+              </Box>
+            </Box>
+          )
+        ) : frameURL && isImage ? (
           <Box sx={{ width: '100%', height: '100%', display: 'grid', placeItems: 'center', overflow: 'auto' }}>
             <Box
               component="img"

--- a/frontend/src/pages/GitRepoDetail.tsx
+++ b/frontend/src/pages/GitRepoDetail.tsx
@@ -89,6 +89,7 @@ import SettingsTab from '../components/git/SettingsTab'
 import PullRequests from '../components/git/PullRequests'
 import CreateProjectDialog from '../components/project/CreateProjectDialog'
 import { TypesExternalRepositoryType, TypesAzureDevOps, TypesGitRepository } from '../api/api'
+import { copyTextToClipboard } from '../utils/clipboard'
 
 const TAB_NAMES = ['code', 'wiki', 'search', 'changelog', 'connect', 'settings', 'access', 'commits', 'pull-requests'] as const
 type TabName = typeof TAB_NAMES[number]
@@ -407,17 +408,23 @@ const GitRepoDetail: FC = () => {
   }
 
   const handleCopyCloneCommand = (command: string) => {
-    navigator.clipboard.writeText(command)
-    setCopiedClone(true)
-    snackbar.success('Clone URL copied to clipboard')
-    setTimeout(() => setCopiedClone(false), 2000)
+    void copyTextToClipboard(command)
+      .then(() => {
+        setCopiedClone(true)
+        snackbar.success('Clone URL copied to clipboard')
+        setTimeout(() => setCopiedClone(false), 2000)
+      })
+      .catch(() => snackbar.error('Failed to copy clone URL'))
   }
 
   const handleCopySha = (sha: string) => {
-    navigator.clipboard.writeText(sha)
-    setCopiedSha(sha)
-    snackbar.success('SHA copied to clipboard')
-    setTimeout(() => setCopiedSha(null), 2000)
+    void copyTextToClipboard(sha)
+      .then(() => {
+        setCopiedSha(sha)
+        snackbar.success('SHA copied to clipboard')
+        setTimeout(() => setCopiedSha(null), 2000)
+      })
+      .catch(() => snackbar.error('Failed to copy SHA'))
   }
 
   const handleViewEnrichments = (commitSha: string) => {

--- a/frontend/src/pages/Jobs.tsx
+++ b/frontend/src/pages/Jobs.tsx
@@ -38,6 +38,7 @@ import ExternalAgentDesktopViewer from '../components/external-agent/ExternalAge
 import useAccount from '../hooks/useAccount'
 import useApi from '../hooks/useApi'
 import useSnackbar from '../hooks/useSnackbar'
+import { copyTextToClipboard } from '../utils/clipboard'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
 import {
@@ -286,8 +287,9 @@ const ApiCallBlock: FC<ApiCallBlockProps> = ({ label, curl }) => {
             size="small"
             onClick={(e) => {
               e.stopPropagation()
-              navigator.clipboard.writeText(curl)
-              snackbar.success('Copied')
+              void copyTextToClipboard(curl)
+                .then(() => snackbar.success('Copied'))
+                .catch(() => snackbar.error('Failed to copy'))
             }}
           >
             <CopyIcon sx={{ fontSize: 14 }} />

--- a/frontend/src/pages/OrgApiKeys.test.tsx
+++ b/frontend/src/pages/OrgApiKeys.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import OrgApiKeys from './OrgApiKeys'
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  delete: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  apiKeys: [] as Array<{ key: string; name: string }>,
+}))
+
+vi.mock('../hooks/useAccount', () => ({
+  default: () => ({
+    user: { id: 'user_1' },
+    isOrgAdmin: true,
+    organizationTools: {
+      organization: { id: 'org_1', name: 'Test organization' },
+    },
+  }),
+}))
+
+vi.mock('../hooks/useSnackbar', () => ({
+  default: () => ({
+    success: mocks.success,
+    error: mocks.error,
+  }),
+}))
+
+vi.mock('../services/orgApiKeyService', () => ({
+  useListOrgApiKeys: () => ({ data: mocks.apiKeys, isLoading: false }),
+  useCreateOrgApiKey: () => ({ mutateAsync: mocks.create, isPending: false }),
+  useDeleteOrgApiKey: () => ({ mutateAsync: mocks.delete, isPending: false }),
+}))
+
+vi.mock('../components/system/Page', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../components/widgets/ApiCodeExamples', () => ({
+  default: () => null,
+}))
+
+const originalSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+
+describe('OrgApiKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.create.mockResolvedValue({
+      key: 'hl-created-api-key',
+      name: 'CI',
+    })
+    mocks.apiKeys = []
+  })
+
+  afterEach(() => {
+    if (originalSecureContext) {
+      Object.defineProperty(window, 'isSecureContext', originalSecureContext)
+    } else {
+      Reflect.deleteProperty(window, 'isSecureContext')
+    }
+  })
+
+  it('shows the created key and accurate CLI authentication instructions', async () => {
+    render(<OrgApiKeys />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create API Key' }))
+    fireEvent.change(screen.getByLabelText('Key Name'), { target: { value: 'CI' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledWith('CI'))
+    expect(await screen.findByRole('heading', { name: 'API key created' })).toBeInTheDocument()
+    expect(screen.getAllByText(/hl-created-api-key/)).toHaveLength(2)
+    expect(screen.getByText(/export HELIX_URL=/)).toBeInTheDocument()
+    expect(screen.getByText(/export HELIX_API_KEY='hl-created-api-key'/)).toBeInTheDocument()
+    expect(screen.getByText(/helix organization list/)).toBeInTheDocument()
+    expect(screen.getByText(/there is no separate login command/i)).toBeInTheDocument()
+  })
+
+  it('copies an organization key on an insecure HTTP origin', async () => {
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    })
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    })
+    mocks.apiKeys = [{ key: 'hl-organization-key', name: 'CI' }]
+
+    render(<OrgApiKeys />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy API key' }))
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'))
+  })
+})

--- a/frontend/src/pages/OrgApiKeys.tsx
+++ b/frontend/src/pages/OrgApiKeys.tsx
@@ -27,9 +27,11 @@ import { Copy, Check, Trash2, Plus } from 'lucide-react'
 
 import Page from '../components/system/Page'
 import ApiCodeExamples from '../components/widgets/ApiCodeExamples'
+import CreatedOrgApiKeyDialog from '../components/orgs/CreatedOrgApiKeyDialog'
 import useAccount from '../hooks/useAccount'
 import useSnackbar from '../hooks/useSnackbar'
 import { useListOrgApiKeys, useCreateOrgApiKey, useDeleteOrgApiKey } from '../services/orgApiKeyService'
+import { copyTextToClipboard } from '../utils/clipboard'
 
 function maskKey(key: string): string {
   if (key.length <= 8) return key
@@ -41,7 +43,7 @@ const CopyKeyButton: FC<{ apiKey: string }> = ({ apiKey }) => {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(apiKey)
+      await copyTextToClipboard(apiKey)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch (err) {
@@ -51,7 +53,7 @@ const CopyKeyButton: FC<{ apiKey: string }> = ({ apiKey }) => {
 
   return (
     <Tooltip title={copied ? 'Copied!' : 'Copy API key'}>
-      <IconButton size="small" onClick={handleCopy}>
+      <IconButton size="small" onClick={handleCopy} aria-label="Copy API key">
         {copied ? <Check size={16} /> : <Copy size={16} />}
       </IconButton>
     </Tooltip>
@@ -69,6 +71,7 @@ const OrgApiKeys: FC = () => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null)
   const [menuKeyId, setMenuKeyId] = useState<string | null>(null)
   const [examplesDialogKey, setExamplesDialogKey] = useState<string | null>(null)
+  const [createdKey, setCreatedKey] = useState<string | null>(null)
 
   const organization = account.organizationTools.organization
   const orgId = organization?.id || ''
@@ -84,10 +87,14 @@ const OrgApiKeys: FC = () => {
       return
     }
     try {
-      await createMutation.mutateAsync(newKeyName.trim())
+      const created = await createMutation.mutateAsync(newKeyName.trim())
+      if (!created.key) {
+        throw new Error('Create API key response did not include the key')
+      }
       snackbar.success('API key created')
       setCreateDialogOpen(false)
       setNewKeyName('')
+      setCreatedKey(created.key)
     } catch {
       snackbar.error('Failed to create API key')
     }
@@ -296,6 +303,12 @@ const OrgApiKeys: FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <CreatedOrgApiKeyDialog
+        apiKey={createdKey || ''}
+        open={Boolean(createdKey)}
+        onClose={() => setCreatedKey(null)}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -208,6 +208,11 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
   const [startupScript, setStartupScript] = useState("");
   const [guidelines, setGuidelines] = useState("");
   const [autoStartBacklogTasks, setAutoStartBacklogTasks] = useState(false);
+  const [autoArchiveCompletedTasks, setAutoArchiveCompletedTasks] =
+    useState(false);
+  const [archiveStaleTasksEnabled, setArchiveStaleTasksEnabled] =
+    useState(false);
+  const [archiveStaleTasksDays, setArchiveStaleTasksDays] = useState(6);
   const [pullRequestReviewsEnabled, setPullRequestReviewsEnabled] =
     useState(false);
   const [koditEnabled, setKoditEnabled] = useState(true);
@@ -625,6 +630,9 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
       setStartupScript(project.startup_script || "");
       setGuidelines(project.guidelines || "");
       setAutoStartBacklogTasks(project.auto_start_backlog_tasks || false);
+      setAutoArchiveCompletedTasks(project.auto_archive_completed_tasks || false);
+      setArchiveStaleTasksEnabled(project.archive_stale_tasks_enabled || false);
+      setArchiveStaleTasksDays(project.archive_stale_tasks_days || 6);
       setPullRequestReviewsEnabled(
         project.pull_request_reviews_enabled || false,
       );
@@ -669,6 +677,12 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
         startup_script: startupScript,
         guidelines,
         auto_start_backlog_tasks: autoStartBacklogTasks,
+        auto_archive_completed_tasks: autoArchiveCompletedTasks,
+        archive_stale_tasks_enabled: archiveStaleTasksEnabled,
+        archive_stale_tasks_days: Math.min(
+          365,
+          Math.max(1, archiveStaleTasksDays || 6),
+        ),
         pull_request_reviews_enabled: pullRequestReviewsEnabled,
         metadata: {
           board_settings: {
@@ -1539,10 +1553,10 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
 
   const renderBoardTab = () => (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {/* Kanban Board Settings */}
+      {/* Board Automation */}
       <Box>
         <Typography variant="h6" gutterBottom>
-          Kanban Board Settings
+          Board Automation
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           Configure work-in-progress (WIP) limits for the Kanban board
@@ -1634,6 +1648,95 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
                 });
               }}
             />
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box sx={{ flex: 1, mr: 2 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                Automatically archive completed tasks
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Archive tasks immediately when they enter Done.
+              </Typography>
+            </Box>
+            <Switch
+              checked={autoArchiveCompletedTasks}
+              onChange={(e) => {
+                const newValue = e.target.checked;
+                setAutoArchiveCompletedTasks(newValue);
+                updateProjectMutation.mutate({
+                  auto_archive_completed_tasks: newValue,
+                });
+              }}
+            />
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box sx={{ flex: 1, mr: 2 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                Archive stale tasks
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Archive tasks with no new messages or activity for a number of
+                days.
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                flexShrink: 0,
+              }}
+            >
+              {archiveStaleTasksEnabled && (
+                <TextField
+                  label="Days"
+                  value={archiveStaleTasksDays}
+                  onChange={(e) => {
+                    const parsed = parseInt(e.target.value, 10);
+                    setArchiveStaleTasksDays(
+                      Number.isNaN(parsed) ? 0 : parsed,
+                    );
+                  }}
+                  onBlur={() => {
+                    const clamped = Math.min(
+                      365,
+                      Math.max(1, archiveStaleTasksDays || 6),
+                    );
+                    setArchiveStaleTasksDays(clamped);
+                    updateProjectMutation.mutate({
+                      archive_stale_tasks_days: clamped,
+                    });
+                  }}
+                  size="small"
+                  sx={{ width: 110 }}
+                />
+              )}
+              <Switch
+                checked={archiveStaleTasksEnabled}
+                onChange={(e) => {
+                  const newValue = e.target.checked;
+                  setArchiveStaleTasksEnabled(newValue);
+                  updateProjectMutation.mutate({
+                    archive_stale_tasks_enabled: newValue,
+                    ...(newValue && archiveStaleTasksDays < 1
+                      ? { archive_stale_tasks_days: 6 }
+                      : {}),
+                  });
+                }}
+              />
+            </Box>
           </Box>
           <Box
             sx={{

--- a/frontend/src/services/artifactService.ts
+++ b/frontend/src/services/artifactService.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { TypesArtifact } from '../api/api'
@@ -14,6 +15,7 @@ export type ArtifactForm = {
 export const projectArtifactsQueryKey = (projectId: string) => ['project-artifacts', projectId]
 export const artifactQueryKey = (artifactId: string) => ['artifact', artifactId]
 export const artifactViewerQueryKey = (artifactId: string) => ['artifact-viewer', artifactId]
+export const artifactMarkdownSourceQueryKey = (artifactId: string) => ['artifact-markdown-source', artifactId]
 
 export const artifactMutationData = (form: ArtifactForm) => ({
   name: form.name,
@@ -46,6 +48,20 @@ export const useGetArtifactViewer = (artifactId: string) => {
       return response.data
     },
     enabled: !!artifactId,
+  })
+}
+
+export const useGetArtifactMarkdownSource = (artifactId: string, enabled: boolean) => {
+  return useQuery<string>({
+    queryKey: artifactMarkdownSourceQueryKey(artifactId),
+    queryFn: async () => {
+      const response = await axios.get<string>(`/artifacts/${artifactId}/document`, {
+        responseType: 'text',
+        transformResponse: [(data) => data],
+      })
+      return response.data
+    },
+    enabled: !!artifactId && enabled,
   })
 }
 
@@ -87,7 +103,7 @@ export const useCreateArtifact = (projectId: string) => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (form: ArtifactForm) => {
-      if (!form.artifact) throw new Error('Choose an HTML, ZIP, PDF, or image file')
+      if (!form.artifact) throw new Error('Choose an HTML, Markdown, ZIP, PDF, or image file')
       const response = await apiClient.v1ProjectsArtifactsCreate(projectId, {
         ...artifactMutationData(form),
         artifact: form.artifact,

--- a/frontend/src/services/userService.test.tsx
+++ b/frontend/src/services/userService.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useRegenerateUserAPIKey } from './userService'
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  delete: vi.fn(),
+}))
+
+vi.mock('../hooks/useApi', () => ({
+  default: () => ({
+    getApiClient: () => ({
+      v1ApiKeysCreate: mocks.create,
+      v1ApiKeysDelete: mocks.delete,
+    }),
+  }),
+}))
+
+describe('useRegenerateUserAPIKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.delete.mockResolvedValue({ data: '' })
+    mocks.create.mockResolvedValue({ data: 'hl-new-key' })
+  })
+
+  it('deletes the visible key before explicitly creating its replacement', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useRegenerateUserAPIKey(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync('hl-old-key')
+    })
+
+    expect(mocks.delete).toHaveBeenCalledWith({ key: 'hl-old-key' })
+    expect(mocks.create).toHaveBeenCalledWith({
+      name: 'API Key',
+      type: 'api',
+      app_id: '',
+    })
+    expect(mocks.delete.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.create.mock.invocationCallOrder[0],
+    )
+  })
+})

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -145,9 +145,13 @@ export function useRegenerateUserAPIKey() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (keyToRegenerate: string) => {
-      // Delete the existing key - backend will auto-create a new one when none exist
       await apiClient.v1ApiKeysDelete({ key: keyToRegenerate })
-      return keyToRegenerate
+      const response = await apiClient.v1ApiKeysCreate({
+        name: 'API Key',
+        type: 'api',
+        app_id: '',
+      })
+      return response.data
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: userQueryKey("api-keys") })

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -36,6 +36,16 @@ vi.mock('dompurify', () => {
 // Stub global window objects used in components
 global.window.scrollTo = vi.fn();
 
+// jsdom never implements window.isSecureContext, so it reads as undefined and
+// every component using the shared clipboard helper silently takes the
+// insecure-context (execCommand) path, which jsdom also lacks. Helix is served
+// over HTTPS/localhost in practice, so default the flag to true like real
+// deployments. Tests that exercise the insecure fallback redefine it per case.
+Object.defineProperty(window, 'isSecureContext', {
+  configurable: true,
+  value: true,
+});
+
 // Stub localStorage if not fully provided by jsdom
 if (!global.localStorage || typeof global.localStorage.clear !== 'function') {
   const store: Record<string, string> = {};

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -20,8 +20,12 @@ export async function copyTextToClipboard(text: string): Promise<void> {
   textArea.setAttribute('readonly', '')
   textArea.style.position = 'fixed'
   textArea.style.left = '-9999px'
+  textArea.style.top = '0'
+  textArea.style.opacity = '0'
   document.body.appendChild(textArea)
+  textArea.focus({ preventScroll: true })
   textArea.select()
+  textArea.setSelectionRange(0, text.length)
 
   try {
     if (!document.execCommand('copy')) {

--- a/frontend/src/utils/clipboardUsage.test.ts
+++ b/frontend/src/utils/clipboardUsage.test.ts
@@ -1,0 +1,32 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sourceRoot = resolve(process.cwd(), 'src')
+const allowedDirectClipboardFiles = new Set([
+  'components/external-agent/DesktopStreamViewer.tsx',
+  'utils/clipboard.ts',
+])
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return []
+    return [path]
+  })
+}
+
+describe('clipboard usage', () => {
+  it('routes ordinary text copies through the shared clipboard helper', () => {
+    const directWriteText = new RegExp(
+      ['navigator', 'clipboard', 'writeText'].join('\\s*\\.\\s*'),
+    )
+    const violations = sourceFiles(sourceRoot)
+      .map((path) => relative(sourceRoot, path))
+      .filter((path) => !allowedDirectClipboardFiles.has(path))
+      .filter((path) => directWriteText.test(readFileSync(resolve(sourceRoot, path), 'utf8')))
+
+    expect(violations).toEqual([])
+  })
+})

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3593,24 +3593,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - gitlab
-    - github
-    - local
-    - slack
-    - helix_events
     - webhook
-    - cron
+    - gitlab
+    - slack
     - email
+    - local
+    - helix_events
+    - cron
+    - github
     type: string
     x-enum-varnames:
-    - KindGitLab
-    - KindGitHub
-    - KindLocal
-    - KindSlack
-    - KindHelixEvents
     - KindWebhook
-    - KindCron
+    - KindGitLab
+    - KindSlack
     - KindEmail
+    - KindLocal
+    - KindHelixEvents
+    - KindCron
+    - KindGitHub
   transport.ResolvedActivation:
     properties:
       address:
@@ -8416,6 +8416,15 @@ definitions:
         items:
           type: string
         type: array
+      archive_stale_tasks_days:
+        description: Idle days before a stale task is archived
+        type: integer
+      archive_stale_tasks_enabled:
+        description: Archive tasks idle for ArchiveStaleTasksDays
+        type: boolean
+      auto_archive_completed_tasks:
+        description: Archive automation, reconciled by the spec task orchestrator
+        type: boolean
       auto_start_backlog_tasks:
         description: Automation settings
         type: boolean
@@ -8814,6 +8823,15 @@ definitions:
         items:
           type: string
         type: array
+      archive_stale_tasks_days:
+        description: Idle days before a stale task is archived (1-365)
+        type: integer
+      archive_stale_tasks_enabled:
+        description: Archive tasks idle for ArchiveStaleTasksDays
+        type: boolean
+      auto_archive_completed_tasks:
+        description: Archive tasks immediately when they enter Done
+        type: boolean
       auto_start_backlog_tasks:
         type: boolean
       code_agent_config:
@@ -23820,6 +23838,10 @@ paths:
       - description: Organization ID
         in: query
         name: org_id
+        type: string
+      - description: Filter by organization code-agent harness policy
+        in: query
+        name: code_agent_runtime
         type: string
       - description: Include all endpoints (system admin only)
         in: query

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3593,23 +3593,23 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - webhook
-    - gitlab
     - slack
-    - email
-    - local
-    - helix_events
     - cron
+    - gitlab
+    - local
+    - email
+    - webhook
+    - helix_events
     - github
     type: string
     x-enum-varnames:
-    - KindWebhook
-    - KindGitLab
     - KindSlack
-    - KindEmail
-    - KindLocal
-    - KindHelixEvents
     - KindCron
+    - KindGitLab
+    - KindLocal
+    - KindEmail
+    - KindWebhook
+    - KindHelixEvents
     - KindGitHub
   transport.ResolvedActivation:
     properties:
@@ -4041,12 +4041,14 @@ definitions:
     - spa
     - pdf
     - image
+    - markdown
     type: string
     x-enum-varnames:
     - ArtifactKindSingleFile
     - ArtifactKindSPA
     - ArtifactKindPDF
     - ArtifactKindImage
+    - ArtifactKindMarkdown
   types.ArtifactVersion:
     properties:
       artifact_id:
@@ -15712,8 +15714,8 @@ paths:
     put:
       consumes:
       - multipart/form-data
-      description: Patch metadata and optionally upload replacement HTML, PDF, image,
-        or ZIP content as a new version.
+      description: Patch metadata and optionally upload replacement HTML, Markdown,
+        PDF, or ZIP content as a new version.
       parameters:
       - description: Artifact ID
         in: path
@@ -15740,7 +15742,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: Replacement HTML, PDF, image, or ZIP content
+      - description: Replacement HTML, Markdown, PDF, or ZIP content
         in: formData
         name: artifact
         type: file
@@ -22406,8 +22408,8 @@ paths:
     post:
       consumes:
       - multipart/form-data
-      description: Upload one HTML, PDF, or image file, or a ZIP containing a compiled
-        static SPA.
+      description: Upload one HTML, Markdown, PDF, or image file, or a ZIP containing
+        a compiled static SPA.
       parameters:
       - description: Project ID
         in: path
@@ -22435,7 +22437,7 @@ paths:
         in: formData
         name: with_subdomain
         type: boolean
-      - description: HTML, PDF, image, or ZIP bundle
+      - description: HTML, Markdown, PDF, image, or ZIP bundle
         in: formData
         name: artifact
         required: true

--- a/openapi.json
+++ b/openapi.json
@@ -18331,6 +18331,14 @@
                         }
                     },
                     {
+                        "description": "Filter by organization code-agent harness policy",
+                        "name": "code_agent_runtime",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Include all endpoints (system admin only)",
                         "name": "all",
                         "in": "query",
@@ -33086,24 +33094,24 @@
             "transport.Kind": {
                 "type": "string",
                 "enum": [
-                    "gitlab",
-                    "github",
-                    "local",
-                    "slack",
-                    "helix_events",
                     "webhook",
+                    "gitlab",
+                    "slack",
+                    "email",
+                    "local",
+                    "helix_events",
                     "cron",
-                    "email"
+                    "github"
                 ],
                 "x-enum-varnames": [
-                    "KindGitLab",
-                    "KindGitHub",
-                    "KindLocal",
-                    "KindSlack",
-                    "KindHelixEvents",
                     "KindWebhook",
+                    "KindGitLab",
+                    "KindSlack",
+                    "KindEmail",
+                    "KindLocal",
+                    "KindHelixEvents",
                     "KindCron",
-                    "KindEmail"
+                    "KindGitHub"
                 ]
             },
             "transport.ResolvedActivation": {
@@ -39648,6 +39656,18 @@
                             "type": "string"
                         }
                     },
+                    "archive_stale_tasks_days": {
+                        "description": "Idle days before a stale task is archived",
+                        "type": "integer"
+                    },
+                    "archive_stale_tasks_enabled": {
+                        "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                        "type": "boolean"
+                    },
+                    "auto_archive_completed_tasks": {
+                        "description": "Archive automation, reconciled by the spec task orchestrator",
+                        "type": "boolean"
+                    },
                     "auto_start_backlog_tasks": {
                         "description": "Automation settings",
                         "type": "boolean"
@@ -40221,6 +40241,18 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "archive_stale_tasks_days": {
+                        "description": "Idle days before a stale task is archived (1-365)",
+                        "type": "integer"
+                    },
+                    "archive_stale_tasks_enabled": {
+                        "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                        "type": "boolean"
+                    },
+                    "auto_archive_completed_tasks": {
+                        "description": "Archive tasks immediately when they enter Done",
+                        "type": "boolean"
                     },
                     "auto_start_backlog_tasks": {
                         "type": "boolean"

--- a/openapi.json
+++ b/openapi.json
@@ -3287,7 +3287,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.",
                 "tags": [
                     "Artifacts"
                 ],
@@ -3330,7 +3330,7 @@
                                         "type": "boolean"
                                     },
                                     "artifact": {
-                                        "description": "Replacement HTML, PDF, image, or ZIP content",
+                                        "description": "Replacement HTML, Markdown, PDF, or ZIP content",
                                         "type": "string",
                                         "format": "binary"
                                     }
@@ -15809,7 +15809,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "tags": [
                     "Artifacts"
                 ],
@@ -15852,7 +15852,7 @@
                                         "type": "boolean"
                                     },
                                     "artifact": {
-                                        "description": "HTML, PDF, image, or ZIP bundle",
+                                        "description": "HTML, Markdown, PDF, image, or ZIP bundle",
                                         "type": "string",
                                         "format": "binary"
                                     }
@@ -33094,23 +33094,23 @@
             "transport.Kind": {
                 "type": "string",
                 "enum": [
-                    "webhook",
-                    "gitlab",
                     "slack",
-                    "email",
-                    "local",
-                    "helix_events",
                     "cron",
+                    "gitlab",
+                    "local",
+                    "email",
+                    "webhook",
+                    "helix_events",
                     "github"
                 ],
                 "x-enum-varnames": [
-                    "KindWebhook",
-                    "KindGitLab",
                     "KindSlack",
-                    "KindEmail",
-                    "KindLocal",
-                    "KindHelixEvents",
                     "KindCron",
+                    "KindGitLab",
+                    "KindLocal",
+                    "KindEmail",
+                    "KindWebhook",
+                    "KindHelixEvents",
                     "KindGitHub"
                 ]
             },
@@ -33737,13 +33737,15 @@
                     "single_file",
                     "spa",
                     "pdf",
-                    "image"
+                    "image",
+                    "markdown"
                 ],
                 "x-enum-varnames": [
                     "ArtifactKindSingleFile",
                     "ArtifactKindSPA",
                     "ArtifactKindPDF",
-                    "ArtifactKindImage"
+                    "ArtifactKindImage",
+                    "ArtifactKindMarkdown"
                 ]
             },
             "types.ArtifactVersion": {

--- a/swagger.json
+++ b/swagger.json
@@ -15432,6 +15432,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by organization code-agent harness policy",
+                        "name": "code_agent_runtime",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "Include all endpoints (system admin only)",
                         "name": "all",
@@ -28494,24 +28500,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "gitlab",
-                "github",
-                "local",
-                "slack",
-                "helix_events",
                 "webhook",
+                "gitlab",
+                "slack",
+                "email",
+                "local",
+                "helix_events",
                 "cron",
-                "email"
+                "github"
             ],
             "x-enum-varnames": [
-                "KindGitLab",
-                "KindGitHub",
-                "KindLocal",
-                "KindSlack",
-                "KindHelixEvents",
                 "KindWebhook",
+                "KindGitLab",
+                "KindSlack",
+                "KindEmail",
+                "KindLocal",
+                "KindHelixEvents",
                 "KindCron",
-                "KindEmail"
+                "KindGitHub"
             ]
         },
         "transport.ResolvedActivation": {
@@ -35056,6 +35062,18 @@
                         "type": "string"
                     }
                 },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive automation, reconciled by the spec task orchestrator",
+                    "type": "boolean"
+                },
                 "auto_start_backlog_tasks": {
                     "description": "Automation settings",
                     "type": "boolean"
@@ -35629,6 +35647,18 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "archive_stale_tasks_days": {
+                    "description": "Idle days before a stale task is archived (1-365)",
+                    "type": "integer"
+                },
+                "archive_stale_tasks_enabled": {
+                    "description": "Archive tasks idle for ArchiveStaleTasksDays",
+                    "type": "boolean"
+                },
+                "auto_archive_completed_tasks": {
+                    "description": "Archive tasks immediately when they enter Done",
+                    "type": "boolean"
                 },
                 "auto_start_backlog_tasks": {
                     "type": "boolean"

--- a/swagger.json
+++ b/swagger.json
@@ -2763,7 +2763,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Patch metadata and optionally upload replacement HTML, PDF, image, or ZIP content as a new version.",
+                "description": "Patch metadata and optionally upload replacement HTML, Markdown, PDF, or ZIP content as a new version.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -2814,7 +2814,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "Replacement HTML, PDF, image, or ZIP content",
+                        "description": "Replacement HTML, Markdown, PDF, or ZIP content",
                         "name": "artifact",
                         "in": "formData"
                     }
@@ -13334,7 +13334,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Upload one HTML, PDF, or image file, or a ZIP containing a compiled static SPA.",
+                "description": "Upload one HTML, Markdown, PDF, or image file, or a ZIP containing a compiled static SPA.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -13386,7 +13386,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "HTML, PDF, image, or ZIP bundle",
+                        "description": "HTML, Markdown, PDF, image, or ZIP bundle",
                         "name": "artifact",
                         "in": "formData",
                         "required": true
@@ -28500,23 +28500,23 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "gitlab",
                 "slack",
-                "email",
-                "local",
-                "helix_events",
                 "cron",
+                "gitlab",
+                "local",
+                "email",
+                "webhook",
+                "helix_events",
                 "github"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindGitLab",
                 "KindSlack",
-                "KindEmail",
-                "KindLocal",
-                "KindHelixEvents",
                 "KindCron",
+                "KindGitLab",
+                "KindLocal",
+                "KindEmail",
+                "KindWebhook",
+                "KindHelixEvents",
                 "KindGitHub"
             ]
         },
@@ -29143,13 +29143,15 @@
                 "single_file",
                 "spa",
                 "pdf",
-                "image"
+                "image",
+                "markdown"
             ],
             "x-enum-varnames": [
                 "ArtifactKindSingleFile",
                 "ArtifactKindSPA",
                 "ArtifactKindPDF",
-                "ArtifactKindImage"
+                "ArtifactKindImage",
+                "ArtifactKindMarkdown"
             ]
         },
         "types.ArtifactVersion": {


### PR DESCRIPTION
## Summary

- add project board automation settings for immediate event-driven archiving when a task enters Done and hourly cleanup of inactive tasks
- keep personal API keys stable across page refreshes and make regeneration an explicit delete/create operation
- show newly created organization API keys once in a setup dialog with copyable install and Helix CLI authentication examples
- route ordinary website copy actions through the shared insecure-context-safe clipboard helper

## Testing

- `go test ./pkg/services -count=1`
- `go test ./pkg/server -run 'TestGetAPIKeysReturnsStableLatestPersonalKey|TestPersonalAPIKeyRejectsScopedKeys' -count=1`
- `go build ./pkg/services ./pkg/server ./pkg/store ./pkg/types`
- `yarn test src/components/session/MarkdownCodeBlock.test.tsx src/components/account/ApiKeysSettings.test.tsx src/pages/OrgApiKeys.test.tsx src/services/userService.test.tsx src/utils/clipboardUsage.test.ts --run`
- `yarn tsc`
- `yarn build`
- live local Helix: verified board automation controls and settings round-trip, stable personal key refreshes, personal/org/dialog copy actions over plain HTTP, and CLI authentication with `helix organization list`
