### PR TITLE
Usability fixes for CLI

### DIFF
--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -46,8 +46,8 @@ func newCreateCommand() *cobra.Command {
 		Short: "Create an artifact from HTML, Markdown, a compiled SPA, PDF, or image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			projectID := firstNonEmpty(flags.projectID, os.Getenv("HELIX_PROJECT_ID"))
-			if projectID == "" {
+			projectRef := firstNonEmpty(flags.projectID, os.Getenv("HELIX_PROJECT_ID"))
+			if projectRef == "" {
 				return errors.New("project is required: pass --project or set HELIX_PROJECT_ID")
 			}
 			if strings.TrimSpace(flags.name) == "" {
@@ -66,6 +66,11 @@ func newCreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			project, err := cli.LookupProject(cmd.Context(), apiClient, projectRef, "")
+			if err != nil {
+				return err
+			}
+			projectID := project.ID
 			sourceSession, sourceTask := resolveArtifactProvenance(cmd, &flags, projectID)
 			name, description, entrypoint, withSubdomain := flags.name, flags.description, flags.entrypoint, flags.subdomain
 			artifact, err := apiClient.CreateArtifact(cmd.Context(), projectID, &client.ArtifactUploadRequest{
@@ -153,15 +158,19 @@ func newListCommand() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List artifacts in a project",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			projectID = firstNonEmpty(projectID, os.Getenv("HELIX_PROJECT_ID"))
-			if projectID == "" {
+			projectRef := firstNonEmpty(projectID, os.Getenv("HELIX_PROJECT_ID"))
+			if projectRef == "" {
 				return errors.New("project is required: pass --project or set HELIX_PROJECT_ID")
 			}
 			apiClient, err := newClient()
 			if err != nil {
 				return err
 			}
-			artifacts, err := apiClient.ListArtifacts(cmd.Context(), projectID)
+			project, err := cli.LookupProject(cmd.Context(), apiClient, projectRef, "")
+			if err != nil {
+				return err
+			}
+			artifacts, err := apiClient.ListArtifacts(cmd.Context(), project.ID)
 			if err != nil {
 				return err
 			}
@@ -181,7 +190,7 @@ func newListCommand() *cobra.Command {
 			return cli.RenderTable(table)
 		},
 	}
-	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Project ID (env: HELIX_PROJECT_ID)")
+	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Project ID or name (env: HELIX_PROJECT_ID)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print JSON")
 	return cmd
 }
@@ -229,7 +238,7 @@ func newDeleteCommand() *cobra.Command {
 
 func addUploadFlags(cmd *cobra.Command, flags *uploadFlags, includeProject bool) {
 	if includeProject {
-		cmd.Flags().StringVarP(&flags.projectID, "project", "p", "", "Project ID (env: HELIX_PROJECT_ID)")
+		cmd.Flags().StringVarP(&flags.projectID, "project", "p", "", "Project ID or name (env: HELIX_PROJECT_ID)")
 	}
 	cmd.Flags().StringVarP(&flags.name, "name", "n", "", "Artifact name")
 	cmd.Flags().StringVar(&flags.description, "description", "", "Artifact description")

--- a/api/pkg/cli/project_lookup.go
+++ b/api/pkg/cli/project_lookup.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// LookupProject resolves either a canonical project ID or an exact project
+// name. Without an organization reference it searches the caller's personal
+// projects and every organization they belong to. Duplicate names are rejected
+// so a command never silently targets the wrong project.
+func LookupProject(ctx context.Context, apiClient client.Client, projectRef, orgRef string) (*types.Project, error) {
+	projectRef = strings.TrimSpace(projectRef)
+	if projectRef == "" {
+		return nil, fmt.Errorf("project is required")
+	}
+	if strings.HasPrefix(projectRef, system.ProjectPrefix) {
+		project, err := apiClient.GetProject(ctx, projectRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get project %s: %w", projectRef, err)
+		}
+		return project, nil
+	}
+
+	projects := make([]*types.Project, 0)
+	if orgRef != "" {
+		org, err := LookupOrganization(ctx, apiClient, orgRef)
+		if err != nil {
+			return nil, err
+		}
+		orgProjects, err := apiClient.ListProjects(ctx, org.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list projects in %s: %w", org.Name, err)
+		}
+		projects = append(projects, orgProjects...)
+	} else {
+		personalProjects, err := apiClient.ListProjects(ctx, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list personal projects: %w", err)
+		}
+		projects = append(projects, personalProjects...)
+
+		organizations, err := apiClient.ListOrganizations(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list organizations: %w", err)
+		}
+		for _, org := range organizations {
+			orgProjects, err := apiClient.ListProjects(ctx, org.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list projects in %s: %w", org.Name, err)
+			}
+			projects = append(projects, orgProjects...)
+		}
+	}
+
+	matchesByID := make(map[string]*types.Project)
+	for _, project := range projects {
+		if project != nil && (project.Name == projectRef || project.ID == projectRef) {
+			matchesByID[project.ID] = project
+		}
+	}
+	if len(matchesByID) == 0 {
+		return nil, fmt.Errorf("project not found: %s", projectRef)
+	}
+	if len(matchesByID) == 1 {
+		for _, project := range matchesByID {
+			return project, nil
+		}
+	}
+
+	ids := make([]string, 0, len(matchesByID))
+	for id := range matchesByID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return nil, fmt.Errorf("project name %q is ambiguous; use one of these IDs: %s", projectRef, strings.Join(ids, ", "))
+}

--- a/api/pkg/cli/project_lookup_test.go
+++ b/api/pkg/cli/project_lookup_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/client"
+)
+
+func TestLookupProjectResolvesOrganizationProjectName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("organization_id") == "":
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/api/v1/organizations":
+			_, _ = w.Write([]byte(`[{"id":"org_test","name":"Acme"}]`))
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("organization_id") == "org_test":
+			_, _ = w.Write([]byte(`[{"id":"prj_test","name":"CLI project","organization_id":"org_test"}]`))
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	apiClient, err := client.NewClient(server.URL, "test-token", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, err := LookupProject(t.Context(), apiClient, "CLI project", "")
+	if err != nil {
+		t.Fatalf("LookupProject returned an error: %v", err)
+	}
+	if project.ID != "prj_test" {
+		t.Fatalf("project ID = %q, want prj_test", project.ID)
+	}
+}
+
+func TestLookupProjectRejectsAmbiguousNames(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("organization_id") == "":
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/api/v1/organizations":
+			_, _ = w.Write([]byte(`[{"id":"org_a","name":"A"},{"id":"org_b","name":"B"}]`))
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("organization_id") == "org_a":
+			_, _ = w.Write([]byte(`[{"id":"prj_a","name":"Duplicate"}]`))
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("organization_id") == "org_b":
+			_, _ = w.Write([]byte(`[{"id":"prj_b","name":"Duplicate"}]`))
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	apiClient, err := client.NewClient(server.URL, "test-token", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LookupProject(t.Context(), apiClient, "Duplicate", "")
+	if err == nil || !containsAll(err.Error(), "ambiguous", "prj_a", "prj_b") {
+		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+}
+
+func containsAll(value string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(value, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/api/pkg/cli/secret/create.go
+++ b/api/pkg/cli/secret/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -16,7 +17,7 @@ func init() {
 	createCmd.Flags().StringP("name", "n", "", "Name of the secret")
 	createCmd.Flags().StringP("value", "v", "", "Value of the secret")
 	createCmd.Flags().StringP("app-id", "a", "", "App ID to associate the secret with")
-	createCmd.Flags().StringP("project", "p", "", "Project ID to associate the secret with (injected as env var in project sessions)")
+	createCmd.Flags().StringP("project", "p", "", "Project ID or name to associate the secret with (injected as env var in project sessions)")
 	_ = createCmd.MarkFlagRequired("name")
 }
 
@@ -46,13 +47,21 @@ var createCmd = &cobra.Command{
 		}
 
 		secret := &types.CreateSecretRequest{
-			Name:      name,
-			Value:     value,
-			AppID:     appID,
-			ProjectID: projectID,
+			Name:  name,
+			Value: value,
+			AppID: appID,
 		}
 
-		_, err = apiClient.CreateSecret(cmd.Context(), secret)
+		if projectID != "" {
+			project, resolveErr := cli.LookupProject(cmd.Context(), apiClient, projectID, "")
+			if resolveErr != nil {
+				return resolveErr
+			}
+			projectID = project.ID
+			_, err = apiClient.CreateProjectSecret(cmd.Context(), projectID, secret)
+		} else {
+			_, err = apiClient.CreateSecret(cmd.Context(), secret)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to create secret: %w", err)
 		}

--- a/api/pkg/cli/secret/delete.go
+++ b/api/pkg/cli/secret/delete.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().StringP("name", "n", "", "Name of the secret to delete")
+	deleteCmd.Flags().StringP("project", "p", "", "Project ID or name containing the secret")
 }
 
 var deleteCmd = &cobra.Command{
@@ -22,6 +25,7 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Look for either name or first arg
 		name, _ := cmd.Flags().GetString("name")
+		projectRef, _ := cmd.Flags().GetString("project")
 		if name == "" {
 			if len(args) > 0 {
 				name = args[0]
@@ -38,8 +42,16 @@ var deleteCmd = &cobra.Command{
 			return err
 		}
 
-		// Fetch the list of secrets
-		secrets, err := apiClient.ListSecrets(cmd.Context(), nil)
+		var secrets []*types.Secret
+		if projectRef != "" {
+			project, resolveErr := cli.LookupProject(cmd.Context(), apiClient, projectRef, "")
+			if resolveErr != nil {
+				return resolveErr
+			}
+			secrets, err = apiClient.ListProjectSecrets(cmd.Context(), project.ID)
+		} else {
+			secrets, err = apiClient.ListSecrets(cmd.Context(), nil)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to fetch secrets: %w", err)
 		}

--- a/api/pkg/cli/secret/list.go
+++ b/api/pkg/cli/secret/list.go
@@ -9,12 +9,15 @@ import (
 
 	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 var orgFlag string
+var projectFlag string
 
 func init() {
 	listCmd.Flags().StringVarP(&orgFlag, "org", "o", "", "Organization name or ID (env: HELIX_ORG). Lists org-owned secrets instead of personal secrets.")
+	listCmd.Flags().StringVarP(&projectFlag, "project", "p", "", "Project ID or name. Lists secrets injected into that project's sessions.")
 	rootCmd.AddCommand(listCmd)
 }
 
@@ -25,38 +28,55 @@ var listCmd = &cobra.Command{
 	Long: `List helix secrets.
 
 By default lists the current user's personal secrets. Pass --org to list
-secrets owned by an organization instead. The HELIX_ORG environment
-variable is honoured if --org is not given but you want org-scoped results.`,
+secrets owned by an organization, or --project to list project-scoped secrets.
+The HELIX_ORG environment variable is also used to resolve a project name.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		apiClient, err := client.NewClientFromEnv()
 		if err != nil {
 			return err
 		}
 
-		var filter *client.SecretFilter
 		orgRef := orgFlag
 		if orgRef == "" {
 			orgRef = os.Getenv("HELIX_ORG")
 		}
-		if orgRef != "" {
+		if projectFlag != "" && cmd.Flags().Changed("org") {
+			return fmt.Errorf("--project and --org are mutually exclusive")
+		}
+
+		var secrets []*types.Secret
+		if projectFlag != "" {
+			project, err := cli.LookupProject(cmd.Context(), apiClient, projectFlag, orgRef)
+			if err != nil {
+				return err
+			}
+			secrets, err = apiClient.ListProjectSecrets(cmd.Context(), project.ID)
+			if err != nil {
+				return fmt.Errorf("failed to list project secrets: %w", err)
+			}
+		} else if orgRef != "" {
 			org, err := cli.LookupOrganization(cmd.Context(), apiClient, orgRef)
 			if err != nil {
 				return err
 			}
-			filter = &client.SecretFilter{OrganizationID: org.ID}
+			secrets, err = apiClient.ListSecrets(cmd.Context(), &client.SecretFilter{OrganizationID: org.ID})
+			if err != nil {
+				return fmt.Errorf("failed to list secrets: %w", err)
+			}
+		} else {
+			secrets, err = apiClient.ListSecrets(cmd.Context(), nil)
+			if err != nil {
+				return fmt.Errorf("failed to list secrets: %w", err)
+			}
 		}
 
-		secrets, err := apiClient.ListSecrets(cmd.Context(), filter)
-		if err != nil {
-			return fmt.Errorf("failed to list secrets: %w", err)
-		}
-
-		table := cli.NewSimpleTable(cmd.OutOrStdout(), []string{"Name", "App ID", "Created", "Updated"})
+		table := cli.NewSimpleTable(cmd.OutOrStdout(), []string{"Name", "App ID", "Project ID", "Created", "Updated"})
 
 		for _, s := range secrets {
 			row := []string{
 				s.Name,
 				s.AppID,
+				s.ProjectID,
 				s.Created.Format(time.RFC3339),
 				s.Updated.Format(time.RFC3339),
 			}

--- a/api/pkg/cli/secret/update.go
+++ b/api/pkg/cli/secret/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -16,6 +17,7 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 	updateCmd.Flags().StringP("name", "n", "", "Name of the secret")
 	updateCmd.Flags().StringP("value", "v", "", "New value of the secret")
+	updateCmd.Flags().StringP("project", "p", "", "Project ID or name containing the secret")
 	_ = updateCmd.MarkFlagRequired("name")
 }
 
@@ -26,6 +28,7 @@ var updateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		value, _ := cmd.Flags().GetString("value")
+		projectRef, _ := cmd.Flags().GetString("project")
 
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -54,8 +57,16 @@ var updateCmd = &cobra.Command{
 
 		var existingSecret types.Secret
 
-		// Fetch the existing secret
-		secrets, err := apiClient.ListSecrets(cmd.Context(), nil)
+		var secrets []*types.Secret
+		if projectRef != "" {
+			project, resolveErr := cli.LookupProject(cmd.Context(), apiClient, projectRef, "")
+			if resolveErr != nil {
+				return resolveErr
+			}
+			secrets, err = apiClient.ListProjectSecrets(cmd.Context(), project.ID)
+		} else {
+			secrets, err = apiClient.ListSecrets(cmd.Context(), nil)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to fetch existing secret: %w", err)
 		}

--- a/api/pkg/cli/spectask/files_cmd.go
+++ b/api/pkg/cli/spectask/files_cmd.go
@@ -25,8 +25,11 @@ func newFilesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "files <session-id>",
 		Short: "List files in a session's workspace",
-		Long: `List the files in a running session container's workspace (the same
-listing the web UI Files browser shows).
+		Long: `List files below a running session's /home/retro/work directory.
+
+This includes Git checkouts and sibling output directories created by the
+agent. Pass --workspace to restrict the listing to one repository's tracked and
+non-ignored files.
 
 Examples:
   helix spectask files ses_01xxx
@@ -42,6 +45,8 @@ Examples:
 			u := fmt.Sprintf("%s/api/v1/external-agents/%s/workspace-files", apiURL, sessionID)
 			if workspace != "" {
 				u += "?workspace=" + url.QueryEscape(workspace)
+			} else {
+				u += "?root=work"
 			}
 			body, err := workspaceGET(u, token)
 			if err != nil {
@@ -70,7 +75,7 @@ Examples:
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&workspace, "workspace", "", "Workspace/repo name (default: primary)")
+	cmd.Flags().StringVar(&workspace, "workspace", "", "Restrict listing to a workspace/repo name (default: full /home/retro/work tree)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print JSON")
 	return cmd
 }
@@ -86,11 +91,12 @@ func newDownloadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download <session-id> <remote-path>",
 		Short: "Download a file from a session's workspace",
-		Long: `Download a file from a running session container's workspace.
+		Long: `Download a file from a running session container's /home/retro/work directory.
 
-<remote-path> is relative to the workspace root. By default the file is written
-to the current directory under its base name; use -o to choose a path, or -o -
-to stream to stdout.
+<remote-path> is relative to /home/retro/work, so files beside repository
+checkouts are directly reachable. Pass --workspace to make it relative to one
+repository instead. By default the file is written to the current directory
+under its base name; use -o to choose a path, or -o - to stream to stdout.
 
 Examples:
   helix spectask download ses_01xxx engagement/findings.json
@@ -108,6 +114,8 @@ Examples:
 			q.Set("path", remotePath)
 			if workspace != "" {
 				q.Set("workspace", workspace)
+			} else {
+				q.Set("root", "work")
 			}
 			u := fmt.Sprintf("%s/api/v1/external-agents/%s/workspace-file/download?%s", apiURL, sessionID, q.Encode())
 			body, err := workspaceGET(u, token)
@@ -129,7 +137,7 @@ Examples:
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&workspace, "workspace", "", "Workspace/repo name (default: primary)")
+	cmd.Flags().StringVar(&workspace, "workspace", "", "Resolve the remote path inside this workspace/repo (default: /home/retro/work)")
 	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Local output path (default: base name; '-' for stdout)")
 	return cmd
 }

--- a/api/pkg/cli/spectask/mcp_cmd.go
+++ b/api/pkg/cli/spectask/mcp_cmd.go
@@ -609,7 +609,7 @@ Examples:
 			// Pinned to the desktop runtime: step 5 screenshots the session, which
 			// a headless project default would not provide.
 			task, err := createSpecTask(apiURL, token, "E2E Test Task", taskPrompt, projectID,
-				string(types.SandboxRuntimeUbuntuDesktop))
+				string(types.SandboxRuntimeUbuntuDesktop), false)
 			if err != nil {
 				return fmt.Errorf("failed to create task: %w", err)
 			}

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -84,14 +84,17 @@ func newStartCommand() *cobra.Command {
 	var quiet bool
 	var wait bool
 	var noWait bool
+	var justDoIt bool
 
 	cmd := &cobra.Command{
 		Use:   "start [task-id]",
-		Short: "Start a spec task planning session (creates sandbox)",
-		Long: `Start a spec task planning session which creates a sandbox.
+		Short: "Start a spec task agent session (creates sandbox)",
+		Long: `Start a spec task agent session which creates a sandbox.
 
 If no task-id is provided, a new spec task will be created.
 Use --project to specify which project to create the task in.
+Use --just-do-it when the prompt is already a complete brief and the agent
+should begin implementation without a spec-writing and approval phase.
 Use --runtime to pick the sandbox environment:
   ubuntu-desktop   full GNOME desktop you can stream and screenshot (default)
   headless-ubuntu  agent-only, no compositor or streaming — faster and cheaper
@@ -121,6 +124,11 @@ Example workflow:
 				if runtime != "" {
 					return fmt.Errorf("--runtime can only be set when creating a task; %s already has a fixed runtime", taskID)
 				}
+				if justDoIt {
+					if _, err := setSpecTaskJustDoIt(apiURL, token, taskID); err != nil {
+						return fmt.Errorf("failed to enable just-do-it mode: %w", err)
+					}
+				}
 			} else {
 				// Create a new spec task
 				if projectID == "" {
@@ -145,9 +153,9 @@ Example workflow:
 					}
 				}
 				if taskPrompt == "" {
-					taskPrompt = "Testing RevDial connectivity"
+					taskPrompt = "Complete the requested task"
 				}
-				task, err := createSpecTask(apiURL, token, taskName, taskPrompt, projectID, runtime)
+				task, err := createSpecTask(apiURL, token, taskName, taskPrompt, projectID, runtime, justDoIt)
 				if err != nil {
 					return fmt.Errorf("failed to create spec task: %w", err)
 				}
@@ -169,9 +177,10 @@ Example workflow:
 				}
 			}
 
-			// Start planning - this triggers async session creation
+			// Start the task agent. The server selects planning or direct
+			// implementation according to the task's just-do-it mode.
 			if !quiet {
-				fmt.Printf("Starting planning for task %s...\n", taskID)
+				fmt.Printf("Starting agent for task %s...\n", taskID)
 			}
 			task, err := triggerStartPlanning(apiURL, token, taskID)
 			if err != nil {
@@ -193,7 +202,7 @@ Example workflow:
 				if quiet {
 					fmt.Println(taskID)
 				} else {
-					fmt.Printf("\n✅ Task created — planning started: %s\n", taskID)
+					fmt.Printf("\n✅ Task agent started: %s\n", taskID)
 					if taskURL := buildTaskURL(apiURL, task, projectID); taskURL != "" {
 						fmt.Printf("   Open in browser: %s\n", taskURL)
 					}
@@ -263,6 +272,8 @@ Example workflow:
 	cmd.Flags().StringVar(&runtime, "runtime", "", "Sandbox environment for the new task: ubuntu-desktop (streamable GNOME desktop) or headless-ubuntu (agent only, no desktop). Empty = project default. Immutable once the task exists.")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output the task ID (session ID with --wait)")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Block until the sandbox has booted, then print session-level connect info (default: return immediately with the task URL — the browser page shows it loading)")
+	cmd.Flags().BoolVar(&justDoIt, "just-do-it", false, "Skip spec planning and go straight to implementation")
+	cmd.Flags().Bool("auto-start", false, "Start immediately (already the behavior of this command; accepted for create-command parity)")
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Deprecated: no-wait is now the default; kept as a no-op for back-compat")
 	_ = cmd.Flags().MarkHidden("no-wait")
 
@@ -383,7 +394,7 @@ func newStopCommand() *cobra.Command {
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "stop <session-id>",
+		Use:   "stop <session-id|task-id>",
 		Short: "Stop a running sandbox session",
 		Long: `Stops a running sandbox session and its container.
 
@@ -391,6 +402,7 @@ Use --all to stop all sessions with external agents.
 
 Examples:
   helix spectask stop ses_01xxx      # Stop specific session
+  helix spectask stop spt_01xxx      # Stop a task, or no-op if it is not running
   helix spectask stop --all          # Stop all sessions
 `,
 		Args: cobra.MaximumNArgs(1),
@@ -406,14 +418,45 @@ Examples:
 				return fmt.Errorf("session ID required (or use --all)")
 			}
 
-			sessionID := args[0]
-			return stopSession(apiURL, token, sessionID)
+			id := args[0]
+			if strings.HasPrefix(id, "spt_") {
+				return stopSpecTask(apiURL, token, id)
+			}
+			return stopSession(apiURL, token, id)
 		},
 	}
 
 	cmd.Flags().BoolVar(&all, "all", false, "Stop all sessions with external agents")
 
 	return cmd
+}
+
+func stopSpecTask(apiURL, token, taskID string) error {
+	url := fmt.Sprintf("%s/api/v1/spec-tasks/%s/stop-agent", apiURL, taskID)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to stop task agent: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("stop failed: %d - %s", resp.StatusCode, string(body))
+	}
+	var task SpecTask
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return fmt.Errorf("decode stopped task: %w", err)
+	}
+	if task.PlanningSessionID == "" {
+		fmt.Printf("Task %s is not running; nothing to stop.\n", taskID)
+	} else {
+		fmt.Printf("Task %s agent stopped.\n", taskID)
+	}
+	return nil
 }
 
 func stopSession(apiURL, token, sessionID string) error {
@@ -504,6 +547,7 @@ type SpecTask struct {
 	ProjectID         string               `json:"project_id"`
 	PlanningSessionID string               `json:"planning_session_id"`
 	SandboxRuntime    types.SandboxRuntime `json:"sandbox_runtime"`
+	JustDoItMode      bool                 `json:"just_do_it_mode"`
 }
 
 // buildTaskURL returns the frontend task-detail page URL, which is known the
@@ -540,17 +584,13 @@ type SessionMetadata struct {
 	StatusMessage   string `json:"status_message"`
 }
 
-func createSpecTask(apiURL, token, name, prompt, projectID, runtime string) (*SpecTask, error) {
-	payload := map[string]string{
-		"name":   name,
-		"prompt": prompt, // API expects "prompt" not "description"
-	}
-	if projectID != "" {
-		payload["project_id"] = projectID
-	}
-	// Omitted means "inherit the project default" — the server resolves it.
-	if runtime != "" {
-		payload["sandbox_runtime"] = runtime
+func createSpecTask(apiURL, token, name, prompt, projectID, runtime string, justDoIt bool) (*SpecTask, error) {
+	payload := types.CreateTaskRequest{
+		Name:           name,
+		Prompt:         prompt,
+		ProjectID:      projectID,
+		SandboxRuntime: types.SandboxRuntime(runtime),
+		JustDoItMode:   justDoIt,
 	}
 	jsonData, _ := json.Marshal(payload)
 
@@ -579,6 +619,36 @@ func createSpecTask(apiURL, token, name, prompt, projectID, runtime string) (*Sp
 		return nil, err
 	}
 
+	return &task, nil
+}
+
+func setSpecTaskJustDoIt(apiURL, token, taskID string) (*SpecTask, error) {
+	enabled := true
+	payload := types.SpecTaskUpdateRequest{JustDoItMode: &enabled}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/api/v1/spec-tasks/%s", apiURL, taskID)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
+	}
+	var task SpecTask
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, err
+	}
 	return &task, nil
 }
 

--- a/api/pkg/cli/spectask/spectask_test.go
+++ b/api/pkg/cli/spectask/spectask_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -72,7 +73,7 @@ func TestCreateSpecTaskPayloadContainsNoAppIdentity(t *testing.T) {
 	}))
 	defer server.Close()
 
-	task, err := createSpecTask(server.URL, "test-token", "test", "prompt", "prj_test", "headless-ubuntu")
+	task, err := createSpecTask(server.URL, "test-token", "test", "prompt", "prj_test", "headless-ubuntu", true)
 	if err != nil {
 		t.Fatalf("createSpecTask returned an error: %v", err)
 	}
@@ -88,5 +89,71 @@ func TestCreateSpecTaskPayloadContainsNoAppIdentity(t *testing.T) {
 	}
 	if payload["project_id"] != "prj_test" {
 		t.Fatalf("project_id missing from payload: %#v", payload)
+	}
+	if payload["just_do_it_mode"] != true {
+		t.Fatalf("just_do_it_mode missing from payload: %#v", payload)
+	}
+}
+
+func TestStartAcceptsDirectImplementationFlags(t *testing.T) {
+	command := newStartCommand()
+	for _, name := range []string{"just-do-it", "auto-start"} {
+		if command.Flags().Lookup(name) == nil {
+			t.Fatalf("start command is missing --%s", name)
+		}
+	}
+}
+
+func TestStopSpecTaskNoOpsWhenTaskHasNoSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/spec-tasks/spt_test/stop-agent" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"spt_test","planning_session_id":""}`))
+	}))
+	defer server.Close()
+
+	if err := stopSpecTask(server.URL, "test-token", "spt_test"); err != nil {
+		t.Fatalf("stopSpecTask returned an error: %v", err)
+	}
+}
+
+func TestQueueSessionMessageReturnsImmediately(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/sessions/ses_test/messages" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"prompt_id":"prm_test"}`))
+	}))
+	defer server.Close()
+
+	output, err := queueSessionMessage(server.URL, "test-token", "ses_test", "collect files")
+	if err != nil {
+		t.Fatalf("queueSessionMessage returned an error: %v", err)
+	}
+	if !output.Delivered || output.PromptID != "prm_test" {
+		t.Fatalf("unexpected output: %#v", output)
+	}
+}
+
+func TestSendWaitTimeoutIsSuccessfulDelivery(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+
+	output, err := sendSessionMessageAndWait(server.URL, "test-token", "ses_test", "collect files", 10*time.Millisecond)
+	if err != nil {
+		close(release)
+		t.Fatalf("timeout should be a successful delivery outcome: %v", err)
+	}
+	close(release)
+	if !output.Delivered || !output.StillRunning {
+		t.Fatalf("unexpected output: %#v", output)
 	}
 }

--- a/api/pkg/cli/spectask/test_cmd.go
+++ b/api/pkg/cli/spectask/test_cmd.go
@@ -17,10 +17,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// isTimeoutErr reports whether an HTTP request failed because our own client
-// deadline expired, as opposed to never reaching the server. The two demand
-// opposite responses: a timeout means the request is in flight and must not be
-// re-sent, while an unreachable server can be retried safely.
+// isTimeoutErr reports whether an HTTP request exceeded the caller's wait
+// budget. A synchronous chat request must not be retried after this point,
+// because the server may still be processing the delivered turn.
 func isTimeoutErr(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
 		return true
@@ -478,22 +477,60 @@ func outputHuman(suite *TestSuite) error {
 	return nil
 }
 
-// Script-friendly command for sending a message and waiting for response
+type queuedSessionMessageRequest struct {
+	Content string `json:"content"`
+}
+
+type queuedSessionMessageResponse struct {
+	PromptID string `json:"prompt_id"`
+}
+
+type blockingChatRequest struct {
+	SessionID string                `json:"session_id"`
+	Messages  []blockingChatMessage `json:"messages"`
+	Stream    bool                  `json:"stream"`
+}
+
+type blockingChatMessage struct {
+	Role    string              `json:"role"`
+	Content blockingChatContent `json:"content"`
+}
+
+type blockingChatContent struct {
+	ContentType string   `json:"content_type"`
+	Parts       []string `json:"parts"`
+}
+
+type blockingChatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+type sendCommandOutput struct {
+	PromptID     string `json:"prompt_id,omitempty"`
+	Delivered    bool   `json:"delivered"`
+	StillRunning bool   `json:"still_running,omitempty"`
+	Response     string `json:"response,omitempty"`
+}
+
+// Script-friendly command for sending a message and optionally waiting for response.
 func newSendCommand() *cobra.Command {
 	var waitForComplete bool
-	var pollInterval int
 	var maxWait int
 	var jsonOutput bool
+	var quiet bool
 
 	cmd := &cobra.Command{
 		Use:   "send <session-id|task-id> <message>",
 		Short: "Send a message to a session and optionally wait for completion",
-		Long: `Send a message to a session for scripted testing.
+		Long: `Queue a message for a session and return immediately by default.
 
-This command is designed for scripted/automated testing:
-  - Sends a message to the session
-  - Optionally waits for the agent to complete processing
-  - Returns structured output suitable for parsing
+The default path uses Helix's durable prompt queue, so the message remains
+pending while the agent is busy or reconnecting. Pass --wait to use the
+synchronous chat path and wait for the reply.
 
 Examples:
   # Send and immediately return
@@ -510,155 +547,136 @@ Examples:
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if waitForComplete && maxWait <= 0 {
+				return fmt.Errorf("--max-wait must be greater than zero")
+			}
 			sessionID, err := resolveSessionID(args[0])
 			if err != nil {
 				return err
 			}
-			message := args[1]
-			apiURL := getAPIURL()
-			token := getToken()
-
-			// Send the message with retry for session not ready
-			chatURL := fmt.Sprintf("%s/api/v1/sessions/chat", apiURL)
-			deadline := time.Now().Add(time.Duration(maxWait) * time.Second)
-
-			var body []byte
-			var response map[string]interface{}
-
-			for time.Now().Before(deadline) {
-				payload := map[string]interface{}{
-					"session_id": sessionID,
-					"messages": []map[string]interface{}{
-						{
-							"role": "user",
-							"content": map[string]interface{}{
-								"content_type": "text",
-								"parts":        []string{message},
-							},
-						},
-					},
-					"stream": false,
-				}
-				jsonData, _ := json.Marshal(payload)
-
-				req, err := http.NewRequest("POST", chatURL, bytes.NewBuffer(jsonData))
+			message, apiURL, token := args[1], getAPIURL(), getToken()
+			if !waitForComplete {
+				output, err := queueSessionMessage(apiURL, token, sessionID, message)
 				if err != nil {
 					return err
 				}
-				req.Header.Set("Authorization", "Bearer "+token)
-				req.Header.Set("Content-Type", "application/json")
-
-				// /sessions/chat is blocking for zed_external sessions: it holds
-				// the connection for the whole agent turn, which is routinely
-				// minutes. Give the request the rest of our budget rather than a
-				// fixed 30s, or the client gives up mid-turn.
-				client := &http.Client{Timeout: time.Until(deadline)}
-				resp, err := client.Do(req)
-				if err != nil {
-					// A timeout means the POST was already delivered and the agent
-					// is working on it — retrying would send the user's message a
-					// second time. Only a failure to reach the server at all is
-					// safe to retry.
-					if isTimeoutErr(err) {
-						return fmt.Errorf("timed out after %ds waiting for the agent's reply; "+
-							"the message was delivered and the turn is still running "+
-							"(raise --max-wait, or poll the session instead): %w", maxWait, err)
-					}
-					fmt.Fprintf(os.Stderr, "Waiting for session to be ready...\n")
-					time.Sleep(5 * time.Second)
-					continue
-				}
-
-				body, _ = io.ReadAll(resp.Body)
-				resp.Body.Close()
-
-				if resp.StatusCode == http.StatusOK {
-					break
-				}
-
-				// Retry on 5xx errors (session not ready)
-				if resp.StatusCode >= 500 {
-					fmt.Fprintf(os.Stderr, "Waiting for session to be ready...\n")
-					time.Sleep(5 * time.Second)
-					continue
-				}
-
-				return fmt.Errorf("chat API returned %d: %s", resp.StatusCode, string(body))
+				return printSendCommandOutput(cmd, output, jsonOutput, quiet)
 			}
 
-			if err := json.Unmarshal(body, &response); err != nil {
-				// Might be plain text response
-				response = map[string]interface{}{
-					"response": strings.TrimSpace(string(body)),
-				}
+			output, err := sendSessionMessageAndWait(apiURL, token, sessionID, message, time.Duration(maxWait)*time.Second)
+			if err != nil {
+				return err
 			}
-
-			if waitForComplete {
-				// Poll for session to become idle
-				fmt.Fprintf(os.Stderr, "Waiting for agent to complete...\n")
-				ticker := time.NewTicker(time.Duration(pollInterval) * time.Second)
-				defer ticker.Stop()
-
-				timeout := time.After(time.Duration(maxWait) * time.Second)
-
-				for {
-					select {
-					case <-timeout:
-						return fmt.Errorf("timeout waiting for agent to complete")
-					case <-ticker.C:
-						session, err := getSessionDetails(apiURL, token, sessionID)
-						if err != nil {
-							continue
-						}
-						// Check if agent is still working
-						if session.Mode != "action" {
-							goto done
-						}
-					}
-				}
-			done:
-				// Fetch the latest interaction to get the actual response
-				historyURL := fmt.Sprintf("%s/api/v1/sessions/%s/interactions", apiURL, sessionID)
-				req, err := http.NewRequest("GET", historyURL, nil)
-				if err == nil {
-					req.Header.Set("Authorization", "Bearer "+token)
-					if resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req); err == nil {
-						defer resp.Body.Close()
-						if body, err := io.ReadAll(resp.Body); err == nil {
-							var interactions []map[string]interface{}
-							if json.Unmarshal(body, &interactions) == nil && len(interactions) > 0 {
-								// Get the last interaction's response_message
-								lastInteraction := interactions[len(interactions)-1]
-								if msg, ok := lastInteraction["response_message"].(string); ok && msg != "" {
-									response["response"] = msg
-								}
-							}
-						}
-					}
-				}
-			}
-
-			if jsonOutput {
-				encoder := json.NewEncoder(os.Stdout)
-				encoder.SetIndent("", "  ")
-				return encoder.Encode(response)
-			}
-
-			// Human output
-			if respText, ok := response["response"].(string); ok {
-				fmt.Printf("%s\n", respText)
-			} else {
-				fmt.Printf("%v\n", response)
-			}
-
-			return nil
+			return printSendCommandOutput(cmd, output, jsonOutput, quiet)
 		},
 	}
 
 	cmd.Flags().BoolVar(&waitForComplete, "wait", false, "Wait for agent to complete processing")
-	cmd.Flags().IntVar(&pollInterval, "poll", 2, "Poll interval in seconds when waiting")
 	cmd.Flags().IntVar(&maxWait, "max-wait", 300, "Maximum wait time in seconds")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress confirmation output")
+	cmd.Flags().Int("poll", 2, "Deprecated: --wait no longer polls")
+	_ = cmd.Flags().MarkDeprecated("poll", "--wait now uses the synchronous response directly")
 
 	return cmd
+}
+
+func queueSessionMessage(apiURL, token, sessionID, message string) (*sendCommandOutput, error) {
+	payload, err := json.Marshal(queuedSessionMessageRequest{Content: message})
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/api/v1/sessions/%s/messages", apiURL, sessionID)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to queue message: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read queue response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("message API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var queued queuedSessionMessageResponse
+	if err := json.Unmarshal(body, &queued); err != nil {
+		return nil, fmt.Errorf("decode queue response: %w", err)
+	}
+	return &sendCommandOutput{PromptID: queued.PromptID, Delivered: true}, nil
+}
+
+func sendSessionMessageAndWait(apiURL, token, sessionID, message string, timeout time.Duration) (*sendCommandOutput, error) {
+	payload, err := json.Marshal(blockingChatRequest{
+		SessionID: sessionID,
+		Messages: []blockingChatMessage{{
+			Role:    "user",
+			Content: blockingChatContent{ContentType: "text", Parts: []string{message}},
+		}},
+		Stream: false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, apiURL+"/api/v1/sessions/chat", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		if isTimeoutErr(err) {
+			return &sendCommandOutput{Delivered: true, StillRunning: true}, nil
+		}
+		return nil, fmt.Errorf("failed to send message: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read chat response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("chat API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var chatResponse blockingChatResponse
+	if err := json.Unmarshal(body, &chatResponse); err != nil {
+		return nil, fmt.Errorf("decode chat response: %w", err)
+	}
+	responseText := ""
+	if len(chatResponse.Choices) > 0 {
+		responseText = chatResponse.Choices[0].Message.Content
+	}
+	return &sendCommandOutput{Delivered: true, Response: responseText}, nil
+}
+
+func printSendCommandOutput(cmd *cobra.Command, output *sendCommandOutput, jsonOutput, quiet bool) error {
+	if quiet {
+		return nil
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(output)
+	}
+	if output.StillRunning {
+		fmt.Fprintln(cmd.OutOrStdout(), "Message delivered; the agent is still running.")
+		return nil
+	}
+	if output.Response != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), output.Response)
+		return nil
+	}
+	if output.PromptID != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Message queued (%s).\n", output.PromptID)
+		return nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Message delivered.")
+	return nil
 }

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	SearchKnowledge(ctx context.Context, f *KnowledgeSearchQuery) ([]*types.KnowledgeSearchResult, error)
 
 	ListSecrets(ctx context.Context, f *SecretFilter) ([]*types.Secret, error)
+	ListProjectSecrets(ctx context.Context, projectID string) ([]*types.Secret, error)
 	CreateSecret(ctx context.Context, secret *types.CreateSecretRequest) (*types.Secret, error)
 	CreateProjectSecret(ctx context.Context, projectID string, secret *types.CreateSecretRequest) (*types.Secret, error)
 	UpdateSecret(ctx context.Context, id string, secret *types.Secret) (*types.Secret, error)
@@ -92,6 +93,8 @@ type Client interface {
 
 	// Projects
 	ApplyProject(ctx context.Context, req *types.ProjectApplyRequest) (*types.ProjectApplyResponse, error)
+	GetProject(ctx context.Context, projectID string) (*types.Project, error)
+	ListProjects(ctx context.Context, organizationID string) ([]*types.Project, error)
 
 	// Project artifacts
 	ListArtifacts(ctx context.Context, projectID string) ([]*types.Artifact, error)

--- a/api/pkg/client/project.go
+++ b/api/pkg/client/project.go
@@ -5,9 +5,34 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 
 	"github.com/helixml/helix/api/pkg/types"
 )
+
+// GetProject returns one project by its canonical ID.
+func (c *HelixClient) GetProject(ctx context.Context, projectID string) (*types.Project, error) {
+	var project types.Project
+	if err := c.makeRequest(ctx, http.MethodGet, "/projects/"+url.PathEscape(projectID), nil, &project); err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+// ListProjects returns the caller's personal projects, or their visible
+// projects in organizationID when it is set.
+func (c *HelixClient) ListProjects(ctx context.Context, organizationID string) ([]*types.Project, error) {
+	path := "/projects"
+	if organizationID != "" {
+		path += "?organization_id=" + url.QueryEscape(organizationID)
+	}
+	var projects []*types.Project
+	if err := c.makeRequest(ctx, http.MethodGet, path, nil, &projects); err != nil {
+		return nil, err
+	}
+	return projects, nil
+}
 
 // ApplyProject idempotently creates or updates a project from a declarative spec.
 func (c *HelixClient) ApplyProject(ctx context.Context, req *types.ProjectApplyRequest) (*types.ProjectApplyResponse, error) {

--- a/api/pkg/client/secret.go
+++ b/api/pkg/client/secret.go
@@ -33,6 +33,17 @@ func (c *HelixClient) ListSecrets(ctx context.Context, f *SecretFilter) ([]*type
 	return secrets, nil
 }
 
+// ListProjectSecrets retrieves the write-only metadata for secrets attached to
+// one project. Secret values are never returned by the API.
+func (c *HelixClient) ListProjectSecrets(ctx context.Context, projectID string) ([]*types.Secret, error) {
+	var secrets []*types.Secret
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/secrets", url.PathEscape(projectID)), nil, &secrets)
+	if err != nil {
+		return nil, err
+	}
+	return secrets, nil
+}
+
 // CreateSecret creates a new secret
 func (c *HelixClient) CreateSecret(ctx context.Context, secret *types.CreateSecretRequest) (*types.Secret, error) {
 	var createdSecret types.Secret
@@ -80,7 +91,7 @@ func (c *HelixClient) CreateProjectSecret(ctx context.Context, projectID string,
 	}
 
 	var created types.Secret
-	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/secrets", projectID), bytes.NewBuffer(bts), &created)
+	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/secrets", url.PathEscape(projectID)), bytes.NewBuffer(bts), &created)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/desktop/desktop.go
+++ b/api/pkg/desktop/desktop.go
@@ -559,7 +559,7 @@ func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
 	// /exec is not desktop-specific either: git identity sync on spec approval
 	// and the Claude/Codex subscription login flows all target headless
 	// containers. The server is loopback-only and reached through authenticated
-	// RevDial API routes; the command allowlist is an additional boundary.
+	// RevDial API routes; authorization is enforced by the public API route.
 	mux.HandleFunc("/exec", s.handleExec)
 	mux.HandleFunc("/workspaces", s.handleWorkspaces)
 	mux.HandleFunc("/workspace/review", s.handleWorkspaceReview)
@@ -570,7 +570,7 @@ func (s *Server) registerWorkspaceRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/workspace/checkpoints/capture", s.handleWorkspaceCheckpointCapture)
 	mux.HandleFunc("/workspace/checkpoints/diff", s.handleWorkspaceCheckpointDiff)
 	// Git plumbing used by the fork-and-pause safety net stays on fixed,
-	// dedicated endpoints rather than weakening the generic /exec allowlist.
+	// dedicated endpoints so callers receive structured responses.
 	mux.HandleFunc("/workspace/status", s.handleWorkspaceStatus)
 	mux.HandleFunc("/workspace/commit-and-push", s.handleWorkspaceCommitAndPush)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {

--- a/api/pkg/desktop/diff.go
+++ b/api/pkg/desktop/diff.go
@@ -60,21 +60,7 @@ func (s *Server) handleWorkspaces(w http.ResponseWriter, r *http.Request) {
 // repos.
 func findAllWorkspaces() []WorkspaceInfo {
 	var workspaces []WorkspaceInfo
-
-	workDirs := []string{
-		os.Getenv("WORKSPACE_DIR"),
-		"/home/retro/work",
-	}
-
-	var baseDir string
-	for _, dir := range workDirs {
-		if dir != "" {
-			if info, err := os.Stat(dir); err == nil && info.IsDir() {
-				baseDir = dir
-				break
-			}
-		}
-	}
+	baseDir := findAgentWorkspaceRoot()
 
 	if baseDir == "" {
 		return workspaces
@@ -108,6 +94,18 @@ func findAllWorkspaces() []WorkspaceInfo {
 	}
 
 	return workspaces
+}
+
+func findAgentWorkspaceRoot() string {
+	for _, dir := range []string{os.Getenv("WORKSPACE_DIR"), agentWorkspaceRoot} {
+		if dir == "" {
+			continue
+		}
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
 }
 
 // getWorkspaceInfo builds workspace info for a git repository

--- a/api/pkg/desktop/exec.go
+++ b/api/pkg/desktop/exec.go
@@ -28,8 +28,11 @@ type ExecResponse struct {
 	PID      int    `json:"pid,omitempty"` // Only set for background commands
 }
 
-// handleExec executes a restricted command in the container. The HTTP server
-// is loopback-only; authenticated API handlers reach it through RevDial.
+// handleExec executes a command in the container. The HTTP server is
+// loopback-only; authenticated API handlers reach it through RevDial after
+// checking that the caller can update the session. A command allowlist here is
+// not a meaningful boundary once shell interpreters are supported: it only
+// makes normal terminal work fail while providing no additional isolation.
 //
 // POST /exec
 // Request body: {"command": ["vkcube"], "background": true}
@@ -48,44 +51,6 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	if len(req.Command) == 0 {
 		http.Error(w, "command is required", http.StatusBadRequest)
-		return
-	}
-
-	// Security: Only allow specific commands for safety
-	allowedCommands := map[string]bool{
-		"vkcube":                   true,
-		"glxgears":                 true,
-		"pkill":                    true,
-		"killall":                  true,
-		"ls":                       true,
-		"echo":                     true,
-		"weston-simple-egl":        true,
-		"cat":                      true,
-		"test":                     true,
-		"npm":                      true, // Codex login wrapper installs the Codex CLI
-		"helix-codex-auth-wrapper": true, // runs Codex device authentication with stdout capture
-		"git":                      true, // scoped further below: only identity writes via gitInvocationAllowed
-	}
-
-	cmdName := req.Command[0]
-	if !allowedCommands[cmdName] {
-		s.logger.Warn("exec: blocked disallowed command", "command", cmdName)
-		http.Error(w, fmt.Sprintf("command not allowed: %s", cmdName), http.StatusForbidden)
-		return
-	}
-	if cmdName == "cat" && !catInvocationAllowed(req.Command) {
-		s.logger.Warn("exec: blocked cat outside subscription login files", "args", req.Command)
-		http.Error(w, "cat invocation not allowed", http.StatusForbidden)
-		return
-	}
-
-	// Extra scoping for git: `git` is a dispatcher with ~150 subcommands, some
-	// of which can exfiltrate secrets (e.g. via a custom credential.helper) or
-	// make destructive filesystem changes. Only allow the identity-writing
-	// subset used by the spec-approval flow.
-	if cmdName == "git" && !gitInvocationAllowed(req.Command) {
-		s.logger.Warn("exec: blocked git invocation", "args", req.Command)
-		http.Error(w, "git invocation not allowed (only 'git config --global user.name|user.email <value>')", http.StatusForbidden)
 		return
 	}
 
@@ -151,39 +116,4 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
-}
-
-func catInvocationAllowed(cmd []string) bool {
-	if len(cmd) != 2 || cmd[0] != "cat" {
-		return false
-	}
-	switch cmd[1] {
-	case "/home/retro/.codex/auth.json", "/tmp/codex-auth-stdout.txt", "/tmp/codex-auth-error.txt":
-		return true
-	default:
-		return false
-	}
-}
-
-// gitInvocationAllowed restricts `git` invocations to the identity-writing
-// subset: `git config --global user.name <value>` or
-// `git config --global user.email <value>`. Any other form is rejected.
-//
-// This exists because `git` as a dispatcher is extremely broad: allowing the
-// binary unconditionally would permit arbitrary `git clone`, custom
-// credential helpers, object fetches over HTTP, etc. from anyone able to
-// reach the exec endpoint.
-func gitInvocationAllowed(cmd []string) bool {
-	if len(cmd) != 5 {
-		return false
-	}
-	if cmd[0] != "git" || cmd[1] != "config" || cmd[2] != "--global" {
-		return false
-	}
-	if cmd[3] != "user.name" && cmd[3] != "user.email" {
-		return false
-	}
-	// Reject values that look like flags so we can't be tricked into
-	// invoking `git config --global user.name --some-other-flag`.
-	return !strings.HasPrefix(cmd[4], "-")
 }

--- a/api/pkg/desktop/exec_test.go
+++ b/api/pkg/desktop/exec_test.go
@@ -8,70 +8,15 @@ import (
 	"testing"
 )
 
-func TestCatInvocationAllowed(t *testing.T) {
-	cases := []struct {
-		name string
-		cmd  []string
-		want bool
-	}{
-		{"allow Codex credentials", []string{"cat", "/home/retro/.codex/auth.json"}, true},
-		{"allow Codex stdout", []string{"cat", "/tmp/codex-auth-stdout.txt"}, true},
-		{"allow Codex error", []string{"cat", "/tmp/codex-auth-error.txt"}, true},
-		{"reject process environment", []string{"cat", "/proc/1/environ"}, false},
-		{"reject traversal", []string{"cat", "/tmp/../proc/1/environ"}, false},
-		{"reject flags", []string{"cat", "--", "/home/retro/.codex/auth.json"}, false},
-		{"reject multiple files", []string{"cat", "/tmp/codex-auth-stdout.txt", "/etc/passwd"}, false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := catInvocationAllowed(tc.cmd); got != tc.want {
-				t.Fatalf("catInvocationAllowed(%v) = %v, want %v", tc.cmd, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestExecRejectsUnsafeCommands(t *testing.T) {
+func TestExecAllowsGeneralSandboxCommands(t *testing.T) {
 	server := NewServer(Config{}, slog.Default())
-	for _, body := range []string{
-		`{"command":["cat","/proc/1/environ"]}`,
-		`{"command":["claude","--version"]}`,
-	} {
-		recorder := httptest.NewRecorder()
-		request := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
-		server.handleExec(recorder, request)
-		if recorder.Code != http.StatusForbidden {
-			t.Fatalf("body %s returned %d, want %d", body, recorder.Code, http.StatusForbidden)
-		}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{"command":["sh","-c","printf general-command"]}`))
+	server.handleExec(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("returned %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}
-}
-
-func TestGitInvocationAllowed(t *testing.T) {
-	cases := []struct {
-		name string
-		cmd  []string
-		want bool
-	}{
-		{"allow user.name", []string{"git", "config", "--global", "user.name", "Alice"}, true},
-		{"allow user.email", []string{"git", "config", "--global", "user.email", "alice@example.com"}, true},
-		{"reject missing subcommand", []string{"git"}, false},
-		{"reject non-config subcommand", []string{"git", "clone", "--global", "user.name", "x"}, false},
-		{"reject non-global scope", []string{"git", "config", "--system", "user.name", "x"}, false},
-		{"reject other key", []string{"git", "config", "--global", "credential.helper", "store"}, false},
-		{"reject extra args", []string{"git", "config", "--global", "user.name", "Alice", "extra"}, false},
-		{"reject flag as value", []string{"git", "config", "--global", "user.name", "--some-flag"}, false},
-		{"reject short flag as value", []string{"git", "config", "--global", "user.email", "-x"}, false},
-		{"reject wrong binary", []string{"not-git", "config", "--global", "user.name", "x"}, false},
-		{"reject empty slice", []string{}, false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := gitInvocationAllowed(tc.cmd)
-			if got != tc.want {
-				t.Fatalf("gitInvocationAllowed(%v) = %v, want %v", tc.cmd, got, tc.want)
-			}
-		})
+	if !strings.Contains(recorder.Body.String(), `"output":"general-command"`) {
+		t.Fatalf("unexpected response: %s", recorder.Body.String())
 	}
 }

--- a/api/pkg/desktop/workspace_review.go
+++ b/api/pkg/desktop/workspace_review.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime"
 	"net/http"
 	"os"
@@ -172,9 +173,18 @@ func (s *Server) handleWorkspaceFiles(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	workDir, workspace, err := resolveReviewWorkspace(r.URL.Query().Get("workspace"))
+	workDir, workspace, workRoot, err := resolveWorkspaceBrowseRoot(r.URL.Query().Get("root"), r.URL.Query().Get("workspace"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if workRoot {
+		entries, truncated, err := listSessionWorkRoot(workDir)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("list session work root: %v", err), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, types.WorkspaceFilesResponse{Workspace: workspace, Entries: entries, Truncated: truncated})
 		return
 	}
 	// listTruncated matters: a workspace whose path listing exceeds the output
@@ -268,7 +278,7 @@ func (s *Server) handleWorkspaceFileDownload(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	workDir, _, err := resolveReviewWorkspace(r.URL.Query().Get("workspace"))
+	workDir, _, workRoot, err := resolveWorkspaceBrowseRoot(r.URL.Query().Get("root"), r.URL.Query().Get("workspace"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -278,7 +288,7 @@ func (s *Server) handleWorkspaceFileDownload(w http.ResponseWriter, r *http.Requ
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if !workspaceFileIsBrowsable(r.Context(), workDir, rel) {
+	if !workRoot && !workspaceFileIsBrowsable(r.Context(), workDir, rel) {
 		http.Error(w, "path is not a browsable workspace file", http.StatusBadRequest)
 		return
 	}
@@ -296,6 +306,78 @@ func (s *Server) handleWorkspaceFileDownload(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": filepath.Base(rel)}))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	http.ServeContent(w, r, filepath.Base(rel), info.ModTime(), file)
+}
+
+func resolveWorkspaceBrowseRoot(rootMode, workspace string) (string, string, bool, error) {
+	if rootMode == "" {
+		workDir, resolvedWorkspace, err := resolveReviewWorkspace(workspace)
+		return workDir, resolvedWorkspace, false, err
+	}
+	if rootMode != "work" {
+		return "", "", false, fmt.Errorf("unknown workspace root %q", rootMode)
+	}
+	if workspace != "" {
+		return "", "", false, fmt.Errorf("workspace and root cannot be combined")
+	}
+	workDir := findAgentWorkspaceRoot()
+	if workDir == "" {
+		return "", "", false, fmt.Errorf("session work root not found")
+	}
+	return workDir, "work", true, nil
+}
+
+func listSessionWorkRoot(workDir string) ([]types.WorkspaceFileEntry, bool, error) {
+	entries := make([]types.WorkspaceFileEntry, 0)
+	truncated := false
+	err := filepath.WalkDir(workDir, func(pathValue string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if pathValue == workDir {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() == ".git" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if len(entries) >= workspaceTreeEntryLimit {
+			truncated = true
+			return fs.SkipAll
+		}
+		rel, err := filepath.Rel(workDir, pathValue)
+		if err != nil {
+			return err
+		}
+		kind := "file"
+		var size int64
+		if entry.IsDir() {
+			kind = "directory"
+		} else {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if !info.Mode().IsRegular() {
+				return nil
+			}
+			size = info.Size()
+		}
+		entries = append(entries, types.WorkspaceFileEntry{Path: filepath.ToSlash(rel), Kind: kind, Size: size})
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries, truncated, nil
 }
 
 func (s *Server) handleWorkspaceFileWrite(w http.ResponseWriter, r *http.Request) {

--- a/api/pkg/desktop/workspace_review_test.go
+++ b/api/pkg/desktop/workspace_review_test.go
@@ -551,6 +551,36 @@ func TestWorkspaceFilesListsTrackedAndUntrackedOnly(t *testing.T) {
 	assert.Equal(t, workspace, response.Workspace)
 }
 
+func TestWorkspaceFilesAndDownloadIncludeSiblingOutputsFromWorkRoot(t *testing.T) {
+	workRoot := t.TempDir()
+	t.Setenv("WORKSPACE_DIR", workRoot)
+	require.NoError(t, os.MkdirAll(filepath.Join(workRoot, "repo", ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(workRoot, "engagement"), 0o755))
+	contents := []byte("collected output\n")
+	require.NoError(t, os.WriteFile(filepath.Join(workRoot, "engagement", "findings.json"), contents, 0o644))
+	server := newTestServer(t)
+
+	listReq := httptest.NewRequest(http.MethodGet, "/workspace/files?root=work", nil)
+	listRecorder := httptest.NewRecorder()
+	server.handleWorkspaceFiles(listRecorder, listReq)
+	require.Equal(t, http.StatusOK, listRecorder.Code, listRecorder.Body.String())
+	var response types.WorkspaceFilesResponse
+	require.NoError(t, json.Unmarshal(listRecorder.Body.Bytes(), &response))
+	paths := make(map[string]string, len(response.Entries))
+	for _, entry := range response.Entries {
+		paths[entry.Path] = entry.Kind
+	}
+	assert.Equal(t, "directory", paths["engagement"])
+	assert.Equal(t, "file", paths["engagement/findings.json"])
+	assert.NotContains(t, paths, "repo/.git")
+
+	downloadReq := httptest.NewRequest(http.MethodGet, "/workspace/file/download?root=work&path=engagement/findings.json", nil)
+	downloadRecorder := httptest.NewRecorder()
+	server.handleWorkspaceFileDownload(downloadRecorder, downloadReq)
+	require.Equal(t, http.StatusOK, downloadRecorder.Code, downloadRecorder.Body.String())
+	assert.Equal(t, contents, downloadRecorder.Body.Bytes())
+}
+
 func TestListWorkspaceSkillsUsesProjectPrecedenceAndFollowsSymlinks(t *testing.T) {
 	workDir := t.TempDir()
 	homeDir := t.TempDir()

--- a/api/pkg/desktop/workspace_test.go
+++ b/api/pkg/desktop/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"mime/multipart"
 	"net"
@@ -149,18 +150,21 @@ func TestWorkspaceOnlyServerServesFilesAndDiffsWithoutDesktop(t *testing.T) {
 	_ = response.Body.Close()
 	require.Equal(t, http.StatusNotFound, response.StatusCode)
 
-	// /exec IS served headless — git identity sync and the subscription login
-	// flows run against headless containers. Its allowlist still applies.
-	response, err = http.Post(baseURL+"/exec", "application/json", strings.NewReader(`{"command":["rm","-rf","/"]}`))
+	// /exec is served headless because terminal workflows and server setup both
+	// need the same command surface as desktop sessions.
+	response, err = http.Post(baseURL+"/exec", "application/json", strings.NewReader(`{"command":["sh","-c","printf headless-ready"]}`))
 	require.NoError(t, err)
+	body, readErr := io.ReadAll(response.Body)
 	_ = response.Body.Close()
-	require.Equal(t, http.StatusForbidden, response.StatusCode)
+	require.NoError(t, readErr)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	assert.JSONEq(t, `{"success":true,"output":"headless-ready","exit_code":0}`, string(body))
 
 	cancel()
 	require.ErrorIs(t, <-errCh, context.Canceled)
 }
 
-func TestWorkspaceOnlyServerAllowsRestrictedExecForServerSetup(t *testing.T) {
+func TestWorkspaceOnlyServerAllowsExecForServerSetup(t *testing.T) {
 	server := NewServer(Config{WorkspaceOnly: true}, slog.Default())
 
 	recorder := httptest.NewRecorder()

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -4227,7 +4227,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Executes a command inside the sandbox container for benchmarking and debugging.\nOnly specific safe commands are allowed (vkcube, glxgears, pkill).",
+                "description": "Executes a command inside the caller's sandbox container.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4577,6 +4577,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Workspace name",
                         "name": "workspace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Set to work to list the full session work root (requires update access)",
+                        "name": "root",
                         "in": "query"
                     }
                 ],

--- a/api/pkg/server/external_agent_handlers.go
+++ b/api/pkg/server/external_agent_handlers.go
@@ -368,8 +368,7 @@ func (apiServer *HelixAPIServer) getExternalAgentScreenshot(res http.ResponseWri
 }
 
 // @Summary Execute command in sandbox
-// @Description Executes a command inside the sandbox container for benchmarking and debugging.
-// @Description Only specific safe commands are allowed (vkcube, glxgears, pkill).
+// @Description Executes a command inside the caller's sandbox container.
 // @Tags ExternalAgents
 // @Accept json
 // @Produce json
@@ -404,7 +403,7 @@ func (apiServer *HelixAPIServer) execInSandbox(res http.ResponseWriter, req *htt
 	log.Info().Str("session_id", session.ID).Str("owner", session.Owner).Msg("🔧 execInSandbox: session found")
 
 	// Verify ownership
-	err = apiServer.authorizeUserToSession(req.Context(), user, session, types.ActionGet)
+	err = apiServer.authorizeUserToSession(req.Context(), user, session, types.ActionUpdate)
 	if err != nil {
 		http.Error(res, err.Error(), http.StatusForbidden)
 		return

--- a/api/pkg/server/secrets_handlers.go
+++ b/api/pkg/server/secrets_handlers.go
@@ -86,6 +86,18 @@ func (s *HelixAPIServer) createSecret(_ http.ResponseWriter, r *http.Request) (*
 	if err := json.NewDecoder(r.Body).Decode(&secretReq); err != nil {
 		return nil, system.NewHTTPError400(err.Error())
 	}
+	if secretReq.ProjectID != "" {
+		project, err := s.Store.GetProject(ctx, secretReq.ProjectID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, system.NewHTTPError404("project not found")
+			}
+			return nil, system.NewHTTPError500(err.Error())
+		}
+		if err := s.authorizeUserToProject(ctx, user, project, types.ActionCreate); err != nil {
+			return nil, system.NewHTTPError403("not authorized to create secrets in this project")
+		}
+	}
 
 	// Encrypt the secret value before storing
 	encryptionKey, err := s.getEncryptionKey()
@@ -147,15 +159,20 @@ func (s *HelixAPIServer) updateSecret(_ http.ResponseWriter, r *http.Request) (*
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	// Check authorization: either user owns the secret OR has access to the project
-	authorized := false
-	if existing.Owner == user.ID {
-		authorized = true
-	} else if existing.ProjectID != "" {
-		// For project secrets, check if user has update access to the project
-		if err := s.authorizeUserToProjectByID(ctx, user, existing.ProjectID, types.ActionUpdate); err == nil {
-			authorized = true
+	// Project-scoped rows remain governed by their project even when their
+	// original creator still owns the secret row. This validates that the
+	// project still exists and prevents an owner from rotating a credential in
+	// a project they can no longer update.
+	authorized := existing.Owner == user.ID && existing.ProjectID == ""
+	if existing.ProjectID != "" {
+		project, projectErr := s.Store.GetProject(ctx, existing.ProjectID)
+		if projectErr != nil {
+			if errors.Is(projectErr, store.ErrNotFound) {
+				return nil, system.NewHTTPError404("project not found")
+			}
+			return nil, system.NewHTTPError500(projectErr.Error())
 		}
+		authorized = s.authorizeUserToProject(ctx, user, project, types.ActionUpdate) == nil
 	}
 	if !authorized {
 		// Return 404 instead of 403 to avoid leaking existence of secret

--- a/api/pkg/server/secrets_project_validation_test.go
+++ b/api/pkg/server/secrets_project_validation_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateSecretRejectsUnknownProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	mockStore.EXPECT().GetProject(gomock.Any(), "prj_missing").Return(nil, store.ErrNotFound)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewBufferString(
+		`{"name":"TOKEN","value":"secret","project_id":"prj_missing"}`,
+	))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user_test"}))
+	_, httpErr := server.createSecret(httptest.NewRecorder(), req)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestUpdateSecretRejectsOrphanedProjectScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	secret := &types.Secret{ID: "sec_test", Name: "TOKEN", Owner: "user_test", ProjectID: "prj_missing"}
+	mockStore.EXPECT().GetSecret(gomock.Any(), secret.ID).Return(secret, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), secret.ProjectID).Return(nil, store.ErrNotFound)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/secrets/sec_test", bytes.NewBufferString(
+		`{"name":"TOKEN","value":"rotated"}`,
+	))
+	req = mux.SetURLVars(req, map[string]string{"id": secret.ID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user_test"}))
+	_, httpErr := server.updateSecret(httptest.NewRecorder(), req)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1194,7 +1194,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/external-agents/{sessionID}/clipboard", apiServer.setExternalAgentClipboard).Methods("POST")               // Write local clipboard to remote desktop
 	authRouter.HandleFunc("/external-agents/{sessionID}/upload", apiServer.uploadFileToSandbox).Methods("POST")                        // Upload files to sandbox container
 	authRouter.HandleFunc("/external-agents/{sessionID}/file", apiServer.getExternalAgentFile).Methods(http.MethodGet)                 // Read uploaded chat attachments
-	authRouter.HandleFunc("/external-agents/{sessionID}/exec", apiServer.execInSandbox).Methods("POST")                                // Execute safe commands (vkcube, glxgears for benchmarks)
+	authRouter.HandleFunc("/external-agents/{sessionID}/exec", apiServer.execInSandbox).Methods("POST")                                // Execute an authenticated sandbox command
 	authRouter.HandleFunc("/external-agents/{sessionID}/ws/input", apiServer.proxyInputWebSocket).Methods("GET")                       // WebSocket: keyboard/mouse input stream
 	authRouter.HandleFunc("/external-agents/{sessionID}/ws/stream", apiServer.proxyStreamWebSocket).Methods("GET")                     // WebSocket: H.264 video stream (primary)
 	authRouter.HandleFunc("/external-agents/{sessionID}/configure-pending-session", apiServer.configurePendingSession).Methods("POST") // Configure session before container starts

--- a/api/pkg/server/session_workspace_handlers.go
+++ b/api/pkg/server/session_workspace_handlers.go
@@ -20,9 +20,8 @@ package server
 //
 // Both helpers reach the desktop via RevDial → /workspace/status and
 // /workspace/commit-and-push (defined in api/pkg/desktop/workspace.go).
-// We deliberately do NOT use the generic /exec endpoint because it's
-// allowlist-restricted to a small set of safe commands — git plumbing
-// runs through dedicated endpoints with structured request/response.
+// Git plumbing runs through dedicated endpoints with structured
+// request/response payloads instead of parsing generic command output.
 
 import (
 	"bufio"

--- a/api/pkg/server/spec_task_attachments_handlers.go
+++ b/api/pkg/server/spec_task_attachments_handlers.go
@@ -17,9 +17,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Statuses past which attachments are read-only — the agent has already started using
-// them and changing them mid-flight would be confusing.
-var specTaskAttachmentReadOnlyStatuses = map[types.SpecTaskStatus]bool{
+// Uploads remain available while an agent is working. StageUploadedAttachments
+// commits late files and queues a note to the active session, so blocking them
+// during implementation contradicts the delivery mechanism and makes
+// just-do-it tasks impossible to correct. Once delivery has reached a PR the
+// task input is terminal and uploads are locked again.
+var specTaskAttachmentUploadReadOnlyStatuses = map[types.SpecTaskStatus]bool{
+	types.TaskStatusPullRequest: true,
+	types.TaskStatusDone:        true,
+}
+
+// Deletion remains stricter than upload because removing a committed attachment
+// also requires removing it from helix-specs. A corrected file can still be
+// uploaded and the running agent is notified.
+var specTaskAttachmentDeleteReadOnlyStatuses = map[types.SpecTaskStatus]bool{
 	types.TaskStatusSpecApproved:         true,
 	types.TaskStatusImplementationQueued: true,
 	types.TaskStatusImplementation:       true,
@@ -29,8 +40,12 @@ var specTaskAttachmentReadOnlyStatuses = map[types.SpecTaskStatus]bool{
 	types.TaskStatusImplementationFailed: true,
 }
 
-func specTaskAttachmentsLocked(status types.SpecTaskStatus) bool {
-	return specTaskAttachmentReadOnlyStatuses[status]
+func specTaskAttachmentUploadsLocked(status types.SpecTaskStatus) bool {
+	return specTaskAttachmentUploadReadOnlyStatuses[status]
+}
+
+func specTaskAttachmentDeletesLocked(status types.SpecTaskStatus) bool {
+	return specTaskAttachmentDeleteReadOnlyStatuses[status]
 }
 
 // uploadSpecTaskAttachments godoc
@@ -71,8 +86,8 @@ func (s *HelixAPIServer) uploadSpecTaskAttachments(w http.ResponseWriter, r *htt
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if specTaskAttachmentsLocked(task.Status) {
-		http.Error(w, "task is past spec_review — attachments are read-only", http.StatusConflict)
+	if specTaskAttachmentUploadsLocked(task.Status) {
+		http.Error(w, "task has reached pull request delivery — attachments are read-only", http.StatusConflict)
 		return
 	}
 
@@ -332,7 +347,7 @@ func (s *HelixAPIServer) deleteSpecTaskAttachment(w http.ResponseWriter, r *http
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if specTaskAttachmentsLocked(task.Status) {
+	if specTaskAttachmentDeletesLocked(task.Status) {
 		http.Error(w, "task is past spec_review — attachments are read-only", http.StatusConflict)
 		return
 	}

--- a/api/pkg/server/spec_task_attachments_validation_test.go
+++ b/api/pkg/server/spec_task_attachments_validation_test.go
@@ -56,27 +56,28 @@ func TestSvgContainsScript(t *testing.T) {
 	assert.True(t, svgContainsScript([]byte(`<SVG><SCRIPT/></SVG>`)))
 }
 
-func TestSpecTaskAttachmentsLocked(t *testing.T) {
+func TestSpecTaskAttachmentUploadsStayOpenWhileAgentIsWorking(t *testing.T) {
 	for _, status := range []types.SpecTaskStatus{
 		types.TaskStatusBacklog,
 		types.TaskStatusQueuedSpecGeneration,
 		types.TaskStatusSpecGeneration,
 		types.TaskStatusSpecReview,
 		types.TaskStatusSpecRevision,
-	} {
-		assert.False(t, specTaskAttachmentsLocked(status), "expected unlocked for %s", status)
-	}
-	for _, status := range []types.SpecTaskStatus{
 		types.TaskStatusSpecApproved,
 		types.TaskStatusImplementationQueued,
 		types.TaskStatusImplementation,
 		types.TaskStatusImplementationReview,
-		types.TaskStatusPullRequest,
-		types.TaskStatusDone,
 		types.TaskStatusImplementationFailed,
 	} {
-		assert.True(t, specTaskAttachmentsLocked(status), "expected locked for %s", status)
+		assert.False(t, specTaskAttachmentUploadsLocked(status), "expected uploads unlocked for %s", status)
 	}
+	for _, status := range []types.SpecTaskStatus{
+		types.TaskStatusPullRequest,
+		types.TaskStatusDone,
+	} {
+		assert.True(t, specTaskAttachmentUploadsLocked(status), "expected uploads locked for %s", status)
+	}
+	assert.True(t, specTaskAttachmentDeletesLocked(types.TaskStatusImplementation))
 }
 
 func TestSpecTaskAttachmentLimits(t *testing.T) {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -4223,7 +4223,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Executes a command inside the sandbox container for benchmarking and debugging.\nOnly specific safe commands are allowed (vkcube, glxgears, pkill).",
+                "description": "Executes a command inside the caller's sandbox container.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4573,6 +4573,12 @@
                         "type": "string",
                         "description": "Workspace name",
                         "name": "workspace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Set to work to list the full session work root (requires update access)",
+                        "name": "root",
                         "in": "query"
                     }
                 ],

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -16639,9 +16639,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: |-
-        Executes a command inside the sandbox container for benchmarking and debugging.
-        Only specific safe commands are allowed (vkcube, glxgears, pkill).
+      description: Executes a command inside the caller's sandbox container.
       parameters:
       - description: Session ID
         in: path
@@ -16866,6 +16864,11 @@ paths:
       - description: Workspace name
         in: query
         name: workspace
+        type: string
+      - description: Set to work to list the full session work root (requires update
+          access)
+        in: query
+        name: root
         type: string
       produces:
       - application/json

--- a/api/pkg/server/workspace_review_handlers.go
+++ b/api/pkg/server/workspace_review_handlers.go
@@ -85,11 +85,16 @@ func (apiServer *HelixAPIServer) getWorkspaceReview(w http.ResponseWriter, req *
 // @Produce json
 // @Param sessionID path string true "Session ID"
 // @Param workspace query string false "Workspace name"
+// @Param root query string false "Set to work to list the full session work root (requires update access)"
 // @Success 200 {object} types.WorkspaceFilesResponse
 // @Router /api/v1/external-agents/{sessionID}/workspace-files [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getWorkspaceFiles(w http.ResponseWriter, req *http.Request) {
-	apiServer.proxyAuthorizedWorkspaceGET(w, req, "/workspace/files", &types.WorkspaceFilesResponse{})
+	action := types.ActionGet
+	if req.URL.Query().Get("root") != "" {
+		action = types.ActionUpdate
+	}
+	apiServer.proxyAuthorizedWorkspaceGETWithAction(w, req, "/workspace/files", &types.WorkspaceFilesResponse{}, action)
 }
 
 // getWorkspaceFile godoc
@@ -109,7 +114,11 @@ func (apiServer *HelixAPIServer) getWorkspaceFile(w http.ResponseWriter, req *ht
 
 // downloadWorkspaceFile streams a complete, binary-safe workspace file from the task desktop.
 func (apiServer *HelixAPIServer) downloadWorkspaceFile(w http.ResponseWriter, req *http.Request) {
-	session, ok := apiServer.authorizeWorkspaceReviewRequest(w, req, types.ActionGet)
+	action := types.ActionGet
+	if req.URL.Query().Get("root") != "" {
+		action = types.ActionUpdate
+	}
+	session, ok := apiServer.authorizeWorkspaceReviewRequest(w, req, action)
 	if !ok {
 		return
 	}
@@ -195,7 +204,11 @@ func (apiServer *HelixAPIServer) getWorkspaceSkills(w http.ResponseWriter, req *
 }
 
 func (apiServer *HelixAPIServer) proxyAuthorizedWorkspaceGET(w http.ResponseWriter, req *http.Request, desktopPath string, response interface{}) {
-	session, ok := apiServer.authorizeWorkspaceReviewRequest(w, req, types.ActionGet)
+	apiServer.proxyAuthorizedWorkspaceGETWithAction(w, req, desktopPath, response, types.ActionGet)
+}
+
+func (apiServer *HelixAPIServer) proxyAuthorizedWorkspaceGETWithAction(w http.ResponseWriter, req *http.Request, desktopPath string, response interface{}, action types.Action) {
+	session, ok := apiServer.authorizeWorkspaceReviewRequest(w, req, action)
 	if !ok {
 		return
 	}

--- a/design/2026-09-02-cli-usability-fixes.md
+++ b/design/2026-09-02-cli-usability-fixes.md
@@ -1,0 +1,22 @@
+# CLI usability fixes
+
+Several CLI workflows had related usability inconsistencies.
+
+- `spectask exec` advertised arbitrary commands but the desktop still enforced a
+  benchmark-era command allowlist.
+- `spectask files` and `download` treated the primary Git repository as the
+  session work root, hiding deliverables written beside the checkout.
+- `spectask start`, `stop`, and `send` bypassed task-aware or asynchronous APIs
+  that already model the requested behavior.
+- artifact and secret commands did not share project-name resolution.
+- the generic secret API accepted project IDs without validating the project or
+  the caller's access.
+- attachment upload locking contradicted the late-upload staging path, which is
+  explicitly safe after a task session starts and notifies the running agent.
+
+The implementation should preserve the repository-scoped browser file view,
+while allowing the CLI to request the full `/home/retro/work` tree under update
+authorization. Project references should resolve across the caller's personal
+and organization projects and reject ambiguous names. Project-scoped secret
+validation belongs in the API even when the CLI uses the dedicated project
+route, because raw API clients must not create orphaned rows.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -10949,7 +10949,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Executes a command inside the sandbox container for benchmarking and debugging. Only specific safe commands are allowed (vkcube, glxgears, pkill).
+     * @description Executes a command inside the caller's sandbox container.
      *
      * @tags ExternalAgents
      * @name V1ExternalAgentsExecCreate
@@ -11091,6 +11091,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query?: {
         /** Workspace name */
         workspace?: string;
+        /** Set to work to list the full session work root (requires update access) */
+        root?: string;
       },
       params: RequestParams = {},
     ) =>

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -16639,9 +16639,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: |-
-        Executes a command inside the sandbox container for benchmarking and debugging.
-        Only specific safe commands are allowed (vkcube, glxgears, pkill).
+      description: Executes a command inside the caller's sandbox container.
       parameters:
       - description: Session ID
         in: path
@@ -16866,6 +16864,11 @@ paths:
       - description: Workspace name
         in: query
         name: workspace
+        type: string
+      - description: Set to work to list the full session work root (requires update
+          access)
+        in: query
+        name: root
         type: string
       produces:
       - application/json

--- a/openapi.json
+++ b/openapi.json
@@ -4962,7 +4962,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Executes a command inside the sandbox container for benchmarking and debugging.\nOnly specific safe commands are allowed (vkcube, glxgears, pkill).",
+                "description": "Executes a command inside the caller's sandbox container.",
                 "tags": [
                     "ExternalAgents"
                 ],
@@ -5410,6 +5410,14 @@
                     {
                         "description": "Workspace name",
                         "name": "workspace",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Set to work to list the full session work root (requires update access)",
+                        "name": "root",
                         "in": "query",
                         "schema": {
                             "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -4223,7 +4223,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Executes a command inside the sandbox container for benchmarking and debugging.\nOnly specific safe commands are allowed (vkcube, glxgears, pkill).",
+                "description": "Executes a command inside the caller's sandbox container.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4573,6 +4573,12 @@
                         "type": "string",
                         "description": "Workspace name",
                         "name": "workspace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Set to work to list the full session work root (requires update access)",
+                        "name": "root",
                         "in": "query"
                     }
                 ],


### PR DESCRIPTION
## Summary

- allow authenticated task owners to run general sandbox commands and collect files from the full session work root
- make task start, stop, messaging, and late attachments work cleanly for scripted workflows
- resolve artifact and secret project names consistently, add project-scoped secret management, and validate project scopes
- regenerate the OpenAPI client and document the CLI behavior

## Testing

- `go test ./api/pkg/server/... -count=1`
- `go test ./api/pkg/desktop/... ./api/pkg/cli/... -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/` (from `api/`)
- `go build .`
- `yarn build` (from `frontend/`)
- live CLI acceptance against `http://localhost:8080` for project-name artifact lookup, project secret create/list/rotate/delete, missing-project rejection, task start/stop, direct implementation mode, and queued/quiet messaging