### PR TITLE
fix(sandbox): reconcile stale web service containers

### DIFF
--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -377,6 +377,9 @@ func (c *Controller) StartReaper(ctx context.Context, interval time.Duration) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if err := c.ReconcileWebServiceContainers(ctx); err != nil {
+				log.Warn().Err(err).Msg("web service container reconciliation failed")
+			}
 			if err := c.ReapExpired(ctx); err != nil {
 				log.Warn().Err(err).Msg("sandbox reaper iteration failed")
 			}

--- a/api/pkg/sandbox/controller_cleanup.go
+++ b/api/pkg/sandbox/controller_cleanup.go
@@ -2,8 +2,12 @@ package sandbox
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
 
@@ -26,4 +30,77 @@ func (c *Controller) CleanupStoppedNonPersistent(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// ReconcileWebServiceContainers removes physical containers whose exact
+// sandbox row was already superseded and soft-deleted. Every missing piece of
+// evidence retains the container so a current customer web service is never
+// removed on an inference.
+func (c *Controller) ReconcileWebServiceContainers(ctx context.Context) error {
+	sandboxes, err := c.store.ListSandboxes(ctx, &store.ListSandboxesQuery{IncludeDeleted: true})
+	if err != nil {
+		return fmt.Errorf("list sandbox history: %w", err)
+	}
+	byID := make(map[string]*types.Sandbox, len(sandboxes))
+	for _, sb := range sandboxes {
+		if sb != nil {
+			byID[sb.ID] = sb
+		}
+	}
+
+	hosts, err := c.store.ListSandboxInstances(ctx)
+	if err != nil {
+		return fmt.Errorf("list sandbox instances: %w", err)
+	}
+	var errs []error
+	for _, host := range hosts {
+		if host.Status != "online" {
+			continue
+		}
+		hydraClient := c.newHydraClient(host.ID)
+		listCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		containers, listErr := hydraClient.ListDevContainers(listCtx)
+		cancel()
+		if listErr != nil {
+			errs = append(errs, fmt.Errorf("list dev containers on %s: %w", host.ID, listErr))
+			continue
+		}
+		if containers == nil {
+			continue
+		}
+		for _, container := range containers.Containers {
+			sb := byID[container.SessionID]
+			if sb == nil || sb.HostDeviceID != host.ID || sb.DeletedAt == nil || sb.Purpose != types.SandboxPurposeWebService || sb.ProjectID == "" {
+				continue
+			}
+
+			deleteCtx, deleteCancel := context.WithTimeout(ctx, 5*time.Minute)
+			state, stateErr := c.store.GetProjectWebServiceState(deleteCtx, sb.ProjectID)
+			if stateErr != nil {
+				deleteCancel()
+				errs = append(errs, fmt.Errorf("get web service state for project %s: %w", sb.ProjectID, stateErr))
+				continue
+			}
+			if state == nil || state.ActiveSandboxID == "" || state.ActiveSandboxID == sb.ID {
+				deleteCancel()
+				continue
+			}
+			if _, err := hydraClient.DeleteDevContainer(deleteCtx, sb.ID); err != nil {
+				deleteCancel()
+				errs = append(errs, fmt.Errorf("delete superseded web service sandbox %s: %w", sb.ID, err))
+				continue
+			}
+			if err := c.store.DecrementSandboxContainerCount(deleteCtx, host.ID); err != nil {
+				log.Warn().Err(err).Str("sandbox_id", sb.ID).Str("host_device_id", host.ID).
+					Msg("failed to decrement active_sandboxes after reconciling web service container")
+			}
+			if err := hydraClient.ForgetSandboxOps(deleteCtx, sb.ID); err != nil {
+				log.Debug().Err(err).Str("sandbox_id", sb.ID).Msg("hydra ForgetSandboxOps failed after web service reconciliation")
+			}
+			deleteCancel()
+			log.Info().Str("sandbox_id", sb.ID).Str("active_sandbox_id", state.ActiveSandboxID).
+				Msg("deleted superseded web service container")
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -21,6 +21,7 @@ import (
 // in a fake without standing up a RevDial connection.
 type hydraProvisionClient interface {
 	CreateDevContainer(ctx context.Context, req *hydra.CreateDevContainerRequest) (*hydra.DevContainerResponse, error)
+	ListDevContainers(ctx context.Context) (*hydra.ListDevContainersResponse, error)
 	DeleteDevContainer(ctx context.Context, sessionID string) (*hydra.DevContainerResponse, error)
 	ForgetSandboxOps(ctx context.Context, sessionID string) error
 }

--- a/api/pkg/sandbox/controller_provision_test.go
+++ b/api/pkg/sandbox/controller_provision_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -33,8 +34,16 @@ type fakeHydra struct {
 
 	createResp *hydra.DevContainerResponse
 	createErr  error
+	listResp   *hydra.ListDevContainersResponse
+	listErr    error
 	deleteErr  error
 	forgetErr  error
+}
+
+func (f *fakeHydra) ListDevContainers(_ context.Context) (*hydra.ListDevContainersResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listResp, f.listErr
 }
 
 func (f *fakeHydra) CreateDevContainer(_ context.Context, req *hydra.CreateDevContainerRequest) (*hydra.DevContainerResponse, error) {
@@ -597,6 +606,104 @@ func (s *ProvisionSuite) TestDeleteSkipsHydraWhenSandboxHasNoHost() {
 	s.Require().Empty(s.hydra.deleteCalls, "Delete must not contact hydra for sandboxes without a host")
 }
 
+func (s *ProvisionSuite) TestReconcileWebServiceContainersDeletesSupersededContainer() {
+	deletedAt := time.Now()
+	old := &types.Sandbox{
+		ID: "sbx_old", ProjectID: "prj_1", HostDeviceID: "host-a",
+		Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt,
+	}
+	s.store.EXPECT().ListSandboxes(gomock.Any(), &store.ListSandboxesQuery{IncludeDeleted: true}).Return([]*types.Sandbox{old}, nil)
+	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{{ID: "host-a", Status: "online"}}, nil)
+	s.store.EXPECT().GetProjectWebServiceState(gomock.Any(), "prj_1").Return(&types.ProjectWebServiceState{
+		ProjectID: "prj_1", ActiveSandboxID: "sbx_current",
+	}, nil)
+	s.store.EXPECT().DecrementSandboxContainerCount(gomock.Any(), "host-a").Return(errors.New("count failed"))
+	s.hydra.listResp = &hydra.ListDevContainersResponse{Containers: []hydra.DevContainerResponse{{SessionID: old.ID}}}
+	s.hydra.forgetErr = errors.New("forget failed")
+
+	s.Require().NoError(s.controller.ReconcileWebServiceContainers(s.ctx))
+	s.Require().Equal([]string{old.ID}, s.hydra.deletes())
+	s.Require().Equal([]string{old.ID}, s.hydra.forgetCalls)
+}
+
+func TestReconcileWebServiceContainersRetainsWithoutCompleteSupersessionEvidence(t *testing.T) {
+	deletedAt := time.Now()
+	tests := []struct {
+		name          string
+		row           *types.Sandbox
+		hostDeviceID  string
+		hostStatus    string
+		listErr       error
+		state         *types.ProjectWebServiceState
+		stateErr      error
+		deleteErr     error
+		expectState   bool
+		expectAttempt bool
+		expectError   bool
+	}{
+		{name: "missing row"},
+		{name: "non-deleted row", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService}},
+		{name: "non-webservice row", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: "", DeletedAt: &deletedAt}},
+		{name: "missing project", row: &types.Sandbox{ID: "sbx_old", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}},
+		{name: "host mismatch", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, hostDeviceID: "host-b"},
+		{name: "offline host", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, hostStatus: "offline"},
+		{name: "hydra list error", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, listErr: errors.New("list failed"), expectError: true},
+		{name: "state error", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, stateErr: errors.New("state failed"), expectState: true, expectError: true},
+		{name: "nil state", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, expectState: true},
+		{name: "empty active sandbox", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, state: &types.ProjectWebServiceState{ProjectID: "prj_1"}, expectState: true},
+		{name: "still active", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, state: &types.ProjectWebServiceState{ProjectID: "prj_1", ActiveSandboxID: "sbx_old"}, expectState: true},
+		{name: "hydra delete error", row: &types.Sandbox{ID: "sbx_old", ProjectID: "prj_1", Purpose: types.SandboxPurposeWebService, DeletedAt: &deletedAt}, state: &types.ProjectWebServiceState{ProjectID: "prj_1", ActiveSandboxID: "sbx_current"}, deleteErr: errors.New("delete failed"), expectState: true, expectAttempt: true, expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := store.NewMockStore(ctrl)
+			runtimes, err := NewRuntimeRegistry(config.Sandboxes{Runtimes: "headless-ubuntu=ubuntu:22.04|sleep infinity", DefaultRuntime: "headless-ubuntu"})
+			require.NoError(t, err)
+			controller := New(mockStore, nil, runtimes, "https://api.example.com", "/sandbox-host")
+			fake := &fakeHydra{
+				listResp:  &hydra.ListDevContainersResponse{Containers: []hydra.DevContainerResponse{{SessionID: "sbx_old"}}},
+				listErr:   tt.listErr,
+				deleteErr: tt.deleteErr,
+			}
+			controller.newHydraClient = func(string) hydraProvisionClient { return fake }
+
+			rows := []*types.Sandbox{}
+			if tt.row != nil {
+				if tt.hostDeviceID == "" {
+					tt.row.HostDeviceID = "host-a"
+				} else {
+					tt.row.HostDeviceID = tt.hostDeviceID
+				}
+				rows = append(rows, tt.row)
+			}
+			mockStore.EXPECT().ListSandboxes(gomock.Any(), &store.ListSandboxesQuery{IncludeDeleted: true}).Return(rows, nil)
+			hostStatus := tt.hostStatus
+			if hostStatus == "" {
+				hostStatus = "online"
+			}
+			mockStore.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{{ID: "host-a", Status: hostStatus}}, nil)
+			if tt.expectState {
+				mockStore.EXPECT().GetProjectWebServiceState(gomock.Any(), "prj_1").Return(tt.state, tt.stateErr)
+			}
+
+			err = controller.ReconcileWebServiceContainers(context.Background())
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.expectAttempt {
+				require.Equal(t, []string{"sbx_old"}, fake.deletes())
+			} else {
+				require.Empty(t, fake.deletes())
+			}
+			require.Empty(t, fake.forgetCalls)
+		})
+	}
+}
+
 // TestStartReaperRunsThenStopsOnContextCancel: the reaper goroutine must
 // shut down cleanly when its context is cancelled. We validate by giving
 // it a tight tick interval so at least one iteration runs, then cancel.
@@ -607,6 +714,8 @@ func (s *ProvisionSuite) TestStartReaperRunsThenStopsOnContextCancel() {
 	// tick to complete before the context is cancelled — match each call
 	// AnyTimes to tolerate the inherent race with the cancel.
 	s.store.EXPECT().ListExpiredSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s.store.EXPECT().ListSandboxes(gomock.Any(), &store.ListSandboxesQuery{IncludeDeleted: true}).Return(nil, nil).AnyTimes()
+	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return(nil, nil).AnyTimes()
 	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{}, nil).AnyTimes()
 	s.store.EXPECT().ListStoppedNonPersistentSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 

--- a/api/pkg/server/agent_sandboxes_handlers.go
+++ b/api/pkg/server/agent_sandboxes_handlers.go
@@ -57,6 +57,7 @@ type SandboxInstanceInfo struct {
 type DevContainerWithClients struct {
 	hydra.DevContainerResponse
 	SandboxID        string               `json:"sandbox_id"`
+	Purpose          string               `json:"purpose,omitempty"`
 	Clients          []ClientInfo         `json:"clients,omitempty"`
 	VideoStats       *VideoStreamingStats `json:"video_stats,omitempty"`
 	SessionName      string               `json:"session_name,omitempty"`
@@ -126,6 +127,17 @@ func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, 
 	if err != nil {
 		http.Error(rw, fmt.Sprintf("Failed to list sandboxes: %v", err), http.StatusInternalServerError)
 		return
+	}
+	sandboxRows, err := apiServer.Store.ListSandboxes(ctx, &store.ListSandboxesQuery{IncludeDeleted: true})
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("Failed to list sandbox rows: %v", err), http.StatusInternalServerError)
+		return
+	}
+	sandboxByID := make(map[string]*types.Sandbox, len(sandboxRows))
+	for _, sb := range sandboxRows {
+		if sb != nil {
+			sandboxByID[sb.ID] = sb
+		}
 	}
 
 	// Convert to response format
@@ -208,51 +220,46 @@ func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, 
 		}
 	}
 
-	// Enrich containers with session details (name, age, owner) and spec task info
+	// Enrich containers with session or sandbox details.
 	for i := range allDevContainers {
-		dc := &allDevContainers[i]
-		if dc.SessionID == "" {
-			continue
-		}
+		apiServer.enrichDevContainer(ctx, &allDevContainers[i], sandboxByID)
+	}
+
+	response := &AgentSandboxesDebugResponse{
+		Message:       "Hydra-based sandbox infrastructure",
+		Sandboxes:     sandboxInfos,
+		GPUs:          allGPUs,
+		DevContainers: allDevContainers,
+	}
+
+	writeResponse(rw, response, http.StatusOK)
+}
+
+func (apiServer *HelixAPIServer) enrichDevContainer(ctx context.Context, dc *DevContainerWithClients, sandboxByID map[string]*types.Sandbox) {
+	if dc.SessionID == "" {
+		return
+	}
+
+	var owner, organizationID, projectID string
+	sandboxRow := sandboxByID[dc.SessionID]
+	if sandboxRow != nil {
+		dc.Purpose = sandboxRow.Purpose
+		dc.SessionName = sandboxRow.Name
+		dc.SessionAge = formatDuration(time.Since(sandboxRow.CreatedAt))
+		owner = sandboxRow.Owner
+		organizationID = sandboxRow.OrganizationID
+		projectID = sandboxRow.ProjectID
+	} else {
 		session, err := apiServer.Store.GetSession(ctx, dc.SessionID)
 		if err != nil {
-			continue
+			return
 		}
 		dc.SessionName = session.Name
 		dc.SessionAge = formatDuration(time.Since(session.Created))
+		owner = session.Owner
+		organizationID = session.OrganizationID
+		projectID = session.ProjectID
 
-		if session.Owner != "" {
-			user, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: session.Owner})
-			if err == nil && user != nil {
-				if user.FullName != "" {
-					dc.OwnerName = user.FullName
-				} else {
-					dc.OwnerName = user.Username
-				}
-			}
-		}
-
-		// Look up org and project names
-		if session.OrganizationID != "" {
-			dc.OrganizationID = session.OrganizationID
-			org, err := apiServer.Store.GetOrganization(ctx, &store.GetOrganizationQuery{ID: session.OrganizationID})
-			if err == nil && org != nil {
-				if org.DisplayName != "" {
-					dc.OrganizationName = org.DisplayName
-				} else {
-					dc.OrganizationName = org.Name
-				}
-			}
-		}
-		if session.ProjectID != "" {
-			dc.ProjectID = session.ProjectID
-			project, err := apiServer.Store.GetProject(ctx, session.ProjectID)
-			if err == nil && project != nil {
-				dc.ProjectName = project.Name
-			}
-		}
-
-		// Look up spec task: try work session first, then planning session fallback
 		specTask := apiServer.findSpecTaskForSession(ctx, dc.SessionID)
 		if specTask != nil {
 			dc.TaskID = specTask.ID
@@ -268,14 +275,41 @@ func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, 
 		}
 	}
 
-	response := &AgentSandboxesDebugResponse{
-		Message:       "Hydra-based sandbox infrastructure",
-		Sandboxes:     sandboxInfos,
-		GPUs:          allGPUs,
-		DevContainers: allDevContainers,
+	if owner != "" {
+		user, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: owner})
+		if err == nil && user != nil {
+			if user.FullName != "" {
+				dc.OwnerName = user.FullName
+			} else {
+				dc.OwnerName = user.Username
+			}
+		}
 	}
-
-	writeResponse(rw, response, http.StatusOK)
+	if organizationID != "" {
+		dc.OrganizationID = organizationID
+		org, err := apiServer.Store.GetOrganization(ctx, &store.GetOrganizationQuery{ID: organizationID})
+		if err == nil && org != nil {
+			if org.DisplayName != "" {
+				dc.OrganizationName = org.DisplayName
+			} else {
+				dc.OrganizationName = org.Name
+			}
+		}
+	}
+	if projectID != "" {
+		dc.ProjectID = projectID
+		project, err := apiServer.Store.GetProject(ctx, projectID)
+		if err == nil && project != nil {
+			dc.ProjectName = project.Name
+		}
+	}
+	if sandboxRow != nil && sandboxRow.Purpose == types.SandboxPurposeWebService {
+		name := dc.ProjectName
+		if name == "" {
+			name = sandboxRow.Name
+		}
+		dc.SessionName = "Web service: " + name
+	}
 }
 
 // queryDesktopClients queries the desktop server's /clients endpoint via Hydra proxy

--- a/api/pkg/server/agent_sandboxes_handlers_test.go
+++ b/api/pkg/server/agent_sandboxes_handlers_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestEnrichDevContainerUsesWebServiceSandboxRow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	deletedAt := time.Now()
+	row := &types.Sandbox{
+		ID: "sbx_web", Name: "fallback", Purpose: types.SandboxPurposeWebService,
+		Owner: "user_1", OrganizationID: "org_1", ProjectID: "prj_1", CreatedAt: time.Now().Add(-time.Hour), DeletedAt: &deletedAt,
+	}
+	dc := &DevContainerWithClients{}
+	dc.SessionID = row.ID
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "user_1"}).Return(&types.User{ID: "user_1", FullName: "Customer"}, nil)
+	mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org_1"}).Return(&types.Organization{ID: "org_1", DisplayName: "FindAI"}, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), "prj_1").Return(&types.Project{ID: "prj_1", Name: "Website"}, nil)
+
+	server.enrichDevContainer(context.Background(), dc, map[string]*types.Sandbox{row.ID: row})
+
+	require.Equal(t, types.SandboxPurposeWebService, dc.Purpose)
+	require.Equal(t, "Web service: Website", dc.SessionName)
+	require.NotEmpty(t, dc.SessionAge)
+	require.Equal(t, "Customer", dc.OwnerName)
+	require.Equal(t, "FindAI", dc.OrganizationName)
+	require.Equal(t, "Website", dc.ProjectName)
+	require.Equal(t, "org_1", dc.OrganizationID)
+	require.Equal(t, "prj_1", dc.ProjectID)
+}
+
+func TestEnrichDevContainerFallsBackToWebServiceSandboxName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	row := &types.Sandbox{ID: "sbx_web", Name: "FindAI fallback", Purpose: types.SandboxPurposeWebService, ProjectID: "prj_1"}
+	dc := &DevContainerWithClients{}
+	dc.SessionID = row.ID
+	mockStore.EXPECT().GetProject(gomock.Any(), "prj_1").Return(nil, errors.New("not found"))
+
+	server.enrichDevContainer(context.Background(), dc, map[string]*types.Sandbox{row.ID: row})
+
+	require.Equal(t, "Web service: FindAI fallback", dc.SessionName)
+}
+
+func TestAgentSandboxesDebugFailsClosedWhenSandboxRowsCannotBeListed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	mockStore.EXPECT().ListSandboxInstances(gomock.Any()).Return(nil, nil)
+	mockStore.EXPECT().ListSandboxes(gomock.Any(), &store.ListSandboxesQuery{IncludeDeleted: true}).Return(nil, errors.New("database unavailable"))
+
+	rw := httptest.NewRecorder()
+	server.getAgentSandboxesDebug(rw, httptest.NewRequest(http.MethodGet, "/api/v1/admin/agent-sandboxes/debug", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rw.Code)
+	require.Contains(t, rw.Body.String(), "Failed to list sandbox rows")
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -26340,6 +26340,9 @@ const docTemplate = `{
                 "project_name": {
                     "type": "string"
                 },
+                "purpose": {
+                    "type": "string"
+                },
                 "render_node": {
                     "description": "/dev/dri/renderD128 or SOFTWARE",
                     "type": "string"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -26336,6 +26336,9 @@
                 "project_name": {
                     "type": "string"
                 },
+                "purpose": {
+                    "type": "string"
+                },
                 "render_node": {
                     "description": "/dev/dri/renderD128 or SOFTWARE",
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -2082,6 +2082,8 @@ definitions:
         type: string
       project_name:
         type: string
+      purpose:
+        type: string
       render_node:
         description: /dev/dri/renderD128 or SOFTWARE
         type: string

--- a/api/pkg/store/store_sandboxes_test.go
+++ b/api/pkg/store/store_sandboxes_test.go
@@ -19,9 +19,63 @@ func newSandboxTestStore(t *testing.T) *PostgresStore {
 	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&types.Sandbox{}))
+	require.NoError(t, db.AutoMigrate(&types.Sandbox{}, &types.ProjectWebServiceState{}))
 
 	return &PostgresStore{gdb: db, Store: orgstore.New(db)}
+}
+
+func TestSetActiveWebServiceSandboxRequiresEligibleSandbox(t *testing.T) {
+	tests := []struct {
+		name      string
+		projectID string
+		purpose   string
+		deleted   bool
+		wantErr   bool
+	}{
+		{name: "web service", projectID: "prj_1", purpose: types.SandboxPurposeWebService},
+		{name: "deleted", projectID: "prj_1", purpose: types.SandboxPurposeWebService, deleted: true, wantErr: true},
+		{name: "wrong project", projectID: "prj_2", purpose: types.SandboxPurposeWebService, wantErr: true},
+		{name: "ordinary sandbox", projectID: "prj_1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := newSandboxTestStore(t)
+			require.NoError(t, store.UpsertProjectWebServiceState(ctx, &types.ProjectWebServiceState{
+				ProjectID:       "prj_1",
+				ActiveSandboxID: "sbx_current",
+			}))
+
+			sb, err := store.CreateSandbox(ctx, &types.Sandbox{
+				ID:             "sbx_candidate",
+				OrganizationID: "org_1",
+				ProjectID:      tt.projectID,
+				Owner:          "user_1",
+				Runtime:        types.SandboxRuntimeHeadlessUbuntu,
+				Purpose:        tt.purpose,
+			})
+			require.NoError(t, err)
+			if tt.deleted {
+				require.NoError(t, store.DeleteSandbox(ctx, sb.ID))
+			}
+
+			err = store.SetActiveWebServiceSandbox(ctx, "prj_1", sb.ID)
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrNotFound)
+			} else {
+				require.NoError(t, err)
+			}
+
+			state, err := store.GetProjectWebServiceState(ctx, "prj_1")
+			require.NoError(t, err)
+			if tt.wantErr {
+				require.Equal(t, "sbx_current", state.ActiveSandboxID)
+			} else {
+				require.Equal(t, sb.ID, state.ActiveSandboxID)
+			}
+		})
+	}
 }
 
 func TestSetSandboxContainerIgnoresDeletedRows(t *testing.T) {

--- a/api/pkg/store/vhost.go
+++ b/api/pkg/store/vhost.go
@@ -166,13 +166,26 @@ func (s *PostgresStore) SetActiveWebServiceSandbox(ctx context.Context, projectI
 	if projectID == "" {
 		return fmt.Errorf("project_id is required")
 	}
-	return s.gdb.WithContext(ctx).
+	if sandboxID == "" {
+		return fmt.Errorf("sandbox_id is required")
+	}
+	res := s.gdb.WithContext(ctx).
 		Model(&types.ProjectWebServiceState{}).
-		Where("project_id = ?", projectID).
+		Where(`project_id = ? AND EXISTS (
+			SELECT 1 FROM sandboxes
+			WHERE id = ? AND project_id = ? AND purpose = ? AND deleted_at IS NULL
+		)`, projectID, sandboxID, projectID, types.SandboxPurposeWebService).
 		Updates(map[string]interface{}{
 			"active_sandbox_id": sandboxID,
 			"updated_at":        time.Now(),
-		}).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // SetWebServiceHostDeviceID records the runner the project's web service is

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1371,6 +1371,7 @@ export interface ServerDevContainerWithClients {
   owner_name?: string;
   project_id?: string;
   project_name?: string;
+  purpose?: string;
   /** /dev/dri/renderD128 or SOFTWARE */
   render_node?: string;
   sandbox_id?: string;

--- a/frontend/src/components/admin/Runners.test.tsx
+++ b/frontend/src/components/admin/Runners.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DevContainerCard } from './Runners'
+
+vi.mock('../../contexts/account', () => ({
+  useAccount: () => ({ orgNavigate: vi.fn() }),
+}))
+
+const container = {
+  session_id: 'ses_ordinary',
+  container_id: 'ctr_ordinary',
+  container_name: 'ordinary',
+  status: 'running',
+  container_type: 'ubuntu',
+  sandbox_id: 'runner_1',
+}
+
+describe('DevContainerCard', () => {
+  it('shows the backend title without a stop control for web services', () => {
+    render(
+      <DevContainerCard
+        container={{ ...container, session_id: 'sbx_web', purpose: 'web-service', session_name: 'Web service: FindAI' }}
+        onStop={vi.fn()}
+        isStopping={false}
+      />,
+    )
+
+    expect(screen.getByText('Web service: FindAI')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Stop container' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the stop control for ordinary sessions', () => {
+    render(
+      <DevContainerCard
+        container={{ ...container, session_name: 'Coding session' }}
+        onStop={vi.fn()}
+        isStopping={false}
+      />,
+    )
+
+    expect(screen.getByText('Coding session')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Stop container' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -92,6 +92,7 @@ interface DevContainerWithClients {
   gpu_vendor?: string
   render_node?: string
   sandbox_id: string
+  purpose?: string
   clients?: ClientInfo[]
   video_stats?: VideoStreamingStats
   session_name?: string
@@ -540,7 +541,7 @@ interface DevContainerCardProps {
   isStopping: boolean
 }
 
-const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStopping }) => {
+export const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStopping }) => {
   const clients = container.clients || []
   const account = useAccount()
 
@@ -571,19 +572,22 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
           size="small"
           color={getStatusColor(container.status)}
         />
-        <Tooltip title="Stop container" arrow>
-          <IconButton
-            size="small"
-            onClick={() => onStop(container.session_id)}
-            disabled={isStopping}
-            sx={{
-              color: 'error.main',
-              '&:hover': { backgroundColor: 'rgba(244, 67, 54, 0.1)' },
-            }}
-          >
-            {isStopping ? <CircularProgress size={16} /> : <CloseIcon fontSize="small" />}
-          </IconButton>
-        </Tooltip>
+        {container.purpose !== 'web-service' && (
+          <Tooltip title="Stop container" arrow>
+            <IconButton
+              aria-label="Stop container"
+              size="small"
+              onClick={() => onStop(container.session_id)}
+              disabled={isStopping}
+              sx={{
+                color: 'error.main',
+                '&:hover': { backgroundColor: 'rgba(244, 67, 54, 0.1)' },
+              }}
+            >
+              {isStopping ? <CircularProgress size={16} /> : <CloseIcon fontSize="small" />}
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
 
       {/* Task/session title */}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -2082,6 +2082,8 @@ definitions:
         type: string
       project_name:
         type: string
+      purpose:
+        type: string
       render_node:
         description: /dev/dri/renderD128 or SOFTWARE
         type: string

--- a/openapi.json
+++ b/openapi.json
@@ -30932,6 +30932,9 @@
                     "project_name": {
                         "type": "string"
                     },
+                    "purpose": {
+                        "type": "string"
+                    },
                     "render_node": {
                         "description": "/dev/dri/renderD128 or SOFTWARE",
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -26336,6 +26336,9 @@
                 "project_name": {
                     "type": "string"
                 },
+                "purpose": {
+                    "type": "string"
+                },
                 "render_node": {
                     "description": "/dev/dri/renderD128 or SOFTWARE",
                     "type": "string"


### PR DESCRIPTION
## Summary
- reconcile physically present web-service containers whose sandbox rows are soft-deleted and no longer active
- preserve active, pending, ambiguous, and unreachable web-service containers
- identify web-service containers in Admin > Runners, give them project names, and remove the invalid session stop action

## Safety
- requires an exact Hydra container match, a historical web-service row, a soft-delete marker, matching runner ownership, and a fresh different active sandbox ID
- any missing or failed check retains the container for a later sweep
- no live SaaS containers were changed during development

## Verification
- `go test ./pkg/sandbox -count=1`
- `go test ./pkg/server -run "Test(EnrichDevContainer|AgentSandboxesDebug)" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `yarn test Runners.test.tsx --run`
- `./stack update_openapi`
- `git diff --check`

## Known baseline issue
- `yarn build` is blocked by the existing case-sensitive filename pair `WorkspaceReviewMessage.tsx` and `workspaceReviewMessage.ts` imported by `InteractionInference.tsx`.