### PR TITLE
Fix legacy organization agent provider migration

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -82,11 +82,10 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 		return substitutions, err
 	}
 
-	// One predicate, case-insensitive on names: substitution catalogs are
-	// name-keyed (alt.Provider is always a canonical name) but the
-	// agent-stored value may be an ID, a canonical global name, or a
-	// legacy mixed-case name. Single helper avoids the case-sensitive Go
-	// map gotcha that the previous double-keyed providerSet papered over.
+	// One predicate for all supported provider reference shapes. Provider
+	// endpoint presets used to be stored as names such as "user/anthropic",
+	// while global endpoints are now exposed as "anthropic". Treat those as
+	// the same provider kind; DB-backed pe_ references must still match by ID.
 	providerKnown := func(ref string) bool {
 		if ref == "" {
 			return false
@@ -95,7 +94,7 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 			if ep.ID != "" && ep.ID == ref {
 				return true
 			}
-			if strings.EqualFold(ep.Name, ref) {
+			if types.CanonicalProviderName(ep.Name) == types.CanonicalProviderName(ref) {
 				return true
 			}
 		}
@@ -702,15 +701,16 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 	}
 
 	// Provider references are IDs for DB-backed providers, canonical names
-	// for env-baked globals. Match incoming agent values against either —
-	// case-insensitive on names so a legacy agent that stored "OpenAI" still
-	// matches the canonical "openai" record.
+	// for env-baked globals, and (on legacy agents) preset names such as
+	// "user/openai". Match IDs exactly and names by canonical provider kind.
+	// This lets a legacy org agent be saved and migrated when the matching
+	// org/global provider exists, without making a personal pe_ ID visible.
 	providerKnown := func(ref string) bool {
 		for _, ep := range endpoints {
 			if ep.ID != "" && ep.ID == ref {
 				return true
 			}
-			if strings.EqualFold(ep.Name, ref) {
+			if types.CanonicalProviderName(ep.Name) == types.CanonicalProviderName(ref) {
 				return true
 			}
 		}

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -1534,6 +1534,31 @@ func TestValidateProvidersAndModels_UnavailableProviderMessage(t *testing.T) {
 	require.ErrorContains(t, err, "provider 'pe_provider' is not available")
 }
 
+func TestValidateProvidersAndModels_LegacyPresetNameMatchesOrganizationProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+	user := &types.User{ID: "user1"}
+	app := &types.App{
+		OrganizationID: "org1",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{Assistants: []types.AssistantConfig{{
+			Provider: "user/anthropic",
+			Model:    "claude-sonnet",
+		}}}},
+	}
+
+	mockProviderManager.EXPECT().
+		ListProviderEndpointsForOwner(ctx, "org1", types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{{
+			ID:           "global/anthropic",
+			Name:         "anthropic",
+			EndpointType: types.ProviderEndpointTypeGlobal,
+		}}, nil)
+
+	require.NoError(t, server.validateProvidersAndModels(ctx, user, app))
+}
+
 // TestListEndpointsForApp covers app-scoped provider snapshots.
 func TestListEndpointsForApp(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/api/pkg/server/code_agent_provider_endpoint.go
+++ b/api/pkg/server/code_agent_provider_endpoint.go
@@ -74,7 +74,14 @@ func (s *HelixAPIServer) resolveCodeAgentProviderEndpoint(
 		ownerType = types.OwnerTypeOrg
 	}
 	if types.IsGlobalProviderID(providerRef) {
-		endpoint, err := s.getBuiltInProviderEndpoint(ctx, types.CanonicalProviderName(providerRef))
+		providerName := types.CanonicalProviderName(providerRef)
+		var endpoint *types.ProviderEndpoint
+		var err error
+		if providerName == string(types.ProviderOpenAI) {
+			endpoint, err = s.getBuiltInOpenAIProviderEndpoint()
+		} else {
+			endpoint, err = s.getBuiltInProviderEndpoint(ctx, providerName)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -87,6 +94,16 @@ func (s *HelixAPIServer) resolveCodeAgentProviderEndpoint(
 			return nil, fmt.Errorf("list providers: %w", err)
 		}
 		if endpoint := resolveProviderEndpointRef(endpoints, providerRef); endpoint != nil {
+			// Provider-manager global entries are discovery-only synthetics and
+			// intentionally do not expose credentials. Hydrate a selected built-in
+			// before the code-agent proxy tries to authenticate upstream. A real
+			// org/DB endpoint wins in resolveProviderEndpointRef and is left intact.
+			if endpoint.ID == types.GlobalProviderID(string(types.ProviderOpenAI)) {
+				return s.getBuiltInOpenAIProviderEndpoint()
+			}
+			if endpoint.ID == types.GlobalProviderID(string(types.ProviderAnthropic)) {
+				return s.getBuiltInProviderEndpoint(ctx, string(types.ProviderAnthropic))
+			}
 			return endpoint, nil
 		}
 	}

--- a/api/pkg/server/code_agent_provider_endpoint_test.go
+++ b/api/pkg/server/code_agent_provider_endpoint_test.go
@@ -88,6 +88,33 @@ func TestResolveCodeAgentProviderEndpointPrefersLegacyNamedOrganizationAnthropic
 	require.Same(t, orgEndpoint, endpoint)
 }
 
+func TestResolveCodeAgentProviderEndpointHydratesLegacyNamedGlobalOpenAI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	providerManager := manager.NewMockProviderManager(ctrl)
+	providerManager.EXPECT().
+		ListProviderEndpointsForOwner(gomock.Any(), "org_1", types.OwnerTypeOrg).
+		Return([]*types.ProviderEndpoint{{
+			ID:           "global/openai",
+			Name:         "openai",
+			EndpointType: types.ProviderEndpointTypeGlobal,
+		}}, nil)
+
+	server := &HelixAPIServer{
+		Cfg: &config.ServerConfig{Providers: config.Providers{OpenAI: config.OpenAI{
+			APIKey:  "global-key",
+			BaseURL: "https://api.openai.com/v1",
+		}}},
+		providerManager: providerManager,
+	}
+	endpoint, err := server.resolveCodeAgentProviderEndpoint(context.Background(), &types.User{
+		ID: "user_1", OrganizationID: "org_1",
+	}, "user/openai")
+
+	require.NoError(t, err)
+	require.Equal(t, "global-key", endpoint.APIKey)
+	require.Equal(t, "https://api.openai.com/v1", endpoint.BaseURL)
+}
+
 func TestResolveCodeAgentProviderEndpointKeepsExplicitDatabaseID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	providerManager := manager.NewMockProviderManager(ctrl)


### PR DESCRIPTION
## Summary
Allow organization agents with legacy provider names such as `user/anthropic` to match an available organization or global provider, so administrators can update and save those agents without restoring personal-provider access. Personal `pe_` provider IDs that are not visible to the organization remain rejected.

Hydrate synthetic global OpenAI endpoints from the configured `OPENAI_API_KEY` and `OPENAI_BASE_URL` before proxying Codex Responses API requests. This prevents coding-agent requests from failing with a misleading missing API key error when the global OpenAI provider is configured through the control-plane environment.

## Testing
Added regression coverage for saving an organization agent with a legacy provider name and for resolving a legacy global OpenAI reference with its configured credentials and base URL.

Focused provider validation and code-agent endpoint tests pass. The complete `api/pkg/server` test package was also run; changed tests pass, while unrelated in-process organization tests fail because the test binary was built with `CGO_ENABLED=0` and `go-sqlite3` requires CGO.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1h4njxxg6q45bj88tdenqd7)

🚀 Built with [Helix](https://helix.ml)