### PR TITLE
fix: render Markdown blockquotes in artifacts and chat

### DIFF
--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -12,9 +12,9 @@ import Box from "@mui/material/Box";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import type { PluggableList } from "unified";
 import { TypesSession } from "../../api/api";
-
-import DOMPurify from "dompurify";
 
 // Import the new Citation component
 import Citation, { Excerpt } from "./Citation";
@@ -91,9 +91,6 @@ export class MessageProcessor {
     if (this.options.isStreaming) {
       processedMessage = this.removeTrailingTripleDash(processedMessage);
     }
-
-    // Sanitize HTML
-    processedMessage = this.sanitizeHtml(processedMessage);
 
     // Note: Blinker is now rendered as a separate React component (StreamingIndicator)
     // instead of being injected into the markdown content. This fixes issues where
@@ -475,10 +472,6 @@ export class MessageProcessor {
   private removeTrailingTripleDash(message: string): string {
     // Remove triple dash at the end of content during streaming
     return message.replace(/\n---\s*$/, "");
-  }
-
-  private sanitizeHtml(message: string): string {
-    return sanitizeChatMarkdown(message);
   }
 
   private addCitationData(message: string): string {
@@ -917,6 +910,18 @@ const InteractionMarkdown: FC<InteractionMarkdownProps> = ({
           "& a": {
             color: theme.palette.mode === "light" ? "#333" : "inherit",
           },
+          "& blockquote": {
+            margin: "1rem 0",
+            padding: "0.125rem 0 0.125rem 1rem",
+            borderLeft: `3px solid ${chatColors.borderStrong}`,
+            color: chatColors.muted,
+          },
+          "& blockquote > :first-of-type": {
+            marginTop: 0,
+          },
+          "& blockquote > :last-child": {
+            marginBottom: 0,
+          },
 
           "& .doc-citation": {
             color: theme.palette.mode === "light" ? "#333" : "#fff",
@@ -1127,7 +1132,13 @@ const MemoizedMarkdownRenderer: FC<{ processedContent: string }> = React.memo(
 
     // Memoize plugins arrays to prevent unnecessary re-renders
     const remarkPluginsArray = useMemo(() => [remarkGfm], []);
-    const rehypePluginsArray = useMemo(() => [rehypeRaw], []);
+    const rehypePluginsArray = useMemo(
+      (): PluggableList => [
+        rehypeRaw,
+        [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
+      ],
+      [],
+    );
 
     return (
       <Markdown
@@ -1176,106 +1187,21 @@ const WorkspaceFileReference: FC<{ path: string; label: string }> = ({ path, lab
   );
 };
 
-// Shared HTML sanitization for chat markdown. Applied both by the
-// MessageProcessor (session messages) and the no-session rendering path used
-// by standalone surfaces such as markdown artifacts.
-export function sanitizeChatMarkdown(message: string): string {
-  // Temporarily replace code blocks to protect them from sanitization
-  const codeBlocks: string[] = [];
-  let processedMessage = message.replace(
-    /```(?:[\w]*)\n([\s\S]*?)```/g,
-    (match, codeContent) => {
-      codeBlocks.push(match);
-      return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
-    },
-  );
-
-  // Also protect inline code spans
-  const inlineCode: string[] = [];
-  processedMessage = processedMessage.replace(/`([^`]+)`/g, (match) => {
-    inlineCode.push(match);
-    return `__INLINE_CODE_${inlineCode.length - 1}__`;
-  });
-
-  // Escape HTML-like tags that aren't in our allowlist BEFORE DOMPurify
-  // This prevents malformed tags like <svg xmlns="... from breaking rendering
-  const ALLOWED_TAG_NAMES = [
-    "a",
-    "p",
-    "br",
-    "strong",
-    "em",
-    "div",
-    "span",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "ul",
-    "ol",
-    "li",
-    "code",
-    "pre",
-    "blockquote",
-    "details",
-    "summary",
-    "table",
-    "thead",
-    "tbody",
-    "tr",
-    "th",
-    "td",
-  ];
-  processedMessage = processedMessage.replace(
-    /<(\/?)([\w-]+)/g,
-    (match, slash, tagName) => {
-      if (ALLOWED_TAG_NAMES.includes(tagName.toLowerCase())) {
-        return match; // Keep allowed tags
-      }
-      return `&lt;${slash}${tagName}`; // Escape disallowed tags
-    },
-  );
-
-  // Use DOMPurify to sanitize HTML while preserving safe tags and attributes
-  processedMessage = DOMPurify.sanitize(processedMessage, {
-    ALLOWED_TAGS: ALLOWED_TAG_NAMES,
-    ALLOWED_ATTR: [
-      "href",
+const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [
+      ...(defaultSchema.attributes?.a || []),
+      ["className", "doc-citation", "filter-mention", "doc-group-link"],
       "target",
-      "class",
-      "style",
       "title",
-      "id",
-      "aria-hidden",
-      "aria-label",
-      "role",
     ],
-    ADD_ATTR: ["target"],
-  });
-
-  // Restore inline code
-  inlineCode.forEach((code, index) => {
-    processedMessage = processedMessage.replace(
-      `__INLINE_CODE_${index}__`,
-      code,
-    );
-  });
-
-  // Restore code blocks
-  codeBlocks.forEach((codeBlock, index) => {
-    processedMessage = processedMessage.replace(
-      `__CODE_BLOCK_${index}__`,
-      codeBlock,
-    );
-  });
-
-  return processedMessage;
-}
+  },
+};
 
 function processBasicContent(text: string): string {
-  return sanitizeChatMarkdown(text);
+  return text;
 }
 
 // Export with React.memo to prevent unnecessary re-renders

--- a/frontend/src/components/session/MarkdownRendering.test.tsx
+++ b/frontend/src/components/session/MarkdownRendering.test.tsx
@@ -1,0 +1,58 @@
+import { render, waitFor, within } from '@testing-library/react'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TypesSession } from '../../api/api'
+import Markdown from './Markdown'
+
+vi.unmock('react-markdown')
+
+const session = { id: 'session-1', config: {} } as TypesSession
+const theme = createTheme({ palette: { mode: 'dark' } })
+const quote = [
+  '> “Webhook Relay lets you receive webhooks on your local machine.”',
+  '>',
+  '> — from <https://webhookrelay.com>',
+].join('\n')
+
+describe('Markdown rendering', () => {
+  it('renders blockquotes in Agent Chat and markdown artifacts', async () => {
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <div data-testid="agent-chat">
+          <Markdown text={quote} session={session} getFileURL={() => ''} />
+        </div>
+        <div data-testid="artifact">
+          <Markdown text={quote} session={null} renderThinkingWidget={false} />
+        </div>
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(within(getByTestId('agent-chat')).getByText(/Webhook Relay/).closest('blockquote')).not.toBeNull()
+      expect(within(getByTestId('artifact')).getByText(/Webhook Relay/).closest('blockquote')).not.toBeNull()
+    })
+
+    for (const surface of ['agent-chat', 'artifact']) {
+      const container = within(getByTestId(surface))
+      const link = container.getByRole('link', { name: 'https://webhookrelay.com' })
+      expect(link).toHaveAttribute('href', 'https://webhookrelay.com')
+      expect(getByTestId(surface)).not.toHaveTextContent('> “Webhook Relay')
+    }
+  })
+
+  it('sanitizes unsafe raw HTML after parsing markdown', async () => {
+    const { container, getByText } = render(
+      <ThemeProvider theme={theme}>
+        <Markdown
+          text={'<script>alert("xss")</script>\n\n<iframe src="https://example.com"></iframe>\n\nSafe content'}
+          session={null}
+        />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => expect(getByText('Safe content')).toBeInTheDocument())
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+})

--- a/frontend/src/components/session/MessageProcessor.test.tsx
+++ b/frontend/src/components/session/MessageProcessor.test.tsx
@@ -9,20 +9,6 @@ import {
 } from "../../api/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-// Mock DOMPurify
-vi.mock("dompurify", () => {
-  return {
-    default: {
-      sanitize: (html: string) => {
-        // Simple mock sanitizer that removes <script> and <iframe> tags
-        return html
-          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
-          .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, "");
-      },
-    },
-  };
-});
-
 // Mock data for tests
 const mockInteraction: Partial<TypesInteraction> = {
   id: "int1",
@@ -467,7 +453,7 @@ And inline code \`const y = 10;\` too.`;
     });
   });
 
-  describe("HTML sanitization", () => {
+  describe("HTML processing", () => {
     test("Safe HTML should be preserved", () => {
       const message = `<p>This is a <strong>paragraph</strong> with <em>formatting</em>.</p>
 <a href="https://example.com">Link</a>
@@ -489,28 +475,6 @@ And inline code \`const y = 10;\` too.`;
       expect(result).toContain("<ul><li>");
     });
 
-    test("Unsafe HTML should be removed", () => {
-      const message = `<script>alert("xss")</script>
-<p>Safe content</p>
-<iframe src="https://malicious.com"></iframe>`;
-
-      const processor = new MessageProcessor(message, {
-        session: mockSession as TypesSession,
-        getFileURL: mockGetFileURL,
-        isStreaming: false,
-      });
-
-      const result = processor.process();
-
-      // With our mock implementation, script and iframe tags should be removed
-      expect(result).not.toContain('<script>alert("xss")</script>');
-      expect(result).not.toContain(
-        '<iframe src="https://malicious.com"></iframe>',
-      );
-
-      // Safe content should be preserved
-      expect(result).toContain("<p>Safe content</p>");
-    });
   });
 
   describe("Triple dash handling", () => {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -2,37 +2,6 @@ import '@testing-library/jest-dom'
 import { createElement } from 'react'
 import { vi } from 'vitest'
 
-// Mock for DOMPurify that simulates basic sanitization behavior
-vi.mock('dompurify', () => {
-  return {
-    default: {
-      sanitize: (html: string, config: any = {}) => {
-        // Basic simulation of DOMPurify's sanitization
-        if (!html) return '';
-        
-        // Parse allowed tags from config or use defaults
-        const allowedTags = config.ALLOWED_TAGS || [
-          'b', 'i', 'u', 'strong', 'em', 'code', 'pre', 
-          'a', 'span', 'div', 'p', 'ul', 'ol', 'li',
-          'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'details', 'summary'
-        ];
-        
-        // Keep think-container and thinking classes for testing
-        let sanitized = html;
-        
-        // Simulate preserving allowed tags
-        if (allowedTags.includes('div')) {
-          // Preserve think-container divs for testing
-          const thinkingPattern = /<div class="think-container( thinking)?"/g;
-          sanitized = sanitized.replace(thinkingPattern, (match) => match);
-        }
-        
-        return sanitized;
-      }
-    }
-  }
-})
-
 // Stub global window objects used in components
 global.window.scrollTo = vi.fn();
 


### PR DESCRIPTION
## Summary
- parse Markdown before sanitizing the rendered HTML tree
- render shared blockquote styling in artifacts and Agent Chat
- add regression coverage for both rendering modes and unsafe raw HTML

## Verification
- `yarn test src/components/session/MarkdownRendering.test.tsx src/components/session/MessageProcessor.test.tsx src/components/session/MarkdownLayout.test.tsx`
- `yarn tsc`
- `yarn build`
- local browser E2E on the reported artifact and an existing Agent Chat transcript