### PR TITLE
fix(claude): delegate subscriptions at organization level

### DIFF
--- a/api/pkg/external-agent/subscription_preflight.go
+++ b/api/pkg/external-agent/subscription_preflight.go
@@ -28,28 +28,37 @@ func (h *HydraExecutor) verifySubscriptionCredentials(ctx context.Context, agent
 	// Login and exploratory desktops have no parent app — and the Codex/Claude
 	// login flows start exactly such a desktop to *obtain* the subscription, so
 	// they must never be gated on already having one.
-	if session.ParentApp == "" {
+	if session.ParentApp == "" && session.Metadata.SpecTaskID == "" {
 		return nil
 	}
-	app, err := h.store.GetApp(ctx, session.ParentApp)
-	if err != nil || app == nil {
-		return nil
-	}
-
-	// Match buildCodeAgentConfig: the first zed_external assistant is the one
-	// whose runtime and credentials the container is configured from.
-	var assistant *types.AssistantConfig
-	for i := range app.Config.Helix.Assistants {
-		if app.Config.Helix.Assistants[i].AgentType == types.AgentTypeZedExternal {
-			assistant = &app.Config.Helix.Assistants[i]
-			break
+	var runtime types.CodeAgentRuntime
+	var credentialType types.CodeAgentCredentialType
+	if session.Metadata.SpecTaskID != "" {
+		task, err := h.store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+		if err != nil || task == nil || task.CodeAgentConfig == nil {
+			return nil
+		}
+		runtime = task.CodeAgentConfig.Runtime
+		credentialType = task.CodeAgentConfig.CredentialType
+	} else {
+		app, err := h.store.GetApp(ctx, session.ParentApp)
+		if err != nil || app == nil {
+			return nil
+		}
+		for i := range app.Config.Helix.Assistants {
+			assistant := &app.Config.Helix.Assistants[i]
+			if assistant.AgentType == types.AgentTypeZedExternal {
+				runtime = assistant.CodeAgentRuntime
+				credentialType = assistant.CodeAgentCredentialType
+				break
+			}
 		}
 	}
-	if assistant == nil || !assistant.CodeAgentCredentialType.IsSubscription() {
+	if !credentialType.IsSubscription() {
 		return nil
 	}
 
-	switch assistant.CodeAgentRuntime {
+	switch runtime {
 	case types.CodeAgentRuntimeClaudeCode:
 		sub, err := h.store.GetSessionClaudeSubscription(ctx, session)
 		if err != nil || sub == nil || sub.Status != "active" {

--- a/api/pkg/external-agent/subscription_preflight_test.go
+++ b/api/pkg/external-agent/subscription_preflight_test.go
@@ -118,6 +118,27 @@ func TestVerifySubscriptionCredentials_LoginDesktopSkipped(t *testing.T) {
 	assert.NoError(t, h.verifySubscriptionCredentials(context.Background(), &types.DesktopAgent{SessionID: "ses_login"}))
 }
 
+func TestVerifySubscriptionCredentials_ParentlessSpecTaskMissingClaude(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	session := &types.Session{
+		ID: "ses_spec", Owner: "usr_member", OrganizationID: "org_1",
+		Metadata: types.SessionMetadata{SpecTaskID: "spt_1"},
+	}
+	mockStore.EXPECT().GetSession(gomock.Any(), "ses_spec").Return(session, nil)
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "spt_1").Return(&types.SpecTask{
+		ID: "spt_1",
+		CodeAgentConfig: &types.CodeAgentExecutionConfig{
+			Runtime: types.CodeAgentRuntimeClaudeCode, CredentialType: types.CodeAgentCredentialTypeSubscription,
+		},
+	}, nil)
+	mockStore.EXPECT().GetSessionClaudeSubscription(gomock.Any(), session).Return(nil, store.ErrNotFound)
+
+	err := h.verifySubscriptionCredentials(context.Background(), &types.DesktopAgent{SessionID: "ses_spec"})
+	require.ErrorContains(t, err, "Claude subscription")
+}
+
 // The browser has to decide which provider login to offer. Pattern-matching the
 // prose would break the moment the wording changes, so the error carries the
 // provider structurally.

--- a/api/pkg/server/claude_subscription_delegation_test.go
+++ b/api/pkg/server/claude_subscription_delegation_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUpdateClaudeSubscriptionDelegationRejectsAnotherOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	user := &types.User{ID: "usr_a"}
+	sub := &types.ClaudeSubscription{ID: "sub_a", OwnerID: user.ID, OwnerType: types.OwnerTypeUser}
+
+	mockStore.EXPECT().GetClaudeSubscription(gomock.Any(), "sub_a").Return(sub, nil)
+	mockStore.EXPECT().ListOrganizationMemberships(gomock.Any(), &store.ListOrganizationMembershipsQuery{UserID: user.ID}).Return(
+		[]*types.OrganizationMembership{{UserID: user.ID, OrganizationID: "org_1"}}, nil,
+	)
+	mockStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(
+		&types.OrganizationMembership{UserID: user.ID, OrganizationID: "org_1", Role: types.OrganizationRoleOwner}, nil,
+	)
+	mockStore.EXPECT().GetOrgCodeAgentHarness(gomock.Any(), "org_1", types.CodeAgentRuntimeClaudeCode).Return(nil, store.ErrNotFound)
+	mockStore.EXPECT().UpdateClaudeSubscriptionDelegation(gomock.Any(), "sub_a", []string{"org_1"}).Return(
+		nil, &store.ClaudeSubscriptionDelegationConflictError{OrganizationID: "org_1", OwnerID: "usr_b"},
+	)
+	mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org_1"}).Return(
+		&types.Organization{ID: "org_1", Name: "customer", DisplayName: "Customer Org"}, nil,
+	)
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_b"}).Return(
+		&types.User{ID: "usr_b", FullName: "Beatrice"}, nil,
+	)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/claude-subscriptions/sub_a/delegation", bytes.NewBufferString(`{"delegated_org_ids":["org_1"]}`))
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": "sub_a"})
+	req = req.WithContext(setRequestUser(req.Context(), *user))
+
+	_, httpErr := server.updateClaudeSubscriptionDelegation(nil, req)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	require.Equal(t, "Customer Org already uses Beatrice's Claude subscription. Ask Beatrice to remove that delegation before adding yours.", httpErr.Message)
+	require.NotContains(t, httpErr.Message, "org_1")
+}

--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -151,10 +151,12 @@ func (apiServer *HelixAPIServer) createClaudeSubscriptionFrom(ctx context.Contex
 		}
 	}
 
-	// Delete any existing subscriptions for this owner before creating a new one.
+	// Re-authentication replaces credentials, not the owner's explicit sharing consent.
 	existingSubs, _ := apiServer.Store.ListClaudeSubscriptions(ctx, ownerID)
+	var delegatedOrgIDs []string
 	for _, old := range existingSubs {
 		if old.OwnerType == ownerType {
+			delegatedOrgIDs = append(delegatedOrgIDs, old.DelegatedOrgIDs...)
 			_ = apiServer.Store.DeleteClaudeSubscription(ctx, old.ID)
 			log.Info().Str("old_subscription_id", old.ID).Msg("Deleted old Claude subscription on re-auth")
 		}
@@ -173,6 +175,7 @@ func (apiServer *HelixAPIServer) createClaudeSubscriptionFrom(ctx context.Contex
 		RefreshTokenExpiresAt: refreshTokenExpiresAt,
 		Status:                "active",
 		CreatedBy:             user.ID,
+		DelegatedOrgIDs:       delegatedOrgIDs,
 	}
 
 	created, err := apiServer.Store.CreateClaudeSubscription(ctx, sub)
@@ -627,16 +630,34 @@ func (apiServer *HelixAPIServer) updateClaudeSubscriptionDelegation(_ http.Respo
 		}
 		harnesses[orgID] = harness
 	}
+	updated, err := apiServer.Store.UpdateClaudeSubscriptionDelegation(req.Context(), sub.ID, granted)
+	if err != nil {
+		var conflict *store.ClaudeSubscriptionDelegationConflictError
+		if errors.As(err, &conflict) {
+			org, orgErr := apiServer.lookupOrg(req.Context(), conflict.OrganizationID)
+			if orgErr != nil {
+				return nil, system.NewHTTPError500("failed to resolve organization name")
+			}
+			owner, ownerErr := apiServer.Store.GetUser(req.Context(), &store.GetUserQuery{ID: conflict.OwnerID})
+			if ownerErr != nil {
+				return nil, system.NewHTTPError500("failed to resolve subscription owner")
+			}
+			orgName := org.DisplayName
+			if orgName == "" {
+				orgName = org.Name
+			}
+			ownerName := userDisplayName(owner)
+			return nil, system.NewHTTPError409(fmt.Sprintf(
+				"%s already uses %s's Claude subscription. Ask %s to remove that delegation before adding yours.",
+				orgName, ownerName, ownerName,
+			))
+		}
+		return nil, system.NewHTTPError500("failed to update subscription: " + err.Error())
+	}
 	for orgID := range harnesses {
 		if err := apiServer.enableSubscriptionCodeAgentHarness(req.Context(), orgID, user.ID, types.CodeAgentRuntimeClaudeCode); err != nil {
 			return nil, system.NewHTTPError500(err.Error())
 		}
-	}
-
-	sub.DelegatedOrgIDs = granted
-	updated, err := apiServer.Store.UpdateClaudeSubscription(req.Context(), sub)
-	if err != nil {
-		return nil, system.NewHTTPError500("failed to update subscription: " + err.Error())
 	}
 
 	log.Info().

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -31442,7 +31442,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.CodeAgentExecutionConfig"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Resolution\nfails closed unless that user has delegated to this organization.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -31571,7 +31571,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or\ncredential resolution fails closed. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -34358,8 +34358,14 @@ const docTemplate = `{
                 "runtime": {
                     "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
+                "subscription_credential_type": {
+                    "type": "string"
+                },
                 "subscription_enabled": {
                     "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
                 },
                 "supports_subscription": {
                     "type": "boolean"

--- a/api/pkg/server/org_code_agent_harness_handlers.go
+++ b/api/pkg/server/org_code_agent_harness_handlers.go
@@ -104,9 +104,15 @@ func (apiServer *HelixAPIServer) buildOrgCodeAgentHarnessStatuses(ctx context.Co
 		policies[row.Runtime] = row
 	}
 
-	hasClaude, err := apiServer.viewerHasClaudeSubscription(ctx, orgID, userID)
+	claudeSub, err := apiServer.Store.GetDelegatedClaudeSubscriptionForOrg(ctx, orgID)
+	if errors.Is(err, store.ErrNotFound) {
+		claudeSub, err = apiServer.Store.GetEffectiveClaudeSubscription(ctx, userID, orgID)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve Claude subscription: %w", err)
+		if !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("failed to resolve Claude subscription: %w", err)
+		}
+		claudeSub = nil
 	}
 	hasCodex, err := apiServer.viewerHasCodexSubscription(ctx, orgID, userID)
 	if err != nil {
@@ -128,13 +134,31 @@ func (apiServer *HelixAPIServer) buildOrgCodeAgentHarnessStatuses(ctx context.Co
 		}
 		switch runtime {
 		case types.CodeAgentRuntimeClaudeCode:
-			status.ViewerHasSubscription = hasClaude
+			status.ViewerHasSubscription = claudeSub != nil && claudeSub.Status == "active"
+			if claudeSub != nil && subscriptionDelegatedToOrg(claudeSub, orgID) {
+				status.SubscriptionOwnerName = claudeSub.OwnerID
+				if owner, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: claudeSub.OwnerID}); err == nil {
+					if name := userDisplayName(owner); name != "" {
+						status.SubscriptionOwnerName = name
+					}
+				}
+				status.SubscriptionCredentialType = claudeSub.CredentialType
+			}
 		case types.CodeAgentRuntimeCodexCLI:
 			status.ViewerHasSubscription = hasCodex
 		}
 		statuses = append(statuses, status)
 	}
 	return statuses, nil
+}
+
+func subscriptionDelegatedToOrg(sub *types.ClaudeSubscription, orgID string) bool {
+	for _, delegatedOrgID := range sub.DelegatedOrgIDs {
+		if delegatedOrgID == orgID {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeHarnessProviderRefs(refs []string) ([]string, error) {
@@ -186,14 +210,6 @@ func normalizeHarnessCredentialSources(update *types.OrgCodeAgentHarnessUpdate) 
 
 func claudeHarnessUsesAPIProviderMode(harness *types.OrgCodeAgentHarness) bool {
 	return harness != nil && !(harness.SubscriptionEnabled != nil && *harness.SubscriptionEnabled) && (harness.ProviderRefs == nil || len(harness.ProviderRefs) > 0)
-}
-
-func (apiServer *HelixAPIServer) viewerHasClaudeSubscription(ctx context.Context, orgID, userID string) (bool, error) {
-	_, err := apiServer.Store.GetEffectiveClaudeSubscription(ctx, userID, orgID)
-	if errors.Is(err, store.ErrNotFound) {
-		return false, nil
-	}
-	return err == nil, err
 }
 
 func (apiServer *HelixAPIServer) viewerHasCodexSubscription(ctx context.Context, orgID, userID string) (bool, error) {

--- a/api/pkg/server/org_code_agent_harness_handlers_test.go
+++ b/api/pkg/server/org_code_agent_harness_handlers_test.go
@@ -238,8 +238,14 @@ func TestBuildOrgCodeAgentHarnessStatuses(t *testing.T) {
 			ProviderRefs:        []string{"provider-1"},
 		}}, nil,
 	)
-	mockStore.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "user_1", "org_1").Return(
-		&types.ClaudeSubscription{}, nil,
+	mockStore.EXPECT().GetDelegatedClaudeSubscriptionForOrg(gomock.Any(), "org_1").Return(
+		&types.ClaudeSubscription{
+			OwnerID: "user_delegate", Status: "active", DelegatedOrgIDs: []string{"org_1"},
+			AccountEmail: "claude@example.com", CredentialType: "setup_token",
+		}, nil,
+	)
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "user_delegate"}).Return(
+		&types.User{ID: "user_delegate", Email: "delegate@example.com"}, nil,
 	)
 	mockStore.EXPECT().GetEffectiveCodexSubscription(gomock.Any(), "user_1", "org_1").Return(
 		nil, store.ErrNotFound,
@@ -260,6 +266,8 @@ func TestBuildOrgCodeAgentHarnessStatuses(t *testing.T) {
 	assert.False(t, *byRuntime[types.CodeAgentRuntimeClaudeCode].SubscriptionEnabled)
 	assert.Equal(t, []string{"provider-1"}, byRuntime[types.CodeAgentRuntimeClaudeCode].ProviderRefs)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeClaudeCode].ViewerHasSubscription)
+	assert.Equal(t, "delegate@example.com", byRuntime[types.CodeAgentRuntimeClaudeCode].SubscriptionOwnerName)
+	assert.Equal(t, "setup_token", byRuntime[types.CodeAgentRuntimeClaudeCode].SubscriptionCredentialType)
 	assert.True(t, byRuntime[types.CodeAgentRuntimeCodexCLI].Enabled)
 	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].ProviderRefs)
 	assert.Nil(t, byRuntime[types.CodeAgentRuntimeCodexCLI].SubscriptionEnabled)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -31438,7 +31438,7 @@
                     "$ref": "#/definitions/types.CodeAgentExecutionConfig"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Resolution\nfails closed unless that user has delegated to this organization.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -31567,7 +31567,7 @@
                     "type": "string"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or\ncredential resolution fails closed. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -34354,8 +34354,14 @@
                 "runtime": {
                     "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
+                "subscription_credential_type": {
+                    "type": "string"
+                },
                 "subscription_enabled": {
                     "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
                 },
                 "supports_subscription": {
                     "type": "boolean"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5780,8 +5780,8 @@ definitions:
           CredentialOwnerID optionally names the user whose Claude subscription should
           authenticate this task's agent, for orchestrators dispatching work on a
           human's behalf under one service API key. Credential resolution only — the
-          task is still created by, owned by, and attributed to the caller. Ignored
-          unless that user has delegated their subscription to this organization.
+          task is still created by, owned by, and attributed to the caller. Resolution
+          fails closed unless that user has delegated to this organization.
         type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
@@ -5882,8 +5882,8 @@ definitions:
           authenticates as the person it acts for, exactly as CreateTaskRequest does
           for a run dispatched by hand. Credential resolution only: the task is still
           created by, owned by, and attributed to the trigger's app owner, and the
-          named user must have delegated their subscription to this organization or it
-          is ignored. Currently honoured by the spec_task action.
+          named user must have delegated their subscription to this organization or
+          credential resolution fails closed. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -7917,8 +7917,12 @@ definitions:
         type: array
       runtime:
         $ref: '#/definitions/types.CodeAgentRuntime'
+      subscription_credential_type:
+        type: string
       subscription_enabled:
         type: boolean
+      subscription_owner_name:
+        type: string
       supports_subscription:
         type: boolean
       viewer_has_subscription:

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -201,6 +201,16 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 	if project != nil {
 		organizationID = project.OrganizationID
 	}
+	credentialOwnerID := req.CredentialOwnerID
+	if credentialOwnerID == "" && organizationID != "" && codeAgentConfig != nil &&
+		codeAgentConfig.Runtime == types.CodeAgentRuntimeClaudeCode && codeAgentConfig.CredentialType.IsSubscription() {
+		delegated, err := s.store.GetDelegatedClaudeSubscriptionForOrg(ctx, organizationID)
+		if err == nil {
+			credentialOwnerID = delegated.OwnerID
+		} else if !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("resolve organization Claude subscription: %w", err)
+		}
+	}
 
 	// Determine initial status. If AutoStart is requested, skip backlog and queue
 	// immediately (mirrors cloneTaskToProject behaviour). This bypasses the project's
@@ -238,8 +248,8 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		JustDoItMode:             req.JustDoItMode, // Set Just Do It mode from request
 		// Credential-only override: whose Claude subscription authenticates this
 		// task's agent. Enforced at resolution time against the named user's
-		// delegation grant, so an unauthorised value simply has no effect.
-		CredentialOwnerID: req.CredentialOwnerID,
+		// delegation grant; missing or revoked grants fail closed.
+		CredentialOwnerID: credentialOwnerID,
 		// Branch configuration
 		BranchMode:   branchMode,
 		BaseBranch:   req.BaseBranch,    // User-specified base branch (empty = use repo default)

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -106,6 +106,62 @@ func TestSpecDrivenTaskService_CreateTaskFromPrompt(t *testing.T) {
 	// Note: Goroutine will fail gracefully, we only test the synchronous part
 }
 
+func TestSpecDrivenTaskService_SnapshotsDelegatedClaudeOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := NewSpecDrivenTaskService(
+		mockStore, nil, "test-helix-agent", nil, nil, nil, nil, nil, NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+	ctx := context.Background()
+	config := &types.CodeAgentExecutionConfig{
+		Runtime: types.CodeAgentRuntimeClaudeCode, CredentialType: types.CodeAgentCredentialTypeSubscription,
+	}
+	mockStore.EXPECT().GetProject(ctx, "project_1").Return(&types.Project{
+		ID: "project_1", OrganizationID: "org_1", CodeAgentConfig: config,
+	}, nil)
+	mockStore.EXPECT().GetDelegatedClaudeSubscriptionForOrg(ctx, "org_1").Return(
+		&types.ClaudeSubscription{OwnerID: "usr_delegate"}, nil,
+	)
+	mockStore.EXPECT().IncrementGlobalTaskNumber(ctx).Return(1, nil)
+	mockStore.EXPECT().CreateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, task *types.SpecTask) error {
+			require.Equal(t, "usr_delegate", task.CredentialOwnerID)
+			return nil
+		},
+	)
+
+	task, err := service.CreateTaskFromPrompt(ctx, &types.CreateTaskRequest{
+		ProjectID: "project_1", UserID: "usr_member", Prompt: "Do work",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "usr_delegate", task.CredentialOwnerID)
+}
+
+func TestSpecDrivenTaskService_ExplicitClaudeOwnerWins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := NewSpecDrivenTaskService(
+		mockStore, nil, "test-helix-agent", nil, nil, nil, nil, nil, NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+	ctx := context.Background()
+	mockStore.EXPECT().GetProject(ctx, "project_1").Return(&types.Project{
+		ID: "project_1", OrganizationID: "org_1",
+		CodeAgentConfig: &types.CodeAgentExecutionConfig{
+			Runtime: types.CodeAgentRuntimeClaudeCode, CredentialType: types.CodeAgentCredentialTypeSubscription,
+		},
+	}, nil)
+	mockStore.EXPECT().IncrementGlobalTaskNumber(ctx).Return(1, nil)
+	mockStore.EXPECT().CreateSpecTask(ctx, gomock.Any()).Return(nil)
+
+	task, err := service.CreateTaskFromPrompt(ctx, &types.CreateTaskRequest{
+		ProjectID: "project_1", UserID: "usr_member", Prompt: "Do work", CredentialOwnerID: "usr_explicit",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "usr_explicit", task.CredentialOwnerID)
+}
+
 func TestSpecDrivenTaskService_CreateTaskFromPromptRejectsInvalidSandboxRuntime(t *testing.T) {
 	service := NewSpecDrivenTaskService(
 		nil, nil, "test-helix-agent", nil, nil, nil, nil, nil, NewDisabledKoditService(),

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -927,10 +927,12 @@ type Store interface {
 	GetClaudeSubscription(ctx context.Context, id string) (*types.ClaudeSubscription, error)
 	GetClaudeSubscriptionForOwner(ctx context.Context, ownerID string, ownerType types.OwnerType) (*types.ClaudeSubscription, error)
 	UpdateClaudeSubscription(ctx context.Context, sub *types.ClaudeSubscription) (*types.ClaudeSubscription, error)
+	UpdateClaudeSubscriptionDelegation(ctx context.Context, id string, orgIDs []string) (*types.ClaudeSubscription, error)
 	UpdateClaudeSubscriptionCredentialsIfNewer(ctx context.Context, id, encryptedCredentials string, expiresAt, refreshTokenExpiresAt, refreshedAt time.Time) (bool, error)
 	UpdateClaudeSubscriptionStatus(ctx context.Context, sub *types.ClaudeSubscription) error
 	DeleteClaudeSubscription(ctx context.Context, id string) error
 	ListClaudeSubscriptions(ctx context.Context, ownerID string) ([]*types.ClaudeSubscription, error)
+	GetDelegatedClaudeSubscriptionForOrg(ctx context.Context, orgID string) (*types.ClaudeSubscription, error)
 	GetEffectiveClaudeSubscription(ctx context.Context, userID, orgID string) (*types.ClaudeSubscription, error)
 	GetSessionClaudeSubscription(ctx context.Context, session *types.Session) (*types.ClaudeSubscription, error)
 	CreateCodexSubscription(ctx context.Context, sub *types.CodexSubscription) (*types.CodexSubscription, error)

--- a/api/pkg/store/store_claude_subscription.go
+++ b/api/pkg/store/store_claude_subscription.go
@@ -4,12 +4,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
+
+type ClaudeSubscriptionDelegationConflictError struct {
+	OrganizationID string
+	OwnerID        string
+}
+
+func (e *ClaudeSubscriptionDelegationConflictError) Error() string {
+	return fmt.Sprintf("organization %s already has a delegated Claude subscription", e.OrganizationID)
+}
 
 func (s *PostgresStore) CreateClaudeSubscription(ctx context.Context, sub *types.ClaudeSubscription) (*types.ClaudeSubscription, error) {
 	if sub.ID == "" {
@@ -77,6 +88,47 @@ func (s *PostgresStore) UpdateClaudeSubscription(ctx context.Context, sub *types
 		return nil, err
 	}
 	return s.GetClaudeSubscription(ctx, sub.ID)
+}
+
+func (s *PostgresStore) UpdateClaudeSubscriptionDelegation(ctx context.Context, id string, orgIDs []string) (*types.ClaudeSubscription, error) {
+	var updated *types.ClaudeSubscription
+	err := s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var sub types.ClaudeSubscription
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", id).First(&sub).Error; err != nil {
+			return err
+		}
+		lockIDs := append([]string{}, sub.DelegatedOrgIDs...)
+		lockIDs = append(lockIDs, orgIDs...)
+		sort.Strings(lockIDs)
+		for i, orgID := range lockIDs {
+			if i > 0 && orgID == lockIDs[i-1] {
+				continue
+			}
+			var org types.Organization
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Select("id").Where("id = ?", orgID).First(&org).Error; err != nil {
+				return err
+			}
+		}
+		for _, orgID := range orgIDs {
+			var other types.ClaudeSubscription
+			err := tx.Where("id <> ? AND owner_type = ? AND ? = ANY(delegated_org_ids)", id, types.OwnerTypeUser, orgID).
+				Order("created ASC, id ASC").First(&other).Error
+			if err == nil {
+				return &ClaudeSubscriptionDelegationConflictError{OrganizationID: orgID, OwnerID: other.OwnerID}
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+		}
+		sub.DelegatedOrgIDs = orgIDs
+		sub.Updated = time.Now()
+		if err := tx.Save(&sub).Error; err != nil {
+			return err
+		}
+		updated = &sub
+		return nil
+	})
+	return updated, err
 }
 
 // UpdateClaudeSubscriptionCredentialsIfNewer writes rotated credentials only when
@@ -160,6 +212,27 @@ func (s *PostgresStore) ListClaudeSubscriptions(ctx context.Context, ownerID str
 	return subs, nil
 }
 
+func (s *PostgresStore) GetDelegatedClaudeSubscriptionForOrg(ctx context.Context, orgID string) (*types.ClaudeSubscription, error) {
+	if orgID == "" {
+		return nil, ErrNotFound
+	}
+	var subs []*types.ClaudeSubscription
+	if err := s.gdb.WithContext(ctx).
+		Where("owner_type = ? AND ? = ANY(delegated_org_ids)", types.OwnerTypeUser, orgID).
+		Order("created ASC, id ASC").
+		Limit(2).
+		Find(&subs).Error; err != nil {
+		return nil, err
+	}
+	if len(subs) == 0 {
+		return nil, ErrNotFound
+	}
+	if len(subs) > 1 {
+		return nil, fmt.Errorf("multiple Claude subscriptions are delegated to organization %s", orgID)
+	}
+	return subs[0], nil
+}
+
 // GetSessionClaudeSubscription resolves the Claude subscription that should
 // authenticate a session's agent.
 //
@@ -169,20 +242,29 @@ func (s *PostgresStore) ListClaudeSubscriptions(ctx context.Context, ownerID str
 // The delegation check is the consent gate: without it, anyone who can create a
 // session could name any user as credential owner and spend their Claude quota.
 //
-// A named-but-undelegated (or missing) credential owner falls back to the
-// session owner's normal resolution rather than failing, so a revoked delegation
-// degrades to previous behaviour instead of bricking the agent.
+// An explicit credential owner fails closed when missing or undelegated. Once a
+// task records who pays for it, resolution must not silently switch billing.
 func (s *PostgresStore) GetSessionClaudeSubscription(ctx context.Context, session *types.Session) (*types.ClaudeSubscription, error) {
 	if session == nil {
 		return nil, ErrNotFound
 	}
-	if owner := session.Metadata.CredentialOwnerID; owner != "" && owner != session.Owner {
+	if owner := session.Metadata.CredentialOwnerID; owner != "" {
 		sub, err := s.GetClaudeSubscriptionForOwner(ctx, owner, types.OwnerTypeUser)
-		if err != nil && !errors.Is(err, ErrNotFound) {
+		if err != nil {
 			return nil, err
 		}
-		if err == nil && subscriptionDelegatedTo(sub, session.OrganizationID) {
+		if owner == session.Owner || subscriptionDelegatedTo(sub, session.OrganizationID) {
 			return sub, nil
+		}
+		return nil, ErrNotFound
+	}
+	if session.Metadata.SpecTaskID != "" {
+		sub, err := s.GetDelegatedClaudeSubscriptionForOrg(ctx, session.OrganizationID)
+		if err == nil {
+			return sub, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
 		}
 	}
 	return s.GetEffectiveClaudeSubscription(ctx, session.Owner, session.OrganizationID)

--- a/api/pkg/store/store_claude_subscription_delegation_test.go
+++ b/api/pkg/store/store_claude_subscription_delegation_test.go
@@ -1,8 +1,12 @@
 package store
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -55,4 +59,113 @@ func TestSubscriptionDelegatedTo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (suite *PostgresStoreTestSuite) TestUpdateClaudeSubscriptionDelegationConcurrent() {
+	suffix := system.GenerateUUID()
+	org, err := suite.db.CreateOrganization(suite.ctx, &types.Organization{
+		ID: system.GenerateOrganizationID(), Name: "delegation-race-" + suffix, Owner: "usr_owner_" + suffix,
+	})
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() { _ = suite.db.DeleteOrganization(context.Background(), org.ID) })
+	create := func(owner string) *types.ClaudeSubscription {
+		sub, err := suite.db.CreateClaudeSubscription(suite.ctx, &types.ClaudeSubscription{
+			OwnerID: owner, OwnerType: types.OwnerTypeUser, Status: "active",
+			EncryptedCredentials: "encrypted", CreatedBy: owner,
+		})
+		suite.Require().NoError(err)
+		suite.T().Cleanup(func() { _ = suite.db.DeleteClaudeSubscription(context.Background(), sub.ID) })
+		return sub
+	}
+	subA := create("usr_a_" + suffix)
+	subB := create("usr_b_" + suffix)
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, sub := range []*types.ClaudeSubscription{subA, subB} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			<-start
+			_, err := suite.db.UpdateClaudeSubscriptionDelegation(context.Background(), id, []string{org.ID})
+			results <- err
+		}(sub.ID)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	conflicts := 0
+	for result := range results {
+		if result == nil {
+			successes++
+			continue
+		}
+		var conflict *ClaudeSubscriptionDelegationConflictError
+		suite.Require().True(errors.As(result, &conflict), result.Error())
+		suite.Equal(org.ID, conflict.OrganizationID)
+		conflicts++
+	}
+	suite.Equal(1, successes)
+	suite.Equal(1, conflicts)
+
+	delegated, err := suite.db.GetDelegatedClaudeSubscriptionForOrg(suite.ctx, org.ID)
+	suite.Require().NoError(err)
+	suite.Contains([]string{subA.ID, subB.ID}, delegated.ID)
+}
+
+func (suite *PostgresStoreTestSuite) TestDelegatedClaudeSubscriptionResolution() {
+	suffix := system.GenerateUUID()
+	orgID := "org_" + suffix
+	create := func(owner string, orgs ...string) *types.ClaudeSubscription {
+		sub, err := suite.db.CreateClaudeSubscription(suite.ctx, &types.ClaudeSubscription{
+			OwnerID: owner, OwnerType: types.OwnerTypeUser, Status: "active",
+			EncryptedCredentials: "encrypted", CreatedBy: owner, DelegatedOrgIDs: orgs,
+		})
+		suite.Require().NoError(err)
+		suite.T().Cleanup(func() { _ = suite.db.DeleteClaudeSubscription(context.Background(), sub.ID) })
+		return sub
+	}
+
+	delegated := create("usr_delegate_"+suffix, orgID)
+	owner := create("usr_owner_" + suffix)
+
+	sub, err := suite.db.GetDelegatedClaudeSubscriptionForOrg(suite.ctx, orgID)
+	suite.Require().NoError(err)
+	suite.Equal(delegated.ID, sub.ID)
+
+	sub, err = suite.db.GetSessionClaudeSubscription(suite.ctx, &types.Session{
+		Owner: owner.OwnerID, OrganizationID: orgID,
+		Metadata: types.SessionMetadata{SpecTaskID: "spt_1"},
+	})
+	suite.Require().NoError(err)
+	suite.Equal(delegated.ID, sub.ID)
+
+	sub, err = suite.db.GetSessionClaudeSubscription(suite.ctx, &types.Session{
+		Owner: owner.OwnerID, OrganizationID: orgID,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(owner.ID, sub.ID)
+
+	sub, err = suite.db.GetSessionClaudeSubscription(suite.ctx, &types.Session{
+		Owner: owner.OwnerID, OrganizationID: orgID,
+		Metadata: types.SessionMetadata{SpecTaskID: "spt_1", CredentialOwnerID: delegated.OwnerID},
+	})
+	suite.Require().NoError(err)
+	suite.Equal(delegated.ID, sub.ID)
+
+	undelegated := create("usr_undelegated_" + suffix)
+	_, err = suite.db.GetSessionClaudeSubscription(suite.ctx, &types.Session{
+		Owner: owner.OwnerID, OrganizationID: orgID,
+		Metadata: types.SessionMetadata{SpecTaskID: "spt_1", CredentialOwnerID: undelegated.OwnerID},
+	})
+	suite.True(errors.Is(err, ErrNotFound))
+
+	create("usr_other_"+suffix, orgID)
+	_, err = suite.db.GetDelegatedClaudeSubscriptionForOrg(suite.ctx, orgID)
+	suite.ErrorContains(err, "multiple Claude subscriptions")
+	_, err = suite.db.GetDelegatedClaudeSubscriptionForOrg(suite.ctx, "org_missing_"+suffix)
+	suite.True(errors.Is(err, ErrNotFound))
 }

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -2733,6 +2733,21 @@ func (mr *MockStoreMockRecorder) GetDecodedLicense(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDecodedLicense", reflect.TypeOf((*MockStore)(nil).GetDecodedLicense), ctx)
 }
 
+// GetDelegatedClaudeSubscriptionForOrg mocks base method.
+func (m *MockStore) GetDelegatedClaudeSubscriptionForOrg(ctx context.Context, orgID string) (*types.ClaudeSubscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDelegatedClaudeSubscriptionForOrg", ctx, orgID)
+	ret0, _ := ret[0].(*types.ClaudeSubscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDelegatedClaudeSubscriptionForOrg indicates an expected call of GetDelegatedClaudeSubscriptionForOrg.
+func (mr *MockStoreMockRecorder) GetDelegatedClaudeSubscriptionForOrg(ctx, orgID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDelegatedClaudeSubscriptionForOrg", reflect.TypeOf((*MockStore)(nil).GetDelegatedClaudeSubscriptionForOrg), ctx, orgID)
+}
+
 // GetDiskUsageHistory mocks base method.
 func (m *MockStore) GetDiskUsageHistory(ctx context.Context, sandboxID string, since time.Time) ([]*types.DiskUsageHistory, error) {
 	m.ctrl.T.Helper()
@@ -6518,6 +6533,21 @@ func (m *MockStore) UpdateClaudeSubscriptionCredentialsIfNewer(ctx context.Conte
 func (mr *MockStoreMockRecorder) UpdateClaudeSubscriptionCredentialsIfNewer(ctx, id, encryptedCredentials, expiresAt, refreshTokenExpiresAt, refreshedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClaudeSubscriptionCredentialsIfNewer", reflect.TypeOf((*MockStore)(nil).UpdateClaudeSubscriptionCredentialsIfNewer), ctx, id, encryptedCredentials, expiresAt, refreshTokenExpiresAt, refreshedAt)
+}
+
+// UpdateClaudeSubscriptionDelegation mocks base method.
+func (m *MockStore) UpdateClaudeSubscriptionDelegation(ctx context.Context, id string, orgIDs []string) (*types.ClaudeSubscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClaudeSubscriptionDelegation", ctx, id, orgIDs)
+	ret0, _ := ret[0].(*types.ClaudeSubscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateClaudeSubscriptionDelegation indicates an expected call of UpdateClaudeSubscriptionDelegation.
+func (mr *MockStoreMockRecorder) UpdateClaudeSubscriptionDelegation(ctx, id, orgIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClaudeSubscriptionDelegation", reflect.TypeOf((*MockStore)(nil).UpdateClaudeSubscriptionDelegation), ctx, id, orgIDs)
 }
 
 // UpdateClaudeSubscriptionStatus mocks base method.

--- a/api/pkg/types/org_code_agent_harness.go
+++ b/api/pkg/types/org_code_agent_harness.go
@@ -51,12 +51,14 @@ type OrgCodeAgentHarnessesUpdateRequest struct {
 // combined with SubscriptionEnabled to decide whether subscription models are
 // available to the requesting member.
 type OrgCodeAgentHarnessStatus struct {
-	Runtime               CodeAgentRuntime `json:"runtime"`
-	Enabled               bool             `json:"enabled"`
-	SubscriptionEnabled   *bool            `json:"subscription_enabled"`
-	ProviderRefs          []string         `json:"provider_refs"`
-	SupportsSubscription  bool             `json:"supports_subscription"`
-	ViewerHasSubscription bool             `json:"viewer_has_subscription"`
+	Runtime                    CodeAgentRuntime `json:"runtime"`
+	Enabled                    bool             `json:"enabled"`
+	SubscriptionEnabled        *bool            `json:"subscription_enabled"`
+	ProviderRefs               []string         `json:"provider_refs"`
+	SupportsSubscription       bool             `json:"supports_subscription"`
+	ViewerHasSubscription      bool             `json:"viewer_has_subscription"`
+	SubscriptionOwnerName      string           `json:"subscription_owner_name,omitempty"`
+	SubscriptionCredentialType string           `json:"subscription_credential_type,omitempty"`
 }
 
 func (h *OrgCodeAgentHarness) AllowsSubscription() bool {

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -245,8 +245,8 @@ type CreateTaskRequest struct {
 	// CredentialOwnerID optionally names the user whose Claude subscription should
 	// authenticate this task's agent, for orchestrators dispatching work on a
 	// human's behalf under one service API key. Credential resolution only — the
-	// task is still created by, owned by, and attributed to the caller. Ignored
-	// unless that user has delegated their subscription to this organization.
+	// task is still created by, owned by, and attributed to the caller. Resolution
+	// fails closed unless that user has delegated to this organization.
 	CredentialOwnerID string `json:"credential_owner_id,omitempty"`
 
 	// Branch configuration

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1916,8 +1916,8 @@ type CronTrigger struct {
 	// authenticates as the person it acts for, exactly as CreateTaskRequest does
 	// for a run dispatched by hand. Credential resolution only: the task is still
 	// created by, owned by, and attributed to the trigger's app owner, and the
-	// named user must have delegated their subscription to this organization or it
-	// is ignored. Currently honoured by the spec_task action.
+	// named user must have delegated their subscription to this organization or
+	// credential resolution fails closed. Currently honoured by the spec_task action.
 	CredentialOwnerID string `json:"credential_owner_id,omitempty" yaml:"credential_owner_id,omitempty"`
 
 	// JustDoItMode makes the spec_task action skip spec generation and go straight

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3701,8 +3701,8 @@ export interface TypesCreateTaskRequest {
    * CredentialOwnerID optionally names the user whose Claude subscription should
    * authenticate this task's agent, for orchestrators dispatching work on a
    * human's behalf under one service API key. Credential resolution only — the
-   * task is still created by, owned by, and attributed to the caller. Ignored
-   * unless that user has delegated their subscription to this organization.
+   * task is still created by, owned by, and attributed to the caller. Resolution
+   * fails closed unless that user has delegated to this organization.
    */
   credential_owner_id?: string;
   /** Optional: IDs of tasks this task depends on */
@@ -3771,8 +3771,8 @@ export interface TypesCronTrigger {
    * authenticates as the person it acts for, exactly as CreateTaskRequest does
    * for a run dispatched by hand. Credential resolution only: the task is still
    * created by, owned by, and attributed to the trigger's app owner, and the
-   * named user must have delegated their subscription to this organization or it
-   * is ignored. Currently honoured by the spec_task action.
+   * named user must have delegated their subscription to this organization or
+   * credential resolution fails closed. Currently honoured by the spec_task action.
    */
   credential_owner_id?: string;
   emails?: string[];
@@ -5028,7 +5028,9 @@ export interface TypesOrgCodeAgentHarnessStatus {
   enabled?: boolean;
   provider_refs?: string[];
   runtime?: TypesCodeAgentRuntime;
+  subscription_credential_type?: string;
   subscription_enabled?: boolean;
+  subscription_owner_name?: string;
   supports_subscription?: boolean;
   viewer_has_subscription?: boolean;
 }

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.delegation.test.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.delegation.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ClaudeSubscriptionConnect from './ClaudeSubscriptionConnect'
 
 const delegationUpdate = vi.fn()
+const snackbarError = vi.fn()
 const organizations = [{
   id: 'org_1',
   name: 'Hello',
@@ -30,7 +31,7 @@ vi.mock('../../hooks/useApi', () => ({
 }))
 
 vi.mock('../../hooks/useSnackbar', () => ({
-  default: () => ({ success: vi.fn(), error: vi.fn() }),
+  default: () => ({ success: vi.fn(), error: snackbarError }),
 }))
 
 vi.mock('../../hooks/useAccount', () => ({
@@ -53,7 +54,10 @@ function renderAccount() {
 }
 
 describe('ClaudeSubscriptionConnect delegation', () => {
-  beforeEach(() => delegationUpdate.mockReset())
+  beforeEach(() => {
+    delegationUpdate.mockReset()
+    snackbarError.mockReset()
+  })
 
   it('enables subscription mode when sharing succeeds', async () => {
     delegationUpdate.mockResolvedValue({ data: {} })
@@ -69,7 +73,7 @@ describe('ClaudeSubscriptionConnect delegation', () => {
 
   it('asks before replacing API-provider mode', async () => {
     delegationUpdate
-      .mockRejectedValueOnce({ response: { status: 409 } })
+      .mockRejectedValueOnce({ response: { status: 409, data: { message: 'organization org_1 is using API-provider mode' } } })
       .mockResolvedValueOnce({ data: {} })
     renderAccount()
 
@@ -82,5 +86,19 @@ describe('ClaudeSubscriptionConnect delegation', () => {
       delegated_org_ids: ['org_1'],
       switch_to_subscription: true,
     }))
+  })
+
+  it('shows another-owner conflicts without offering an API mode switch', async () => {
+    delegationUpdate.mockRejectedValue({
+      response: { status: 409, data: { message: "Hello already uses Beatrice's Claude subscription. Ask Beatrice to remove that delegation before adding yours." } },
+    })
+    renderAccount()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Hello' }))
+
+    await waitFor(() => expect(snackbarError).toHaveBeenCalledWith(
+      "Hello already uses Beatrice's Claude subscription. Ask Beatrice to remove that delegation before adding yours.",
+    ))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -124,14 +124,13 @@ const DelegationPicker: FC<DelegationPickerProps> = ({
   return (
     <Box sx={{ mt: 1.5 }}>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-        Sharing with an organization enables Claude Code subscription mode there. Its agents can
-        then use this subscription when they run work on your behalf - for example a bot you own
-        that is launched by a shared service account.
+        Delegating to an organization makes this its Claude Code subscription. Any member can use
+        it for tasks in that organization, billed to the Claude account connected here.
       </Typography>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
         {grantedCount === 0
-          ? `Not shared with any of your ${withIDs.length} organizations.`
-          : `Shared with ${grantedCount} of ${withIDs.length} organizations.`}
+          ? `Not delegated to any of your ${withIDs.length} organizations.`
+          : `Delegated to ${grantedCount} of ${withIDs.length} organizations.`}
       </Typography>
       {withIDs.length > DELEGATION_FILTER_THRESHOLD && (
         <TextField
@@ -345,7 +344,9 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
       setDelegationConflict(null)
     },
     onError: (error: any, variables) => {
-      if (error?.response?.status === 409 && !variables.switchToSubscription) {
+      if (error?.response?.status === 409
+        && error?.response?.data?.message?.includes('API-provider mode')
+        && !variables.switchToSubscription) {
         setDelegationConflict({
           id: variables.id,
           orgIDs: variables.orgIDs,

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.test.tsx
@@ -77,6 +77,38 @@ describe('CodeAgentHarnessesSection', () => {
     })).toBeInTheDocument()
   })
 
+  it('shows the delegator and organization without an opaque Claude identity', () => {
+    render(
+      <CodeAgentHarnessesSection
+        harnesses={[{ ...harnesses[0], subscription_owner_name: 'Alex' }]}
+        endpoints={[]}
+        organizationName="Customer"
+        subscriptionIdentity={() => 'Authenticated as Claude org abc'}
+        onChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
+    expect(screen.getByText('Subscription owner: Alex')).toBeInTheDocument()
+    expect(screen.getByText('Delegated to: Customer')).toBeInTheDocument()
+    expect(screen.queryByText('Authenticated as Claude org abc')).not.toBeInTheDocument()
+  })
+
+  it('shows an available delegate when subscription mode is disabled', () => {
+    render(
+      <CodeAgentHarnessesSection
+        harnesses={[{
+          ...harnesses[0], subscription_enabled: false, subscription_owner_name: 'Alex',
+        }]}
+        endpoints={[]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Claude Code settings' }))
+    expect(screen.getByText('Subscription owner: Alex')).toBeInTheDocument()
+  })
+
   it('writes an explicit provider allow-list when a provider is disabled', () => {
     const onChange = vi.fn()
     render(

--- a/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
+++ b/frontend/src/components/providers/CodeAgentHarnessesSection.tsx
@@ -88,6 +88,7 @@ const CodeAgentHarnessesSection: FC<{
         const subscriptionActionNode = harness.supports_subscription
           ? subscriptionAction?.(harness.runtime || '')
           : null
+        const subscriptionIdentityNode = subscriptionIdentity?.(harness.runtime || '')
         const requiredProviderName = requiredProviderNameForRuntime(harness.runtime)
 
         return (
@@ -113,9 +114,21 @@ const CodeAgentHarnessesSection: FC<{
                       {harness.runtime === 'claude_code' ? 'Claude subscription' : 'ChatGPT subscription'}
                     </Typography>
                     <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
-                      {subscriptionIdentity?.(harness.runtime || '')
+                      {harness.subscription_owner_name
+                        ? `Subscription owner: ${harness.subscription_owner_name}`
+                        : subscriptionIdentityNode
                         || (viewerHasSubscription ? 'Connected' : 'Not connected')}
                     </Typography>
+                    {harness.subscription_owner_name && organizationName && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
+                        Delegated to: {organizationName}
+                      </Typography>
+                    )}
+                    {harness.subscription_owner_name && harness.subscription_credential_type === 'setup_token' && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
+                        Authentication: Setup token
+                      </Typography>
+                    )}
                   </Box>
                   <Stack
                     direction="row"

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5780,8 +5780,8 @@ definitions:
           CredentialOwnerID optionally names the user whose Claude subscription should
           authenticate this task's agent, for orchestrators dispatching work on a
           human's behalf under one service API key. Credential resolution only — the
-          task is still created by, owned by, and attributed to the caller. Ignored
-          unless that user has delegated their subscription to this organization.
+          task is still created by, owned by, and attributed to the caller. Resolution
+          fails closed unless that user has delegated to this organization.
         type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
@@ -5882,8 +5882,8 @@ definitions:
           authenticates as the person it acts for, exactly as CreateTaskRequest does
           for a run dispatched by hand. Credential resolution only: the task is still
           created by, owned by, and attributed to the trigger's app owner, and the
-          named user must have delegated their subscription to this organization or it
-          is ignored. Currently honoured by the spec_task action.
+          named user must have delegated their subscription to this organization or
+          credential resolution fails closed. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -7917,8 +7917,12 @@ definitions:
         type: array
       runtime:
         $ref: '#/definitions/types.CodeAgentRuntime'
+      subscription_credential_type:
+        type: string
       subscription_enabled:
         type: boolean
+      subscription_owner_name:
+        type: string
       supports_subscription:
         type: boolean
       viewer_has_subscription:

--- a/openapi.json
+++ b/openapi.json
@@ -36034,7 +36034,7 @@
                         "$ref": "#/components/schemas/types.CodeAgentExecutionConfig"
                     },
                     "credential_owner_id": {
-                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Resolution\nfails closed unless that user has delegated to this organization.",
                         "type": "string"
                     },
                     "depends_on": {
@@ -36163,7 +36163,7 @@
                         "type": "string"
                     },
                     "credential_owner_id": {
-                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or\ncredential resolution fails closed. Currently honoured by the spec_task action.",
                         "type": "string"
                     },
                     "emails": {
@@ -38950,8 +38950,14 @@
                     "runtime": {
                         "$ref": "#/components/schemas/types.CodeAgentRuntime"
                     },
+                    "subscription_credential_type": {
+                        "type": "string"
+                    },
                     "subscription_enabled": {
                         "type": "boolean"
+                    },
+                    "subscription_owner_name": {
+                        "type": "string"
                     },
                     "supports_subscription": {
                         "type": "boolean"

--- a/swagger.json
+++ b/swagger.json
@@ -31438,7 +31438,7 @@
                     "$ref": "#/definitions/types.CodeAgentExecutionConfig"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Resolution\nfails closed unless that user has delegated to this organization.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -31567,7 +31567,7 @@
                     "type": "string"
                 },
                 "credential_owner_id": {
-                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or\ncredential resolution fails closed. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -34354,8 +34354,14 @@
                 "runtime": {
                     "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
+                "subscription_credential_type": {
+                    "type": "string"
+                },
                 "subscription_enabled": {
                     "type": "boolean"
+                },
+                "subscription_owner_name": {
+                    "type": "string"
                 },
                 "supports_subscription": {
                     "type": "boolean"


### PR DESCRIPTION
## Summary

- resolve a user-owned Claude Code subscription delegated to an organization for every organization task
- snapshot the credential owner on new tasks and fail closed when delegation is missing or revoked
- enforce one delegated Claude subscription per organization atomically
- show the subscription owner and delegated organization in provider settings
- reject a second delegate with an actionable owner-named snackbar
- validate parentless SpecTask subscription credentials before desktop startup

## Security

- delegation remains explicit and may only be changed by the subscription owner
- only organization owners receive the existing delegate identity in conflict responses
- Claude account email is not exposed by the member-scoped provider endpoint

## Tests

- `go test ./pkg/external-agent ./pkg/server ./pkg/services -count=1`
- `go build ./pkg/server ./pkg/store ./pkg/types ./pkg/services ./pkg/external-agent`
- PostgreSQL concurrent delegation test: passed with exactly one winner and one conflict
- focused frontend tests: 17 passed
- `git diff --check`

## Not tested

- End-to-end UI flow was not run because this worktree was not deployed to the active local stack.
- Local `yarn build` remains blocked by the pre-existing macOS case collision between `WorkspaceReviewMessage.tsx` and `workspaceReviewMessage.ts`; this branch does not modify those files.