### PR TITLE
fix(frontend): show project creation errors

### DIFF
--- a/frontend/src/components/project/CreateProjectDialog.test.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.test.tsx
@@ -66,12 +66,17 @@ vi.mock('./BrowseProvidersDialog', () => ({
   default: () => null,
 }))
 
-function renderDialog(repositories: TypesGitRepository[] = []) {
+function renderDialog(
+  repositories: TypesGitRepository[] = [],
+  onClose = vi.fn(),
+  onSuccess = vi.fn(),
+) {
   return render(
     <QueryClientProvider client={new QueryClient()}>
       <CreateProjectDialog
         open
-        onClose={vi.fn()}
+        onClose={onClose}
+        onSuccess={onSuccess}
         repositories={repositories}
         onCreateRepo={mocks.createRepo}
       />
@@ -140,6 +145,29 @@ describe('CreateProjectDialog', () => {
         model: 'claude-opus-5',
       }),
     }))
+  })
+
+  it('shows subscription policy failures without closing the dialog', async () => {
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+    mocks.createProject.mockRejectedValue({
+      response: {
+        data: 'subscription credentials are not enabled for coding-agent harness "claude_code" in this organization',
+      },
+    })
+    renderDialog([], onClose, onSuccess)
+
+    fireEvent.change(screen.getByRole('textbox', { name: /^Name$/i }), {
+      target: { value: 'Demo project' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Create Project/i }))
+
+    expect(await screen.findByText(
+      'Claude Code subscription access is not enabled for this organization. Ask an organization administrator to enable it in Settings > Providers, or select another coding agent.',
+    )).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
   })
 
   it('submits with Cmd or Ctrl plus Enter', async () => {

--- a/frontend/src/components/project/CreateProjectDialog.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.tsx
@@ -24,6 +24,7 @@ import type { TypesGitRepository, TypesAzureDevOps } from '../../api/api'
 import { useCreateProject, useListProjects } from '../../services'
 import useAccount from '../../hooks/useAccount'
 import useSnackbar from '../../hooks/useSnackbar'
+import { extractErrorMessage } from '../../hooks/useErrorCallback'
 import { CodeAgentRuntime } from '../../contexts/apps'
 import { RECOMMENDED_CODING_MODELS } from '../../constants/models'
 import CodingAgentForm from '../agent/CodingAgentForm'
@@ -302,7 +303,10 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
         }
       }
     } catch (err) {
-      snackbar.error('Failed to create project')
+      const errorMessage = extractErrorMessage(err) || 'Failed to create project'
+      setRepoError(errorMessage.includes('subscription credentials are not enabled for coding-agent harness')
+        ? `${getAgentHarnessLabel(codeAgentConfig?.runtime)} subscription access is not enabled for this organization. Ask an organization administrator to enable it in Settings > Providers, or select another coding agent.`
+        : errorMessage)
     }
   }
 


### PR DESCRIPTION
## Summary

- Surface backend project creation errors in the existing inline alert.
- Translate the Claude Code subscription policy failure into actionable guidance.
- Keep the dialog open so the user can change the coding agent and retry.

## Screenshot

![Claude Code subscription error shown in the project creation dialog](https://gist.githubusercontent.com/chocobar/25b0ddbff7d48a20278d08db3933e426/raw/project-create-claude-code-error.png)

## Verification

- `yarn vitest run src/components/project/CreateProjectDialog.test.tsx` - 7 tests passed.
- Clean Linux production frontend build passed.
- Standalone Playwright test intercepted the exact backend HTTP 400 and verified the error remains visible in the open dialog.
