### PR TITLE
fix(api): preserve server-owned secret fields on PUT /secrets/{id}

### DIFF
--- a/api/pkg/server/secrets_handlers.go
+++ b/api/pkg/server/secrets_handlers.go
@@ -206,6 +206,22 @@ func (s *HelixAPIServer) updateSecret(_ http.ResponseWriter, r *http.Request) (*
 	secret.OwnerType = existing.OwnerType
 	secret.ProjectID = existing.ProjectID
 	secret.AppID = existing.AppID
+	// The store persists a full row (GORM Save), so any field the client
+	// omitted would otherwise be written back as its zero value. Scope is
+	// fixed at creation (an omitted scope used to silently zero it, changing
+	// which sessions the secret is injected into), Name must not blank, and an
+	// omitted/empty value must keep the stored ciphertext rather than delete
+	// the secret's value.
+	secret.Scope = existing.Scope
+	if secret.Name == "" {
+		secret.Name = existing.Name
+	}
+	if len(secret.Value) == 0 {
+		secret.Value = existing.Value
+	}
+	if secret.Created.IsZero() {
+		secret.Created = existing.Created
+	}
 
 	updatedSecret, err := s.Store.UpdateSecret(ctx, &secret)
 	if err != nil {

--- a/api/pkg/server/secrets_update_preservation_test.go
+++ b/api/pkg/server/secrets_update_preservation_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/crypto"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// The store persists an updated secret with a full-row Save, so every field a
+// PUT body omits used to be written back as its zero value: an omitted scope
+// silently zeroed the injection scope, an omitted value blanked the stored
+// ciphertext, and omitted name/created were wiped too. The handler must carry
+// those over from the stored row.
+
+func putSecret(t *testing.T, server *HelixAPIServer, id string, body string) (*types.Secret, *system.HTTPError) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/secrets/"+id, bytes.NewBufferString(body))
+	req = mux.SetURLVars(req, map[string]string{"id": id})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user_test"}))
+	return server.updateSecret(httptest.NewRecorder(), req)
+}
+
+func TestUpdateSecretOmittedFieldsPreserved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	created := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+	existing := &types.Secret{
+		ID: "sec_test", Owner: "user_test", OwnerType: types.OwnerTypeUser,
+		Name: "OLD_NAME", Scope: types.SecretScopeProd, Created: created,
+		Value: []byte("stored-ciphertext-A"),
+	}
+	mockStore.EXPECT().GetSecret(gomock.Any(), "sec_test").Return(existing, nil)
+
+	var saved *types.Secret
+	mockStore.EXPECT().UpdateSecret(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, s *types.Secret) (*types.Secret, error) {
+			cp := *s
+			saved = &cp
+			return s, nil
+		})
+
+	// PUT with only a new name: no value, no scope, no created.
+	updated, httpErr := putSecret(t, server, "sec_test", `{"name":"NEW_NAME"}`)
+	require.Nil(t, httpErr)
+	require.NotNil(t, saved)
+
+	require.Equal(t, "NEW_NAME", saved.Name)
+	require.Equal(t, types.SecretScopeProd, saved.Scope, "omitted scope must keep the stored scope")
+	require.Equal(t, []byte("stored-ciphertext-A"), saved.Value, "omitted value must keep the stored ciphertext")
+	require.True(t, saved.Created.Equal(created), "omitted created must keep the stored creation time")
+	require.Equal(t, "user_test", saved.Owner)
+	require.Equal(t, types.OwnerTypeUser, saved.OwnerType)
+	require.Empty(t, updated.Value, "response must not leak the value")
+}
+
+func TestUpdateSecretRotatesValueAndPreservesScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	existing := &types.Secret{
+		ID: "sec_test", Owner: "user_test", OwnerType: types.OwnerTypeUser,
+		Name: "TOKEN", Scope: types.SecretScopeDev, Created: time.Now().Add(-time.Hour),
+		Value: []byte("stored-ciphertext-A"),
+	}
+	mockStore.EXPECT().GetSecret(gomock.Any(), "sec_test").Return(existing, nil)
+
+	var saved *types.Secret
+	mockStore.EXPECT().UpdateSecret(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, s *types.Secret) (*types.Secret, error) {
+			cp := *s
+			saved = &cp
+			return s, nil
+		})
+
+	// []byte fields travel base64-encoded in JSON: "dG9wc2VjcmV0" is "topsecret".
+	_, httpErr := putSecret(t, server, "sec_test", `{"value":"dG9wc2VjcmV0"}`)
+	require.Nil(t, httpErr)
+	require.NotNil(t, saved)
+
+	require.Equal(t, "TOKEN", saved.Name, "omitted name must keep the stored name")
+	require.Equal(t, types.SecretScopeDev, saved.Scope)
+	require.NotEqual(t, []byte("stored-ciphertext-A"), saved.Value, "provided value must replace the stored one")
+	require.NotEqual(t, []byte("topsecret"), saved.Value, "the stored value must not be plaintext")
+
+	key, err := crypto.GetEncryptionKey()
+	require.NoError(t, err)
+	plaintext, err := crypto.DecryptAES256GCM(string(saved.Value), key)
+	require.NoError(t, err, "rotated value must decrypt under the server key")
+	require.Equal(t, "topsecret", string(plaintext))
+}
+
+func TestUpdateSecretProjectScopedPreservesScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	// Old-style user-owned project (no organization): the project owner is
+	// authorized to rotate secrets in it.
+	existing := &types.Secret{
+		ID: "sec_proj", Owner: "user_test", OwnerType: types.OwnerTypeUser,
+		Name: "MP_PASSWORD", ProjectID: "prj_1", Scope: types.SecretScopeProd,
+		Value: []byte("stored-ciphertext-A"),
+	}
+	mockStore.EXPECT().GetSecret(gomock.Any(), "sec_proj").Return(existing, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), "prj_1").Return(&types.Project{ID: "prj_1", UserID: "user_test"}, nil)
+
+	var saved *types.Secret
+	mockStore.EXPECT().UpdateSecret(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, s *types.Secret) (*types.Secret, error) {
+			cp := *s
+			saved = &cp
+			return s, nil
+		})
+
+	_, httpErr := putSecret(t, server, "sec_proj", `{"name":"MP_PASSWORD","value":"bmV3LXNlY3JldA=="}`)
+	require.Nil(t, httpErr)
+	require.NotNil(t, saved)
+
+	require.Equal(t, "prj_1", saved.ProjectID)
+	require.Equal(t, types.SecretScopeProd, saved.Scope, "scope must survive a value rotation on a project secret")
+}


### PR DESCRIPTION
## Problem
`PUT /api/v1/secrets/{id}` decodes the request body into a fresh `types.Secret` and the store persists it with a full-row GORM `Save`, so **any field the body omitted was written back as its zero value**. Observed twice on a live instance (agentic pentest engagement, 2026-09-02):

1. A value rotation whose JSON omitted `scope` silently zeroed a project secret's injection scope (an empty scope happens to behave like `dev`, so the breakage was invisible until a secret stopped rotating).
2. A PUT without `value` blanks the stored ciphertext entirely — the secret's value is deleted while the row still looks healthy (`updated_at` moves, no error returned).

The handler already carried `Owner`/`OwnerType`/`ProjectID`/`AppID` over from the stored row; `Scope`, `Name`, `Created` and an omitted `Value` were missed.

## Fix
Extend the existing carry-over block in `updateSecret`:
- `Scope` always preserved (fixed at creation, never client-editable via PUT — same policy as `ProjectID`),
- `Name` / `Created` kept when the body omits them,
- stored ciphertext kept when the body provides no value.

## Tests (`secrets_update_preservation_test.go`, handler-level, mock store captures the persisted row)
- `TestUpdateSecretOmittedFieldsPreserved` — name-only PUT: scope, ciphertext, created, owner all survive; response still strips the value.
- `TestUpdateSecretRotatesValueAndPreservesScope` — value rotation: new value is encrypted (not plaintext) and round-trips under the server key via `crypto.DecryptAES256GCM`; omitted name/scope preserved.
- `TestUpdateSecretProjectScopedPreservesScope` — project-scoped secret keeps `ProjectID` and `scope=prod` through a value rotation (old-style user-owned project authz path).

`go test ./api/pkg/server/ -run 'TestUpdateSecret|TestCreateSecretRejects'` passes (3 new + 2 pre-existing). Also verified against a live dev stack: a scope-omitting rotation PUT on a real project secret now preserves `scope`, and a value-omitting PUT leaves the row byte-identical.

## Notes
No migration needed (no schema change). `createProjectSecret` already defaults `scope=dev`; `helix secret update` CLI (newer generations) round-trips the full row and is unaffected.