### PR TITLE
fix(frontend): autosave organization settings

### DIFF
--- a/frontend/src/components/helix-org/WorkerRuntimePanel.test.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.test.tsx
@@ -1,0 +1,65 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import WorkerRuntimePanel from './WorkerRuntimePanel'
+
+const mocks = vi.hoisted(() => ({
+  setSetting: vi.fn(),
+  settingsData: { specs: [] },
+  pending: false,
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+vi.mock('../../services/codeAgentHarnessesService', () => ({
+  useOrgCodeAgentHarnesses: () => ({ data: [], isLoading: false }),
+}))
+vi.mock('../../services/helixOrgService', () => ({
+  useHelixOrgBase: () => ({ orgID: 'org-1' }),
+  useHelixOrgSettings: () => ({ data: mocks.settingsData, isLoading: false }),
+  useSetHelixOrgSetting: () => ({ mutateAsync: mocks.setSetting, isPending: mocks.pending }),
+}))
+vi.mock('./BotRuntimeForm', () => ({
+  default: ({ onChange, disabled }: { onChange: (patch: { runtime: string }) => void; disabled: boolean }) => (
+    <button disabled={disabled} onClick={() => { void onChange({ runtime: 'qwen_code' }) }}>Change runtime</button>
+  ),
+}))
+
+describe('WorkerRuntimePanel save feedback', () => {
+  beforeEach(() => {
+    mocks.setSetting.mockReset()
+    mocks.pending = false
+  })
+
+  it('shows saved feedback after an automatic update', async () => {
+    mocks.setSetting.mockResolvedValue(undefined)
+    render(<WorkerRuntimePanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change runtime' }))
+
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
+  it('shows failure feedback after an automatic update fails', async () => {
+    let rejectUpdate!: (error: Error) => void
+    mocks.setSetting.mockImplementation(() => new Promise((_, reject) => {
+      rejectUpdate = reject
+    }))
+    render(<WorkerRuntimePanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change runtime' }))
+
+    expect(await screen.findByText('Saving...')).toBeInTheDocument()
+    act(() => rejectUpdate(new Error('network failed')))
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('disables controls while an update is pending', () => {
+    mocks.pending = true
+    render(<WorkerRuntimePanel />)
+
+    expect(screen.getByRole('button', { name: 'Change runtime' })).toBeDisabled()
+  })
+
+})

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -3,10 +3,12 @@
 
 import { FC, useEffect, useMemo, useState } from 'react'
 import Paper from '@mui/material/Paper'
+import Typography from '@mui/material/Typography'
 
 import AgentConfigForm, { AgentConfigValue } from './BotRuntimeForm'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
+import { extractErrorMessage } from '../../hooks/useErrorCallback'
 import { useOrgCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
 import {
   SettingsSpecDTO,
@@ -63,6 +65,13 @@ const DefaultAgentConfigPanel: FC = () => {
   }
 
   const [value, setValue] = useState<AgentConfigValue>(initial)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') return
+    const timeout = window.setTimeout(() => setSaveStatus('idle'), 3000)
+    return () => window.clearTimeout(timeout)
+  }, [saveStatus])
 
   // Re-seed local state when the loaded data lands or refreshes.
   useEffect(() => {
@@ -71,18 +80,24 @@ const DefaultAgentConfigPanel: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 
-  const handlePatch = (patch: Partial<AgentConfigValue>) => {
+  const handlePatch = async (patch: Partial<AgentConfigValue>) => {
     const next = { ...value, ...patch }
     setValue(next)
-    setMut
-      .mutateAsync({ key: 'agent.default', value: JSON.stringify({
+    setSaveStatus('saving')
+    try {
+      await setMut.mutateAsync({ key: 'agent.default', value: JSON.stringify({
         code_agent_runtime: next.runtime,
         code_agent_credential_type: next.credentials,
         provider: next.provider,
         model: next.model,
       }) })
-      .then(() => snackbar.success('Default agent configuration saved'))
-      .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
+      snackbar.success('Default agent configuration saved')
+      setSaveStatus('saved')
+    } catch (e: any) {
+      const message = extractErrorMessage(e) || 'save failed'
+      snackbar.error(message)
+      setSaveStatus('error')
+    }
   }
 
   const subscriptionAvailability = {
@@ -100,11 +115,24 @@ const DefaultAgentConfigPanel: FC = () => {
     <Paper variant="outlined" sx={{ p: 3 }}>
       {isLoading || loadingHarnesses
         ? <LoadingSpinner />
-        : <AgentConfigForm
-            value={value}
-            onChange={handlePatch}
-            subscriptionAvailability={subscriptionAvailability}
-          />}
+        : <>
+            <AgentConfigForm
+              value={value}
+              onChange={handlePatch}
+              disabled={setMut.isPending}
+              subscriptionAvailability={subscriptionAvailability}
+            />
+            {saveStatus !== 'idle' && (
+              <Typography
+                role="status"
+                variant="caption"
+                color={saveStatus === 'error' ? 'error.main' : saveStatus === 'saved' ? 'success.main' : 'text.secondary'}
+                sx={{ display: 'block', mt: 2 }}
+              >
+                {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'saved' ? 'Saved' : 'Save failed'}
+              </Typography>
+            )}
+          </>}
     </Paper>
   )
 }

--- a/frontend/src/pages/HelixOrgSettings.test.tsx
+++ b/frontend/src/pages/HelixOrgSettings.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HelixOrgSettings from './HelixOrgSettings'
+
+const mocks = vi.hoisted(() => ({
+  setSetting: vi.fn(),
+  deleteSetting: vi.fn(),
+}))
+
+vi.mock('../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+vi.mock('../components/helix-org/GitHubAppPanel', () => ({ default: () => null }))
+vi.mock('../components/helix-org/SlackIntegrationsPanel', () => ({ default: () => null }))
+vi.mock('../services/helixOrgService', () => ({
+  useHelixOrgSettings: () => ({
+    data: {
+      specs: [{ key: 'helix.url', type: 'string', configured: true, value: 'https://old.example' }],
+    },
+    isLoading: false,
+  }),
+  useSetHelixOrgSetting: () => ({ mutateAsync: mocks.setSetting, isPending: false }),
+  useDeleteHelixOrgSetting: () => ({ mutateAsync: mocks.deleteSetting, isPending: false }),
+}))
+
+describe('HelixOrgSettings autosave', () => {
+  beforeEach(() => {
+    mocks.setSetting.mockReset()
+    mocks.deleteSetting.mockReset()
+  })
+
+  it('saves edited and blank values on blur without a Save button', async () => {
+    mocks.setSetting.mockResolvedValue(undefined)
+    render(<HelixOrgSettings />)
+
+    const input = screen.getByDisplayValue('https://old.example')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(mocks.setSetting).toHaveBeenCalledWith({ key: 'helix.url', value: '' }))
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument()
+  })
+
+  it('shows a visible failure when autosave fails', async () => {
+    mocks.setSetting.mockRejectedValue(new Error('network failed'))
+    render(<HelixOrgSettings />)
+
+    const input = screen.getByDisplayValue('https://old.example')
+    fireEvent.change(input, { target: { value: 'https://new.example' } })
+    fireEvent.blur(input)
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -11,10 +11,10 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import SaveIcon from '@mui/icons-material/Save'
 
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import useSnackbar from '../hooks/useSnackbar'
+import { extractErrorMessage } from '../hooks/useErrorCallback'
 import GitHubAppPanel from '../components/helix-org/GitHubAppPanel'
 import SlackIntegrationsPanel from '../components/helix-org/SlackIntegrationsPanel'
 import {
@@ -79,6 +79,13 @@ const GenericSettingRow: FC<{ spec: SettingsSpecDTO }> = ({ spec }) => {
   const snackbar = useSnackbar()
   const [value, setValue] = useState('')
   const [dirty, setDirty] = useState(false)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') return
+    const timeout = window.setTimeout(() => setSaveStatus('idle'), 3000)
+    return () => window.clearTimeout(timeout)
+  }, [saveStatus])
 
   useEffect(() => {
     setValue(spec.value ?? '')
@@ -86,20 +93,25 @@ const GenericSettingRow: FC<{ spec: SettingsSpecDTO }> = ({ spec }) => {
   }, [spec.value, spec.configured])
 
   const handleSave = async () => {
+    if (!dirty || setMut.isPending) return
+    setSaveStatus('saving')
     try {
       await setMut.mutateAsync({ key: spec.key, value })
       snackbar.success(`${spec.key} saved`)
       setDirty(false)
+      setSaveStatus('saved')
     } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+      snackbar.error(extractErrorMessage(e) || 'save failed')
+      setSaveStatus('error')
     }
   }
   const handleClear = async () => {
     try {
       await delMut.mutateAsync(spec.key)
       snackbar.success(`${spec.key} cleared`)
+      setSaveStatus('idle')
     } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'clear failed')
+      snackbar.error(extractErrorMessage(e) || 'clear failed')
     }
   }
   return (
@@ -118,19 +130,33 @@ const GenericSettingRow: FC<{ spec: SettingsSpecDTO }> = ({ spec }) => {
           fullWidth
           size="small"
           value={value}
-          onChange={(e) => { setValue(e.target.value); setDirty(true) }}
+          onChange={(e) => { setValue(e.target.value); setDirty(true); setSaveStatus('idle') }}
+          onBlur={handleSave}
+          disabled={setMut.isPending}
           placeholder={spec.type === 'string' ? '"plain string (no quotes needed in UI)"' : 'raw JSON per spec type'}
           multiline={spec.type !== 'string'}
           minRows={spec.type !== 'string' ? 3 : undefined}
         />
-        <Stack direction="row" spacing={1}>
-          <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={!dirty || setMut.isPending}>
-            {setMut.isPending ? 'Saving…' : 'Save'}
-          </Button>
+        <Stack direction="row" spacing={1} alignItems="center">
           {spec.configured && (
-            <Button size="small" color="error" onClick={handleClear} disabled={delMut.isPending}>
+            <Button
+              size="small"
+              color="error"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleClear}
+              disabled={delMut.isPending || setMut.isPending}
+            >
               Clear
             </Button>
+          )}
+          {saveStatus !== 'idle' && (
+            <Typography
+              role="status"
+              variant="caption"
+              color={saveStatus === 'error' ? 'error.main' : saveStatus === 'saved' ? 'success.main' : 'text.secondary'}
+            >
+              {saveStatus === 'saving' ? 'Saving...' : saveStatus === 'saved' ? 'Saved' : 'Save failed'}
+            </Typography>
           )}
         </Stack>
       </Stack>

--- a/frontend/src/pages/OrgSettings.test.tsx
+++ b/frontend/src/pages/OrgSettings.test.tsx
@@ -1,0 +1,105 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import OrgSettings from './OrgSettings'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  updateOrganization: vi.fn(),
+  organization: {
+    id: 'org-1',
+    name: 'acme',
+    display_name: 'Acme',
+    auto_join_domain: 'acme.com',
+    memberships: [{ user_id: 'user-1', role: 'owner' }],
+  },
+}))
+
+vi.mock('../hooks/useRouter', () => ({
+  default: () => ({ navigate: mocks.navigate }),
+}))
+vi.mock('../hooks/useSnackbar', () => ({
+  default: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+vi.mock('../hooks/useAccount', () => ({
+  default: () => ({
+    user: { id: 'user-1' },
+    isOrgAdmin: true,
+    organizationTools: {
+      organization: mocks.organization,
+      organizations: [],
+      updateOrganization: mocks.updateOrganization,
+      deleteOrganization: vi.fn(),
+    },
+  }),
+}))
+vi.mock('../components/system/Page', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('../components/common/CopyButton', () => ({ default: () => null }))
+vi.mock('../components/helix-org/WorkerRuntimePanel', () => ({ default: () => null }))
+vi.mock('./HelixOrgSettings', () => ({ default: () => null }))
+
+describe('OrgSettings autosave', () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset()
+    mocks.updateOrganization.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('saves valid changed fields on blur and shows confirmation', async () => {
+    vi.useFakeTimers()
+    let resolveUpdate!: (updated: boolean) => void
+    mocks.updateOrganization.mockImplementation(() => new Promise((resolve) => {
+      resolveUpdate = resolve
+    }))
+    render(<OrgSettings />)
+
+    fireEvent.change(screen.getByLabelText(/Name/), { target: { value: 'Acme Corp' } })
+    fireEvent.blur(screen.getByLabelText(/Name/))
+
+    expect(screen.getByText('Saving organization settings...')).toBeInTheDocument()
+    expect(mocks.updateOrganization).toHaveBeenCalledWith(
+      'org-1',
+      expect.objectContaining({ display_name: 'Acme Corp' }),
+    )
+    await act(async () => resolveUpdate(true))
+    expect(screen.getByText('Organization settings saved')).toBeInTheDocument()
+    act(() => vi.advanceTimersByTime(2999))
+    expect(screen.getByText('Organization settings saved')).toBeInTheDocument()
+    act(() => vi.advanceTimersByTime(1))
+    expect(screen.queryByText('Organization settings saved')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Update Organization' })).not.toBeInTheDocument()
+  })
+
+  it('shows failure and does not navigate when the update returns false', async () => {
+    vi.useFakeTimers()
+    let resolveUpdate!: (updated: boolean) => void
+    mocks.updateOrganization.mockImplementation(() => new Promise((resolve) => {
+      resolveUpdate = resolve
+    }))
+    render(<OrgSettings />)
+
+    fireEvent.change(screen.getByLabelText(/Slug/), { target: { value: 'new-acme' } })
+    fireEvent.blur(screen.getByLabelText(/Slug/))
+
+    await act(async () => resolveUpdate(false))
+    expect(screen.getByText('Failed to save organization settings')).toBeInTheDocument()
+    act(() => vi.advanceTimersByTime(3000))
+    expect(screen.getByText('Failed to save organization settings')).toBeInTheDocument()
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+
+  it('does not save invalid values', async () => {
+    render(<OrgSettings />)
+
+    fireEvent.change(screen.getByLabelText(/Auto-Join Domain/), { target: { value: '@acme.com' } })
+    fireEvent.blur(screen.getByLabelText(/Auto-Join Domain/))
+
+    expect(await screen.findByText("Domain should not start with @, use 'example.com' not '@example.com'")).toBeInTheDocument()
+    expect(mocks.updateOrganization).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC, useState, useEffect, useRef } from "react";
 import Container from "@mui/material/Container";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
@@ -36,7 +36,10 @@ const OrgSettings: FC = () => {
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const savedValues = useRef({ slug: "", name: "", autoJoinDomain: "" });
   const [errors, setErrors] = useState<{
     slug?: string;
     name?: string;
@@ -44,6 +47,13 @@ const OrgSettings: FC = () => {
   }>({});
 
   const organization = account.organizationTools.organization;
+
+  useEffect(() => {
+    if (saveStatus !== "saved") return;
+    const timeout = window.setTimeout(() => setSaveStatus("idle"), 3000);
+    return () => window.clearTimeout(timeout);
+  }, [saveStatus]);
+
   const isOrgOwner =
     !!account.user &&
     !!organization &&
@@ -52,22 +62,9 @@ const OrgSettings: FC = () => {
         membership.user_id === account.user?.id && membership.role === "owner",
     );
 
-  // Generate slug from name for new organizations
-  const handleNameBlur = () => {
-    // Only auto-generate slug if:
-    // 1. Current slug is empty
-    // 2. User hasn't manually edited the slug
-    if (slug === "" && !slugManuallyEdited && name) {
-      // Convert name to slug format: lowercase, replace spaces with hyphens
-      const generatedSlug = name.toLowerCase().replace(/\s+/g, "-");
-      setSlug(generatedSlug);
-    }
-  };
-
-  // Mark slug as manually edited when user changes it
   const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSlugManuallyEdited(true);
     setSlug(e.target.value);
+    setSaveStatus("idle");
   };
 
   // Validate form before submission
@@ -109,18 +106,27 @@ const OrgSettings: FC = () => {
     return Object.keys(newErrors).length === 0;
   };
 
-  // Handle form submission
-  const handleSubmit = async () => {
-    // Validate form before submission
+  const handleSave = async () => {
     if (!validateForm()) {
+      return;
+    }
+
+    const normalizedDomain = autoJoinDomain.trim().toLowerCase();
+    if (
+      slug === savedValues.current.slug &&
+      name === savedValues.current.name &&
+      normalizedDomain === savedValues.current.autoJoinDomain
+    ) {
       return;
     }
 
     try {
       setLoading(true);
+      setSaveStatus("saving");
 
       if (!organization || !organization.id) {
         snackbar.error("Organization not found");
+        setSaveStatus("error");
         return;
       }
 
@@ -129,21 +135,28 @@ const OrgSettings: FC = () => {
         ...organization,
         name: slug, // 'name' field in API is our 'slug'
         display_name: name, // 'display_name' in API is our 'name'
-        auto_join_domain: autoJoinDomain.trim().toLowerCase() || undefined,
+        auto_join_domain: normalizedDomain,
       } as TypesOrganization;
 
-      await account.organizationTools.updateOrganization(
+      const updated = await account.organizationTools.updateOrganization(
         organization.id,
         updatedOrg,
       );
-      snackbar.success("Organization updated successfully");
+      if (!updated) {
+        setSaveStatus("error");
+        return;
+      }
 
-      if (slug != organization.name) {
+      savedValues.current = { slug, name, autoJoinDomain: normalizedDomain };
+      setSaveStatus("saved");
+
+      if (slug !== organization.name) {
         router.navigate("org_general", { org_id: slug });
       }
     } catch (error) {
       console.error("Error updating organization:", error);
       snackbar.error("Failed to update organization");
+      setSaveStatus("error");
     } finally {
       setLoading(false);
     }
@@ -154,6 +167,11 @@ const OrgSettings: FC = () => {
       setSlug(organization.name || "");
       setName(organization.display_name || "");
       setAutoJoinDomain(organization.auto_join_domain || "");
+      savedValues.current = {
+        slug: organization.name || "",
+        name: organization.display_name || "",
+        autoJoinDomain: organization.auto_join_domain || "",
+      };
     }
   }, [organization]);
 
@@ -217,14 +235,17 @@ const OrgSettings: FC = () => {
           </Typography>
 
           {organization ? (
-            <Box component="form" sx={{ mt: 3 }}>
+            <Box sx={{ mt: 3 }}>
               {/* Name field (formerly Display Name) */}
               <TextField
                 label="Name"
                 fullWidth
                 value={name}
-                onChange={(e) => setName(e.target.value)}
-                onBlur={handleNameBlur}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setSaveStatus("idle");
+                }}
+                onBlur={handleSave}
                 disabled={loading || isReadOnly}
                 required
                 error={!!errors.name}
@@ -243,6 +264,7 @@ const OrgSettings: FC = () => {
                 fullWidth
                 value={slug}
                 onChange={handleSlugChange}
+                onBlur={handleSave}
                 disabled={loading || isReadOnly}
                 required
                 error={!!errors.slug}
@@ -282,7 +304,11 @@ const OrgSettings: FC = () => {
                 label="Auto-Join Domain"
                 fullWidth
                 value={autoJoinDomain}
-                onChange={(e) => setAutoJoinDomain(e.target.value)}
+                onChange={(e) => {
+                  setAutoJoinDomain(e.target.value);
+                  setSaveStatus("idle");
+                }}
+                onBlur={handleSave}
                 disabled={loading || isReadOnly}
                 error={!!errors.autoJoinDomain}
                 helperText={
@@ -295,6 +321,24 @@ const OrgSettings: FC = () => {
                   readOnly: isReadOnly,
                 }}
               />
+              {saveStatus !== "idle" && (
+                <Alert
+                  severity={
+                    saveStatus === "error"
+                      ? "error"
+                      : saveStatus === "saved"
+                        ? "success"
+                        : "info"
+                  }
+                  sx={{ mb: 3 }}
+                >
+                  {saveStatus === "saving"
+                    ? "Saving organization settings..."
+                    : saveStatus === "saved"
+                      ? "Organization settings saved"
+                      : "Failed to save organization settings"}
+                </Alert>
+              )}
               {autoJoinDomain && !errors.autoJoinDomain && (
                 <Alert severity="info" sx={{ mb: 3 }}>
                   Users with <strong>@{autoJoinDomain.toLowerCase()}</strong>{" "}
@@ -302,22 +346,6 @@ const OrgSettings: FC = () => {
                   they log in via OIDC (e.g., Google, Azure AD). This only works
                   for OIDC authentication with verified emails.
                 </Alert>
-              )}
-
-              {!isReadOnly && (
-                <Box
-                  sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}
-                >
-                  <Button
-                    onClick={handleSubmit}
-                    variant="outlined"
-                    color="secondary"
-                    disabled={loading}
-                    startIcon={loading ? <CircularProgress size={20} /> : null}
-                  >
-                    Update Organization
-                  </Button>
-                </Box>
               )}
 
               <Box sx={{ mt: 4 }}>


### PR DESCRIPTION
## Summary

- Autosave Organization Settings > General fields when focus leaves a changed, valid field.
- Autosave generic organization settings and retain explicit Clear, Connect, and Delete actions.
- Show nearby save feedback for identity, default-agent, and generic settings.
- Hide successful feedback after 3 seconds; keep failures visible until edit or retry.
- Do not navigate after a failed slug update.

This PR is scoped to Organization Settings > General. It does not change unrelated forms elsewhere in Helix.

## Screenshots

### Saving

![Inline saving feedback](https://gist.githubusercontent.com/chocobar/605df755b94d3091fe517c441bfff927/raw/org-general-saving-inline.png)

### Saved

![Inline saved feedback](https://gist.githubusercontent.com/chocobar/605df755b94d3091fe517c441bfff927/raw/org-general-saved-inline.png)

### Failure

![Inline failure feedback](https://gist.githubusercontent.com/chocobar/605df755b94d3091fe517c441bfff927/raw/org-general-failure-inline.png)

## Verification

- `yarn vitest run src/pages/OrgSettings.test.tsx src/pages/HelixOrgSettings.test.tsx src/components/helix-org/WorkerRuntimePanel.test.tsx` - 8 tests passed.
- Clean Linux `yarn build` passed.
- Standalone Playwright exercised save, refresh persistence, clear, subsequent save, and an intercepted failed update.
