### PR TITLE
Always show the new chat action

### DIFF
--- a/frontend/src/components/session/ProjectChatGroup.test.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.test.tsx
@@ -219,6 +219,12 @@ describe('ProjectChatGroup', () => {
     expect(onToggle).not.toHaveBeenCalled()
   })
 
+  it('always shows the new chat affordance', () => {
+    renderEmptyProject()
+
+    expect(screen.getByText('New')).toHaveStyle({ opacity: '1' })
+  })
+
   it('collapses from the chevron, and only from the chevron', () => {
     const onToggle = vi.fn()
     const onNewTask = vi.fn()

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -316,12 +316,6 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
           '&:hover': {
             backgroundColor: lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)',
           },
-          '&:hover .sidebar-group-new, &:focus-within .sidebar-group-new': {
-            opacity: 1,
-          },
-          '@media (hover: none)': onNewTask ? {
-            '& .sidebar-group-new': { opacity: 1 },
-          } : undefined,
         }}
       >
         <Box
@@ -406,8 +400,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
               font: 'inherit',
               fontSize: '10px',
               fontWeight: 500,
-              opacity: 0,
-              transition: 'opacity 100ms ease',
+              opacity: 1,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'flex-end',


### PR DESCRIPTION
## Summary
Keep the “+ New” action in each chat project visible at all times so new users can discover how to start a chat without first hovering or scrolling. Remove the hover-only visibility styling and add regression coverage for the persistent affordance.

## Testing
- `yarn test src/components/session/ProjectChatGroup.test.tsx` — 15 tests passed.
- `yarn tsc` — passed.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1hpqaghdtpt688pf03r0tyj)

🚀 Built with [Helix](https://helix.ml)