### PR TITLE
feat(artifacts): restore artifact downloads

### DIFF
--- a/api/pkg/server/artifact_handlers.go
+++ b/api/pkg/server/artifact_handlers.go
@@ -1057,6 +1057,100 @@ func (s *HelixAPIServer) serveArtifactDocument(w http.ResponseWriter, r *http.Re
 	s.serveArtifactFile(w, r, artifact, "")
 }
 
+// serveArtifactDownload delivers artifact content as a file attachment so the
+// project list can hand users the original upload. Single file artifacts stream
+// the file itself; multi-file bundles stream a ZIP of the active version.
+func (s *HelixAPIServer) serveArtifactDownload(w http.ResponseWriter, r *http.Request) {
+	artifactID := mux.Vars(r)["artifact_id"]
+	artifact, err := s.Store.GetArtifact(r.Context(), artifactID)
+	if err != nil || artifact.ActiveVersion == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if artifact.Visibility != types.ArtifactVisibilityPublic {
+		user := getRequestUser(r)
+		if user == nil || user.ID == "" {
+			http.Error(w, "artifact access required", http.StatusUnauthorized)
+			return
+		}
+		if err := s.authorizeUserToProjectByID(r.Context(), user, artifact.ProjectID, types.ActionGet); err != nil {
+			http.Error(w, "artifact access denied", http.StatusForbidden)
+			return
+		}
+	}
+	setArtifactDocumentSecurityHeaders(w.Header(), artifactRequestOrigin(r, s.Cfg.WebServer.URL))
+	if len(artifact.ActiveVersion.Files) > 1 {
+		s.serveArtifactBundle(w, r, artifact)
+		return
+	}
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{
+		"filename": artifactDownloadFilename(artifact, path.Ext(artifact.Entrypoint)),
+	}))
+	s.serveArtifactFile(w, r, artifact, "")
+}
+
+// serveArtifactBundle streams the active version as a ZIP. The archive is built
+// on the fly, so a filestore failure mid-stream truncates the download - the
+// response is already committed by then and there is no status left to send.
+func (s *HelixAPIServer) serveArtifactBundle(w http.ResponseWriter, r *http.Request, artifact *types.Artifact) {
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{
+		"filename": artifactDownloadFilename(artifact, ".zip"),
+	}))
+	if r.Method == http.MethodHead {
+		return
+	}
+	archive := zip.NewWriter(w)
+	for _, file := range artifact.ActiveVersion.Files {
+		if err := writeArtifactBundleEntry(r.Context(), archive, s.Controller.Options.Filestore, artifact.ActiveVersion, file.Path); err != nil {
+			log.Warn().Err(err).Str("artifact_id", artifact.ID).Str("path", file.Path).Msg("stream artifact bundle")
+			return
+		}
+	}
+	if err := archive.Close(); err != nil {
+		log.Warn().Err(err).Str("artifact_id", artifact.ID).Msg("close artifact bundle")
+	}
+}
+
+func writeArtifactBundleEntry(ctx context.Context, archive *zip.Writer, fs filestore.FileStore, version *types.ArtifactVersion, filePath string) error {
+	reader, err := fs.OpenFile(ctx, path.Join(version.StoragePrefix, filePath))
+	if err != nil {
+		return fmt.Errorf("open artifact file: %w", err)
+	}
+	defer reader.Close()
+	entry, err := archive.CreateHeader(&zip.FileHeader{Name: filePath, Method: zip.Deflate, Modified: version.CreatedAt})
+	if err != nil {
+		return fmt.Errorf("create archive entry: %w", err)
+	}
+	if _, err := io.Copy(entry, reader); err != nil {
+		return fmt.Errorf("write archive entry: %w", err)
+	}
+	return nil
+}
+
+// artifactDownloadFilename names the attachment after the artifact so downloads
+// are recognisable, falling back to the stored entrypoint.
+func artifactDownloadFilename(artifact *types.Artifact, ext string) string {
+	base := strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == '"' || r < 32 || r == 127 {
+			return -1
+		}
+		return r
+	}, artifact.Name)
+	base = strings.Trim(strings.TrimSpace(base), ".")
+	if base == "" {
+		if ext == ".zip" {
+			return "artifact.zip"
+		}
+		return path.Base(artifact.Entrypoint)
+	}
+	if ext != "" && !strings.EqualFold(path.Ext(base), ext) {
+		base += ext
+	}
+	return base
+}
+
 func (s *HelixAPIServer) serveArtifactFile(w http.ResponseWriter, r *http.Request, artifact *types.Artifact, requestedPath string) {
 	filename, metadata, ok := resolveArtifactFile(artifact, requestedPath)
 	if !ok {

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -3,13 +3,21 @@ package server
 import (
 	"archive/zip"
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/controller"
+	"github.com/helixml/helix/api/pkg/filestore"
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestReadArtifactZIP(t *testing.T) {
@@ -182,4 +190,93 @@ func TestArtifactDownloadFilename(t *testing.T) {
 	require.Equal(t, "etcpasswd.html", artifactDownloadFilename(&types.Artifact{Name: "../../etc/passwd", Entrypoint: "index.html"}, ".html"))
 	require.Equal(t, "index.html", artifactDownloadFilename(&types.Artifact{Name: "  ", Entrypoint: "index.html"}, ".html"))
 	require.Equal(t, "artifact.zip", artifactDownloadFilename(&types.Artifact{Name: "...", Entrypoint: "index.html"}, ".zip"))
+}
+
+func TestServeArtifactDownloadSingleFile(t *testing.T) {
+	mockStore, mockFilestore, server := newArtifactDownloadTestServer(t)
+	body := "# Engagement notes\n"
+	artifact := artifactDownloadTestArtifact("Engagement notes", "notes.md", []types.ArtifactFile{{
+		Path: "notes.md", Size: int64(len(body)), ContentType: "text/markdown; charset=utf-8", SHA256: "notes-sha",
+	}})
+	mockStore.EXPECT().GetArtifact(gomock.Any(), artifact.ID).Return(artifact, nil)
+	mockFilestore.EXPECT().OpenFile(gomock.Any(), "artifacts/artv_test/notes.md").Return(io.NopCloser(strings.NewReader(body)), nil)
+
+	response := httptest.NewRecorder()
+	request := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/artifacts/art_test/download", nil), map[string]string{"artifact_id": artifact.ID})
+	server.serveArtifactDownload(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "attachment; filename=\"Engagement notes.md\"", response.Header().Get("Content-Disposition"))
+	require.Equal(t, "text/markdown; charset=utf-8", response.Header().Get("Content-Type"))
+	require.Equal(t, body, response.Body.String())
+}
+
+func TestServeArtifactDownloadBundle(t *testing.T) {
+	mockStore, mockFilestore, server := newArtifactDownloadTestServer(t)
+	files := []types.ArtifactFile{
+		{Path: "index.html", Size: 14, ContentType: "text/html; charset=utf-8", SHA256: "index-sha"},
+		{Path: "assets/app.js", Size: 15, ContentType: "text/javascript; charset=utf-8", SHA256: "app-sha"},
+	}
+	artifact := artifactDownloadTestArtifact("Assessment dashboard", "index.html", files)
+	mockStore.EXPECT().GetArtifact(gomock.Any(), artifact.ID).Return(artifact, nil)
+	mockFilestore.EXPECT().OpenFile(gomock.Any(), "artifacts/artv_test/index.html").Return(io.NopCloser(strings.NewReader("<h1>Hello</h1>")), nil)
+	mockFilestore.EXPECT().OpenFile(gomock.Any(), "artifacts/artv_test/assets/app.js").Return(io.NopCloser(strings.NewReader("console.log('x')")), nil)
+
+	response := httptest.NewRecorder()
+	request := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/artifacts/art_test/download", nil), map[string]string{"artifact_id": artifact.ID})
+	server.serveArtifactDownload(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "application/zip", response.Header().Get("Content-Type"))
+	require.Equal(t, "attachment; filename=\"Assessment dashboard.zip\"", response.Header().Get("Content-Disposition"))
+
+	archive, err := zip.NewReader(bytes.NewReader(response.Body.Bytes()), int64(response.Body.Len()))
+	require.NoError(t, err)
+	require.Len(t, archive.File, 2)
+	require.Equal(t, "index.html", archive.File[0].Name)
+	require.Equal(t, "assets/app.js", archive.File[1].Name)
+	entry, err := archive.File[1].Open()
+	require.NoError(t, err)
+	defer entry.Close()
+	content, err := io.ReadAll(entry)
+	require.NoError(t, err)
+	require.Equal(t, "console.log('x')", string(content))
+}
+
+func TestServeArtifactDownloadRejectsAnonymousPrivateAccess(t *testing.T) {
+	mockStore, _, server := newArtifactDownloadTestServer(t)
+	artifact := artifactDownloadTestArtifact("Private report", "report.pdf", []types.ArtifactFile{{Path: "report.pdf"}})
+	artifact.Visibility = types.ArtifactVisibilityProject
+	mockStore.EXPECT().GetArtifact(gomock.Any(), artifact.ID).Return(artifact, nil)
+
+	response := httptest.NewRecorder()
+	request := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/artifacts/art_test/download", nil), map[string]string{"artifact_id": artifact.ID})
+	server.serveArtifactDownload(response, request)
+
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+}
+
+func newArtifactDownloadTestServer(t *testing.T) (*store.MockStore, *filestore.MockFileStore, *HelixAPIServer) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockFilestore := filestore.NewMockFileStore(ctrl)
+	server := &HelixAPIServer{
+		Cfg:   &config.ServerConfig{WebServer: config.WebServer{URL: "https://helix.example"}},
+		Store: mockStore,
+		Controller: &controller.Controller{Options: controller.Options{
+			Filestore: mockFilestore,
+		}},
+	}
+	return mockStore, mockFilestore, server
+}
+
+func artifactDownloadTestArtifact(name, entrypoint string, files []types.ArtifactFile) *types.Artifact {
+	return &types.Artifact{
+		ID: "art_test", ProjectID: "prj_test", Name: name, Entrypoint: entrypoint,
+		Visibility: types.ArtifactVisibilityPublic,
+		ActiveVersion: &types.ArtifactVersion{
+			ID: "artv_test", StoragePrefix: "artifacts/artv_test", Files: files, CreatedAt: time.Unix(1, 0),
+		},
+	}
 }

--- a/api/pkg/server/artifact_handlers_test.go
+++ b/api/pkg/server/artifact_handlers_test.go
@@ -174,3 +174,12 @@ func artifactTestZIP(t *testing.T, files map[string]string) []byte {
 	require.NoError(t, writer.Close())
 	return buffer.Bytes()
 }
+
+func TestArtifactDownloadFilename(t *testing.T) {
+	require.Equal(t, "Q3 report.pdf", artifactDownloadFilename(&types.Artifact{Name: "Q3 report", Entrypoint: "document.pdf"}, ".pdf"))
+	require.Equal(t, "notes.md", artifactDownloadFilename(&types.Artifact{Name: "notes.md", Entrypoint: "notes.md"}, ".md"))
+	require.Equal(t, "dashboard.zip", artifactDownloadFilename(&types.Artifact{Name: "dashboard", Entrypoint: "index.html"}, ".zip"))
+	require.Equal(t, "etcpasswd.html", artifactDownloadFilename(&types.Artifact{Name: "../../etc/passwd", Entrypoint: "index.html"}, ".html"))
+	require.Equal(t, "index.html", artifactDownloadFilename(&types.Artifact{Name: "  ", Entrypoint: "index.html"}, ".html"))
+	require.Equal(t, "artifact.zip", artifactDownloadFilename(&types.Artifact{Name: "...", Entrypoint: "index.html"}, ".zip"))
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1534,6 +1534,8 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	router.Handle("/artifacts/{artifact_id}/embed/{artifact_path:.*}", artifactEmbedHandler).Methods(http.MethodGet, http.MethodHead)
 	artifactDocumentHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.serveArtifactDocument))
 	router.Handle("/artifacts/{artifact_id}/document", artifactDocumentHandler).Methods(http.MethodGet, http.MethodHead)
+	artifactDownloadHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.serveArtifactDownload))
+	router.Handle("/artifacts/{artifact_id}/download", artifactDownloadHandler).Methods(http.MethodGet, http.MethodHead)
 	artifactViewerHandler := apiServer.authMiddleware.extractMiddleware(http.HandlerFunc(apiServer.getArtifactViewer))
 	insecureRouter.Handle("/public/artifacts/{artifact_id}", artifactViewerHandler).Methods(http.MethodGet)
 

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -10,7 +10,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { EllipsisVertical, ExternalLink, Pencil, Trash2 } from 'lucide-react'
+import { Download, EllipsisVertical, ExternalLink, Pencil, Trash2 } from 'lucide-react'
 
 import { TypesArtifact, TypesArtifactKind } from '../../api/api'
 import useRouter from '../../hooks/useRouter'
@@ -46,6 +46,18 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
 
   const openArtifact = (artifact: TypesArtifact) => {
     if (artifact.id) router.navigate('artifact_viewer', { artifact_id: artifact.id })
+  }
+
+  // Same-origin navigation so the session cookie authenticates the download and
+  // the server's Content-Disposition names the file.
+  const downloadArtifact = (artifact: TypesArtifact) => {
+    if (!artifact.id) return
+    const link = document.createElement('a')
+    link.href = `/artifacts/${artifact.id}/download`
+    link.download = ''
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
   }
 
   const openMenu = (event: MouseEvent<HTMLElement>, artifact: TypesArtifact) => {
@@ -109,6 +121,14 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
       }}>
         <ListItemIcon><ExternalLink size={16} /></ListItemIcon>
         <ListItemText primary="Open" />
+      </MenuItem>
+      <MenuItem dense onClick={(event) => {
+        event.stopPropagation()
+        if (currentArtifact) downloadArtifact(currentArtifact)
+        closeMenu()
+      }}>
+        <ListItemIcon><Download size={16} /></ListItemIcon>
+        <ListItemText primary="Download" />
       </MenuItem>
       <MenuItem dense onClick={(event) => {
         event.stopPropagation()


### PR DESCRIPTION
## Summary
- restore the artifact Download action that was committed after PR 3155 had already merged
- download single-file artifacts with their original type and multi-file artifacts as ZIP archives
- enforce existing public/project access checks and safe attachment filenames
- cover single-file, ZIP, and anonymous private-access response paths

## Verification
- CGO_ENABLED=1 go test ./pkg/server -run Test(Artifact|ServeArtifactDownload) -count=1
- CGO_ENABLED=1 go build ./pkg/server/ ./pkg/store/ ./pkg/types/
- cd frontend && yarn build
- live UI: verified Download in table and card menus on the cyber-graybox artifacts page
- live API: authenticated private Markdown download returned 200, attachment filename, text/markdown, and a 13,796-byte body; anonymous request returned 401

## Recovery audit
The old feat/api-keys-board-automation branch and its final T3 checkpoint contain exactly one change not on main: the artifact download commit. The later retained Markdown blockquote stash matches commit ccf1d62861 already on main.