### PR TITLE
fix(sandbox): use standard rootlesskit path

### DIFF
--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -788,8 +788,8 @@ RUN apt-get update \
 COPY --from=rootless-buildkit \
     /usr/bin/buildkitd \
     /usr/bin/buildctl \
-    /usr/bin/rootlesskit \
     /usr/local/bin/
+COPY --from=rootless-buildkit /usr/bin/rootlesskit /usr/bin/rootlesskit
 
 # NVIDIA Container Toolkit (enables GPU passthrough in inner containers)
 # This allows the desktop's dockerd to run containers with --runtime=nvidia

--- a/desktop/shared/17-start-dockerd.sh
+++ b/desktop/shared/17-start-dockerd.sh
@@ -39,6 +39,16 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
     cp /opt/helix/headless-containers.conf /home/retro/.config/containers/containers.conf
     chown retro:retro /home/retro/.config/containers/containers.conf
 
+    if ! gosu retro env \
+        HOME=/home/retro \
+        USER=retro \
+        XDG_RUNTIME_DIR="${PODMAN_RUNTIME}" \
+        /usr/bin/rootlesskit /bin/true; then
+        echo "[buildkit] FATAL: the host blocked /usr/bin/rootlesskit from creating and re-executing in a user namespace"
+        echo "[buildkit] Enable unprivileged user namespaces and permit /usr/bin/rootlesskit in the host security policy"
+        exit 1
+    fi
+
     rm -f "${PODMAN_SOCKET}"
     gosu retro env \
         HOME=/home/retro \
@@ -85,7 +95,7 @@ if [ "${HELIX_ROOTLESS_CONTAINER_ENGINE:-0}" = "1" ]; then
         bash -c '
         while true; do
             echo "[$(date -Iseconds)] Starting rootless BuildKit daemon..."
-            env -u BUILDKIT_HOST rootlesskit \
+            env -u BUILDKIT_HOST /usr/bin/rootlesskit \
                 --state-dir="${BUILDKIT_ROOTLESSKIT_STATE}" \
                 buildkitd \
                 --root="${BUILDKIT_DATA}" \


### PR DESCRIPTION
## Summary
- install the pinned RootlessKit binary at `/usr/bin/rootlesskit` so standard host AppArmor policy recognizes it
- invoke that exact path for rootless BuildKit
- fail before starting background services when the host blocks the required user namespace re-exec

## Verification
- `git diff --check`
- `bash -n desktop/shared/17-start-dockerd.sh`
- Prime: `./stack build-ubuntu` produced `helix-ubuntu:2a34a8`
- Prime: rootless Podman and BuildKit started in a non-privileged headless container
- Prime: Buildx built and loaded a smoke image through BuildKit v0.27.1
- Prime: headless spec task completed with `ROOTLESSKIT_READY` in 23.693 seconds
- Prime: zero kernel records mentioning RootlessKit during the task