### PR TITLE
fix(artifacts): route downloads through API

### DIFF
--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1614,6 +1614,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	// Project audit log routes
 	authRouter.HandleFunc("/projects/{id}/audit-logs", system.Wrapper(apiServer.listProjectAuditLogs)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.getArtifact).Methods(http.MethodGet)
+	authRouter.HandleFunc("/artifacts/{artifact_id}/download", apiServer.serveArtifactDownload).Methods(http.MethodGet, http.MethodHead)
 	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.updateArtifact).Methods(http.MethodPut)
 	authRouter.HandleFunc("/artifacts/{artifact_id}", apiServer.deleteArtifact).Methods(http.MethodDelete)
 	authRouter.HandleFunc("/artifacts/{artifact_id}/versions", apiServer.listArtifactVersions).Methods(http.MethodGet)

--- a/frontend/src/components/artifacts/ArtifactsView.tsx
+++ b/frontend/src/components/artifacts/ArtifactsView.tsx
@@ -53,7 +53,7 @@ const ArtifactsView: FC<Props> = ({ artifacts, mode, onEdit, onDelete }) => {
   const downloadArtifact = (artifact: TypesArtifact) => {
     if (!artifact.id) return
     const link = document.createElement('a')
-    link.href = `/artifacts/${artifact.id}/download`
+    link.href = `/api/v1/artifacts/${artifact.id}/download`
     link.download = ''
     document.body.appendChild(link)
     link.click()


### PR DESCRIPTION
## Summary
- route artifact downloads through the `/api/v1` namespace
- register the authenticated API download endpoint
- retain the existing non-API route for compatibility

## Testing
- `go test ./pkg/server -run 'TestArtifactDownloadFilename|TestServeArtifactDownload' -count=1`\n- `cd frontend && yarn build`