### PR TITLE
Suppress auto-remediation for pre-existing CI failures

### DIFF
--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -507,6 +507,9 @@ func (s *GitRepositoryService) getAzureDevOpsPullRequest(ctx context.Context, re
 	if adoPR.LastMergeSourceCommit != nil && adoPR.LastMergeSourceCommit.CommitId != nil {
 		pr.HeadSHA = *adoPR.LastMergeSourceCommit.CommitId
 	}
+	if adoPR.LastMergeTargetCommit != nil && adoPR.LastMergeTargetCommit.CommitId != nil {
+		pr.BaseSHA = *adoPR.LastMergeTargetCommit.CommitId
+	}
 
 	return pr, nil
 }
@@ -761,6 +764,7 @@ func (s *GitRepositoryService) getGitHubPullRequest(ctx context.Context, repo *t
 		TargetBranch: ghPR.GetBase().GetRef(),
 		URL:          ghPR.GetHTMLURL(),
 		HeadSHA:      ghPR.GetHead().GetSHA(),
+		BaseSHA:      ghPR.GetBase().GetSHA(),
 	}
 
 	if ghPR.GetUser() != nil {
@@ -1078,6 +1082,7 @@ func (s *GitRepositoryService) getGitLabMergeRequest(ctx context.Context, repo *
 		URL:          glMR.WebURL,
 		HeadSHA:      glMR.SHA,
 	}
+	pr.BaseSHA = glMR.DiffRefs.BaseSha
 
 	if glMR.Author != nil {
 		pr.Author = glMR.Author.Username

--- a/api/pkg/services/spec_task_orchestrator_ci.go
+++ b/api/pkg/services/spec_task_orchestrator_ci.go
@@ -66,6 +66,24 @@ func (o *SpecTaskOrchestrator) pollCIStatusForPR(
 		return mutated
 	}
 
+	// Establish that CI was green before this PR before asking the agent to
+	// repair a failure. A red (or unverifiable) target commit makes the failure
+	// pre-existing and outside the task's implied scope.
+	if pr.BaseSHA != "" && (repoPR.CIBaseSHA != pr.BaseSHA || repoPR.CIBaseStatus == "") {
+		baseStatus, baseErr := o.gitService.GetCIStatus(ctx, repoPR.RepositoryID, repoPR.PRID, pr.BaseSHA)
+		if baseErr != nil {
+			log.Debug().Err(baseErr).
+				Str("task_id", task.ID).
+				Str("repo_id", repoPR.RepositoryID).
+				Str("base_sha", pr.BaseSHA).
+				Msg("Failed to fetch base CI status")
+		} else if baseStatus != nil {
+			repoPR.CIBaseSHA = pr.BaseSHA
+			repoPR.CIBaseStatus = baseStatus.State
+			mutated = true
+		}
+	}
+
 	if status.State != prevState || repoPR.CIURL != status.URL || repoPR.CIHeadSHA != headSHA {
 		repoPR.CIStatus = status.State
 		repoPR.CIURL = status.URL
@@ -92,6 +110,15 @@ func (o *SpecTaskOrchestrator) handleCIStatusTransition(
 		return
 	}
 	if newState != CIStatusPassed && newState != CIStatusFailed {
+		return
+	}
+	if newState == CIStatusFailed && repoPR.CIBaseStatus != CIStatusPassed {
+		log.Info().
+			Str("task_id", task.ID).
+			Str("repo_id", repoPR.RepositoryID).
+			Str("pr_id", repoPR.PRID).
+			Str("base_ci_state", repoPR.CIBaseStatus).
+			Msg("Suppressing CI failure notification because base CI was not verified passing")
 		return
 	}
 

--- a/api/pkg/services/spec_task_orchestrator_ci_test.go
+++ b/api/pkg/services/spec_task_orchestrator_ci_test.go
@@ -90,7 +90,7 @@ func TestCITransition_RunningToFailed_NotifiesOnce(t *testing.T) {
 	task := &types.SpecTask{ID: "task-1"}
 	pr := &types.RepoPR{
 		PRID: "pr-2", PRNumber: 12, RepositoryName: "owner/repo",
-		CIURL: "https://example.com/run/42",
+		CIURL: "https://example.com/run/42", CIBaseStatus: CIStatusPassed,
 	}
 
 	o.handleCIStatusTransition(context.Background(), task, pr, CIStatusRunning, CIStatusFailed)
@@ -99,6 +99,19 @@ func TestCITransition_RunningToFailed_NotifiesOnce(t *testing.T) {
 	require.Contains(t, notifier.calls[0].message, "CI failed")
 	require.Contains(t, notifier.calls[0].message, "https://example.com/run/42")
 	require.Contains(t, notifier.calls[0].message, "Please investigate")
+}
+
+func TestCITransition_RunningToFailed_PreExistingFailureDoesNotNotify(t *testing.T) {
+	notifier := &recordingCINotifier{}
+	o := newOrchestratorForCITest(notifier)
+	task := &types.SpecTask{ID: "task-1"}
+
+	for _, baseState := range []string{"", CIStatusNone, CIStatusRunning, CIStatusFailed} {
+		pr := &types.RepoPR{PRID: "pr-2", PRNumber: 12, RepositoryName: "owner/repo", CIBaseStatus: baseState}
+		o.handleCIStatusTransition(context.Background(), task, pr, CIStatusRunning, CIStatusFailed)
+	}
+
+	require.Equal(t, 0, notifier.count())
 }
 
 func TestCITransition_NoOpTransitions_DoNotNotify(t *testing.T) {

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -1213,21 +1213,26 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_Ter
 
 	s.gitService.EXPECT().
 		GetPullRequest(ctx, "repo-1", "1").
-		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1"}, nil)
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1", BaseSHA: "base-sha"}, nil)
 	s.gitService.EXPECT().
 		GetCIStatus(ctx, "repo-1", "1", "sha-1").
 		Return(&types.CIStatus{State: CIStatusPassed}, nil)
+	s.gitService.EXPECT().
+		GetCIStatus(ctx, "repo-1", "1", "base-sha").
+		Return(&types.CIStatus{State: CIStatusPassed}, nil)
 	s.store.EXPECT().UpdateSpecTask(ctx, task).Return(nil)
 	s.Require().NoError(s.orchestrator.processExternalPullRequestStatus(ctx, task))
+	s.Equal("base-sha", task.RepoPullRequests[0].CIBaseSHA)
+	s.Equal(CIStatusPassed, task.RepoPullRequests[0].CIBaseStatus)
 
 	s.gitService.EXPECT().
 		GetPullRequest(ctx, "repo-1", "1").
-		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1"}, nil)
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-1", BaseSHA: "base-sha"}, nil)
 	s.Require().NoError(s.orchestrator.processExternalPullRequestStatus(ctx, task))
 
 	s.gitService.EXPECT().
 		GetPullRequest(ctx, "repo-1", "1").
-		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-2"}, nil)
+		Return(&types.PullRequest{State: types.PullRequestStateOpen, HeadSHA: "sha-2", BaseSHA: "base-sha"}, nil)
 	s.gitService.EXPECT().
 		GetCIStatus(ctx, "repo-1", "1", "sha-2").
 		Return(&types.CIStatus{State: CIStatusRunning}, nil)

--- a/api/pkg/types/git_repositories.go
+++ b/api/pkg/types/git_repositories.go
@@ -306,6 +306,9 @@ type PullRequest struct {
 	// provider's CI/build APIs for the right commit. Empty if the
 	// provider response did not include it.
 	HeadSHA string `json:"head_sha,omitempty"`
+	// BaseSHA is the commit SHA on the target side of the PR. CI failures on
+	// the head are only actionable when CI passed on this commit.
+	BaseSHA string `json:"base_sha,omitempty"`
 }
 
 // CIStatus is the normalized CI verdict returned by GitRepositoryService.

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -43,10 +43,12 @@ type RepoPR struct {
 	// CIHeadSHA is the head commit we last evaluated; it lets the poller
 	// detect a new push and reset CIStatus so a stale "passed" doesn't
 	// suppress a fresh notification when the next commit fails.
-	CIStatus    string    `json:"ci_status,omitempty"`
-	CIURL       string    `json:"ci_url,omitempty"`
-	CIUpdatedAt time.Time `json:"ci_updated_at,omitempty"`
-	CIHeadSHA   string    `json:"ci_head_sha,omitempty"`
+	CIStatus     string    `json:"ci_status,omitempty"`
+	CIURL        string    `json:"ci_url,omitempty"`
+	CIUpdatedAt  time.Time `json:"ci_updated_at,omitempty"`
+	CIHeadSHA    string    `json:"ci_head_sha,omitempty"`
+	CIBaseSHA    string    `json:"ci_base_sha,omitempty"`
+	CIBaseStatus string    `json:"ci_base_status,omitempty"`
 }
 
 // GetFirstOpenPR returns the first open PR from RepoPullRequests, or nil if none.


### PR DESCRIPTION
## Summary
Verify the pull request base commit's CI status before prompting an agent to investigate and fix a failed pipeline. Helix now suppresses automatic remediation when base CI is failing, still running, unavailable, or otherwise not confirmed passing, preventing unrelated tasks from repeatedly modifying merge requests to repair known CI breakage.

The base commit and its cached CI status are tracked for GitHub, GitLab, and Azure DevOps pull requests so subsequent polling and agent pushes do not repeatedly query the same baseline.

## Testing
Ran `go test ./pkg/services ./pkg/types`; all tests passed. Added regression coverage confirming that failed head CI triggers remediation only when base CI passed, and that the cached base verdict is reused across subsequent polls and head commits.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1ny4h8t6y3fmphmdrs6x6kz)

🚀 Built with [Helix](https://helix.ml)