### PR TITLE
feat(chat): project links and sandbox start/stop in session context menu

### DIFF
--- a/frontend/src/components/session/ProjectChatItemContextMenu.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemContextMenu.test.tsx
@@ -10,17 +10,32 @@ const mocks = vi.hoisted(() => ({
   updateSpecTask: vi.fn(),
   success: vi.fn(),
   error: vi.fn(),
+  info: vi.fn(),
+  resumeSession: vi.fn(),
+  stopExternalAgent: vi.fn(),
+  invalidateSpecTaskStatusQueries: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('../../hooks/useSnackbar', () => ({
-  default: () => ({ success: mocks.success, error: mocks.error }),
+  default: () => ({ success: mocks.success, error: mocks.error, info: mocks.info }),
+}))
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => ({
+    getApiClient: () => ({
+      v1SessionsResumeCreate: mocks.resumeSession,
+      v1SessionsStopExternalAgentDelete: mocks.stopExternalAgent,
+    }),
+  }),
 }))
 
 vi.mock('../../services/sessionService', () => ({
+  GET_SESSION_QUERY_KEY: (id: string) => ['session', id],
   useRenameSession: () => ({ mutateAsync: mocks.renameSession }),
 }))
 
 vi.mock('../../services/specTaskService', () => ({
+  invalidateSpecTaskStatusQueries: mocks.invalidateSpecTaskStatusQueries,
   useUpdateSpecTask: () => ({ mutateAsync: mocks.updateSpecTask }),
 }))
 
@@ -90,5 +105,117 @@ describe('ProjectChatItemContextMenu', () => {
     }))
     expect(mocks.updateSpecTask).not.toHaveBeenCalled()
     expect(mocks.success).toHaveBeenCalledWith('Chat renamed')
+  })
+
+  it('opens project board, settings, and artifacts for items in a project', () => {
+    const onOpenProjectBoard = vi.fn()
+    const onOpenProjectSettings = vi.fn()
+    const onOpenProjectArtifacts = vi.fn()
+    renderContextMenu(
+      <ProjectChatItemContextMenu
+        item={{ id: 'session-one', kind: 'session', title: 'Chat', projectId: 'prj-1' }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+        onOpenProjectBoard={onOpenProjectBoard}
+        onOpenProjectSettings={onOpenProjectSettings}
+        onOpenProjectArtifacts={onOpenProjectArtifacts}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Project board' }))
+    expect(onOpenProjectBoard).toHaveBeenCalledWith('prj-1')
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Project settings' }))
+    expect(onOpenProjectSettings).toHaveBeenCalledWith('prj-1')
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Project artifacts' }))
+    expect(onOpenProjectArtifacts).toHaveBeenCalledWith('prj-1')
+  })
+
+  it('hides project actions for items without a project', () => {
+    renderContextMenu(
+      <ProjectChatItemContextMenu
+        item={{ id: 'session-one', kind: 'session', title: 'Chat' }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+        onOpenProjectBoard={vi.fn()}
+        onOpenProjectSettings={vi.fn()}
+        onOpenProjectArtifacts={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('menuitem', { name: 'Project board' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Project settings' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Project artifacts' })).not.toBeInTheDocument()
+  })
+
+  it('starts the sandbox of a stopped spec task', async () => {
+    mocks.resumeSession.mockResolvedValue({})
+    renderContextMenu(
+      <ProjectChatItemContextMenu
+        item={{
+          id: 'task-one',
+          kind: 'spec-task',
+          title: 'Task',
+          task: { id: 'task-one', sandbox_state: 'absent', planning_session_id: 'ses-1' } as any,
+        }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Start sandbox' }))
+
+    await waitFor(() => expect(mocks.resumeSession).toHaveBeenCalledWith('ses-1'))
+    expect(mocks.stopExternalAgent).not.toHaveBeenCalled()
+    expect(mocks.invalidateSpecTaskStatusQueries).toHaveBeenCalled()
+    expect(mocks.success).toHaveBeenCalledWith('Sandbox starting')
+  })
+
+  it('stops the sandbox of a running external-agent chat', async () => {
+    mocks.stopExternalAgent.mockResolvedValue({})
+    renderContextMenu(
+      <ProjectChatItemContextMenu
+        item={{
+          id: 'ses-2',
+          kind: 'session',
+          title: 'Chat',
+          session: {
+            session_id: 'ses-2',
+            metadata: {
+              agent_type: 'zed_external',
+              container_name: 'zed-ses-2',
+              external_agent_status: 'running',
+            },
+          } as any,
+        }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Stop sandbox' }))
+
+    await waitFor(() => expect(mocks.stopExternalAgent).toHaveBeenCalledWith('ses-2'))
+    expect(mocks.resumeSession).not.toHaveBeenCalled()
+    expect(mocks.success).toHaveBeenCalledWith('Sandbox stopped')
+  })
+
+  it('offers no sandbox action for a plain chat session', () => {
+    renderContextMenu(
+      <ProjectChatItemContextMenu
+        item={{
+          id: 'ses-3',
+          kind: 'session',
+          title: 'Chat',
+          session: { session_id: 'ses-3', metadata: {} } as any,
+        }}
+        position={{ mouseX: 50, mouseY: 80 }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('menuitem', { name: 'Start sandbox' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Stop sandbox' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/session/ProjectChatItemContextMenu.tsx
+++ b/frontend/src/components/session/ProjectChatItemContextMenu.tsx
@@ -4,17 +4,21 @@ import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
+import Divider from '@mui/material/Divider'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import TextField from '@mui/material/TextField'
-import { Pencil, Pin, PinOff } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Kanban, PanelsTopLeft, Pencil, Pin, PinOff, Play, Settings, Square } from 'lucide-react'
 
+import useApi from '../../hooks/useApi'
 import useSnackbar from '../../hooks/useSnackbar'
-import { useRenameSession } from '../../services/sessionService'
-import { useUpdateSpecTask } from '../../services/specTaskService'
+import { GET_SESSION_QUERY_KEY, useRenameSession } from '../../services/sessionService'
+import { invalidateSpecTaskStatusQueries, useUpdateSpecTask } from '../../services/specTaskService'
 import { usePinChat, useUnpinChat } from '../../services/chatPinService'
+import { getSandboxControl } from './ProjectChatSidebar.logic'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
 
 export type ProjectChatContextMenuPosition = {
@@ -26,13 +30,21 @@ type ProjectChatItemContextMenuProps = {
   item: SidebarItem | null
   position: ProjectChatContextMenuPosition | null
   onClose: () => void
+  onOpenProjectBoard?: (projectId: string) => void
+  onOpenProjectSettings?: (projectId: string) => void
+  onOpenProjectArtifacts?: (projectId: string) => void
 }
 
 const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
   item,
   position,
   onClose,
+  onOpenProjectBoard,
+  onOpenProjectSettings,
+  onOpenProjectArtifacts,
 }) => {
+  const api = useApi()
+  const queryClient = useQueryClient()
   const snackbar = useSnackbar()
   const renameSession = useRenameSession()
   const updateSpecTask = useUpdateSpecTask()
@@ -41,6 +53,9 @@ const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
   const [renameItem, setRenameItem] = useState<SidebarItem | null>(null)
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
+
+  const projectId = item?.projectId
+  const sandboxControl = item ? getSandboxControl(item) : null
 
   const togglePin = async () => {
     if (!item) return
@@ -55,6 +70,36 @@ const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
       snackbar.success(pinned ? 'Chat unpinned' : 'Chat pinned')
     } catch {
       snackbar.error(pinned ? 'Failed to unpin chat' : 'Failed to pin chat')
+    }
+  }
+
+  const openProjectPage = (open?: (projectId: string) => void) => {
+    if (!projectId || !open) return
+    onClose()
+    open(projectId)
+  }
+
+  const toggleSandbox = async () => {
+    if (!item || !sandboxControl) return
+    const stopping = sandboxControl.state !== 'absent'
+    const taskId = item.kind === 'spec-task' ? item.id : undefined
+    onClose()
+    try {
+      snackbar.info(stopping ? 'Stopping sandbox…' : 'Starting sandbox…')
+      if (stopping) {
+        await api.getApiClient().v1SessionsStopExternalAgentDelete(sandboxControl.sessionId)
+      } else {
+        await api.getApiClient().v1SessionsResumeCreate(sandboxControl.sessionId)
+      }
+      queryClient.invalidateQueries({ queryKey: GET_SESSION_QUERY_KEY(sandboxControl.sessionId) })
+      queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      if (taskId) await invalidateSpecTaskStatusQueries(queryClient, taskId)
+      snackbar.success(stopping ? 'Sandbox stopped' : 'Sandbox starting')
+    } catch (error: any) {
+      const message = typeof error?.response?.data === 'string'
+        ? error.response.data
+        : error?.response?.data?.message || error?.message
+      snackbar.error(message || (stopping ? 'Failed to stop sandbox' : 'Failed to start sandbox'))
     }
   }
 
@@ -108,6 +153,9 @@ const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
     }
   }
 
+  const showProjectActions = !!projectId
+    && (!!onOpenProjectBoard || !!onOpenProjectSettings || !!onOpenProjectArtifacts)
+
   return (
     <>
       <Menu
@@ -128,6 +176,42 @@ const ProjectChatItemContextMenu: FC<ProjectChatItemContextMenuProps> = ({
           </ListItemIcon>
           <ListItemText>Rename</ListItemText>
         </MenuItem>
+        {showProjectActions && <Divider />}
+        {!!projectId && !!onOpenProjectBoard && (
+          <MenuItem onClick={() => openProjectPage(onOpenProjectBoard)}>
+            <ListItemIcon>
+              <Kanban size={16} />
+            </ListItemIcon>
+            <ListItemText>Project board</ListItemText>
+          </MenuItem>
+        )}
+        {!!projectId && !!onOpenProjectSettings && (
+          <MenuItem onClick={() => openProjectPage(onOpenProjectSettings)}>
+            <ListItemIcon>
+              <Settings size={16} />
+            </ListItemIcon>
+            <ListItemText>Project settings</ListItemText>
+          </MenuItem>
+        )}
+        {!!projectId && !!onOpenProjectArtifacts && (
+          <MenuItem onClick={() => openProjectPage(onOpenProjectArtifacts)}>
+            <ListItemIcon>
+              <PanelsTopLeft size={16} />
+            </ListItemIcon>
+            <ListItemText>Project artifacts</ListItemText>
+          </MenuItem>
+        )}
+        {!!sandboxControl && <Divider />}
+        {!!sandboxControl && (
+          <MenuItem onClick={() => void toggleSandbox()}>
+            <ListItemIcon>
+              {sandboxControl.state === 'absent' ? <Play size={16} /> : <Square size={16} />}
+            </ListItemIcon>
+            <ListItemText>
+              {sandboxControl.state === 'absent' ? 'Start sandbox' : 'Stop sandbox'}
+            </ListItemText>
+          </MenuItem>
+        )}
       </Menu>
 
       <Dialog

--- a/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.test.ts
@@ -10,6 +10,7 @@ import {
   compactRelativeTime,
   DEFAULT_PROJECT_CHAT_SIDEBAR_PREFERENCES,
   filterProjectChatGroups,
+  getSandboxControl,
   getSidebarPullRequestIcon,
   getSidebarTaskStatus,
   getChatShortcutNumber,
@@ -494,6 +495,62 @@ describe('ProjectChatSidebar logic', () => {
   it('leaves the browser-reserved new-window chord alone', () => {
     expect(isNewThreadShortcut({ key: 'n', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false })).toBe(false)
     expect(isNewThreadShortcut({ key: 'n', metaKey: false, ctrlKey: true, altKey: false, shiftKey: false })).toBe(false)
+  })
+
+  it('resolves the sandbox control for tasks and external-agent chats', () => {
+    // Spec task: backend-derived state, session id from the attached session summary.
+    expect(getSandboxControl({
+      id: 'task-1',
+      kind: 'spec-task',
+      title: 'Task',
+      task: { id: 'task-1', sandbox_state: 'running' } as any,
+      session: { session_id: 'ses-1' },
+    })).toEqual({ sessionId: 'ses-1', state: 'running' })
+
+    // Spec task without an attached session summary falls back to planning_session_id.
+    expect(getSandboxControl({
+      id: 'task-2',
+      kind: 'spec-task',
+      title: 'Task',
+      task: { id: 'task-2', sandbox_state: 'absent', planning_session_id: 'ses-2' } as any,
+    })).toEqual({ sessionId: 'ses-2', state: 'absent' })
+
+    // Spec task with no session at all: nothing to act on.
+    expect(getSandboxControl({
+      id: 'task-3',
+      kind: 'spec-task',
+      title: 'Task',
+      task: { id: 'task-3', sandbox_state: 'absent' } as any,
+    })).toBeNull()
+
+    // External-agent chat derives state from its session metadata.
+    expect(getSandboxControl({
+      id: 'ses-4',
+      kind: 'session',
+      title: 'Chat',
+      session: {
+        session_id: 'ses-4',
+        metadata: { agent_type: 'zed_external', container_name: 'c', external_agent_status: 'running' },
+      },
+    })).toEqual({ sessionId: 'ses-4', state: 'running' })
+
+    expect(getSandboxControl({
+      id: 'ses-5',
+      kind: 'session',
+      title: 'Chat',
+      session: {
+        session_id: 'ses-5',
+        metadata: { agent_type: 'zed_external', external_agent_status: 'stopped' },
+      },
+    })).toEqual({ sessionId: 'ses-5', state: 'absent' })
+
+    // Plain LLM chat has no sandbox lifecycle and must not be offered start/stop.
+    expect(getSandboxControl({
+      id: 'ses-6',
+      kind: 'session',
+      title: 'Chat',
+      session: { session_id: 'ses-6', metadata: {} },
+    })).toBeNull()
   })
 })
 

--- a/frontend/src/components/session/ProjectChatSidebar.logic.ts
+++ b/frontend/src/components/session/ProjectChatSidebar.logic.ts
@@ -1,6 +1,7 @@
-import type { TypesOrganizationMembership, TypesProject, TypesSessionSummary } from '../../api/api'
+import type { TypesOrganizationMembership, TypesProject, TypesSessionMetadata, TypesSessionSummary } from '../../api/api'
 import type { BotDTO } from '../../services/helixOrgService'
 import type { SpecTask } from '../../services/specTaskService'
+import { deriveSandboxState } from '../external-agent/sandboxState'
 import { matchesAllTokens } from '../../utils/searchUtils'
 
 export type SidebarStatus = {
@@ -223,6 +224,38 @@ export const isOrgAgentSession = (
 export const isExternalAgentSession = (item: SidebarItem): boolean => (
   item.kind === 'session' && item.session?.metadata?.agent_type === 'zed_external'
 )
+
+export type SidebarSandboxControl = {
+  sessionId: string
+  state: 'running' | 'starting' | 'absent'
+}
+
+const sandboxControlFromMetadata = (
+  sessionId: string,
+  metadata?: TypesSessionMetadata,
+): SidebarSandboxControl | null => {
+  const derived = deriveSandboxState(metadata)
+  if (!derived.hasDesktopLifecycleState || derived.sandboxState === 'loading') return null
+  return { sessionId, state: derived.sandboxState }
+}
+
+// Resolves the sandbox lifecycle target for a sidebar row: the session id the
+// resume/stop endpoints act on plus the current container state. Null when the
+// row has no sandbox at all (plain LLM chats, tasks that never provisioned a
+// desktop) so callers don't offer start/stop where it can't apply.
+export const getSandboxControl = (item: SidebarItem): SidebarSandboxControl | null => {
+  if (item.kind === 'spec-task') {
+    const sessionId = item.session?.session_id || item.task?.planning_session_id
+    if (!sessionId) return null
+    const state = item.task?.sandbox_state
+    if (state === 'running' || state === 'starting' || state === 'absent') {
+      return { sessionId, state }
+    }
+    return sandboxControlFromMetadata(sessionId, item.session?.metadata)
+  }
+  if (!isExternalAgentSession(item)) return null
+  return sandboxControlFromMetadata(item.id, item.session?.metadata)
+}
 
 // Archiving is reversible (see the Archived view), so the confirmation exists
 // only to warn about the irreversible side effect: stopping a running agent.

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -948,6 +948,17 @@ const ProjectChatSidebar: FC<{
         item={contextMenuItem}
         position={contextMenuPosition}
         onClose={closeItemContextMenu}
+        onOpenProjectBoard={(projectId) => {
+          account.orgNavigate('project-specs', { id: projectId })
+          onOpenSession()
+        }}
+        onOpenProjectSettings={(projectId) => {
+          openDialog('project-settings', { projectId })
+        }}
+        onOpenProjectArtifacts={(projectId) => {
+          account.orgNavigate('project-artifacts', { id: projectId })
+          onOpenSession()
+        }}
       />
 
       <ProjectChatProjectContextMenu


### PR DESCRIPTION
## What

Right-clicking a session or spec task in the org chat sidebar now offers, in addition to Pin/Rename:

- **Project board** — opens the project's specs/kanban page
- **Project settings** — opens the project-settings dialog
- **Project artifacts** — opens the project's artifacts page
- **Start sandbox / Stop sandbox** — shown only for rows that actually have a sandbox, labeled by current state

## How

- New `getSandboxControl()` in `ProjectChatSidebar.logic.ts` resolves the target session id and sandbox state: spec tasks use the backend-derived `sandbox_state` from the task list (session id from the attached session summary or `planning_session_id`); external-agent chats derive state from session metadata via the existing `deriveSandboxState` helper. Plain LLM chats and items outside a project get no extra entries.
- The menu reuses the same endpoints as the task-detail toolbar (`v1SessionsResumeCreate` / `v1SessionsStopExternalAgentDelete`) and invalidates the session + spec-task queries so sidebar state refreshes.
- Project navigation is wired through the sidebar like the existing project-group context menu.

## Testing

- 7 component tests + a `getSandboxControl` unit suite (38 tests pass), `yarn build` clean.
- Verified live in the dev stack browser: menu contents per row type, board/artifacts navigation URLs, and a full sandbox round-trip (Start → container up → Stop → API log "External Zed agent stopped successfully" → menu back to Start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)