### PR TITLE
Fix diff comments in spec task chat

### DIFF
--- a/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.test.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.test.tsx
@@ -179,7 +179,7 @@ describe("WorkspaceDiffSurface", () => {
     }));
   });
 
-  it("pauses live polling while text is being selected in the diff", () => {
+  it("does not rerender the diff while a pointer interaction is in progress", () => {
     mocks.live.mockReturnValue({
       ...idleQuery,
       data: { workspace: "primary", sources: [source("all")] },
@@ -188,7 +188,8 @@ describe("WorkspaceDiffSurface", () => {
 
     fireEvent.pointerDown(screen.getByTestId("code-view"));
 
-    expect(mocks.live.mock.calls.at(-1)?.[5]).toBe(false);
+    expect(mocks.live.mock.calls).toHaveLength(1);
+    expect(mocks.live.mock.calls[0][5]).toBe(true);
   });
 
   it("reads a fresh 503 as a sandbox that is still coming up", () => {

--- a/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
@@ -521,7 +521,6 @@ const WorkspaceDiffSurface: FC<WorkspaceDiffSurfaceProps> = ({
         <Box
           ref={diffContainerRef}
           sx={{ flex: 1, minHeight: 0 }}
-          onPointerDownCapture={() => setSelectingText(true)}
           onClickCapture={(event) => {
             const { path } = headerPathFromEvent(event);
             if (path) onOpenFile(path);


### PR DESCRIPTION
## Summary
Prevent the workspace diff viewer from rerendering between pointer down and pointer up when a reviewer clicks the comment gutter action. This preserves the diff library's active interaction so the comment editor opens correctly from spec task chat.

## Testing
Ran the focused WorkspaceDiffSurface test suite (10 tests passed) and the full frontend TypeScript compilation successfully.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1tqamk8q8g6m66dhzkhvtn7)

🚀 Built with [Helix](https://helix.ml)