### PR TITLE
Highlight changed files in the workspace explorer

### DIFF
--- a/frontend/src/components/workspace-inspector/pierreStyles.test.ts
+++ b/frontend/src/components/workspace-inspector/pierreStyles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fileDiffPath, parseRenderablePatch, resolveDiffFilePath } from "./pierreStyles";
+import { fileDiffPath, parseRenderablePatch, resolveDiffFilePath, TREE_UNSAFE_CSS } from "./pierreStyles";
 
 describe("parseRenderablePatch", () => {
   it("parses multiple git files for the virtualized diff surface", () => {
@@ -50,5 +50,13 @@ describe("resolveDiffFilePath", () => {
     expect(resolveDiffFilePath("", known)).toBeNull();
     expect(resolveDiffFilePath(undefined, known)).toBeNull();
     expect(resolveDiffFilePath("src/app.ts", [])).toBeNull();
+  });
+});
+
+describe("workspace file tree styles", () => {
+  it("gives changed files a visible row treatment", () => {
+    expect(TREE_UNSAFE_CSS).toContain("button[data-type='item'][data-item-git-status]");
+    expect(TREE_UNSAFE_CSS).toContain("background-color:");
+    expect(TREE_UNSAFE_CSS).toContain("box-shadow: inset 3px 0 0");
   });
 });

--- a/frontend/src/components/workspace-inspector/pierreStyles.ts
+++ b/frontend/src/components/workspace-inspector/pierreStyles.ts
@@ -52,8 +52,24 @@ export const TREE_UNSAFE_CSS = `
   --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
   --trees-font-family-override: ui-sans-serif, system-ui, sans-serif;
   --trees-font-size-override: 12px;
+  --trees-git-added-color-override: #3fb950;
+  --trees-git-modified-color-override: #d29922;
+  --trees-git-deleted-color-override: #f85149;
+  --trees-git-renamed-color-override: #a371f7;
 }
 button[data-type='item'] { border-radius: 5px; }
+button[data-type='item'][data-item-git-status] {
+  background-color: color-mix(in srgb, var(--trees-item-git-status-color) 13%, transparent);
+  box-shadow: inset 3px 0 0 var(--trees-item-git-status-color);
+  font-weight: 600;
+}
+button[data-type='item'][data-item-git-status]:hover {
+  background-color: color-mix(in srgb, var(--trees-item-git-status-color) 20%, transparent);
+}
+button[data-type='item'][data-item-git-status][aria-selected='true'] {
+  outline: 1px solid var(--trees-selected-focused-border-color);
+  outline-offset: -1px;
+}
 `;
 
 export type RenderablePatch =

--- a/frontend/src/components/workspace-inspector/pierreStyles.ts
+++ b/frontend/src/components/workspace-inspector/pierreStyles.ts
@@ -52,23 +52,14 @@ export const TREE_UNSAFE_CSS = `
   --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
   --trees-font-family-override: ui-sans-serif, system-ui, sans-serif;
   --trees-font-size-override: 12px;
-  --trees-git-added-color-override: #3fb950;
-  --trees-git-modified-color-override: #d29922;
-  --trees-git-deleted-color-override: #f85149;
-  --trees-git-renamed-color-override: #a371f7;
 }
 button[data-type='item'] { border-radius: 5px; }
 button[data-type='item'][data-item-git-status] {
   background-color: color-mix(in srgb, var(--trees-item-git-status-color) 13%, transparent);
   box-shadow: inset 3px 0 0 var(--trees-item-git-status-color);
-  font-weight: 600;
 }
 button[data-type='item'][data-item-git-status]:hover {
   background-color: color-mix(in srgb, var(--trees-item-git-status-color) 20%, transparent);
-}
-button[data-type='item'][data-item-git-status][aria-selected='true'] {
-  outline: 1px solid var(--trees-selected-focused-border-color);
-  outline-offset: -1px;
 }
 `;
 


### PR DESCRIPTION
## Summary
Make changed files immediately recognizable in the chat-view workspace explorer with a tinted row background and colored left rail. Both treatments reuse the file tree's native Git status colors so added, modified, deleted, and renamed files remain consistent with its built-in indicators.

## Testing
Ran the focused workspace inspector test suites: 11 tests passed. Ran the frontend TypeScript build check successfully.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1tqdqgw78f98hpptgt6hnpc)

🚀 Built with [Helix](https://helix.ml)