### PR TITLE
fix(chat): address non-blocking review findings from sidebar stacked rows

### DIFF
--- a/frontend/src/components/session/NewChatProjectDialog.test.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.test.tsx
@@ -47,7 +47,7 @@ describe('NewChatProjectDialog', () => {
   it('starts the chat in the project that was clicked', () => {
     const { onSelect, onClose } = renderDialog()
 
-    fireEvent.click(screen.getByLabelText('New chat in home stuff'))
+    fireEvent.click(screen.getByLabelText('New task in home stuff'))
 
     expect(onSelect).toHaveBeenCalledWith({ projectId: 'prj_a' })
     expect(onClose).toHaveBeenCalled()
@@ -79,8 +79,8 @@ describe('NewChatProjectDialog', () => {
 
     fireEvent.change(screen.getByLabelText('Search projects'), { target: { value: 'webhook' } })
 
-    expect(screen.getByLabelText('New chat in webhookrelay')).toBeInTheDocument()
-    expect(screen.queryByLabelText('New chat in home stuff')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('New task in webhookrelay')).toBeInTheDocument()
+    expect(screen.queryByLabelText('New task in home stuff')).not.toBeInTheDocument()
   })
 
   it('keeps Enter safe when the filter empties the list', () => {

--- a/frontend/src/components/session/NewChatProjectDialog.tsx
+++ b/frontend/src/components/session/NewChatProjectDialog.tsx
@@ -252,7 +252,7 @@ const NewChatProjectDialog: FC<NewChatProjectDialogProps> = ({
             role="button"
             tabIndex={-1}
             data-new-chat-row={row.key}
-            aria-label={`New chat in ${row.name}`}
+            aria-label={row.standalone ? 'New chat without a project' : `New task in ${row.name}`}
             onMouseEnter={() => setSelectedIndex(index)}
             onClick={() => choose(row)}
             sx={{

--- a/frontend/src/components/session/ProjectChatItemBadges.tsx
+++ b/frontend/src/components/session/ProjectChatItemBadges.tsx
@@ -1,0 +1,158 @@
+import { FC, useState } from 'react'
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { keyframes } from '@mui/material/styles'
+import { Folder, GitPullRequest } from 'lucide-react'
+
+import { useGetProjectRepositories } from '../../services/projectService'
+import { githubOrgAvatarUrl } from './ProjectChatSidebar.logic'
+import type { SidebarPullRequestIcon, SidebarStatus } from './ProjectChatSidebar.logic'
+
+export const activeStatusDotPulse = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+`
+
+// Project glyph for the stacked (cross-project) row: the GitHub owner avatar
+// when the project's repo lives on github.com, the generic folder otherwise —
+// including when the avatar can't load (air-gapped deployments never reach
+// github.com, so the broken-image state must degrade to the folder).
+export const ProjectRowIcon: FC<{ projectId?: string }> = ({ projectId }) => {
+  const repositoriesQuery = useGetProjectRepositories(projectId || '', !!projectId)
+  // Track which URL failed rather than a boolean so a URL change (repos
+  // resolving late, project reassignment) gets a fresh attempt.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+  const avatarUrl = githubOrgAvatarUrl(repositoriesQuery.data || [])
+  if (avatarUrl && avatarUrl !== failedUrl) {
+    return (
+      <Box
+        component="img"
+        key={avatarUrl}
+        src={avatarUrl}
+        alt=""
+        onError={() => setFailedUrl(avatarUrl)}
+        sx={{ width: 14, height: 14, borderRadius: '3px', flexShrink: 0, display: 'block' }}
+      />
+    )
+  }
+  return <Folder size={12} style={{ opacity: 0.72, flexShrink: 0 }} />
+}
+
+// Workflow badges for a task row in the dense single-line layout: the PR
+// glyph is always present (grey placeholder before a PR exists) and the
+// status renders as dot + label.
+export const TaskStatusIcons: FC<{
+  status: SidebarStatus | null
+  pullRequestIcon?: SidebarPullRequestIcon
+  isAgentWorking: boolean
+}> = ({ status, pullRequestIcon, isAgentWorking }) => (
+  <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+    <Tooltip title={pullRequestIcon?.tooltip || ''}>
+      <Box
+        component="a"
+        href={pullRequestIcon?.url}
+        target={pullRequestIcon?.url ? '_blank' : undefined}
+        rel={pullRequestIcon?.url ? 'noopener noreferrer' : undefined}
+        aria-label={pullRequestIcon?.tooltip}
+        onMouseOver={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation()
+          if (!pullRequestIcon?.url) event.preventDefault()
+        }}
+        sx={{
+          display: 'inline-flex',
+          color: pullRequestIcon?.color || 'currentColor',
+          cursor: pullRequestIcon?.url ? 'pointer' : 'default',
+        }}
+      >
+        <GitPullRequest size={13} />
+      </Box>
+    </Tooltip>
+    {status && (
+      <Tooltip title={status.tooltip || ''} disableHoverListener={!status.tooltip}>
+        <Box
+          onMouseOver={(event) => event.stopPropagation()}
+          sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.45 }}
+        >
+          <Box
+            sx={{
+              width: 5,
+              height: 5,
+              borderRadius: '50%',
+              backgroundColor: status.color,
+              animation: isAgentWorking
+                ? `${activeStatusDotPulse} 2s ease-in-out infinite`
+                : 'none',
+              '@media (prefers-reduced-motion: reduce)': {
+                animation: 'none',
+              },
+            }}
+          />
+          <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
+            {status.label}
+          </Typography>
+        </Box>
+      </Tooltip>
+    )}
+  </Box>
+)
+
+// The stacked row keeps its title line clean: the workflow status collapses
+// to a colored dot at the right edge (label in the tooltip), and the PR icon
+// only appears once a pull request actually exists — the grey "no PR yet"
+// placeholder is noise repeated on every row.
+export const StackedTaskStatusIcons: FC<{
+  status: SidebarStatus | null
+  pullRequestIcon?: SidebarPullRequestIcon
+  /** False while the time slot carries the status label instead. */
+  showStatus: boolean
+  /** No hover on a phone, so the label the tooltip would carry has to live on the row itself. */
+  showLabel: boolean
+}> = ({ status, pullRequestIcon, showStatus, showLabel }) => (
+  <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+    {pullRequestIcon?.url && (
+      <Tooltip title={pullRequestIcon.tooltip}>
+        <Box
+          component="a"
+          href={pullRequestIcon.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={pullRequestIcon.tooltip}
+          onMouseOver={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
+          sx={{ display: 'inline-flex', color: pullRequestIcon.color, cursor: 'pointer' }}
+        >
+          <GitPullRequest size={12} />
+        </Box>
+      </Tooltip>
+    )}
+    {status && showStatus && (
+      <Tooltip title={status.tooltip || status.label}>
+        <Box
+          onMouseOver={(event) => event.stopPropagation()}
+          sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.45, flexShrink: 0 }}
+        >
+          <Box
+            sx={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              flexShrink: 0,
+              backgroundColor: status.color,
+            }}
+          />
+          {showLabel && (
+            <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
+              {status.label}
+            </Typography>
+          )}
+        </Box>
+      </Tooltip>
+    )}
+  </Box>
+)

--- a/frontend/src/components/session/ProjectChatItemRow.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.tsx
@@ -1,57 +1,22 @@
-import { FC, MouseEvent, ReactElement, useState } from 'react'
+import { FC, MouseEvent, ReactElement } from 'react'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { keyframes } from '@mui/material/styles'
-import { Archive, ArchiveRestore, Folder, GitBranch, GitPullRequest, Pin } from 'lucide-react'
+import { Archive, ArchiveRestore, GitBranch, Pin } from 'lucide-react'
 
 import type { TypesOrganizationMembership, TypesUser } from '../../api/api'
 import useApps from '../../hooks/useApps'
 import useIsPhone from '../../hooks/useIsPhone'
 import useLightTheme from '../../hooks/useLightTheme'
-import { useGetProjectRepositories } from '../../services/projectService'
 import AgentHarness from '../agent/AgentHarness'
 import OrganizationUserAvatar, { resolveOrganizationUser } from '../widgets/OrganizationUserAvatar'
 import ProjectChatItemTooltip from './ProjectChatItemTooltip'
+import { activeStatusDotPulse, ProjectRowIcon, StackedTaskStatusIcons, TaskStatusIcons } from './ProjectChatItemBadges'
 import { getProjectChatItemDetails, resolveProjectChatItemBranch } from './projectChatItemDetails'
-import { compactRelativeTime, getSidebarPullRequestIcon, getSidebarTaskStatus, githubOrgAvatarUrl, isActiveSidebarTask } from './ProjectChatSidebar.logic'
+import { compactRelativeTime, getSidebarPullRequestIcon, getSidebarTaskStatus, isActiveSidebarTask } from './ProjectChatSidebar.logic'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
-
-const activeStatusDotPulse = keyframes`
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-`
-
-// Project glyph for the stacked (cross-project) row: the GitHub owner avatar
-// when the project's repo lives on github.com, the generic folder otherwise —
-// including when the avatar can't load (air-gapped deployments never reach
-// github.com, so the broken-image state must degrade to the folder).
-const ProjectRowIcon: FC<{ projectId?: string }> = ({ projectId }) => {
-  const repositoriesQuery = useGetProjectRepositories(projectId || '', !!projectId)
-  // Track which URL failed rather than a boolean so a URL change (repos
-  // resolving late, project reassignment) gets a fresh attempt.
-  const [failedUrl, setFailedUrl] = useState<string | null>(null)
-  const avatarUrl = githubOrgAvatarUrl(repositoriesQuery.data || [])
-  if (avatarUrl && avatarUrl !== failedUrl) {
-    return (
-      <Box
-        component="img"
-        key={avatarUrl}
-        src={avatarUrl}
-        alt=""
-        onError={() => setFailedUrl(avatarUrl)}
-        sx={{ width: 14, height: 14, borderRadius: '3px', flexShrink: 0, display: 'block' }}
-      />
-    )
-  }
-  return <Folder size={12} style={{ opacity: 0.72, flexShrink: 0 }} />
-}
 
 export type ProjectChatItemRowProps = {
   item: SidebarItem
@@ -147,7 +112,18 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
         : stacked
           // Static content sizes the slot so a status label wider than the
           // 28px timestamp column still fits; the archive button overlays it.
-          ? { minWidth: 28, height: 16, flexShrink: 0, position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }
+          // Without hover the overlay would hide the time forever, so
+          // touch devices get the phone treatment: side by side.
+          ? {
+              minWidth: 28,
+              height: 16,
+              flexShrink: 0,
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              '@media (hover: none)': { gap: 0.5 },
+            }
           : { width: 28, height: 28, flexShrink: 0, position: 'relative' }}
     >
       <Typography
@@ -194,6 +170,9 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
             ...(isPhone
               ? { position: 'static', width: 28, height: 28 }
               : { position: 'absolute', top: stacked ? -6 : 0, right: 0, bottom: stacked ? -6 : 0, width: 20, height: 28 }),
+            ...(!isPhone && stacked && {
+              '@media (hover: none)': { position: 'static', top: 'auto', bottom: 'auto', height: 20 },
+            }),
             opacity: 0,
             color: 'inherit',
             transition: 'opacity 100ms ease',
@@ -208,55 +187,11 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
   )
 
   const statusIcons = item.kind === 'spec-task' && (
-    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-      <Tooltip title={pullRequestIcon?.tooltip || ''}>
-        <Box
-          component="a"
-          href={pullRequestIcon?.url}
-          target={pullRequestIcon?.url ? '_blank' : undefined}
-          rel={pullRequestIcon?.url ? 'noopener noreferrer' : undefined}
-          aria-label={pullRequestIcon?.tooltip}
-          onMouseOver={(event) => event.stopPropagation()}
-          onClick={(event) => {
-            event.stopPropagation()
-            if (!pullRequestIcon?.url) event.preventDefault()
-          }}
-          sx={{
-            display: 'inline-flex',
-            color: pullRequestIcon?.color || 'currentColor',
-            cursor: pullRequestIcon?.url ? 'pointer' : 'default',
-          }}
-        >
-          <GitPullRequest size={13} />
-        </Box>
-      </Tooltip>
-      {status && (
-        <Tooltip title={status.tooltip || ''} disableHoverListener={!status.tooltip}>
-          <Box
-            onMouseOver={(event) => event.stopPropagation()}
-            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.45 }}
-          >
-            <Box
-              sx={{
-                width: 5,
-                height: 5,
-                borderRadius: '50%',
-                backgroundColor: status.color,
-                animation: isAgentWorking
-                  ? `${activeStatusDotPulse} 2s ease-in-out infinite`
-                  : 'none',
-                '@media (prefers-reduced-motion: reduce)': {
-                  animation: 'none',
-                },
-              }}
-            />
-            <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
-              {status.label}
-            </Typography>
-          </Box>
-        </Tooltip>
-      )}
-    </Box>
+    <TaskStatusIcons
+      status={status}
+      pullRequestIcon={pullRequestIcon}
+      isAgentWorking={isAgentWorking}
+    />
   )
 
   const titleNode = (
@@ -282,54 +217,13 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
     </Typography>
   )
 
-  // The stacked row keeps its title line clean: the workflow status collapses
-  // to a colored dot at the right edge (label in the tooltip), and the PR icon
-  // only appears once a pull request actually exists — the grey "no PR yet"
-  // placeholder is noise repeated on every row.
   const stackedStatusIcons = item.kind === 'spec-task' && (
-    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-      {pullRequestIcon?.url && (
-        <Tooltip title={pullRequestIcon.tooltip}>
-          <Box
-            component="a"
-            href={pullRequestIcon.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={pullRequestIcon.tooltip}
-            onMouseOver={(event) => event.stopPropagation()}
-            onClick={(event) => event.stopPropagation()}
-            sx={{ display: 'inline-flex', color: pullRequestIcon.color, cursor: 'pointer' }}
-          >
-            <GitPullRequest size={12} />
-          </Box>
-        </Tooltip>
-      )}
-      {status && !showStatusAsTime && (
-        <Tooltip title={status.tooltip || status.label}>
-          <Box
-            onMouseOver={(event) => event.stopPropagation()}
-            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.45, flexShrink: 0 }}
-          >
-            <Box
-              sx={{
-                width: 6,
-                height: 6,
-                borderRadius: '50%',
-                flexShrink: 0,
-                backgroundColor: status.color,
-              }}
-            />
-            {/* No hover on a phone, so the label the tooltip would carry
-                has to live on the row itself. */}
-            {isPhone && (
-              <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
-                {status.label}
-              </Typography>
-            )}
-          </Box>
-        </Tooltip>
-      )}
-    </Box>
+    <StackedTaskStatusIcons
+      status={status}
+      pullRequestIcon={pullRequestIcon}
+      showStatus={!showStatusAsTime}
+      showLabel={isPhone}
+    />
   )
 
   const avatarNode = showTaskAvatars && !!taskPersonId && (
@@ -471,10 +365,12 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
         '&:hover .sidebar-item-time, &:focus-within .sidebar-item-time': { opacity: 0 },
         '&:hover .sidebar-item-archive, &:focus-within .sidebar-item-archive': { opacity: 1 },
         // Without hover the archive button can never appear, so on a
-        // coarse pointer it is always shown. On a phone it gets its
-        // own column instead (below), so the time stays visible too.
+        // coarse pointer it is always shown. Phone and stacked rows give
+        // it its own column (the stacked slot drops its overlay under
+        // hover: none), so the time/status stays visible alongside it;
+        // only the dense single-line desktop row keeps the swap.
         '@media (hover: none)': {
-          '& .sidebar-item-time': { opacity: isPhone ? 1 : 0 },
+          '& .sidebar-item-time': { opacity: isPhone || stacked ? 1 : 0 },
           '& .sidebar-item-archive': { opacity: 1 },
         },
         ...(isPhone && {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -544,7 +544,7 @@ const Home: FC = () => {
   return (
     <Page
       breadcrumbs={[{ title: selectedProject?.name || 'No project' }]}
-      breadcrumbTitle={isProjectContext ? 'New Task' : 'New thread'}
+      breadcrumbTitle={isProjectContext ? 'New task' : 'New thread'}
       breadcrumbShowHome={false}
       disableContentScroll
       px={2}


### PR DESCRIPTION
Follow-up to https://github.com/helixml/helix/pull/3182, addressing the three non-blocking findings left in its final review:

## Touch tablets keep status telemetry on stacked rows

On `hover: none` devices wider than the phone breakpoint, stacked rows previously hid the time/status label permanently (the always-visible archive button occupied the same overlay slot). The stacked slot now drops the overlay under `hover: none`: the archive button becomes a static element beside the time, so the live status label ("Implementation", "Idle", …) and timestamps stay visible. Dense single-line desktop rows keep the existing hover swap — they carry the status dot + label inline, so nothing is lost there.

## "New task" rename finished

- `NewChatProjectDialog` project rows: `aria-label` is now "New task in <project>" (the standalone row keeps "New chat without a project" — it really is a chat).
- `Home.tsx` project-context breadcrumb: "New Task" → "New task" to match the sidebar button casing.

## Row file extracted under the 500-line guideline

`ProjectRowIcon`, the pulse keyframes, and both task status badge clusters moved to `ProjectChatItemBadges.tsx` (row file 545 → 441 lines). Pure extraction — markup unchanged.

## Testing

- `yarn vitest run src/components/session/` — 258 passed / 1 skipped (includes the row, dialog, and logic suites).
- `yarn build` clean.
- Verified live in the dev stack with Playwright: desktop rows unchanged; iPad-landscape emulation (`hover: none`, 1366×1024) shows the stacked row's time/status at full opacity with the archive button beside it, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)