### PR TITLE
fix(desktop): prefer remote workspace review base

### DIFF
--- a/api/pkg/desktop/workspace_review.go
+++ b/api/pkg/desktop/workspace_review.go
@@ -742,13 +742,23 @@ func resolveReviewWorkspace(name string) (string, string, error) {
 
 func resolveReviewBaseBranch(ctx context.Context, workDir, base string) string {
 	candidates := []string{base}
-	if !strings.HasPrefix(base, "origin/") {
-		candidates = append(candidates, "origin/"+base)
+	if base != "HEAD" && !strings.HasPrefix(base, "origin/") && !strings.HasPrefix(base, "refs/") {
+		baseArg, err := validateReviewRef(base)
+		resolved := ""
+		if err == nil {
+			resolved, err = gitText(ctx, workDir,
+				constGitArg("rev-parse"), constGitArg("--symbolic-full-name"), baseArg)
+		}
+		if err == nil && strings.TrimSpace(resolved) == "refs/heads/"+base {
+			candidates = []string{"origin/" + base, base}
+		} else {
+			candidates = append(candidates, "origin/"+base)
+		}
 	}
 	if base == "main" {
-		candidates = append(candidates, "master", "origin/master")
+		candidates = append(candidates, "origin/master", "master")
 	} else if base == "master" {
-		candidates = append(candidates, "main", "origin/main")
+		candidates = append(candidates, "origin/main", "main")
 	}
 	for _, candidate := range candidates {
 		arg, err := validateReviewRef(candidate)

--- a/api/pkg/desktop/workspace_review_test.go
+++ b/api/pkg/desktop/workspace_review_test.go
@@ -91,6 +91,63 @@ func TestWorkspaceReviewRejectsUnknownExplicitBase(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestWorkspaceReviewPrefersRemoteBaseOverStaleLocalBranch(t *testing.T) {
+	repoDir := setupTestGitRepo(t)
+	workspace := useReviewTestWorkspace(t, repoDir)
+	server := newTestServer(t)
+
+	runReviewTestGit(t, repoDir, "checkout", "-b", "upstream")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "upstream.txt"), []byte("upstream\n"), 0o644))
+	runReviewTestGit(t, repoDir, "add", "upstream.txt")
+	runReviewTestGit(t, repoDir, "commit", "-m", "advance upstream")
+	runReviewTestGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runReviewTestGit(t, repoDir, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("feature\n"), 0o644))
+	runReviewTestGit(t, repoDir, "add", "feature.txt")
+	runReviewTestGit(t, repoDir, "commit", "-m", "add feature")
+
+	branch := requestReviewSources(t, server, workspace, "main")[types.WorkspaceReviewSourceBranch]
+	assert.Equal(t, "origin/main", branch.BaseRef)
+	assert.Equal(t, []string{"feature.txt"}, codeChangePaths(branch.Files))
+}
+
+func TestWorkspaceReviewDoesNotReplaceHEADWithRemoteRef(t *testing.T) {
+	repoDir := setupTestGitRepo(t)
+	workspace := useReviewTestWorkspace(t, repoDir)
+	server := newTestServer(t)
+
+	runReviewTestGit(t, repoDir, "update-ref", "refs/remotes/origin/HEAD", "HEAD")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("feature\n"), 0o644))
+	runReviewTestGit(t, repoDir, "add", "feature.txt")
+	runReviewTestGit(t, repoDir, "commit", "-m", "add feature")
+
+	branch := requestReviewSources(t, server, workspace, "HEAD")[types.WorkspaceReviewSourceBranch]
+	assert.Equal(t, "HEAD", branch.BaseRef)
+	assert.Empty(t, branch.Files)
+}
+
+func TestWorkspaceReviewPrefersRemoteCompatibilityFallback(t *testing.T) {
+	repoDir := setupTestGitRepo(t)
+	workspace := useReviewTestWorkspace(t, repoDir)
+	server := newTestServer(t)
+
+	runReviewTestGit(t, repoDir, "branch", "master", "main")
+	runReviewTestGit(t, repoDir, "checkout", "-b", "upstream")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "upstream.txt"), []byte("upstream\n"), 0o644))
+	runReviewTestGit(t, repoDir, "add", "upstream.txt")
+	runReviewTestGit(t, repoDir, "commit", "-m", "advance upstream")
+	runReviewTestGit(t, repoDir, "update-ref", "refs/remotes/origin/master", "HEAD")
+	runReviewTestGit(t, repoDir, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("feature\n"), 0o644))
+	runReviewTestGit(t, repoDir, "add", "feature.txt")
+	runReviewTestGit(t, repoDir, "commit", "-m", "add feature")
+	runReviewTestGit(t, repoDir, "branch", "-D", "main")
+
+	branch := requestReviewSources(t, server, workspace, "main")[types.WorkspaceReviewSourceBranch]
+	assert.Equal(t, "origin/master", branch.BaseRef)
+	assert.Equal(t, []string{"feature.txt"}, codeChangePaths(branch.Files))
+}
+
 func TestWorkspaceCheckpointCaptureDoesNotModifyUserGitState(t *testing.T) {
 	repoDir := setupTestGitRepo(t)
 	workspace := useReviewTestWorkspace(t, repoDir)


### PR DESCRIPTION
## Summary
- prefer the remote-tracking branch when a task base has a stale local branch
- preserve explicit HEAD, tag, SHA, and qualified-ref behavior
- keep main/master compatibility fallbacks remote-first

## Live evidence
- stale local main: 65 files, +5278/-870
- origin/main: 2 files, +3/-3
- task: https://meta.helix.ml/orgs/probably/chat/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1tqamk8q8g6m66dhzkhvtn7?view=changes

## Testing
- go build ./pkg/desktop ./pkg/server ./pkg/store ./pkg/types
- go test ./pkg/desktop -count=1
- git diff --check origin/main...HEAD