### PR TITLE
Wake stopped agents when they receive a message

### DIFF
--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -32,11 +32,11 @@ const desktopResumeReapStaleThreshold = 3 * time.Minute
 // All must hold to classify as orphaned (any failing → treat as busy, defer):
 //   - latest is state=waiting (nothing else can be actively streaming);
 //   - no live WebSocket to the agent (wsLive=false) — a live turn keeps one;
-//   - the thread is already established (ZedThreadID set) — an empty ZedThreadID
-//     is the very-first-message boot race, which must never be reaped (mirrors
-//     the THREAD-ESTABLISHMENT BARRIER in processPendingPromptsForIdleSessions);
-//   - the turn has been idle past desktopResumeReapStaleThreshold — a freshly
-//     created / mid-boot in-flight turn is protected by the staleness window.
+//   - the sandbox is explicitly stopped; OR the thread is established and the
+//     turn has been idle past desktopResumeReapStaleThreshold. A terminal
+//     lifecycle state is authoritative even before first-thread creation, so a
+//     new message can wake the sandbox immediately. Otherwise an empty
+//     ZedThreadID and the staleness window protect a mid-boot first turn.
 func isOrphanedWaitingInteraction(session *types.Session, latest *types.Interaction, wsLive bool, now time.Time) bool {
 	if session == nil || latest == nil {
 		return false
@@ -46,6 +46,9 @@ func isOrphanedWaitingInteraction(session *types.Session, latest *types.Interact
 	}
 	if wsLive {
 		return false
+	}
+	if session.Metadata.ExternalAgentStatus == "stopped" || session.Metadata.ExternalAgentStatus == "terminated_idle" {
+		return true
 	}
 	if session.Metadata.ZedThreadID == "" {
 		return false
@@ -355,11 +358,11 @@ func (apiServer *HelixAPIServer) processPendingPromptsForSession(ctx context.Con
 		// Reap ONLY when all three hold, so we never kill a live or mid-boot
 		// turn:
 		//   - no live WebSocket to the external agent (a live turn has one);
-		//   - the thread is already established (ZedThreadID set) — an empty
-		//     ZedThreadID means the very first message is mid-boot, which we
-		//     must not reap (mirrors the THREAD-ESTABLISHMENT BARRIER above);
-		//   - the waiting interaction is stale beyond the reap threshold — a
-		//     freshly-created in-flight turn is protected.
+		//   - the sandbox explicitly reports a terminal state; OR its thread is
+		//     established and the waiting interaction is stale beyond the reap
+		//     threshold. A known-stopped sandbox can be resumed immediately, even
+		//     if it died during first-thread creation. Ambiguous disconnects retain
+		//     the boot barrier and grace period that protect an in-flight turn.
 		latest := interactions[0]
 		_, wsLive := apiServer.externalAgentWSManager.getConnection(sessionID)
 		if isOrphanedWaitingInteraction(session, latest, wsLive, time.Now()) {

--- a/api/pkg/server/prompt_history_handlers_test.go
+++ b/api/pkg/server/prompt_history_handlers_test.go
@@ -290,6 +290,64 @@ func (s *PromptHistoryHandlersSuite) TestProcessPendingPromptsForSession_BusyInt
 	s.server.processPendingPromptsForSession(context.Background(), sessionID)
 }
 
+func (s *PromptHistoryHandlersSuite) TestIsOrphanedWaitingInteraction_StoppedSandboxReapsImmediately() {
+	now := time.Now()
+	session := &types.Session{ID: "ses_stopped"}
+	session.Metadata.ExternalAgentStatus = "stopped"
+	latest := &types.Interaction{
+		ID:      "int_recent",
+		State:   types.InteractionStateWaiting,
+		Updated: now.Add(-time.Second),
+	}
+
+	s.True(isOrphanedWaitingInteraction(session, latest, false, now),
+		"an explicitly stopped sandbox cannot finish its waiting turn and should be reaped immediately, including during first-thread creation")
+}
+
+func (s *PromptHistoryHandlersSuite) TestIsOrphanedWaitingInteraction_TerminatedIdleReapsImmediately() {
+	now := time.Now()
+	session := &types.Session{ID: "ses_idle_reaped"}
+	session.Metadata.ZedThreadID = "thread-established"
+	session.Metadata.ExternalAgentStatus = "terminated_idle"
+	latest := &types.Interaction{
+		ID:      "int_recent",
+		State:   types.InteractionStateWaiting,
+		Updated: now.Add(-time.Second),
+	}
+
+	s.True(isOrphanedWaitingInteraction(session, latest, false, now))
+}
+
+func (s *PromptHistoryHandlersSuite) TestIsOrphanedWaitingInteraction_AmbiguousDisconnectKeepsGracePeriod() {
+	now := time.Now()
+	session := &types.Session{ID: "ses_disconnected"}
+	session.Metadata.ZedThreadID = "thread-established"
+	session.Metadata.ExternalAgentStatus = "running"
+	latest := &types.Interaction{
+		ID:      "int_recent",
+		State:   types.InteractionStateWaiting,
+		Updated: now.Add(-time.Second),
+	}
+
+	s.False(isOrphanedWaitingInteraction(session, latest, false, now),
+		"a transient disconnect from a nominally running sandbox must retain the stale-turn grace period")
+}
+
+func (s *PromptHistoryHandlersSuite) TestIsOrphanedWaitingInteraction_LiveWSNeverReapsStoppedStatus() {
+	now := time.Now()
+	session := &types.Session{ID: "ses_live"}
+	session.Metadata.ZedThreadID = "thread-established"
+	session.Metadata.ExternalAgentStatus = "stopped"
+	latest := &types.Interaction{
+		ID:      "int_old",
+		State:   types.InteractionStateWaiting,
+		Updated: now.Add(-time.Hour),
+	}
+
+	s.False(isOrphanedWaitingInteraction(session, latest, true, now),
+		"a live websocket remains authoritative over stale lifecycle metadata")
+}
+
 // TestMarkCanonicalSessionStartingForSync_NoWS_MarksStarting verifies that
 // when a chat is sent to a session whose desktop has no live WebSocket,
 // syncPromptHistory's helper flips external_agent_status to "starting"

--- a/frontend/src/components/session/AgentOfflineNotice.tsx
+++ b/frontend/src/components/session/AgentOfflineNotice.tsx
@@ -50,7 +50,7 @@ const AgentOfflineNotice: FC = () => {
           fontFamily: APP_FONT_FAMILY,
         }}
       >
-        Sandbox stopped — the agent is not running. Start it to continue.
+        Sandbox stopped — send a message to wake the agent.
       </Typography>
     </Box>
   );

--- a/frontend/src/components/session/InteractionLiveStream.test.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.test.tsx
@@ -64,7 +64,7 @@ describe("InteractionLiveStream", () => {
     renderStream(true);
 
     expect(screen.getByRole("status", { name: "Sandbox stopped" })).toBeInTheDocument();
-    expect(screen.getByText(/the agent is not running/i)).toBeInTheDocument();
+    expect(screen.getByText(/send a message to wake the agent/i)).toBeInTheDocument();
   });
 
   it("still shows the timer when the sandbox is alive", () => {


### PR DESCRIPTION
## Summary
Allow a new chat message to wake an explicitly stopped agent immediately. The prompt queue now reaps a dead waiting interaction without applying the normal stale-interaction delay when the sandbox reports `stopped` or `terminated_idle`, then proceeds through the existing dispatch and sandbox startup path. Live connections and ambiguous mid-boot disconnects retain their existing safeguards.

Update the stopped-sandbox notice to explain that sending a message wakes the agent.

## Testing
Ran `go test ./api/pkg/server -run 'TestPromptHistoryHandlersSuite' -count=1` successfully. Added regression coverage for stopped and idle-terminated sandboxes, transient disconnects, and live WebSocket connections.

Updated the focused frontend assertion for the new notice text. The frontend test could not be executed in the checkout because Vitest dependencies were not installed (`vitest: not found`).

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1y22e9f18qkepwvf2k09kqt)

🚀 Built with [Helix](https://helix.ml)