### PR TITLE
Fix light mode release text and provider icon visibility

### DIFF
--- a/frontend/src/components/providers/ProviderEndpointIcon.visual.test.tsx
+++ b/frontend/src/components/providers/ProviderEndpointIcon.visual.test.tsx
@@ -1,8 +1,9 @@
 import { render } from '@testing-library/react'
-import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { createTheme, hexToRgb, ThemeProvider } from '@mui/material/styles'
 import { describe, expect, it } from 'vitest'
 
-import ProviderEndpointIcon from './ProviderEndpointIcon'
+import ProviderEndpointIcon, { ProviderMark } from './ProviderEndpointIcon'
+import { PROVIDERS } from './types'
 
 describe('ProviderEndpointIcon theme colors', () => {
   it.each([
@@ -19,5 +20,22 @@ describe('ProviderEndpointIcon theme colors', () => {
     const iconContainer = container.querySelector('svg')?.parentElement
     expect(iconContainer).not.toBeNull()
     expect(getComputedStyle(iconContainer!).color).toBe(theme.palette.text.primary)
+  })
+
+  it.each(['light', 'dark'] as const)('gives current-color provider marks a visible %s theme foreground', (mode) => {
+    const theme = createTheme({ palette: { mode } })
+    const anthropic = PROVIDERS.find(provider => provider.id === 'user/anthropic')!
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <ProviderMark provider={anthropic} />
+      </ThemeProvider>,
+    )
+
+    const mark = container.querySelector('svg')?.parentElement
+    expect(mark).not.toBeNull()
+    const expectedColor = theme.palette.text.primary.startsWith('#')
+      ? hexToRgb(theme.palette.text.primary)
+      : theme.palette.text.primary
+    expect(getComputedStyle(mark!).color).toBe(expectedColor)
   })
 })

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -149,7 +149,8 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                     justifyContent: "space-between",
                     px: 3,
                     py: 1,
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
                     flexShrink: 0,
                 }}
             >
@@ -158,7 +159,7 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                     <Typography
                         variant="body2"
                         sx={{
-                            color: "rgba(255, 255, 255, 0.7)",
+                            color: "text.secondary",
                             textAlign: "center",
                         }}
                     >

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -14,8 +14,6 @@ import { PROVIDERS, Provider } from '../components/providers/types';
 import CustomLogo from '../components/providers/logos/custom';
 import useRouter from '../hooks/useRouter';
 import useAccount from '../hooks/useAccount';
-import AnthropicLogo from '../components/providers/logos/anthropic';
-import OpenAILogo from '../components/providers/logos/openai';
 import ClaudeSubscriptionConnect, { useClaudeSubscriptions } from '../components/account/ClaudeSubscriptionConnect';
 import CodexSubscriptionConnect from '../components/account/CodexSubscriptionConnect';
 import { useCodexSubscriptions } from '../services/codexSubscriptionsService';
@@ -25,7 +23,7 @@ import type { ReactNode } from 'react'
 import { formatCodexAccountDetail, formatCodexAccountRef } from '../components/account/codexSubscriptionUtils';
 import LMStudioModels from '../components/providers/LMStudioModels';
 import CodeAgentHarnessesSection from '../components/providers/CodeAgentHarnessesSection';
-import { getProviderPresetDefinition } from '../components/providers/ProviderEndpointIcon';
+import { getProviderPresetDefinition, ProviderMark } from '../components/providers/ProviderEndpointIcon';
 import {
   useOrgCodeAgentHarnesses,
   useUpdateOrgCodeAgentHarnesses,
@@ -328,8 +326,8 @@ const Providers: React.FC = () => {
             >
               <CardHeader
                 avatar={
-                  <Avatar sx={{ bgcolor: 'white', width: 56, height: 56 }}>
-                    <AnthropicLogo style={{ width: 40, height: 40 }} />
+                  <Avatar sx={{ bgcolor: 'action.hover', width: 56, height: 56 }}>
+                    <ProviderMark provider={PROVIDERS.find(provider => provider.id === 'user/anthropic')!} size={40} />
                   </Avatar>
                 }
                 title="Anthropic"
@@ -348,7 +346,7 @@ const Providers: React.FC = () => {
           <Grid item xs={12} sm={6} display="flex" justifyContent="center">
             <Card sx={{ width: 320, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', boxShadow: 2, borderStyle: 'dashed', borderWidth: 1, borderColor: hasCodexSubscription ? 'success.main' : 'divider' }}>
               <CardHeader
-                avatar={<Avatar sx={{ bgcolor: 'white', width: 56, height: 56 }}><OpenAILogo style={{ width: 40, height: 40 }} /></Avatar>}
+                avatar={<Avatar sx={{ bgcolor: 'action.hover', width: 56, height: 56 }}><ProviderMark provider={PROVIDERS.find(provider => provider.id === 'user/openai')!} size={40} /></Avatar>}
                 title="ChatGPT"
                 titleTypographyProps={{ variant: 'h6', align: 'center' }}
               />
@@ -491,12 +489,8 @@ const Providers: React.FC = () => {
                 >
                   <CardHeader
                     avatar={
-                      <Avatar sx={{ bgcolor: 'white', width: 56, height: 56 }}>
-                        {typeof provider.logo === 'string' ? (
-                          <img src={provider.logo} alt={provider.name} style={{ width: 40, height: 40 }} />
-                        ) : (
-                          <provider.logo style={{ width: 40, height: 40 }} />
-                        )}
+                      <Avatar sx={{ bgcolor: 'action.hover', width: 56, height: 56 }}>
+                        <ProviderMark provider={provider} size={40} />
                       </Avatar>
                     }
                     title={provider.name}
@@ -582,8 +576,8 @@ const Providers: React.FC = () => {
                 >
                   <CardHeader
                     avatar={
-                      <Avatar sx={{ bgcolor: 'white', width: 56, height: 56 }}>
-                        <CustomLogo style={{ width: 40, height: 40 }} />
+                      <Avatar sx={{ bgcolor: 'action.hover', width: 56, height: 56 }}>
+                        <ProviderMark provider={customCardProvider} size={40} />
                       </Avatar>
                     }
                     title={endpoint.name}


### PR DESCRIPTION
## Summary
Use theme-aware foreground, background, and divider colors for the admin release banner and provider cards. Render provider logos through the shared ProviderMark component so current-color icons remain visible in both light and dark modes.

## Testing
Ran the targeted provider icon tests in light and dark themes (7 tests passed), TypeScript compilation, and the production frontend build successfully.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1y1yh4e8x2jkqxtg7zdp2ss)

🚀 Built with [Helix](https://helix.ml)