### PR TITLE
feat(sandbox): refresh agent skills from helixml/skills at task start

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1720,11 +1720,13 @@ steps:
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
         GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
+        SKILLS_COMMIT=$$(awk -F= '$$1 == "SKILLS_COMMIT" { print $$2 }' sandbox-versions.txt)
         echo "Building helix-ubuntu..."
         docker build --pull --provenance=false \
           -f Dockerfile.ubuntu-helix \
           --build-arg CUDA_BASE_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04@sha256:2c8193530ecc423e0f123d0c85b68a15d1395adcddabfc943e2523dbfde172e1 \
           --build-arg GO_VERSION=$${GO_VERSION} \
+          --build-arg SKILLS_COMMIT=$${SKILLS_COMMIT} \
           -t registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-amd64 \
           .
         docker push registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-amd64
@@ -2006,11 +2008,13 @@ steps:
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
         GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
+        SKILLS_COMMIT=$$(awk -F= '$$1 == "SKILLS_COMMIT" { print $$2 }' sandbox-versions.txt)
         echo "Building helix-ubuntu (arm64, no CUDA)..."
         docker build --pull --provenance=false \
           -f Dockerfile.ubuntu-helix \
           --build-arg CUDA_BASE_IMAGE=ubuntu:25.10@sha256:91e7ac4c041dd191af1b9012fadbf489280894699c3f31e180969c4478781b7b \
           --build-arg GO_VERSION=$${GO_VERSION} \
+          --build-arg SKILLS_COMMIT=$${SKILLS_COMMIT} \
           -t registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-arm64 \
           .
         docker push registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-arm64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ See `design/2026-02-04-macos-dev-environment-setup.md` for setup.
 | DRM manager (`api/pkg/drm/`, `api/cmd/helix-drm-manager/`) | `./stack build-drm-manager` | Systemd service on VM guest |
 | Zed config (`zed_config.go`) | No rebuild | API-side, Air hot reloads. Start NEW session |
 | Settings-sync-daemon | `./stack build-ubuntu` | Start NEW session after |
-| Agent skills (`SKILLS_COMMIT` in `sandbox-versions.txt`) | `./stack build-ubuntu` | Start NEW session after |
+| Agent skills (helixml/skills) | None — refreshed from `main` at every container start. `SKILLS_COMMIT` in `sandbox-versions.txt` only pins the offline seed: bump + `./stack build-ubuntu` | Start NEW session after |
 
 Full rebuild order: `build-zed` → `build-ubuntu` → `build-sandbox` (if needed) → start new session.
 
@@ -696,17 +696,21 @@ helix api -X POST /orgs/unmanned-org/bots/chief-of-staff/activate
 ### Agent skills
 
 Skills that teach a coding agent to drive Helix live in
-[helixml/skills](https://github.com/helixml/skills), pinned by `SKILLS_COMMIT` in
-`sandbox-versions.txt`. The desktop images install the selected ones (`HELIX_SKILLS` in
-`Dockerfile.ubuntu-helix`) to `/opt/helix/skills`, and `helix-workspace-setup.sh` links them
-into `~/.claude/skills`, `~/.agents/skills`, and `~/.qwen/skills` on every container start —
-the three directories Claude Code, opencode, goose, and qwen actually scan. Bumping a skill is
-a `SKILLS_COMMIT` edit plus `./stack build-ubuntu`; a new session picks it up.
+[helixml/skills](https://github.com/helixml/skills). The desktop images bake a shallow clone
+at `/opt/helix/skills`, pinned by `SKILLS_COMMIT` in `sandbox-versions.txt` (passed as a
+build-arg by `./stack build-desktop` and `.drone.yml`; the Dockerfile has no default). On
+every container start `helix-workspace-setup.sh` copies it to `~/work/.helix-skills`,
+refreshes it from upstream `main`, and links every skill into `~/.agents/skills` and
+`~/.claude/skills` — the two directories that between them cover zed-agent, Claude Code,
+Codex, Gemini CLI, goose, opencode and qwen. When the fetch fails (air-gapped, proxy) the
+last good checkout is kept, so the pin only matters offline. Per-container knobs:
+`HELIX_SKILLS_REF` (branch/tag/sha; empty disables refresh), `HELIX_SKILLS` (space-separated
+subset to link), `HELIX_SKILLS_REPO`.
 
-Currently installed: **helix-artifacts** — publish and manage project artifacts
-(`helix artifact …`). Control-plane skills (`helix-board`, `helix-deploy`, `helix-e2e`, …) are
-deliberately *not* installed: an agent in a task sandbox should work on the task's repo, not
-reconfigure the Helix running it.
+Inside the sandbox the `helix` CLI authenticates from `HELIX_API_URL` + `USER_API_TOKEN`
+(`config.LoadCliConfig` falls back to them when `HELIX_URL`/`HELIX_API_KEY` are unset), so
+the skills' `helix …` commands work as written. The planning and implementation prompts
+carry a short "## Helix skills" section pointing the agent at them.
 
 `skills/helix-org-cli/SKILL.md` above is a different thing — a skill checked into this repo,
 visible only to an agent working on this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,12 +700,13 @@ Skills that teach a coding agent to drive Helix live in
 at `/opt/helix/skills`, pinned by `SKILLS_COMMIT` in `sandbox-versions.txt` (passed as a
 build-arg by `./stack build-desktop` and `.drone.yml`; the Dockerfile has no default). On
 every container start `helix-workspace-setup.sh` copies it to `~/work/.helix-skills`,
-refreshes it from upstream `main`, and links every skill into `~/.agents/skills` and
-`~/.claude/skills` — the two directories that between them cover zed-agent, Claude Code,
+refreshes it from upstream `main`, and links the default set (`helix-cli`, `helix-artifacts`,
+`helix-spec-tasks`, `helix-board`, `helix-files`) into `~/.agents/skills` and `~/.claude/skills` — the two directories that between them cover zed-agent, Claude Code,
 Codex, Gemini CLI, goose, opencode and qwen. When the fetch fails (air-gapped, proxy) the
 last good checkout is kept, so the pin only matters offline. Per-container knobs:
 `HELIX_SKILLS_REF` (branch/tag/sha; empty disables refresh), `HELIX_SKILLS` (space-separated
-subset to link), `HELIX_SKILLS_REPO`.
+names, or `all` — the operator skills `helix-deploy`/`helix-e2e`/`helix-agents` are opt-in only),
+`HELIX_SKILLS_REPO`. A broken skills checkout never aborts workspace setup.
 
 Inside the sandbox the `helix` CLI authenticates from `HELIX_API_URL` + `USER_API_TOKEN`
 (`config.LoadCliConfig` falls back to them when `HELIX_URL`/`HELIX_API_KEY` are unset), so

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -930,43 +930,34 @@ RUN test -x bin/qwen && \
 
 # Helix agent skills (github.com/helixml/skills).
 #
-# Baked in rather than fetched at session start so an offline or air-gapped
-# deployment gets the same agent capabilities. The canonical copy is root-owned
-# under /opt/helix/skills; helix-workspace-setup.sh symlinks it into each
-# harness's discovery directory on every container start (it cannot be done
-# here — that script replaces ~/.claude with a symlink to persistent workspace
-# storage, which would drop anything this stage wrote there).
+# A shallow clone pinned at SKILLS_COMMIT is baked in as the seed, so an
+# offline or air-gapped deployment still gets the skills. On every container
+# start helix-workspace-setup.sh copies it into persistent workspace storage,
+# refreshes it from upstream (HELIX_SKILLS_REF, default main) when the network
+# allows, and links the selected skills (HELIX_SKILLS, default all) into each
+# harness's discovery directory. The clone keeps its .git so that refresh is a
+# plain `git fetch`. Linking cannot happen here: that script replaces ~/.claude
+# with a symlink to persistent storage, dropping anything this stage wrote.
 #
-# HELIX_SKILLS selects what to install. The repo carries skills for driving a
-# Helix control plane (helix-board, helix-deploy, helix-e2e, …); those are
-# deliberately left out, since an agent in a task sandbox should work on the
-# task's repo, not reconfigure the Helix running it.
-#
-# Keep SKILLS_COMMIT in sync with sandbox-versions.txt.
-ARG SKILLS_COMMIT=657b1314886e8b969d5f54f06cbff47cc9c59bd0
-ARG HELIX_SKILLS="helix-artifacts"
+# SKILLS_COMMIT is read from sandbox-versions.txt by `./stack build-desktop`
+# and .drone.yml. There is deliberately no default so the pin cannot drift.
+ARG SKILLS_COMMIT
 RUN <<_INSTALL_SKILLS
 set -eu
-echo "=== Installing Helix agent skills (${HELIX_SKILLS}) @ ${SKILLS_COMMIT} ==="
-git init -q /tmp/helix-skills
-git -C /tmp/helix-skills fetch -q --depth 1 https://github.com/helixml/skills.git "${SKILLS_COMMIT}"
-git -C /tmp/helix-skills checkout -q FETCH_HEAD
-mkdir -p /opt/helix/skills
-for skill in ${HELIX_SKILLS}; do
-  # Fail the build rather than ship a silently-missing skill: a renamed or
-  # dropped upstream directory must surface here, not as an agent that
-  # quietly has no idea the feature exists.
-  if [ ! -f "/tmp/helix-skills/skills/${skill}/SKILL.md" ]; then
-    echo "ERROR: skills/${skill}/SKILL.md not found at ${SKILLS_COMMIT}" >&2
-    exit 1
-  fi
-  cp -a "/tmp/helix-skills/skills/${skill}" /opt/helix/skills/
-done
-rm -rf /tmp/helix-skills
-echo "${SKILLS_COMMIT}" > /opt/helix/skills.version
+if [ -z "${SKILLS_COMMIT:-}" ]; then
+  echo "ERROR: SKILLS_COMMIT build-arg is required (see sandbox-versions.txt)" >&2
+  exit 1
+fi
+echo "=== Installing Helix agent skills @ ${SKILLS_COMMIT} ==="
+git init -q /opt/helix/skills
+git -C /opt/helix/skills remote add origin https://github.com/helixml/skills.git
+git -C /opt/helix/skills fetch -q --depth 1 origin "${SKILLS_COMMIT}"
+git -C /opt/helix/skills checkout -q --detach FETCH_HEAD
+# Fail the build rather than ship an empty skill set.
+ls -d /opt/helix/skills/skills/*/SKILL.md >/dev/null
 chown -R root:root /opt/helix/skills
 chmod -R a+rX,go-w /opt/helix/skills
-ls /opt/helix/skills
+ls /opt/helix/skills/skills
 _INSTALL_SKILLS
 
 # Sway configuration (GOW pattern)

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -1432,43 +1432,34 @@ _INSTALL_DSH_RUNTIME
 
 # Helix agent skills (github.com/helixml/skills).
 #
-# Baked in rather than fetched at session start so an offline or air-gapped
-# deployment gets the same agent capabilities. The canonical copy is root-owned
-# under /opt/helix/skills; helix-workspace-setup.sh symlinks it into each
-# harness's discovery directory on every container start (it cannot be done
-# here — that script replaces ~/.claude with a symlink to persistent workspace
-# storage, which would drop anything this stage wrote there).
+# A shallow clone pinned at SKILLS_COMMIT is baked in as the seed, so an
+# offline or air-gapped deployment still gets the skills. On every container
+# start helix-workspace-setup.sh copies it into persistent workspace storage,
+# refreshes it from upstream (HELIX_SKILLS_REF, default main) when the network
+# allows, and links the selected skills (HELIX_SKILLS, default all) into each
+# harness's discovery directory. The clone keeps its .git so that refresh is a
+# plain `git fetch`. Linking cannot happen here: that script replaces ~/.claude
+# with a symlink to persistent storage, dropping anything this stage wrote.
 #
-# HELIX_SKILLS selects what to install. The repo carries skills for driving a
-# Helix control plane (helix-board, helix-deploy, helix-e2e, …); those are
-# deliberately left out, since an agent in a task sandbox should work on the
-# task's repo, not reconfigure the Helix running it.
-#
-# Keep SKILLS_COMMIT in sync with sandbox-versions.txt.
-ARG SKILLS_COMMIT=657b1314886e8b969d5f54f06cbff47cc9c59bd0
-ARG HELIX_SKILLS="helix-artifacts"
+# SKILLS_COMMIT is read from sandbox-versions.txt by `./stack build-desktop`
+# and .drone.yml. There is deliberately no default so the pin cannot drift.
+ARG SKILLS_COMMIT
 RUN <<_INSTALL_SKILLS
 set -eu
-echo "=== Installing Helix agent skills (${HELIX_SKILLS}) @ ${SKILLS_COMMIT} ==="
-git init -q /tmp/helix-skills
-git -C /tmp/helix-skills fetch -q --depth 1 https://github.com/helixml/skills.git "${SKILLS_COMMIT}"
-git -C /tmp/helix-skills checkout -q FETCH_HEAD
-mkdir -p /opt/helix/skills
-for skill in ${HELIX_SKILLS}; do
-  # Fail the build rather than ship a silently-missing skill: a renamed or
-  # dropped upstream directory must surface here, not as an agent that
-  # quietly has no idea the feature exists.
-  if [ ! -f "/tmp/helix-skills/skills/${skill}/SKILL.md" ]; then
-    echo "ERROR: skills/${skill}/SKILL.md not found at ${SKILLS_COMMIT}" >&2
-    exit 1
-  fi
-  cp -a "/tmp/helix-skills/skills/${skill}" /opt/helix/skills/
-done
-rm -rf /tmp/helix-skills
-echo "${SKILLS_COMMIT}" > /opt/helix/skills.version
+if [ -z "${SKILLS_COMMIT:-}" ]; then
+  echo "ERROR: SKILLS_COMMIT build-arg is required (see sandbox-versions.txt)" >&2
+  exit 1
+fi
+echo "=== Installing Helix agent skills @ ${SKILLS_COMMIT} ==="
+git init -q /opt/helix/skills
+git -C /opt/helix/skills remote add origin https://github.com/helixml/skills.git
+git -C /opt/helix/skills fetch -q --depth 1 origin "${SKILLS_COMMIT}"
+git -C /opt/helix/skills checkout -q --detach FETCH_HEAD
+# Fail the build rather than ship an empty skill set.
+ls -d /opt/helix/skills/skills/*/SKILL.md >/dev/null
 chown -R root:root /opt/helix/skills
 chmod -R a+rX,go-w /opt/helix/skills
-ls /opt/helix/skills
+ls /opt/helix/skills/skills
 _INSTALL_SKILLS
 
 WORKDIR /

--- a/api/pkg/cli/api/cmd.go
+++ b/api/pkg/cli/api/cmd.go
@@ -45,7 +45,8 @@ Examples:
   helix api -X POST /sessions/chat --input '{"session_id":"ses_…","type":"text","stream":false,"messages":[…]}'
   echo '{"name":"x"}' | helix api -X POST /orgs/unmanned-org/bots --input -
 
-Uses HELIX_URL (default http://localhost:8080) and HELIX_API_KEY.
+Uses HELIX_URL and HELIX_API_KEY; inside a Helix sandbox the exported
+HELIX_API_URL and USER_API_TOKEN are used automatically.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/pkg/cli/artifact/cmd.go
+++ b/api/pkg/cli/artifact/cmd.go
@@ -276,12 +276,7 @@ func resolveArtifactProvenance(cmd *cobra.Command, flags *uploadFlags, projectID
 }
 
 func newClient() (*client.HelixClient, error) {
-	apiURL := firstNonEmpty(os.Getenv("HELIX_URL"), os.Getenv("HELIX_API_URL"), "http://localhost:8080")
-	apiKey := firstNonEmpty(os.Getenv("HELIX_API_KEY"), os.Getenv("USER_API_TOKEN"))
-	if apiKey == "" {
-		return nil, errors.New("authentication is required: set HELIX_API_KEY or USER_API_TOKEN")
-	}
-	return client.NewClient(strings.TrimRight(apiURL, "/"), apiKey, false)
+	return client.NewClientFromEnv()
 }
 
 func openArtifactContent(sourcePath string) (*client.ArtifactContent, func(), error) {

--- a/api/pkg/cli/org/client.go
+++ b/api/pkg/cli/org/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/config"
 )
 
 // httpClient is a thin authenticated HTTP helper for helix-org REST paths
@@ -25,25 +26,14 @@ type httpClient struct {
 }
 
 func newHTTPClient() (*httpClient, error) {
-	c, err := client.NewClientFromEnv()
-	if err != nil {
-		return nil, err
-	}
-	// HelixClient.url already includes /api/v1 — reach it via a small
-	// parallel helper that exposes the same env defaults.
-	url := os.Getenv("HELIX_URL")
-	if url == "" {
-		url = "http://localhost:8080"
-	}
-	url = strings.TrimRight(url, "/")
+	url := strings.TrimRight(config.CliURL("http://localhost:8080"), "/")
 	if !strings.HasSuffix(url, "/api/v1") {
 		url = url + "/api/v1"
 	}
-	apiKey := os.Getenv("HELIX_API_KEY")
+	apiKey := config.CliAPIKey()
 	if apiKey == "" {
 		return nil, fmt.Errorf("HELIX_API_KEY is not set")
 	}
-	_ = c
 	return &httpClient{
 		base:   url,
 		apiKey: apiKey,

--- a/api/pkg/cli/org/client.go
+++ b/api/pkg/cli/org/client.go
@@ -32,7 +32,7 @@ func newHTTPClient() (*httpClient, error) {
 	}
 	apiKey := config.CliAPIKey()
 	if apiKey == "" {
-		return nil, fmt.Errorf("HELIX_API_KEY is not set")
+		return nil, fmt.Errorf("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) is not set")
 	}
 	return &httpClient{
 		base:   url,

--- a/api/pkg/cli/project/inspect.go
+++ b/api/pkg/cli/project/inspect.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -193,15 +193,11 @@ func displayTask(task types.SpecTask) {
 
 // Helper functions
 func getAPIURL() string {
-	url := os.Getenv("HELIX_URL")
-	if url == "" {
-		url = "http://localhost:8080"
-	}
-	return url
+	return config.CliURL("http://localhost:8080")
 }
 
 func getToken() string {
-	token := os.Getenv("HELIX_API_KEY")
+	token := config.CliAPIKey()
 	if token == "" {
 		token = "oh-hallo-insecure-token" // Dev default
 	}

--- a/api/pkg/cli/sandbox/sandbox.go
+++ b/api/pkg/cli/sandbox/sandbox.go
@@ -93,7 +93,7 @@ func newRuntimesCmd() *cobra.Command {
 func newClient() (*client.HelixClient, error) {
 	apiKey := config.CliAPIKey()
 	if apiKey == "" {
-		return nil, errors.New("HELIX_API_KEY is not set")
+		return nil, errors.New("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) is not set")
 	}
 	return client.NewClient(config.CliURL("http://localhost:8080"), apiKey, false)
 }

--- a/api/pkg/cli/sandbox/sandbox.go
+++ b/api/pkg/cli/sandbox/sandbox.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/spf13/cobra"
@@ -90,15 +91,11 @@ func newRuntimesCmd() *cobra.Command {
 }
 
 func newClient() (*client.HelixClient, error) {
-	url := os.Getenv("HELIX_URL")
-	if url == "" {
-		url = "http://localhost:8080"
-	}
-	apiKey := os.Getenv("HELIX_API_KEY")
+	apiKey := config.CliAPIKey()
 	if apiKey == "" {
 		return nil, errors.New("HELIX_API_KEY is not set")
 	}
-	return client.NewClient(url, apiKey, false)
+	return client.NewClient(config.CliURL("http://localhost:8080"), apiKey, false)
 }
 
 // resolveOrg picks the org id. Order:

--- a/api/pkg/cli/spectask/copy_cmd.go
+++ b/api/pkg/cli/spectask/copy_cmd.go
@@ -54,7 +54,7 @@ Examples:
 			token := getToken()
 
 			if apiURL == "" || token == "" {
-				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+				return fmt.Errorf("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) must be set")
 			}
 
 			// Check if local file exists

--- a/api/pkg/cli/spectask/exec_cmd.go
+++ b/api/pkg/cli/spectask/exec_cmd.go
@@ -67,7 +67,7 @@ Examples:
 			token := getToken()
 
 			if apiURL == "" || token == "" {
-				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+				return fmt.Errorf("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) must be set")
 			}
 
 			// Parse environment variables

--- a/api/pkg/cli/spectask/files_cmd.go
+++ b/api/pkg/cli/spectask/files_cmd.go
@@ -40,7 +40,7 @@ Examples:
 			sessionID := args[0]
 			apiURL, token := getAPIURL(), getToken()
 			if apiURL == "" || token == "" {
-				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+				return fmt.Errorf("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) must be set")
 			}
 			u := fmt.Sprintf("%s/api/v1/external-agents/%s/workspace-files", apiURL, sessionID)
 			if workspace != "" {
@@ -108,7 +108,7 @@ Examples:
 			sessionID, remotePath := args[0], args[1]
 			apiURL, token := getAPIURL(), getToken()
 			if apiURL == "" || token == "" {
-				return fmt.Errorf("HELIX_URL and HELIX_API_KEY environment variables must be set")
+				return fmt.Errorf("HELIX_API_KEY (or USER_API_TOKEN inside a Helix sandbox) must be set")
 			}
 			q := url.Values{}
 			q.Set("path", remotePath)

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/cli"
 	"github.com/helixml/helix/api/pkg/client"
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -523,15 +524,11 @@ func stopAllSessions(apiURL, token string) error {
 // Helper functions
 
 func getAPIURL() string {
-	url := os.Getenv("HELIX_URL")
-	if url == "" {
-		url = "http://localhost:8080"
-	}
-	return url
+	return config.CliURL("http://localhost:8080")
 }
 
 func getToken() string {
-	token := os.Getenv("HELIX_API_KEY")
+	token := config.CliAPIKey()
 	if token == "" {
 		token = "oh-hallo-insecure-token" // Dev default
 	}

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -176,6 +176,7 @@ func NewClient(url, apiKey string, tlsSkipVerify bool) (*HelixClient, error) {
 		return nil, errors.New("apiKey is required, find yours in your helix account page and set HELIX_API_KEY and HELIX_URL")
 	}
 
+	url = strings.TrimRight(url, "/")
 	if !strings.HasSuffix(url, "/api/v1") {
 		// append /api/v1 to the url
 		url = url + "/api/v1"

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -173,7 +173,7 @@ func NewClient(url, apiKey string, tlsSkipVerify bool) (*HelixClient, error) {
 	}
 
 	if apiKey == "" {
-		return nil, errors.New("apiKey is required, find yours in your helix account page and set HELIX_API_KEY and HELIX_URL")
+		return nil, errors.New("apiKey is required: set HELIX_API_KEY (find yours in your helix account page) and HELIX_URL; inside a Helix sandbox USER_API_TOKEN and HELIX_API_URL are used automatically")
 	}
 
 	url = strings.TrimRight(url, "/")

--- a/api/pkg/config/cli_config.go
+++ b/api/pkg/config/cli_config.go
@@ -1,23 +1,60 @@
 package config
 
 import (
+	"os"
+
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 )
 
+// DefaultCliURL is the control plane the CLI talks to when nothing else is
+// configured.
+const DefaultCliURL = "https://app.helix.ml"
+
 type CliConfig struct {
-	URL           string `envconfig:"HELIX_URL" default:"https://app.helix.ml"`
+	URL           string `envconfig:"HELIX_URL"`
 	APIKey        string `envconfig:"HELIX_API_KEY"`
 	TLSSkipVerify bool   `envconfig:"HELIX_TLS_SKIP_VERIFY" default:"false"`
 }
 
+// CliURL resolves the control plane URL: HELIX_URL, then HELIX_API_URL (the
+// name a Helix sandbox exports — see hydra_executor.buildEnvVars), then
+// defaultURL. Every `helix` subcommand resolves its URL through here so the
+// sandbox convention works everywhere without per-command fallbacks.
+func CliURL(defaultURL string) string {
+	if url := os.Getenv("HELIX_URL"); url != "" {
+		return url
+	}
+	if url := os.Getenv("HELIX_API_URL"); url != "" {
+		return url
+	}
+	return defaultURL
+}
+
+// CliAPIKey resolves the API key: HELIX_API_KEY, then USER_API_TOKEN (the
+// name a Helix sandbox exports). Empty when neither is set.
+func CliAPIKey() string {
+	if key := os.Getenv("HELIX_API_KEY"); key != "" {
+		return key
+	}
+	return os.Getenv("USER_API_TOKEN")
+}
+
+// LoadCliConfig resolves the control plane URL and API key for the CLI.
+//
+// Two naming conventions are accepted. HELIX_URL / HELIX_API_KEY are what a
+// user sets on their own machine. Inside a Helix sandbox the platform exports
+// HELIX_API_URL / USER_API_TOKEN instead, so those are honoured when the
+// user-facing names are unset: the `helix` CLI, and the agent skills that
+// describe it, work in both places without setup.
 func LoadCliConfig() (CliConfig, error) {
 	_ = godotenv.Load()
 
 	var cfg CliConfig
-	err := envconfig.Process("", &cfg)
-	if err != nil {
+	if err := envconfig.Process("", &cfg); err != nil {
 		return CliConfig{}, err
 	}
+	cfg.URL = CliURL(DefaultCliURL)
+	cfg.APIKey = CliAPIKey()
 	return cfg, nil
 }

--- a/api/pkg/config/cli_config_test.go
+++ b/api/pkg/config/cli_config_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCliConfig_UserEnvironment(t *testing.T) {
+	t.Setenv("HELIX_URL", "https://helix.example.com")
+	t.Setenv("HELIX_API_KEY", "hl-user")
+	t.Setenv("HELIX_API_URL", "http://api:8080")
+	t.Setenv("USER_API_TOKEN", "sandbox-token")
+
+	cfg, err := LoadCliConfig()
+	require.NoError(t, err)
+	require.Equal(t, "https://helix.example.com", cfg.URL)
+	require.Equal(t, "hl-user", cfg.APIKey)
+}
+
+func TestLoadCliConfig_SandboxEnvironment(t *testing.T) {
+	t.Setenv("HELIX_URL", "")
+	t.Setenv("HELIX_API_KEY", "")
+	t.Setenv("HELIX_API_URL", "http://api:8080")
+	t.Setenv("USER_API_TOKEN", "sandbox-token")
+
+	cfg, err := LoadCliConfig()
+	require.NoError(t, err)
+	require.Equal(t, "http://api:8080", cfg.URL)
+	require.Equal(t, "sandbox-token", cfg.APIKey)
+}
+
+func TestLoadCliConfig_DefaultURL(t *testing.T) {
+	t.Setenv("HELIX_URL", "")
+	t.Setenv("HELIX_API_KEY", "hl-user")
+	t.Setenv("HELIX_API_URL", "")
+	t.Setenv("USER_API_TOKEN", "")
+
+	cfg, err := LoadCliConfig()
+	require.NoError(t, err)
+	require.Equal(t, "https://app.helix.ml", cfg.URL)
+}
+
+func TestCliURL_PrefersUserOverSandboxOverDefault(t *testing.T) {
+	t.Setenv("HELIX_URL", "")
+	t.Setenv("HELIX_API_URL", "")
+	require.Equal(t, "http://localhost:8080", CliURL("http://localhost:8080"))
+
+	t.Setenv("HELIX_API_URL", "http://api:8080")
+	require.Equal(t, "http://api:8080", CliURL("http://localhost:8080"))
+
+	t.Setenv("HELIX_URL", "https://helix.example.com")
+	require.Equal(t, "https://helix.example.com", CliURL("http://localhost:8080"))
+}

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1476,6 +1476,9 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 	if agent.ProjectID != "" {
 		env = append(env, fmt.Sprintf("HELIX_PROJECT_ID=%s", agent.ProjectID))
 	}
+	if agent.OrganizationID != "" {
+		env = append(env, fmt.Sprintf("HELIX_ORGANIZATION_ID=%s", agent.OrganizationID))
+	}
 	// NOTE: HELIX_PRIMARY_REPO_NAME is set in StartDesktop after fetching actual repo name
 
 	// Display settings for non-headless containers

--- a/api/pkg/services/agent_instruction_service.go
+++ b/api/pkg/services/agent_instruction_service.go
@@ -153,6 +153,7 @@ If you use an internal to-do tool instead of tasks.md, users cannot see your pro
 2. **/home/retro/work/{{.PrimaryRepoName}}/** = Code changes (push to feature branch) - THIS IS YOUR PRIMARY PROJECT
 {{.RepositorySection}}
 {{.AgentToolsSection}}
+` + helixSkillsSection + `
 ## Task Checklist
 
 Your checklist: /home/retro/work/helix-specs/design/tasks/{{.TaskDirName}}/tasks.md

--- a/api/pkg/services/agent_instruction_service_test.go
+++ b/api/pkg/services/agent_instruction_service_test.go
@@ -42,3 +42,17 @@ func TestBuildApprovalInstructionPromptRecoversSharedSpecsPush(t *testing.T) {
 		t.Fatal("approval prompt still tells the agent to stop on every push failure")
 	}
 }
+
+// TestBuildApprovalInstructionPrompt_HelixSkills mirrors
+// TestBuildPlanningPrompt_HelixSkills for the implementation phase.
+func TestBuildApprovalInstructionPrompt_HelixSkills(t *testing.T) {
+	task := &types.SpecTask{ID: "spt_test", ProjectID: "prj_test", Name: "x", DesignDocPath: "000001_x"}
+
+	out := BuildApprovalInstructionPrompt(task, "feature/x", "main", "", "repo", "", "", "", nil, "")
+
+	for _, want := range []string{"## Helix skills", "`helix-cli`", "`helix-artifacts`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("approval prompt is missing required snippet %q", want)
+		}
+	}
+}

--- a/api/pkg/services/spec_task_prompts.go
+++ b/api/pkg/services/spec_task_prompts.go
@@ -229,8 +229,7 @@ func buildJustDoItPrompt(userPrompt, guidelinesSection, primaryRepoName, repoSec
 **Primary Project Directory:** /home/retro/work/%s/
 %s
 %s%s%s
-
-**For persistent installs:** Add commands to /home/retro/work/helix-specs/.helix/startup.sh (runs at sandbox startup, must be idempotent). Push directly to helix-specs branch.
+`+helixSkillsSection+`**For persistent installs:** Add commands to /home/retro/work/helix-specs/.helix/startup.sh (runs at sandbox startup, must be idempotent). Push directly to helix-specs branch.
 `, userPrompt, guidelinesSection, primaryRepoName, repoSection, attachmentsSection, shellCommandsGuidance, gitInstructions)
 }
 

--- a/api/pkg/services/spec_task_prompts.go
+++ b/api/pkg/services/spec_task_prompts.go
@@ -31,10 +31,10 @@ type PlanningPromptData struct {
 // in its own system prompt, but — as with BuildAgentToolsSection — a capability
 // that is only in a list and never in the task prompt does not get reached for.
 // The set is whatever helix-workspace-setup.sh linked from github.com/helixml/skills
-// at container start, so this names the two that matter most and stays static.
+// at container start (HELIX_SKILLS); this names the default set and stays static.
 const helixSkillsSection = `## Helix skills
 
-The Helix agent skills (github.com/helixml/skills) are installed in this sandbox: ` + "`helix-cli`, `helix-artifacts`, `helix-spec-tasks`, `helix-board`, `helix-files`" + ` and more. Your harness lists each one with its description — read a skill when the task matches it instead of guessing at ` + "`helix`" + ` commands. Read ` + "`helix-cli`" + ` before your first ` + "`helix`" + ` command (the CLI is on PATH and already authenticated for this project), and use ` + "`helix-artifacts`" + ` whenever the user wants a page, dashboard, report, PDF or image they can open from the project.
+This sandbox has Helix agent skills (github.com/helixml/skills) installed — by default ` + "`helix-cli`, `helix-artifacts`, `helix-spec-tasks`, `helix-board` and `helix-files`" + `. Your harness lists the ones actually present with their descriptions — read a skill when the task matches it instead of guessing at ` + "`helix`" + ` commands. Read ` + "`helix-cli`" + ` before your first ` + "`helix`" + ` command (the CLI is on PATH and already authenticated for this project), and use ` + "`helix-artifacts`" + ` whenever the user wants a page, dashboard, report, PDF or image they can open from the project.
 
 `
 

--- a/api/pkg/services/spec_task_prompts.go
+++ b/api/pkg/services/spec_task_prompts.go
@@ -26,6 +26,18 @@ type PlanningPromptData struct {
 	ClonedTaskPreamble string // Special instructions for cloned tasks (non-empty if task was cloned)
 }
 
+// helixSkillsSection tells the agent the Helix agent skills exist and when to
+// open them. Every harness already lists installed skills (name + description)
+// in its own system prompt, but — as with BuildAgentToolsSection — a capability
+// that is only in a list and never in the task prompt does not get reached for.
+// The set is whatever helix-workspace-setup.sh linked from github.com/helixml/skills
+// at container start, so this names the two that matter most and stays static.
+const helixSkillsSection = `## Helix skills
+
+The Helix agent skills (github.com/helixml/skills) are installed in this sandbox: ` + "`helix-cli`, `helix-artifacts`, `helix-spec-tasks`, `helix-board`, `helix-files`" + ` and more. Your harness lists each one with its description — read a skill when the task matches it instead of guessing at ` + "`helix`" + ` commands. Read ` + "`helix-cli`" + ` before your first ` + "`helix`" + ` command (the CLI is on PATH and already authenticated for this project), and use ` + "`helix-artifacts`" + ` whenever the user wants a page, dashboard, report, PDF or image they can open from the project.
+
+`
+
 // planningPromptTemplate is the compiled template for planning prompts
 var planningPromptTemplate = template.Must(template.New("planning").Parse(`## CURRENT PHASE: PLANNING/SPEC-WRITING
 
@@ -48,7 +60,7 @@ ALL work happens in /home/retro/work/. No other paths.
 - /home/retro/work/helix-specs/ = Your design docs go here (ALREADY EXISTS - don't create it)
 - /home/retro/work/<repo>/ = Code repos (don't touch these - implementation happens later)
 {{.RepositorySection}}
-{{.AttachmentsSection}}{{.AgentToolsSection}}## Your Task Directory
+{{.AttachmentsSection}}{{.AgentToolsSection}}` + helixSkillsSection + `## Your Task Directory
 
 Create exactly 3 files in /home/retro/work/helix-specs/design/tasks/{{.TaskDirName}}/ (directory already exists):
 1. requirements.md - User stories + acceptance criteria

--- a/api/pkg/services/spec_task_prompts_test.go
+++ b/api/pkg/services/spec_task_prompts_test.go
@@ -84,3 +84,13 @@ func TestBuildPlanningPrompt_HelixSkills(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildJustDoItPrompt_HelixSkills(t *testing.T) {
+	out := buildJustDoItPrompt("do x", "", "repo", "", "", "", "")
+
+	for _, want := range []string{"## Helix skills", "`helix-cli`", "`helix-artifacts`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("just-do-it prompt is missing required snippet %q", want)
+		}
+	}
+}

--- a/api/pkg/services/spec_task_prompts_test.go
+++ b/api/pkg/services/spec_task_prompts_test.go
@@ -67,3 +67,20 @@ func TestBuildPlanningPrompt_OpenQuestions(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildPlanningPrompt_HelixSkills guards the "## Helix skills" section.
+// The skills are linked into the sandbox by helix-workspace-setup.sh and the
+// harness lists them, but nothing else in the prompt says they exist or when
+// to open one; dropping this section silently returns agents to guessing at
+// `helix` commands.
+func TestBuildPlanningPrompt_HelixSkills(t *testing.T) {
+	task := &types.SpecTask{ID: "spt_test", ProjectID: "prj_test", Name: "x", DesignDocPath: "000001_x"}
+
+	out := BuildPlanningPrompt(task, "", "", "", "", "")
+
+	for _, want := range []string{"## Helix skills", "`helix-cli`", "`helix-artifacts`"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("planning prompt is missing required snippet %q", want)
+		}
+	}
+}

--- a/design/2026-09-07-agent-skills-integration.md
+++ b/design/2026-09-07-agent-skills-integration.md
@@ -1,0 +1,233 @@
+# Agent skills in spec-task sandboxes: current state and integration plan
+
+**Date:** 2026-09-07
+**Status:** Phase 1 implemented (runtime refresh + plumbing); see "Decision" below
+
+Goal: agents running inside Helix spec-task sandboxes should reliably *have*
+the [helixml/skills](https://github.com/helixml/skills) skills, be able to
+*run* what they describe, and be *nudged* to use them when a task matches.
+
+## 1. What exists today (verified 2026-09-07)
+
+### Install path
+
+- `Dockerfile.ubuntu-helix:1448-1472` (and the same block in
+  `Dockerfile.sway-helix:946-969`) shallow-fetches `helixml/skills` at
+  `ARG SKILLS_COMMIT` and copies the dirs named in `ARG HELIX_SKILLS`
+  (default `"helix-artifacts"`) into `/opt/helix/skills`.
+- `desktop/shared/helix-workspace-setup.sh:645-675` symlinks each skill into
+  `~/.claude/skills`, `~/.agents/skills`, `~/.qwen/skills` on every container
+  start (after `~/.claude` is re-pointed at persistent storage).
+- The upstream repo has 8 skills: `helix-cli`, `helix-board`,
+  `helix-spec-tasks`, `helix-files`, `helix-artifacts`, `helix-agents`,
+  `helix-deploy`, `helix-e2e`. The pin `657b131` is upstream HEAD.
+  Only `helix-artifacts` ships, by design (commit `ee7852fb4`: the
+  control-plane skills would point an agent at reconfiguring the Helix that is
+  running it).
+
+### How each harness discovers skills (all checked against source or vendor docs)
+
+| Runtime | Global dirs scanned | Project dirs | Covered by our links? |
+|---|---|---|---|
+| `zed_agent` | `~/.agents/skills` (`agent_skills.rs`) | `<worktree>/.agents/skills`; Helix fork auto-trusts worktrees (`trusted_worktrees.rs:can_trust`, `cfg!(feature="external_websocket_sync")`) | yes |
+| `claude_code` | `~/.claude/skills` | `.claude/skills` | yes |
+| `codex_cli` | `$HOME/.agents/skills`, `/etc/codex/skills`; symlinks followed | `.agents/skills` at cwd/parent/repo root | yes |
+| `gemini_cli` | `~/.gemini/skills` **or** `~/.agents/skills` | `.gemini/skills` or `.agents/skills` | yes |
+| `goose_code` | `~/.agents/skills` (`crates/goose/src/sources.rs` @ `GOOSE_COMMIT`) | `.agents/`, `.goose/`, `.claude/` | yes |
+| `opencode` | `~/.config/opencode/skills`, `~/.claude/skills`, `~/.agents/skills` | `.opencode/`, `.claude/`, `.agents/` | yes (logs one dup warning per skill) |
+| `qwen_code` | `$QWEN_HOME/skills` **and** `~/.agents/skills` (`getSkillsBaseDirs` in the bundled `acpAgent` chunk) | `.qwen/skills`, `.agents/skills` | yes via `~/.agents`; **`~/.qwen/skills` is dead** because settings-sync-daemon sets `QWEN_HOME=/home/retro/work/.qwen-state` |
+| `deepseek_harness` | unknown — not checked | | **unverified** |
+
+Takeaway: `~/.agents/skills` is the universal directory; `~/.claude/skills` is
+needed only for Claude Code. The `~/.qwen/skills` link does nothing.
+
+Every harness also injects the skill catalog (name + description) into its own
+system prompt natively — Zed renders `<available_skills>` from
+`system_prompt.hbs:220-247`. So once a skill is on disk the *harness* already
+advertises it; what is missing is Helix-side context on *when* it matters.
+
+### What is broken
+
+1. **The pin is dead config.** `SKILLS_COMMIT` in `sandbox-versions.txt` is
+   read by nothing — `stack build-desktop` passes only `GO_VERSION`
+   (`stack:868-869`), `.drone.yml:1724-1731` passes `CUDA_BASE_IMAGE` and
+   `GO_VERSION`. The Dockerfile `ARG` default is what gets built; the two
+   values match only by hand, in three files. `CLAUDE.md:704` ("a
+   `SKILLS_COMMIT` edit plus `./stack build-ubuntu`") is wrong.
+2. **The `helix` CLI cannot authenticate inside the sandbox.** The sandbox
+   exports `HELIX_API_URL` + `USER_API_TOKEN` (+ `HELIX_PROJECT_ID`,
+   `HELIX_SPEC_TASK_ID`, `HELIX_SESSION_ID`, `HELIX_USER_ID` —
+   `hydra_executor.go:1370-1480`). The CLI reads `HELIX_URL` (default
+   `https://app.helix.ml`) + `HELIX_API_KEY` (`config/cli_config.go`,
+   `client.go:162-176`). Only `helix artifact` has a private fallback
+   (`cli/artifact/cmd.go:279-280`). Verified with the built binary:
+
+   ```
+   $ HELIX_API_URL=http://localhost:8080 USER_API_TOKEN=hl-test helix api /projects/prj_x
+   Error: apiKey is required, find yours in your helix account page and set HELIX_API_KEY and HELIX_URL
+   ```
+
+   The shipped `helix-artifacts` skill's own first step is
+   `helix api "/projects/${HELIX_PROJECT_ID}"` — it fails in the very
+   environment it is installed into. Every other skill would fail the same way.
+3. **`HELIX_ORGANIZATION_ID` is not set for spec-task desktops** — only for
+   Sandboxes-API containers (`sandbox/controller_provision.go:142`). The
+   `helix-artifacts` skill tells the agent to use it.
+4. **Nothing Helix-side mentions skills.** The planning and implementation
+   prompts (`spec_task_prompts.go`, `agent_instruction_service.go`) describe
+   MCP servers, screenshots, web search, startup scripts — not skills. The
+   precedent for why that matters is `BuildAgentToolsSection`
+   (`spec_task_prompts.go:349-352`): tools that are only in the tool list and
+   never in the prompt don't get reached for.
+5. **Naming collision.** Project Settings already has a "Skills" tab
+   (`ProjectSettingsSidebar.tsx:82`) meaning Helix-app API/MCP tools
+   (`TypesAssistantSkills`), unrelated to `SKILL.md` agent skills. Any UI or
+   docs for agent skills must not reuse that label unqualified.
+
+### What already works and should be reused
+
+- desktop-bridge scans skill roots (`desktop/workspace_review.go:504-534`)
+  and the composer offers `$skill` completion on connected sandboxes
+  (`sandboxComposerSuggestions.logic.ts`, `RobustPromptInput.tsx:127`),
+  inserting `$name` as plain text. Once skills are linked, users can already
+  name them in a message.
+- Project-local skills in the task repo (`<repo>/.agents/skills/`) are
+  honoured by every runtime with zero Helix changes, because the Zed fork
+  auto-trusts worktrees.
+
+## Decision (2026-09-07)
+
+Rather than pin-and-bake, tasks now **always get the latest skills**: the image
+bakes a shallow clone as an offline seed, and `helix-workspace-setup.sh`
+refreshes it from `helixml/skills` `main` at every container start, keeping the
+last good checkout when the fetch fails. **All** skills are linked by default
+(`HELIX_SKILLS` narrows the set per container). Shipped with it: the
+`SKILLS_COMMIT` build-arg plumbing, the CLI credential fallback in
+`config.LoadCliConfig`, `HELIX_ORGANIZATION_ID` for spec-task desktops, links
+into `~/.agents/skills` + `~/.claude/skills` only, and a static "## Helix
+skills" section in both task prompts. The `helix-sandbox` skill (phase 2) is
+still to be written in the skills repo.
+
+## 2. Plan (as originally proposed)
+
+Four phases, ordered so each ships alone. Phases 1–3 are one Helix PR each;
+phase 2 also needs a skills-repo PR.
+
+### Phase 1 — make what is installed actually work (plumbing)
+
+1. **Wire `SKILLS_COMMIT` through the build**, mirroring `QWEN_VERSION`:
+   `stack build-desktop` reads it from `sandbox-versions.txt` and passes
+   `--build-arg SKILLS_COMMIT=…`; `.drone.yml` does the same in the
+   helix-ubuntu step. Drop the hard-coded default from both Dockerfiles'
+   `ARG SKILLS_COMMIT` so a build without the arg fails loudly instead of
+   drifting. `sandbox-versions.txt` becomes the single source.
+2. **Fix CLI credentials at the root, not per-command.** `config.LoadCliConfig`
+   resolves `HELIX_URL` → `HELIX_API_URL` and `HELIX_API_KEY` →
+   `USER_API_TOKEN`, in that order. Remove the private fallback in
+   `cli/artifact/cmd.go` (`newClient`) so there is one resolution path. Add a
+   unit test for both env shapes. Do **not** solve this by exporting
+   `HELIX_URL`/`HELIX_API_KEY` from the sandbox: `HELIX_URL` defaulting to
+   `app.helix.ml` is the footgun, and the CLI is what users run outside the
+   sandbox too.
+3. **Export `HELIX_ORGANIZATION_ID`** in `buildEnvVars` for spec-task desktops
+   (the project's org is known at provisioning). Keeps the skill text true.
+4. **Simplify the link targets** in `helix-workspace-setup.sh` to
+   `~/.agents/skills` + `~/.claude/skills`; drop `~/.qwen/skills` and fix the
+   comment to say why (`QWEN_HOME` override). Add `deepseek_harness` to the
+   verification matrix and check its discovery dir before claiming coverage.
+5. **Fix `CLAUDE.md`** (`Agent skills` rows and the "Agent skills" section) to
+   match.
+
+Verification: inner Helix, one spec task per runtime; `helix spectask exec`
+`ls -l ~/.agents/skills`, `helix api /projects/$HELIX_PROJECT_ID`, and
+`helix artifact list` from inside the container.
+
+### Phase 2 — ship the right skills, selected at runtime
+
+**Bake all skills, select at link time.** Copy the whole `skills/` tree to
+`/opt/helix/skills-available/` at build; `helix-workspace-setup.sh` links only
+the names in `HELIX_SKILLS` (runtime env, default set by the image). Cost is a
+few hundred KB; benefit is that operators and dev stacks can enable
+`helix-board`/`helix-spec-tasks` for an org that wants delegating agents, or
+turn a skill off, without a desktop rebuild. `hydra_executor.buildEnvVars`
+forwards a per-deployment `HELIX_SKILLS` if set. Per-project selection is a
+later UI change on top of the same env var — the plumbing is the same.
+
+**Default set:** `helix-artifacts` plus a new **`helix-sandbox`** skill,
+authored in `helixml/skills`, that is the thing an in-sandbox agent most lacks:
+what this environment is. Contents:
+
+- the env vars that exist (`HELIX_API_URL`, `USER_API_TOKEN`,
+  `HELIX_PROJECT_ID`, `HELIX_SPEC_TASK_ID`, `HELIX_SESSION_ID`,
+  `HELIX_ORGANIZATION_ID`, `HELIX_WORKING_BRANCH`, …) and that `helix` is on
+  PATH and already authenticated;
+- the two repos (`/home/retro/work/<repo>` vs `helix-specs`), the task's
+  design-doc dir, attachments path, screenshots dir, `startup.sh`;
+- what the `helix-desktop` and `chrome-devtools` MCP servers are for;
+- how to publish results (`$helix-artifacts`), attach files to the task, and
+  what *not* to do (no `gh`/ssh for pushes — the "How Pushing Works" section
+  exists because agents keep doing this).
+
+This is progressive disclosure for material the prompt currently repeats in
+full on every turn. **Do not** move phase-critical instructions (where to work,
+tasks.md format, push-after-every-task) out of the prompt; skills are
+on-demand and an agent that never opens one must still behave.
+
+Keep the control-plane skills (`helix-cli`, `helix-board`, `helix-spec-tasks`,
+`helix-files`, `helix-agents`, `helix-deploy`, `helix-e2e`) out of the default
+set. Delegation is already covered by the MCP tools in
+`BuildAgentToolsSection`; the CLI equivalents would be a second, unscoped path
+to the same thing.
+
+The skill repo's README `Version note` says the `spectask board|…` commands are
+post-2.12.3; the desktop image builds the CLI from the same commit as the API,
+so in-sandbox they are always current — but a bumped `SKILLS_COMMIT` must be
+checked against `helix <cmd> --help` in the image, per the repo's own rule.
+
+### Phase 3 — tell the agent, briefly
+
+Add `BuildSkillsSection()` next to `BuildAgentToolsSection` and include it in
+both the planning and approval templates. It is short and static, because the
+harness already prints the catalog:
+
+> ## Helix skills
+> This sandbox ships agent skills (`helix-sandbox`, `helix-artifacts`, …).
+> Your harness lists them with their descriptions; open one when a task
+> matches — e.g. read `helix-sandbox` before your first `helix` command, and
+> use `helix-artifacts` whenever the user wants a page, dashboard, report, PDF
+> or image they can open from the project.
+
+Users can also type `$helix-artifacts` in the composer. Add a one-line mention
+to the composer placeholder/tooltip so the existing `$` completion is
+discoverable; do not build a second skills UI, and do not label anything
+"Skills" in Project Settings without qualifying it (see collision above).
+
+### Phase 4 — verify per runtime, then document
+
+Matrix in the inner Helix: for each of `zed_agent`, `claude_code`,
+`codex_cli`, `gemini_cli`, `goose_code`, `opencode`, `qwen_code`,
+`deepseek_harness`:
+
+1. start a spec task; confirm links in `~/.agents/skills`;
+2. ask the agent "use $helix-sandbox to tell me which project you're in" —
+   expect it to read the skill and run `helix api`/`helix artifact list`
+   successfully;
+3. ask for a one-file HTML report via `$helix-artifacts` — expect an artifact
+   row for the project.
+
+Record which harnesses opened the skill unprompted vs only when named; that
+feedback goes back into the skill descriptions (descriptions are the retrieval
+key). Then update `CLAUDE.md` and `docs`.
+
+## 3. Deferred / explicitly not doing
+
+- **Per-project skill selection UI** — after phase 2 proves the env-var
+  plumbing; needs its own label to avoid the existing "Skills" tab.
+- **Serving skills from `helix-specs/.helix/skills/`** as an org-managed
+  channel (link into `~/.agents/skills` at setup). Cheap and attractive, but
+  the task repo's `.agents/skills/` already gives teams a versioned channel
+  today; add the helix-specs one only if a team asks for skills that must not
+  live in the code repo.
+- **Moving the "Visual Testing" / "Web Search" / push-recovery prose out of the
+  prompts** into `helix-sandbox`. Worth measuring after phase 2 — compare turn
+  counts and screenshot usage on the same tasks before cutting prompt text.

--- a/design/2026-09-07-agent-skills-integration.md
+++ b/design/2026-09-07-agent-skills-integration.md
@@ -100,8 +100,16 @@ advertises it; what is missing is Helix-side context on *when* it matters.
 Rather than pin-and-bake, tasks now **always get the latest skills**: the image
 bakes a shallow clone as an offline seed, and `helix-workspace-setup.sh`
 refreshes it from `helixml/skills` `main` at every container start, keeping the
-last good checkout when the fetch fails. **All** skills are linked by default
-(`HELIX_SKILLS` narrows the set per container). Shipped with it: the
+last good checkout when the fetch fails. The default linked set is the
+**task-facing** skills — `helix-cli`, `helix-artifacts`, `helix-spec-tasks`,
+`helix-board`, `helix-files`. `helix-deploy`, `helix-e2e` and `helix-agents`
+stay opt-in (`HELIX_SKILLS=all` or an explicit list): they teach control-plane
+install/upgrade, DB access and org creation, and a task agent holds a
+`USER_API_TOKEN`-authenticated CLI, so handing them out by default would give a
+prompt-injected agent an on-ramp to the Helix running it (review on PR 3190).
+The task-facing skills widen the earlier `helix-artifacts`-only set on
+purpose: delegation and board/task/file operations are what an in-task agent
+legitimately needs, and are project-scoped by the token. Shipped with it: the
 `SKILLS_COMMIT` build-arg plumbing, the CLI credential fallback in
 `config.LoadCliConfig`, `HELIX_ORGANIZATION_ID` for spec-task desktops, links
 into `~/.agents/skills` + `~/.claude/skills` only, and a static "## Helix

--- a/design/2026-09-07-org-agent-sandbox-migration.md
+++ b/design/2026-09-07-org-agent-sandbox-migration.md
@@ -1,0 +1,423 @@
+# Org agents: migrate the PoC desktop runtime onto the spec-task sandbox model
+
+**Date:** 2026-09-07
+**Status:** Proposal — nothing implemented yet
+**Scope:** `api/pkg/org/**`, `api/pkg/server/helix_org*.go`, `api/pkg/external-agent/hydra_executor.go`,
+`api/pkg/sandbox/controller_session.go`, `frontend/src/components/helix-org/**`, `frontend/src/pages/App.tsx`
+
+## Decisions (2026-09-07)
+
+- Default stays **full desktop**. Headless is opt-in per bot (or per org default).
+- `restart-agent` keeps its current semantics (stop, delete session, fresh session).
+- **One PR.** No billing/usage work; no new lifecycle verbs. There are no org-agent
+  users yet, so compatibility means: existing bots keep working unchanged, and at most
+  a restart is needed to pick up a changed sandbox config.
+- The bot UI gets the full spec-task workspace (desktop, chat, diff, files, terminal,
+  reverse-tunnel browser, share links, controls) — everything except task-only panels.
+
+## 1. Why
+
+Org agents (helix-org Bots) run inside a per-bot Helix project's *exploratory session*
+whose container is started by the same `HydraExecutor.StartDesktop` path spec tasks
+use — but with none of the knobs spec tasks have. Every bot gets an uncapped, full
+GNOME `helix-ubuntu` desktop, billed at the standard 12 vCPU desktop rate, that nobody
+can size, make headless, or find in the Sandboxes list. Status is a two-state boolean
+derived from session metadata.
+
+Spec tasks already solved this (`design/2026-08-14-headless-spec-tasks.md`,
+`design/2026-08-10-spec-task-desktop-billing.md`). This doc maps the current bot
+runtime, contrasts it with spec tasks, and proposes converging bots onto the same
+model: the owning entity (the Bot) is the source of truth for sandbox runtime and size
+on every launch path, and the `sandboxes` row is named and linked.
+
+## 2. Current implementation (as of `main` @ 53f68a160)
+
+### 2.1 Entities
+
+| Entity | Table / type | Owns |
+|---|---|---|
+| Bot (graph node) | `org_bots` → `orgchart.Node` (`api/pkg/org/domain/orgchart/node.go:56`) | id, name, content, tools, project allowlist, `PreserveContext`, `AgentID` (link to App), parents via `org_reporting_lines` |
+| Canonical agent | `types.App` (one Assistant) | system prompt, `CodeAgentRuntime`, credential type, provider, model, reasoning effort, MCP servers |
+| Runtime sidecar | `org_bot_runtime_state` KV (`api/pkg/org/infrastructure/runtime/helix/state.go`) | `project_id`, `agent_app_id`, `repo_id`, `session_id`, `hiring_user_id`, `restart_required_container` |
+| Per-bot project | `projects` row named `<Bot> @ <Org>` + one git repo (`project.go:184 Ensure`) | startup script, secrets, `DefaultHelixAppID` = the App |
+| Bot session | `sessions` row, `session_role=exploratory`, `agent_type=zed_external`, `Metadata.OrgWorkerID`, `RuntimeInstructions`, `AutoRestartOnCrash=true` (`helix_org_inproc.go:948`) | chat history, Zed thread, container pointers (`ContainerID`, `DevContainerID`, `SandboxID`, `ExternalAgentStatus`) |
+| Sandbox meter row | `sandboxes` row, session-backed (`SessionID` set, `TimeoutSeconds=-1`), created by `beginSandboxMetering` (`hydra_executor.go:703`) | billing window, quota slot, host/container ids |
+| Activation audit | `org_activations` | trigger kind, started/ended, outcome |
+
+There is **no bot-level sandbox configuration anywhere**. The only runtime axis a bot
+has is the agent harness on its App.
+
+### 2.2 How a bot is woken (event → activation)
+
+```
+Trigger (GitHub/GitLab/Slack/Postmark webhook, cron via streamcron, manual publish)
+  └─ publishing.Publish            append org_events, wakebus.Notify (NATS wake for live UI)
+       └─ dispatch.Route           org_worker_attachments for that source → one Trigger per bot
+            └─ agentdelivery.Queue NATS JetStream stream HELIX_ORG_AGENT_ACTIVATIONS,
+                                   one durable pull consumer per (org, bot), 1 outstanding msg
+                 └─ Spawner        blocks for the whole activation; Ack on success,
+                                   NakWithDelay(1s…30m backoff) on error; InProgress every 10m
+```
+
+Other entry points into the same queue: `DispatchHire` (bot created), `DispatchManual`
+(REST `/activate`, MCP `start_bot`). Processors fan out from `Route` and publish back
+through `Publish`, so chains recurse through the same path.
+
+Key properties: per-bot FIFO, restart-safe (consumers resume on API boot,
+`queue.go:59`), no coalescing (one trigger per activation), global inflight cap of 8
+(`spawner.go:34`), `CancelOutstanding` drains the consumer on stop/restart.
+
+### 2.3 The activation loop (`spawner.go:117`)
+
+1. Acquire global semaphore slot; create/adopt `org_activations` row.
+2. Resolve the hiring user and put their bearer on the context (all Helix resources are
+   owned by the human who hired the bot).
+3. `ensureProject` → `WorkerProject.Ensure`: upsert project + App + repo, sync the
+   project's `CodeAgentExecutionConfig` from the App, sync runtime secrets, attach the
+   helix-org MCP.
+4. `Mirror.Ensure` — transcript mirror subscribes to the session's pubsub topic and
+   republishes settled entries onto `s-transcript-<bot>`.
+5. Build the mandate from the App's assistant system prompt, render `AGENTS.md` /
+   `CLAUDE.md` instructions, `SyncAgentProfile` onto the existing session.
+6. `ensureSession`:
+   - existing session and `!PreserveContext` → `ClearSession` (wipes interactions and
+     the Zed thread; every activation starts on a fresh context window);
+   - `EnsureAndSend`: existing session → `POST /sessions/{id}/messages` (prompt queue;
+     if the desktop is down `autoStartDevContainerForSession` boots it); no session →
+     `checkDesktopQuota` then `StartExternalAgentSession` → `StartDesktop`.
+7. `pollUntilDone`: poll `GetOutput` with backoff until the *new* interaction reaches a
+   terminal state. Bounded only by the 24h runaway guard. Session-level watchdogs own
+   "is it stuck": `auto_wake_stuck_interactions.go`, `AutoRestartOnCrash`, the dead
+   container reconciler, the orphan reaper.
+8. Return → queue Ack/Nak → `org_activations.Complete`.
+
+Between activations the desktop stays up until the global idle checker stops it
+(`HELIX_DESKTOP_IDLE_TIMEOUT`, default 1h, `idle_checker.go:16`), which sets
+`external_agent_status=terminated_idle`. The next trigger cold-starts it again
+(≈3 min for a GNOME desktop).
+
+### 2.4 What the container actually is
+
+`StartExternalAgentSession` (`session_handlers.go:3091`) builds a `DesktopAgent` with
+`OrganizationID`, `SessionID`, `UserID`, `ProjectPath`, repos — and nothing else. In
+`StartDesktop`:
+
+- `resolveSpecTaskLaunchConfig` (`hydra_executor.go:679`) is a no-op because
+  `SpecTaskID == ""` → `DesktopType` stays `""` → `parseContainerType` → `"ubuntu"` →
+  full GNOME + streaming, privileged isolation, display-capable host required.
+- `VCPUs/MemoryMB` are 0 → hydra runs the container **uncapped**;
+  `desktopBillingResources` bills it at the standard preset (12 vCPU / 24 GB) at the
+  *desktop* price (`hydra_executor.go:731`).
+- The `sandboxes` row is named `Session <id>` (`desktopSandboxName`, `:750`), has no
+  bot link, `Runtime=ubuntu-desktop`.
+- The org-worker bootstrap (`applySessionBootstrap`, `:820`) injects
+  `HELIX_WORKER_ID` and writes `AGENTS.md`/`CLAUDE.md` into the workspace.
+
+Resume paths (`autoStartDevContainerForSession`, `resumeSession`, auto-wake cold start,
+container reconciler) rebuild the `DesktopAgent` from session metadata. Since the
+session carries no runtime/size either, every path lands on the same uncapped desktop.
+
+### 2.5 Lifecycle HTTP API today
+
+Mounted under `/api/v1/orgs/{org}/` by `api/pkg/org/interfaces/server/api/api.go:323`.
+`/agents/*` is canonical; `/bots/*` is an alias with the legacy nested detail shape.
+
+| Verb | Handler | What it does |
+|---|---|---|
+| `POST /agents/{id}/chat` | `ensureBotChat` | ensure project + App, return ids (no container) |
+| `POST /agents/{id}/activate` → 202 | `Activations.Activate` | ensure project synchronously, pre-allocate activation row, enqueue `TriggerManual`. Boots the desktop *as a side effect* of the first prompt |
+| `POST /agents/{id}/stop-agent` | `Activations.Stop` | `CancelOutstanding` + `StopExternalAgent` (container down, session kept) |
+| `POST /agents/{id}/restart-agent` | `Activations.Restart` | cancel + stop + delete session row + clear pointer + `Activate` → brand-new session |
+| `GET /agents`, `GET /agents/{id}` | `listBots`/`getBot` | `agent_status ∈ {running, stopped}` from `session.Metadata.ExternalAgentStatus == "running"` (`helix_org.go:179`), one `GetSession` per bot on list |
+| `PATCH /agents/{id}` | `updateBot` | graph fields + App config (harness, credentials, provider, model, reasoning) in one call |
+
+MCP: `start_bot` / `stop_bot` / `restart_bot` call the same `Activations` service.
+
+### 2.6 UI today
+
+- Live surfaces: org chart (`HelixOrgChart.tsx`), chat panel
+  (`components/helix-org/HelixOrgChatPanel.tsx`), agent settings via the generic
+  `App.tsx` (`org_agent` route). `HelixOrgBots.tsx` and `HelixOrgBotDetail.tsx` are
+  orphaned — their routes redirect (`router.tsx:642-661`).
+- Status: green/grey dot, `Running`/`Stopped`, polled through the bots list.
+- Desktop tab: `ExternalAgentDesktopViewer` with `sandboxId={sessionId}` — the session
+  id stands in for a sandbox identity.
+- Runtime form (`BotRuntimeForm.tsx`): harness, credential source, model, reasoning
+  effort. No environment, no size.
+- `AgentRestartRequiredBanner` already exists, driven by `restart_required`
+  (`RestartFingerprint`, `orgchart/restart.go`) and `restart_required_container`.
+
+### 2.7 What spec tasks do instead
+
+| Concern | Spec task | Org bot |
+|---|---|---|
+| Runtime choice | `SpecTask.SandboxRuntime` (`ubuntu-desktop` / `headless-ubuntu`), immutable after launch, project default, browser-stored personal default | none — always desktop |
+| Size | `SpecTask.SandboxResourceOverrides`, preset ladder 1/4/8/12/16 vCPU, live resize, operator default | none — uncapped, billed as 12 vCPU |
+| Source of truth on every launch path | `resolveSpecTaskLaunchConfig` reloads the task on start / resume / fork / reconcile | nothing; whatever `DesktopAgent` defaults give |
+| Sandbox row | named after the task, `SpecTaskID` set, visible in Sandboxes list with a link back | `Session ses_…`, unlinked |
+| Status | `SandboxState` absent/starting/running + `SandboxStatusIndicator` | running/stopped |
+| Idle | `keep_alive` excludes the task from the idle checker | always idle-stopped after 1h |
+| Restart | `restartSessionContainer` keeps the session and threads | deletes the session |
+| Picker UI | `SpecTaskExecutionControls` (Compute + Environment), locked after start | harness only |
+
+## 3. API: how the spec-task surface is shaped, and what the bot surface becomes
+
+### 3.1 Spec-task API surface (for comparison)
+
+Spec tasks spread their runtime control across three layers. Bots already sit on the
+bottom two; only the top layer is missing.
+
+**Task layer** (`/api/v1/spec-tasks/{id}…`, `server.go:1636-1682`)
+
+| Route | Purpose |
+|---|---|
+| `POST /spec-tasks` (`CreateTaskRequest`) | `sandbox_runtime` and `sandbox_resource_overrides` are set **here only**; runtime is immutable afterwards |
+| `GET /spec-tasks/{id}` | returns `sandbox_runtime`, `sandbox_resource_overrides`, `keep_alive`, derived `sandbox_state` (`absent/starting/running`) |
+| `PUT /spec-tasks/{id}` (`SpecTaskUpdateRequest`) | `keep_alive` and other metadata; not runtime/size |
+| `PATCH /spec-tasks/{id}/execution-config` | `code_agent_config` and/or `sandbox_resource_overrides`; resizes a **running** container via `UpdateDesktopResources` and reports `sandbox_resources_applied` |
+| `POST /spec-tasks/{id}/start-planning` | starts the workflow (creates the planning session, boots the container) |
+| `POST /spec-tasks/{id}/stop-agent` | `StopDesktop` on the planning session; session kept |
+| `GET/DELETE /spec-tasks/{id}/zed-instance` | legacy status/shutdown of the Zed instance |
+
+**Session layer** (`/api/v1/sessions/{id}…`, `server.go:1080-1099`) — shared by spec
+tasks, human desktops and bots already:
+`POST /resume` (rebuilds `DesktopAgent` from session metadata), `DELETE
+/stop-external-agent`, `POST /restart-agent` (`restartSessionContainer`: recreate the
+container, keep session + thread), `POST /messages`, `/cancel`, `/clear`,
+`/switch-agent`, `GET /sandbox-state` (thin: `absent|running` from `Session.SandboxID`).
+
+**Sandbox layer** (`/api/v1/organizations/{org}/sandboxes/{id}`, `/billing`) — the
+metering row. Spec-task rows show up here named after the task with `spec_task_id`.
+
+The pattern: **the owning entity holds the config; the executor reloads it from the
+owning entity on every launch; the session and sandbox layers are generic.**
+
+### 3.2 Bot API after this change
+
+Same pattern, same field names, mounted on the existing org-graph router. No new verbs.
+
+| Route | Change |
+|---|---|
+| `PATCH /orgs/{org}/agents/{id}` | accepts `sandbox_runtime` (`""`, `ubuntu-desktop`, `headless-ubuntu`) and `sandbox_resource_overrides` (`{vcpus, memory_mb}`, must be a preset). Validation reuses `ValidSpecTaskSandboxRuntime` / `ValidPreset`, and the same "no display-capable host" check spec-task create uses (`spec_driven_task_handlers.go:188`). Stored on `org_bots`. Applied at the **next container start**; if a container is running, `restart_required` is stamped (both fields join `RestartFingerprint`) |
+| `POST /orgs/{org}/agents` | same two optional fields at create |
+| `GET /orgs/{org}/agents`, `GET …/{id}` | add `sandbox_runtime`, `sandbox_resource_overrides` (effective values, defaults resolved), `sandbox_id`, `sandbox_status` (`pending/running/stopping/stopped/failed` from the `sandboxes` row, `status_message` on failure). `agent_status` stays `running/stopped` so nothing in the UI breaks |
+| `POST …/activate`, `…/stop-agent`, `…/restart-agent`, `…/chat` | **unchanged**. `restart-agent` is the way to apply a changed runtime |
+| MCP `start_bot` / `stop_bot` / `restart_bot` | unchanged; `create_bot` / `set_bot_*` may take the two fields (optional, cheap) |
+| CLI `helix org agents create/update` | `--sandbox-runtime`, `--sandbox-vcpus` |
+
+Mapping onto spec-task verbs:
+
+| Bot | Spec task equivalent | Difference |
+|---|---|---|
+| `PATCH agents/{id}` with runtime | `POST /spec-tasks` only | bots are long-lived, so runtime is **mutable**, applied on restart. Spec tasks lock it because the workspace/branch state is tied to one container |
+| `PATCH agents/{id}` with size | `PATCH /execution-config` | spec tasks resize live; bots apply on restart in this PR. Live resize is a follow-up: call `UpdateDesktopResources` when a container is running, exactly as the execution-config handler does |
+| `activate` | `start-planning` + first message | same: boots the container as a side effect of the first prompt |
+| `stop-agent` | `stop-agent` | identical semantics (`StopDesktop`, session kept) |
+| `restart-agent` | none at task level; `POST /sessions/{id}/restart-agent` at session level | bot restart deletes the session. Kept as-is per decision |
+| `GET agents/{id}.sandbox_status` | `GET spec-tasks/{id}.sandbox_state` | bot uses the `sandboxes` row (5 states); task derives 3 states from session config. Either is fine; the row is already there and cheaper on list |
+
+What is deliberately **not** added: a `/sandbox` sub-resource, `keep_alive`, a
+session-preserving restart, billing endpoints. All three layers remain reachable for a
+bot through the session and sandbox APIs already (`session_id` and `sandbox_id` are
+on the DTO).
+
+### 3.3 Org-level defaults
+
+`worker.sandbox_runtime` and `worker.sandbox_vcpus` in the config registry next to the
+default agent config, resolved in `resolveWorkerAgentConfig` (`helix_org.go:1614`).
+Resolution order: bot → org default → `EffectiveSpecTaskSandboxRuntime` /
+`DefaultSpecTaskSandboxResources` (the same helpers spec tasks use; no second ladder).
+Global default remains `ubuntu-desktop`.
+
+## 4. Implementation (single PR)
+
+### 4.1 Data
+
+- `org_bots`: `sandbox_runtime varchar(64)`, `sandbox_resource_overrides jsonb`
+  (nullable = inherit). `orgchart.Node` gains the two fields; `RestartFingerprint`
+  includes them.
+- `sandboxes.org_bot_id` (indexed), populated by `BeginSession` via a new
+  `BeginSandboxSessionRequest.OrgBotID`. Row name becomes `<Bot name> @ <Org>` in
+  `desktopSandboxName` when `Metadata.OrgWorkerID` is set. One-off backfill in the
+  migration: join `sessions.config->>'org_worker_id'` for existing session-backed rows.
+- `types.SessionMetadata`: `SandboxRuntime`, `SandboxResourceOverrides`. Set only on
+  sessions with `OrgWorkerID`; spec-task sessions leave them empty (the task is
+  authoritative there, same rule as `CodeAgentConfig`).
+- Org config keys `worker.sandbox_runtime`, `worker.sandbox_vcpus`.
+
+### 4.2 Launch path
+
+- Spawner: on every activation, write the bot's effective runtime/size to the session —
+  through `StartSessionParams` for a fresh session and through `SyncAgentProfile` for an
+  existing one (it already updates session-scoped worker state before each turn).
+- Executor: rename `resolveSpecTaskLaunchConfig` → `resolveLaunchConfig`. Branch:
+  `SpecTaskID != ""` → task (unchanged); else `Metadata.OrgWorkerID != ""` → session
+  metadata (`headless-ubuntu` → `DesktopType="headless"`; preset → `VCPUs/MemoryMB`).
+  Every resume path already goes through `StartDesktop`, so
+  `autoStartDevContainerForSession`, `resumeSession`, auto-wake cold start and the
+  reconciler inherit it. This is the invariant from the headless spec-task doc: "the
+  owning entity is the source of truth on every launch path".
+- `EnsureAndSend.checkDesktopQuota` (`sessions.go:79`) must skip when the bot is
+  headless; `beginSandboxMetering` already enforces the headless cap by pricing type.
+- Status: `orgWorkerRuntime.State` reads the bot's `sandboxes` row (`org_bot_id`) for
+  `sandbox_id` / `sandbox_status`; list does one `ListSandboxes` per org instead of a
+  `GetSession` per bot.
+
+### 4.3 UI: the bot gets the spec-task workspace
+
+Goal: a bot session gets every workspace surface a spec task has — desktop stream, chat,
+changes (diff), files, terminal, reverse-tunnel browser, share-preview links, execution
+controls, sandbox status, start/stop/restart — minus the things a bot does not have
+(specs, design-doc review, approval, PR, attachments, clone groups, thread selector).
+
+**Why this is mostly plumbing.** `SpecTaskDetailContent.tsx` is task-bound only at the
+top: it resolves one `activeSessionId` (`:661`) and hands that to every workspace
+panel. Each panel calls session-keyed endpoints and none of the handlers consult the
+spec task:
+
+| Panel | Component | Endpoint family | Task dependency |
+|---|---|---|---|
+| Desktop stream / screenshots / drop-zone | `external-agent/ExternalAgentDesktopViewer.tsx` | `/external-agents/{sessionId}/ws/stream`, `/ws/input`, `/screenshot`, `/upload`; `/sessions/{id}/resume`, `/stop-external-agent`, `/cancel` | none |
+| Chat | `session/AgentChat.tsx` | `/sessions/{id}/interactions`, `/messages`, `/cancel` | `specTaskId`/`projectId` optional |
+| Changes + Files | `tasks/DiffViewer.tsx` → `workspace-inspector/WorkspaceInspector.tsx` | `/external-agents/{sessionId}/workspaces`, `/workspace-review`, `/workspace-files`, `/workspace-file` (`workspace_review_handlers.go`) | none; `baseBranch` is a prop |
+| Terminal drawer | `tasks/SpecTaskTerminalDrawer.tsx` → `session/SessionTerminal.tsx` | WS `/sessions/{id}/terminal`, `/terminal-sessions` (`session_terminal_handlers.go`, hydra exec) | none |
+| Browser (reverse tunnel) | `tasks/SandboxBrowser.tsx` | `/sessions/{id}/preview-tokens` (`session_preview_handlers.go`), `vhost_routes` → RevDial → hydra dev-container proxy | none; needs `DEV_SUBDOMAIN` |
+| Share preview URLs | `tasks/SharePreviewSection.tsx` | same preview-token hooks + rotate/delete | none |
+| Sandbox status dot | `tasks/SandboxStatusIndicator.tsx` | pure prop | none |
+| Execution controls | `agent/CodeAgentExecutionControls.tsx` | pure value/onChange | none; persistence is the caller's |
+| View toolbar | `tasks/SpecTaskViewToolbar.tsx` | pure props: `TaskView` (`chat\|desktop\|browser\|changes\|files\|details`), `hasSession`, `showDesktop`, start/stop/restart, terminal toggle | none |
+
+Session-backed `sandboxes` rows route hydra ops by the **session id**
+(`Sandbox.HydraOpsID()`), so a bot session already drives the whole
+`/external-agents/{sessionId}/*` surface with no spec task involved.
+
+**What to build.** Extend `components/helix-org/OrgAgentSessionWorkspace.tsx` (today:
+chat + desktop split only, used from `pages/Session.tsx:1607` for sessions with
+`org_worker_id`) into the bot equivalent of `SpecTaskDetailContent`:
+
+- `SpecTaskViewToolbar` with the same `TaskView` set. `hasSession` = bot has a
+  `session_id`; `showDesktop` = effective runtime is `ubuntu-desktop`; start / stop /
+  restart wired to `useActivateBot` / `useStopBotAgent` / `useRestartBotAgent`;
+  terminal toggle opens `SpecTaskTerminalDrawer` on the bot session. `showKeepAlive`
+  stays off (deferred).
+- Views: `chat` → `AgentChat` (no task id); `desktop` → `ExternalAgentDesktopViewer`
+  (already there); `browser` → `SandboxBrowser`; `changes` / `files` → `DiffViewer`
+  with `baseBranch` = the bot repo's default branch; `details` → a bot details pane
+  (below).
+- Details pane (replaces the task's Details view): sandbox runtime + preset picker
+  (`CodeAgentExecutionControls` Compute + Environment, never locked, "takes effect on
+  restart"), harness/model (`BotRuntimeForm`), sandbox status / id / host, project and
+  repo links, `SharePreviewSection`, `AgentRestartRequiredBanner`, and the activation
+  history from `org_activations` (the transcript already exists as
+  `s-transcript-<bot>`). Saving the picker calls `PATCH /orgs/{org}/agents/{id}`.
+- Mount points: `pages/Session.tsx` (org chat → bot row → session) keeps using this
+  component; the `helix_org_bot_detail` route mounts the same workspace so the
+  orphaned `HelixOrgBotDetail.tsx` / `HelixOrgBots.tsx` can go. `HelixOrgChatPanel`
+  keeps its bot picker and lifecycle menu but delegates the body to the workspace.
+- `SandboxStatusIndicator` replaces the local green/grey dot on the chart and chat
+  panel; it maps `sandbox_status` → `running/starting/stopped`.
+- Org settings: the two sandbox defaults next to the default agent config.
+- Sandboxes list: link column to the org agent via `org_bot_id`, mirroring the
+  spec-task link.
+
+**Headless bots.** Desktop tab hidden (same `isHeadless` routing as
+`SpecTaskDetailContent.tsx:767`). Files/diff work through the workspace-only desktop
+bridge, the terminal through hydra exec, and the browser preview through the hydra
+dev-container proxy — none need a compositor. Screenshots do not exist.
+
+**One backend nit.** `GET /external-agents/{sessionId}/workspaces` fills
+`ExpectedBranch` only from the spec task (`session_workspace_handlers.go:339`); without
+one the switch-agent safety net reports "can't save changes". For bot sessions resolve
+it from the bot repo's default branch (the session has `OrgWorkerID`), or the
+switch-agent dialog on a bot will always refuse to auto-commit.
+
+### 4.4 Compatibility
+
+Existing bots have NULL config → resolve to org default → global default
+`ubuntu-desktop` + standard preset. Behaviour is identical to today except the
+container is now capped at the preset (12 vCPU / 24 GB) instead of uncapped; that
+matches what it is already billed as. Sessions created before the change carry no
+metadata until their next activation stamps it, and a restart is the only thing needed
+to pick up a changed runtime.
+
+## 5. What must be validated
+
+Live, in the inner Helix at `localhost:8080`, against a connected Zed. Seeded rows do
+not exercise the resume paths. Per `CLAUDE.md`, test the operation *after* each state
+change, not just the state change.
+
+**Launch config on every path**
+1. Create a bot with `headless-ubuntu` / 4 vCPU → first activation: container has
+   `HELIX_HEADLESS=1`, rootless isolation, `sandboxes` row `runtime=headless-ubuntu`,
+   `vcpus=4`, `org_bot_id` set, name `<Bot> @ <Org>`.
+2. Let the idle checker stop it (set `HELIX_DESKTOP_IDLE_TIMEOUT` low) → fire a cron
+   trigger → the auto-start path boots it headless at 4 vCPU again. Repeat for
+   `POST /sessions/{id}/resume`, the auto-wake cold-start retry, and the container
+   reconciler after a `docker kill`.
+3. Same bot, switch to `ubuntu-desktop` / 12 vCPU → `restart_required=true`, running
+   container untouched → `restart-agent` → new container is a desktop at 12 vCPU, and
+   the next trigger produces a reply.
+4. Desktop bot on a host with `RenderNode=SOFTWARE` → PATCH to desktop rejected;
+   headless placement succeeds on that host.
+5. Pre-existing bot with NULL config → activation still boots a desktop; it is now
+   capped at the standard preset; org default set to headless → *new* bots inherit,
+   existing bots do not.
+
+**Wake loop unchanged**
+6. Publish 5 events in a burst → 5 sequential activations, FIFO, one `org_activations`
+   row each; `stop-agent` mid-burst drains the consumer and nothing fires after.
+7. `PreserveContext=false` → each activation clears the thread; `true` → thread persists
+   across an idle stop + wake.
+8. Kill the API mid-activation → consumer resumes on boot and redelivers.
+
+**Status and API**
+9. `sandbox_status` walks `pending → running → stopped` from the chart and chat panel;
+   a failed boot (bad image tag) yields `failed` with the hydra reason in
+   `status_message`; the queue Naks with backoff.
+10. `activate` / `stop-agent` / `restart-agent` behave exactly as before for a bot that
+    never had sandbox config set.
+11. MCP `start_bot` / `stop_bot` / `restart_bot` and the CLI produce the same
+    transitions; `create_bot` with `sandbox_runtime` lands on the row.
+12. Cross-org: bot ids collide across orgs (`b-root`); the Sandboxes list and the bot
+    DTO never leak another org's row.
+
+**Workspace UI (bot session, desktop and headless variants)**
+13. Chat, Changes, Files, Browser and the terminal drawer all work on a running bot
+    session from the org chat and from the bot detail route; Files shows the bot repo,
+    Changes diffs against its default branch after the bot commits something.
+14. Browser: navigate to a port the bot is serving → a `share-<random>` preview token
+    is minted, the iframe loads, the token is listed and revocable under Details.
+15. Headless bot: Desktop tab absent, everything in 13–14 still works; desktop bot:
+    Desktop tab streams.
+16. Toolbar start/stop/restart change `sandbox_status` and the status dot on the chart
+    and chat panel within one poll; the restart-required banner appears after changing
+    the runtime in Details and disappears after restart.
+17. Switch-agent from a bot session with uncommitted changes offers to commit to the
+    bot repo branch rather than refusing (the `ExpectedBranch` fix).
+18. Mobile width: the toolbar folds like the task page and each view is reachable.
+
+**Regression**
+19. A headless bot can still `create_spectask`, `send_spectask_agent_message`, read
+    files via the desktop bridge's workspace-only API, and use `sandbox_ssh_access`;
+    the org chat Desktop tab is hidden for it and present for a desktop bot.
+20. Org delete tears down bot sandboxes and closes their rows. The org-delete sweep
+    (`0087ceaeb`) walks the org's external-agent sessions, which includes bot sessions,
+    but confirm the session-backed `sandboxes` row is closed too, not just the container.
+21. Migration backfill on a Postgres copy with: bots with and without sessions,
+    sessions whose sandbox row is already closed, two orgs sharing a bot id.
+22. Go: `resolveLaunchConfig` table test covering task / org-worker / plain session on
+    each caller; `BeginSession` reuse with `OrgBotID`; status derivation;
+    `go test ./pkg/server/ ./pkg/sandbox/ ./pkg/external-agent/ ./pkg/org/...`.
+    Frontend: `yarn build`. E2E (`run_docker_e2e.sh`) if the executor change touches
+    the WS sync path.
+
+## 6. Deferred (not in this PR)
+
+- Billing block on the bot page, `org_bot_id` in `OrgComputeUsage`, price hints.
+- `keep_alive` on bots (idle-checker exclusion).
+- Session-preserving restart (`restartSessionContainer`) and a `reset` verb.
+- Live resize via `UpdateDesktopResources` on PATCH while running.
+- A `/agents/{id}/sandbox` sub-resource; removing the `/bots/*` alias.
+- Task-only surfaces that have no bot equivalent: specs / design-doc review, approval
+  and PR actions, attachments, clone groups, the Zed thread selector (a bot has one
+  session). Multi-session bots would need the thread selector back.

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -642,36 +642,69 @@ fi
 echo "  Claude: ~/.claude -> $CLAUDE_STATE_DIR (settings written)"
 echo "  Claude: ~/.claude.json -> $CLAUDE_STATE_DIR/.claude.json"
 
-# Helix agent skills: link the image-baked skills (/opt/helix/skills, installed
-# by Dockerfile.ubuntu-helix) into each harness's discovery directory. This has
-# to run after the ~/.claude symlink above, which replaces whatever was there.
-#   ~/.claude/skills  Claude Code, and opencode's Claude-compatible scan
-#   ~/.agents/skills  goose, and opencode's vendor-neutral scan
-#   ~/.qwen/skills    qwen
-# Linked per skill rather than linking the directory, so skills a user or
-# project installs into those directories are left alone. opencode scans both
-# ~/.claude and ~/.agents, so it logs one "duplicate skill name" warning per
-# skill and keeps the first — harmless, and the price of one copy serving
-# every harness.
-if [ -d /opt/helix/skills ]; then
-    for skills_dir in ~/.claude/skills ~/.agents/skills ~/.qwen/skills; do
-        # Report rather than swallow: a root-owned parent (as ~/.qwen was
-        # before the image chowned it) makes this fail, and a silently
-        # unlinked harness looks identical to one that has no skills.
-        if ! mkdir -p "$skills_dir" 2>/dev/null; then
-            echo "  Skills: cannot create $skills_dir (check ownership) — skipped"
+# Helix agent skills (github.com/helixml/skills).
+#
+# The image carries a shallow clone at /opt/helix/skills (pinned by
+# SKILLS_COMMIT at build). Copy it once into persistent workspace storage, then
+# refresh it from upstream on every start so tasks always run with the latest
+# skills; when the fetch fails (air-gapped, proxy, GitHub down) the last good
+# checkout stays in place. The selected skills are linked into:
+#   ~/.agents/skills  zed-agent, codex, gemini, goose, opencode, qwen
+#   ~/.claude/skills  Claude Code (and opencode's Claude-compatible scan)
+# ~/.qwen/skills is not a discovery dir here: settings-sync-daemon sets
+# QWEN_HOME, so qwen reads $QWEN_HOME/skills and ~/.agents/skills instead.
+# This has to run after the ~/.claude symlink above, which replaces whatever
+# was there. Linked per skill rather than linking the directory, so skills a
+# user or project installs into those directories are left alone.
+#
+#   HELIX_SKILLS_REPO  upstream to refresh from (default github.com/helixml/skills)
+#   HELIX_SKILLS_REF   branch/tag/sha to track (default main; empty = never refresh)
+#   HELIX_SKILLS       space-separated skill names to link (default: all)
+SKILLS_SEED=/opt/helix/skills
+SKILLS_DIR="$WORK_DIR/.helix-skills"
+if [ -d "$SKILLS_SEED/skills" ]; then
+    if [ ! -d "$SKILLS_DIR/.git" ]; then
+        rm -rf "$SKILLS_DIR"
+        cp -r "$SKILLS_SEED" "$SKILLS_DIR"
+    fi
+    SKILLS_REPO="${HELIX_SKILLS_REPO:-https://github.com/helixml/skills.git}"
+    SKILLS_REF="${HELIX_SKILLS_REF-main}"
+    if [ -n "$SKILLS_REF" ]; then
+        if GIT_TERMINAL_PROMPT=0 timeout 30 git -C "$SKILLS_DIR" fetch -q --depth 1 "$SKILLS_REPO" "$SKILLS_REF" 2>/tmp/helix-skills-fetch.err \
+            && git -C "$SKILLS_DIR" checkout -q --detach FETCH_HEAD; then
+            echo "  Skills: refreshed from $SKILLS_REPO@$SKILLS_REF ($(git -C "$SKILLS_DIR" rev-parse --short HEAD))"
+        else
+            echo "  Skills: refresh from $SKILLS_REPO@$SKILLS_REF failed ($(tail -n1 /tmp/helix-skills-fetch.err 2>/dev/null)); keeping $(git -C "$SKILLS_DIR" rev-parse --short HEAD)"
+        fi
+    fi
+    SKILLS_SELECTED="${HELIX_SKILLS:-}"
+    if [ -z "$SKILLS_SELECTED" ]; then
+        SKILLS_SELECTED=$(cd "$SKILLS_DIR/skills" && ls -d */ | tr -d / | tr '\n' ' ')
+    fi
+    SKILLS_LINKED=""
+    for skill in $SKILLS_SELECTED; do
+        if [ -f "$SKILLS_DIR/skills/$skill/SKILL.md" ]; then
+            SKILLS_LINKED="$SKILLS_LINKED $skill"
+        else
+            echo "  Skills: $skill not found in $SKILLS_DIR/skills — skipped"
+        fi
+    done
+    for skills_home in ~/.agents/skills ~/.claude/skills; do
+        # Report rather than swallow: a root-owned parent makes this fail, and
+        # a silently unlinked harness looks identical to one with no skills.
+        if ! mkdir -p "$skills_home" 2>/dev/null; then
+            echo "  Skills: cannot create $skills_home (check ownership) — skipped"
             continue
         fi
-        # ~/.claude lives on the persistent workspace mount, so links written by
-        # an older image outlive it. Drop the ones whose target is gone before
-        # relinking, or a skill dropped from HELIX_SKILLS dangles forever.
-        find "$skills_dir" -maxdepth 1 -type l ! -exec test -e {} \; -delete 2>/dev/null || true
-        for skill in /opt/helix/skills/*/; do
-            [ -f "$skill/SKILL.md" ] || continue
-            ln -sfn "${skill%/}" "$skills_dir/$(basename "$skill")"
+        # Drop every link we manage (into the cache, or an older image's
+        # /opt/helix/skills/<name> layout) so deselected or removed skills
+        # don't linger; links a user or project made are left alone.
+        find "$skills_home" -maxdepth 1 -type l \( -lname "$SKILLS_DIR/*" -o -lname "/opt/helix/skills/*" \) -delete 2>/dev/null || true
+        for skill in $SKILLS_LINKED; do
+            ln -sfn "$SKILLS_DIR/skills/$skill" "$skills_home/$skill"
         done
     done
-    echo "  Skills: $(ls /opt/helix/skills | tr '\n' ' ')-> ~/.claude/skills, ~/.agents/skills, ~/.qwen/skills"
+    echo "  Skills:$SKILLS_LINKED -> ~/.agents/skills, ~/.claude/skills"
 fi
 
 # Browser profile (Chrome / Chromium): symlink ~/.config/google-chrome and

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -651,44 +651,60 @@ echo "  Claude: ~/.claude.json -> $CLAUDE_STATE_DIR/.claude.json"
 # checkout stays in place. The selected skills are linked into:
 #   ~/.agents/skills  zed-agent, codex, gemini, goose, opencode, qwen
 #   ~/.claude/skills  Claude Code (and opencode's Claude-compatible scan)
+# (deepseek_harness discovery is unverified — see the 2026-09-07 design doc.)
 # ~/.qwen/skills is not a discovery dir here: settings-sync-daemon sets
 # QWEN_HOME, so qwen reads $QWEN_HOME/skills and ~/.agents/skills instead.
 # This has to run after the ~/.claude symlink above, which replaces whatever
 # was there. Linked per skill rather than linking the directory, so skills a
 # user or project installs into those directories are left alone.
 #
+# The default set is the task-facing skills. helix-deploy, helix-e2e and
+# helix-agents are operator skills (install/upgrade the control plane, DB
+# access, org creation); a task agent gets them only when an operator opts in,
+# so a prompt-injected agent is not handed an on-ramp to the Helix running it.
+#
 #   HELIX_SKILLS_REPO  upstream to refresh from (default github.com/helixml/skills)
 #   HELIX_SKILLS_REF   branch/tag/sha to track (default main; empty = never refresh)
-#   HELIX_SKILLS       space-separated skill names to link (default: all)
+#   HELIX_SKILLS       space-separated skill names to link, or "all"
+#                      (default: helix-cli helix-artifacts helix-spec-tasks helix-board helix-files)
+#
+# Nothing in here may abort workspace setup (the script runs under set -e):
+# a broken or restructured skills checkout must cost the agent its skills, not
+# its desktop. Hence the function + explicit guards.
 SKILLS_SEED=/opt/helix/skills
 SKILLS_DIR="$WORK_DIR/.helix-skills"
-if [ -d "$SKILLS_SEED/skills" ]; then
+SKILLS_DEFAULT="helix-cli helix-artifacts helix-spec-tasks helix-board helix-files"
+setup_helix_skills() {
     if [ ! -d "$SKILLS_DIR/.git" ]; then
         rm -rf "$SKILLS_DIR"
-        cp -r "$SKILLS_SEED" "$SKILLS_DIR"
+        cp -r "$SKILLS_SEED" "$SKILLS_DIR" || { echo "  Skills: cannot copy seed $SKILLS_SEED -> $SKILLS_DIR"; return 1; }
     fi
-    SKILLS_REPO="${HELIX_SKILLS_REPO:-https://github.com/helixml/skills.git}"
-    SKILLS_REF="${HELIX_SKILLS_REF-main}"
-    if [ -n "$SKILLS_REF" ]; then
-        if GIT_TERMINAL_PROMPT=0 timeout 30 git -C "$SKILLS_DIR" fetch -q --depth 1 "$SKILLS_REPO" "$SKILLS_REF" 2>/tmp/helix-skills-fetch.err \
+    local repo="${HELIX_SKILLS_REPO:-https://github.com/helixml/skills.git}"
+    local ref="${HELIX_SKILLS_REF-main}"
+    if [ -n "$ref" ]; then
+        local fetch_err
+        fetch_err=$(mktemp) || fetch_err=/dev/null
+        if GIT_TERMINAL_PROMPT=0 timeout 30 git -C "$SKILLS_DIR" fetch -q --depth 1 "$repo" "$ref" 2>"$fetch_err" \
             && git -C "$SKILLS_DIR" checkout -q --detach FETCH_HEAD; then
-            echo "  Skills: refreshed from $SKILLS_REPO@$SKILLS_REF ($(git -C "$SKILLS_DIR" rev-parse --short HEAD))"
+            echo "  Skills: refreshed from $repo@$ref ($(git -C "$SKILLS_DIR" rev-parse --short HEAD 2>/dev/null))"
         else
-            echo "  Skills: refresh from $SKILLS_REPO@$SKILLS_REF failed ($(tail -n1 /tmp/helix-skills-fetch.err 2>/dev/null)); keeping $(git -C "$SKILLS_DIR" rev-parse --short HEAD)"
+            echo "  Skills: refresh from $repo@$ref failed ($(tail -n1 "$fetch_err" 2>/dev/null)); keeping $(git -C "$SKILLS_DIR" rev-parse --short HEAD 2>/dev/null)"
         fi
+        [ "$fetch_err" != /dev/null ] && rm -f "$fetch_err"
     fi
-    SKILLS_SELECTED="${HELIX_SKILLS:-}"
-    if [ -z "$SKILLS_SELECTED" ]; then
-        SKILLS_SELECTED=$(cd "$SKILLS_DIR/skills" && ls -d */ | tr -d / | tr '\n' ' ')
+    local selected="${HELIX_SKILLS:-$SKILLS_DEFAULT}"
+    if [ "$selected" = "all" ]; then
+        selected=$(cd "$SKILLS_DIR/skills" 2>/dev/null && ls -d */ 2>/dev/null | tr -d / | tr '\n' ' ') || true
     fi
-    SKILLS_LINKED=""
-    for skill in $SKILLS_SELECTED; do
+    local linked="" skill
+    for skill in $selected; do
         if [ -f "$SKILLS_DIR/skills/$skill/SKILL.md" ]; then
-            SKILLS_LINKED="$SKILLS_LINKED $skill"
+            linked="$linked $skill"
         else
             echo "  Skills: $skill not found in $SKILLS_DIR/skills — skipped"
         fi
     done
+    local skills_home
     for skills_home in ~/.agents/skills ~/.claude/skills; do
         # Report rather than swallow: a root-owned parent makes this fail, and
         # a silently unlinked harness looks identical to one with no skills.
@@ -700,11 +716,16 @@ if [ -d "$SKILLS_SEED/skills" ]; then
         # /opt/helix/skills/<name> layout) so deselected or removed skills
         # don't linger; links a user or project made are left alone.
         find "$skills_home" -maxdepth 1 -type l \( -lname "$SKILLS_DIR/*" -o -lname "/opt/helix/skills/*" \) -delete 2>/dev/null || true
-        for skill in $SKILLS_LINKED; do
-            ln -sfn "$SKILLS_DIR/skills/$skill" "$skills_home/$skill"
+        for skill in $linked; do
+            ln -sfn "$SKILLS_DIR/skills/$skill" "$skills_home/$skill" || echo "  Skills: cannot link $skill into $skills_home"
         done
     done
-    echo "  Skills:$SKILLS_LINKED -> ~/.agents/skills, ~/.claude/skills"
+    echo "  Skills:${linked:- (none)} -> ~/.agents/skills, ~/.claude/skills"
+}
+if [ -d "$SKILLS_SEED/skills" ]; then
+    if ! setup_helix_skills; then
+        echo "  Skills: setup failed — continuing without Helix agent skills"
+    fi
 fi
 
 # Browser profile (Chrome / Chromium): symlink ~/.config/google-chrome and

--- a/stack
+++ b/stack
@@ -892,6 +892,15 @@ function build-desktop() {
     exit 1
   fi
 
+  # Pin for github.com/helixml/skills. The Dockerfile has no default, so
+  # sandbox-versions.txt is the only place this value can come from.
+  local SKILLS_COMMIT
+  SKILLS_COMMIT=$(awk -F= '$1 == "SKILLS_COMMIT" { print $2 }' sandbox-versions.txt)
+  if [ -z "$SKILLS_COMMIT" ]; then
+    echo "❌ SKILLS_COMMIT is not set in sandbox-versions.txt"
+    exit 1
+  fi
+
   # --load: with a docker-container buildx driver (any project-local builder
   # left selected in `docker buildx use`) an unqualified build writes only to
   # the build cache. The image hash read back below would then be the previous
@@ -900,6 +909,7 @@ function build-desktop() {
   # the default docker driver.
   docker buildx build --provenance=false --load -f "$DOCKERFILE" \
     --build-arg "GO_VERSION=${GO_VERSION}" \
+    --build-arg "SKILLS_COMMIT=${SKILLS_COMMIT}" \
     -t "${IMAGE_NAME}:latest" \
     .
 


### PR DESCRIPTION
## What

Agents in spec-task sandboxes now always get the **latest** [helixml/skills](https://github.com/helixml/skills), and the `helix` CLI those skills describe actually works inside the sandbox.

- **Runtime refresh.** The desktop images keep a shallow clone of the skills repo as an offline seed (`/opt/helix/skills`). On every container start `helix-workspace-setup.sh` copies it to `~/work/.helix-skills`, fetches `HELIX_SKILLS_REF` (default `main`), keeps the last good checkout if the fetch fails (air-gapped / proxy / GitHub down), and links every skill — or the `HELIX_SKILLS` subset — into `~/.agents/skills` and `~/.claude/skills`. Those two dirs cover zed-agent, Claude Code, Codex, Gemini CLI, goose, opencode and qwen (checked against each harness's source or vendor docs; table in the design doc). The `~/.qwen/skills` link is dropped — qwen reads `$QWEN_HOME/skills` and settings-sync-daemon overrides `QWEN_HOME`, so it never did anything.
- **`SKILLS_COMMIT` is now real.** It was in `sandbox-versions.txt` but read by nothing; the Dockerfile `ARG` default was what shipped. It is now a required build-arg passed by `./stack build-desktop` and `.drone.yml` (both helix-ubuntu builds), same pattern as `GO_VERSION`.
- **CLI credentials.** The sandbox exports `HELIX_API_URL` + `USER_API_TOKEN`; the CLI read `HELIX_URL` + `HELIX_API_KEY`, and `helix api`, `helix org`, `helix sandbox`, `helix spectask …`, `helix project` each resolved env on their own (only `helix artifact` had a fallback). `config.CliURL` / `config.CliAPIKey` is now the single resolution path honouring both conventions. Before this, the shipped `helix-artifacts` skill's own first step (`helix api "/projects/${HELIX_PROJECT_ID}"`) failed in the sandbox with `apiKey is required`.
- `HELIX_ORGANIZATION_ID` exported for spec-task desktops (the skill already documents it).
- Planning + implementation prompts gain a short `## Helix skills` section — same reasoning as `BuildAgentToolsSection`: a capability that's only in a list and never in the task prompt doesn't get reached for.
- `CLAUDE.md` updated; investigation + plan in `design/2026-09-07-agent-skills-integration.md`.

## Testing

- `go test ./pkg/cli/... ./pkg/client/ ./pkg/config/` and the prompt tests in `./pkg/services/` — green. New tests: `cli_config_test.go` (user env, sandbox env, precedence, default), `*_HelixSkills` for both prompts.
- Built the CLI and ran it with sandbox-shaped env (`HELIX_API_URL` + `USER_API_TOKEN`, no `HELIX_URL`/`HELIX_API_KEY`) against the dev stack with a real key: `helix api /projects/<id>` returns the project, `helix artifact list` works; `helix sandbox|spectask|project|org` all reach the API (401 with a fake key, as expected).
- Ran the new setup-script block standalone against a real shallow clone of the skills repo: fresh start links all 8 skills; a failed fetch (bad `HELIX_SKILLS_REPO`) keeps the previous checkout and still links; `HELIX_SKILLS="helix-artifacts helix-cli nonexistent"` links two, reports the missing one, removes previously-managed links and leaves a user-made link alone; `HELIX_SKILLS_REF=` skips the refresh.
- Live sandbox check (rebuilt `helix-ubuntu`, new spec task, `ls ~/.agents/skills` + `helix api` from inside the container): **in progress** — will update this PR.

## Behaviour notes

- Default linked set is the task-facing skills: `helix-cli helix-artifacts helix-spec-tasks helix-board helix-files` (was `helix-artifacts` only). `helix-deploy`, `helix-e2e`, `helix-agents` are opt-in via `HELIX_SKILLS` (explicit list or `all`) — rationale in the design doc.
- A broken or restructured skills checkout can no longer abort workspace setup; it logs and the desktop boots without skills.
- `helix artifact` with no env at all now defaults to `https://app.helix.ml` like every other command (it used to default to `http://localhost:8080`); inside a sandbox `HELIX_API_URL` is always set so nothing changes there.
- `HELIX_SKILLS_REF=` (empty) pins a sandbox to the image seed for deployments that must not fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

