### PR TITLE
feat(org): org agents choose headless/desktop and size, get the spec-task workspace

### DIFF
--- a/api/cmd/hydra/main.go
+++ b/api/cmd/hydra/main.go
@@ -130,6 +130,14 @@ func run(cmd *cobra.Command, args []string) {
 			log.Error().Err(err).Str("upstream", revDialAPIURL).
 				Msg("Sandbox API proxy not started (bad HELIX_API_URL); session API path unavailable")
 		}
+		// The control plane's SSH proxy (asset and sandbox SSH for agents) sits
+		// beside the API; mirror it on the bridge so sandboxed agents can reach
+		// it as helix-api.internal:2224.
+		if sshUpstream, err := hydra.SandboxSSHProxyUpstream(revDialAPIURL); err != nil {
+			log.Error().Err(err).Str("upstream", revDialAPIURL).Msg("Sandbox SSH proxy not started (bad HELIX_API_URL)")
+		} else if err := server.StartSandboxSSHProxyWithRetry(ctx, "", sshUpstream, 2*time.Second); err != nil {
+			log.Error().Err(err).Str("upstream", sshUpstream).Msg("Sandbox SSH proxy not started")
+		}
 	} else {
 		log.Error().Msg("HELIX_API_URL is empty; sandbox API proxy not started, sessions cannot reach the Helix API")
 	}

--- a/api/pkg/config/asset_ssh_proxy_test.go
+++ b/api/pkg/config/asset_ssh_proxy_test.go
@@ -6,19 +6,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInferAssetSSHProxyAddressUsesSandboxAPIHost(t *testing.T) {
-	address, err := inferAssetSSHProxyAddress("http://api:8080", "https://helix.example.com")
+// Agents live on the isolated sandbox bridge, where only helix-api.internal
+// resolves; the control plane's own host would be advertised to a client that
+// can never reach it.
+func TestAssetSSHProxyAddressDefaultsToSandboxBridge(t *testing.T) {
+	t.Setenv("SANDBOX_API_URL", "http://api:8080")
+	t.Setenv("SERVER_URL", "https://helix.example.com")
+	t.Setenv("ASSET_SSH_PROXY_ADDRESS", "")
+	cfg, err := LoadServerConfig()
 	require.NoError(t, err)
-	require.Equal(t, "api:2224", address)
+	require.Equal(t, "helix-api.internal:2224", cfg.WebServer.AssetSSHProxyAddress)
 }
 
-func TestInferAssetSSHProxyAddressFallsBackToServerHost(t *testing.T) {
-	address, err := inferAssetSSHProxyAddress("", "https://helix.example.com:8080")
+func TestAssetSSHProxyAddressHonoursOverride(t *testing.T) {
+	t.Setenv("ASSET_SSH_PROXY_ADDRESS", "ssh.example.com:2224")
+	cfg, err := LoadServerConfig()
 	require.NoError(t, err)
-	require.Equal(t, "helix.example.com:2224", address)
-}
-
-func TestInferAssetSSHProxyAddressRejectsMissingHostname(t *testing.T) {
-	_, err := inferAssetSSHProxyAddress("://bad", "https://helix.example.com")
-	require.ErrorContains(t, err, "parse SANDBOX_API_URL")
+	require.Equal(t, "ssh.example.com:2224", cfg.WebServer.AssetSSHProxyAddress)
 }

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	"net"
-	"net/url"
 	"strings"
 	"time"
 
@@ -463,11 +461,7 @@ func LoadServerConfig() (ServerConfig, error) {
 		cfg.Notifications.AppURL = cfg.WebServer.URL
 	}
 	if cfg.WebServer.AssetSSHProxyAddress == "" {
-		address, err := inferAssetSSHProxyAddress(cfg.WebServer.SandboxAPIURL, cfg.WebServer.URL)
-		if err != nil {
-			return ServerConfig{}, err
-		}
-		cfg.WebServer.AssetSSHProxyAddress = address
+		cfg.WebServer.AssetSSHProxyAddress = defaultAssetSSHProxyAddress
 	}
 	// The spec task sandbox default is read from packages that have no config
 	// handle (desktopBillingResources is a free function; HydraExecutor holds no
@@ -483,25 +477,12 @@ func LoadServerConfig() (ServerConfig, error) {
 	return cfg, nil
 }
 
-func inferAssetSSHProxyAddress(sandboxAPIURL, serverURL string) (string, error) {
-	endpoint := sandboxAPIURL
-	name := "SANDBOX_API_URL"
-	if endpoint == "" {
-		endpoint = serverURL
-		name = "SERVER_URL"
-	}
-	if endpoint == "" {
-		return "", nil
-	}
-	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return "", fmt.Errorf("parse %s for asset SSH proxy: %w", name, err)
-	}
-	if parsed.Hostname() == "" {
-		return "", fmt.Errorf("%s must include a hostname for the asset SSH proxy", name)
-	}
-	return net.JoinHostPort(parsed.Hostname(), "2224"), nil
-}
+// defaultAssetSSHProxyAddress is where an agent reaches the Helix SSH proxy.
+// Agents run inside session containers on the isolated sandbox bridge, where
+// the only routable control-plane name is helix-api.internal (the Hydra
+// gateway). Hydra mirrors the proxy there on :2224 (hydra.SandboxSSHProxyPort);
+// the control plane's own hostname is deliberately unreachable from a sandbox.
+const defaultAssetSSHProxyAddress = "helix-api.internal:2224"
 
 type Inference struct {
 	Provider string `envconfig:"INFERENCE_PROVIDER" default:"helix" description:"One of helix, openai, or togetherai"`
@@ -901,7 +882,7 @@ type WebServer struct {
 	Host                 string `envconfig:"SERVER_HOST" default:"0.0.0.0" description:"The host to bind the api server to."`
 	Port                 int    `envconfig:"SERVER_PORT" default:"80" description:""`
 	AssetSSHProxyListen  string `envconfig:"ASSET_SSH_PROXY_LISTEN" default:":2224" description:"Address for the Helix managed-resource SSH proxy to listen on."`
-	AssetSSHProxyAddress string `envconfig:"ASSET_SSH_PROXY_ADDRESS" description:"Public host:port for agents to reach the Helix asset and sandbox SSH proxy."`
+	AssetSSHProxyAddress string `envconfig:"ASSET_SSH_PROXY_ADDRESS" description:"host:port agents use to reach the Helix asset and sandbox SSH proxy. Defaults to helix-api.internal:2224, the Hydra-mirrored proxy on the sandbox bridge."`
 	// Can either be a URL to frontend (for dev proxy) or a path to static files (for prod)
 	// Default is dev proxy; Dockerfile sets FRONTEND_URL=/www for production
 	FrontendURL string `envconfig:"FRONTEND_URL" default:"http://frontend:8081" description:"URL to proxy to or filesystem path to serve from"`

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -716,6 +716,7 @@ func (h *HydraExecutor) beginSandboxMetering(ctx context.Context, agent *types.D
 		Owner:          agent.UserID,
 		ProjectID:      agent.ProjectID,
 		SpecTaskID:     agent.SpecTaskID,
+		OrgBotID:       agent.OrgWorkerID,
 		Name:           h.desktopSandboxName(ctx, agent),
 		Runtime:        runtime,
 		VCPUs:          vcpus,
@@ -753,6 +754,12 @@ func (h *HydraExecutor) desktopSandboxName(ctx context.Context, agent *types.Des
 			return task.Name
 		}
 		return agent.SpecTaskID
+	}
+	if agent.OrgWorkerID != "" {
+		if agent.OrgWorkerName != "" {
+			return agent.OrgWorkerName
+		}
+		return agent.OrgWorkerID
 	}
 	return fmt.Sprintf("Session %s", strings.TrimPrefix(agent.SessionID, "ses_"))
 }
@@ -814,9 +821,23 @@ func (h *HydraExecutor) attachSessionBootstrap(ctx context.Context, agent *types
 	if err != nil {
 		return fmt.Errorf("load session bootstrap state for %s: %w", agent.SessionID, err)
 	}
-	return applySessionBootstrap(session.Metadata, agent)
+	if err := applySessionBootstrap(session.Metadata, agent); err != nil {
+		return err
+	}
+	if agent.OrgWorkerID != "" {
+		// The org spawner names the session after the Bot; that is the label
+		// the sandbox billing row gets so the Sandboxes list reads as bots.
+		agent.OrgWorkerName = session.Name
+	}
+	return nil
 }
 
+// applySessionBootstrap turns an org worker's session state into launch
+// inputs: identity env + instruction files, and the sandbox runtime/size the
+// Bot was configured with. It is the org-worker counterpart of
+// resolveSpecTaskLaunchConfig — the session is the source of truth on every
+// path that rebuilds a DesktopAgent (resume, auto-start, auto-wake,
+// reconcile), so a headless Bot can never come back as a desktop.
 func applySessionBootstrap(metadata types.SessionMetadata, agent *types.DesktopAgent) error {
 	workerID := metadata.OrgWorkerID
 	instructions := metadata.RuntimeInstructions
@@ -825,6 +846,15 @@ func applySessionBootstrap(metadata types.SessionMetadata, agent *types.DesktopA
 	}
 	if workerID == "" || instructions == "" {
 		return fmt.Errorf("incomplete org-worker bootstrap state for session %s", agent.SessionID)
+	}
+	agent.OrgWorkerID = workerID
+	if types.EffectiveSpecTaskSandboxRuntime(metadata.SandboxRuntime) == types.SandboxRuntimeHeadlessUbuntu {
+		agent.DesktopType = "headless"
+	}
+	if agent.VCPUs <= 0 || agent.MemoryMB <= 0 {
+		resources := types.EffectiveSpecTaskSandboxResources(metadata.SandboxResourceOverrides)
+		agent.VCPUs = resources.VCPUs
+		agent.MemoryMB = resources.MemoryMB
 	}
 	agent.Env = append(agent.Env, "HELIX_WORKER_ID="+workerID)
 	if agent.WorkspaceFiles == nil {

--- a/api/pkg/external-agent/hydra_executor_bootstrap_test.go
+++ b/api/pkg/external-agent/hydra_executor_bootstrap_test.go
@@ -62,3 +62,46 @@ func TestApplySessionBootstrapRejectsPartialState(t *testing.T) {
 		}
 	}
 }
+
+func TestApplySessionBootstrapAppliesOrgWorkerLaunchConfig(t *testing.T) {
+	agent := &types.DesktopAgent{SessionID: "ses_worker"}
+	err := applySessionBootstrap(types.SessionMetadata{
+		OrgWorkerID:              "b-alex",
+		RuntimeInstructions:      "worker instructions",
+		SandboxRuntime:           types.SandboxRuntimeHeadlessUbuntu,
+		SandboxResourceOverrides: &types.SandboxResourceOverrides{VCPUs: 4, MemoryMB: 8192},
+	}, agent)
+	if err != nil {
+		t.Fatalf("applySessionBootstrap: %v", err)
+	}
+	if agent.OrgWorkerID != "b-alex" {
+		t.Fatalf("OrgWorkerID = %q", agent.OrgWorkerID)
+	}
+	if agent.DesktopType != "headless" {
+		t.Fatalf("DesktopType = %q, want headless", agent.DesktopType)
+	}
+	if agent.VCPUs != 4 || agent.MemoryMB != 8192 {
+		t.Fatalf("resources = %d/%d, want 4/8192", agent.VCPUs, agent.MemoryMB)
+	}
+}
+
+func TestApplySessionBootstrapDefaultsLegacyOrgWorkerToDesktopPreset(t *testing.T) {
+	// Sessions created before the launch config existed carry no runtime or
+	// size. They must keep booting as a desktop, now capped at the standard
+	// preset (what they were already billed as) instead of uncapped.
+	agent := &types.DesktopAgent{SessionID: "ses_worker"}
+	err := applySessionBootstrap(types.SessionMetadata{
+		OrgWorkerID:         "b-legacy",
+		RuntimeInstructions: "worker instructions",
+	}, agent)
+	if err != nil {
+		t.Fatalf("applySessionBootstrap: %v", err)
+	}
+	if agent.DesktopType != "" {
+		t.Fatalf("DesktopType = %q, want desktop default", agent.DesktopType)
+	}
+	std := types.EffectiveSpecTaskSandboxResources(nil)
+	if agent.VCPUs != std.VCPUs || agent.MemoryMB != std.MemoryMB {
+		t.Fatalf("resources = %d/%d, want standard preset %d/%d", agent.VCPUs, agent.MemoryMB, std.VCPUs, std.MemoryMB)
+	}
+}

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -45,6 +45,9 @@ type Server struct {
 	apiProxyListener    net.Listener
 	apiProxyRetryCancel context.CancelFunc
 	apiProxyRetryDone   sync.WaitGroup
+	sshProxyListener    net.Listener
+	sshProxyRetryCancel context.CancelFunc
+	sshProxyRetryDone   sync.WaitGroup
 }
 
 // StartSandboxAPIProxy exposes the fixed Helix API upstream on the isolated
@@ -305,6 +308,7 @@ func (s *Server) Stop(ctx context.Context) error {
 	if s.apiProxyListener != nil {
 		s.apiProxyListener.Close()
 	}
+	s.stopSandboxSSHProxy()
 
 	// Stop manager
 	if err := s.manager.Stop(ctx); err != nil {

--- a/api/pkg/hydra/ssh_proxy.go
+++ b/api/pkg/hydra/ssh_proxy.go
@@ -1,0 +1,142 @@
+package hydra
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// SandboxSSHProxyPort is where the Helix asset/sandbox SSH proxy listens on
+	// the control plane, and the port Hydra mirrors it on inside the isolated
+	// session bridge. Agents reach it as helix-api.internal:2224 — the same
+	// hostname they already use for the API — because nothing else on the
+	// bridge (not the control plane's Docker name, not its public host) is
+	// routable from a session container.
+	SandboxSSHProxyPort          = 2224
+	SandboxSSHProxyListenAddress = SandboxNetworkGateway + ":2224"
+	SandboxSSHProxyAddress       = SandboxAPIProxyHostname + ":2224"
+)
+
+// SandboxSSHProxyUpstream derives the control plane's SSH proxy address from
+// the API URL Hydra already dials: same host, fixed port.
+func SandboxSSHProxyUpstream(rawAPIURL string) (string, error) {
+	parsed, err := url.Parse(rawAPIURL)
+	if err != nil {
+		return "", fmt.Errorf("parse API URL %q: %w", rawAPIURL, err)
+	}
+	if parsed.Hostname() == "" {
+		return "", fmt.Errorf("API URL %q has no hostname", rawAPIURL)
+	}
+	return net.JoinHostPort(parsed.Hostname(), fmt.Sprint(SandboxSSHProxyPort)), nil
+}
+
+// StartSandboxSSHProxyWithRetry forwards raw TCP from the session bridge to
+// the control plane's SSH proxy. It is a byte pipe, not an SSH server: the
+// control plane still authenticates every connection with its certificates,
+// so this adds reach, not trust. Listener failures are retried like the API
+// proxy's, for the same dockerd-bridge-not-ready-yet reason.
+func (s *Server) StartSandboxSSHProxyWithRetry(ctx context.Context, listenAddr, upstreamAddr string, retryInterval time.Duration) error {
+	if listenAddr == "" {
+		listenAddr = SandboxSSHProxyListenAddress
+	}
+	if retryInterval <= 0 {
+		retryInterval = 2 * time.Second
+	}
+	if _, _, err := net.SplitHostPort(upstreamAddr); err != nil {
+		return fmt.Errorf("sandbox SSH proxy upstream %q: %w", upstreamAddr, err)
+	}
+	if s.sshProxyListener != nil || s.sshProxyRetryCancel != nil {
+		return errors.New("sandbox SSH proxy already started")
+	}
+	retryCtx, cancel := context.WithCancel(ctx)
+	s.sshProxyRetryCancel = cancel
+	s.sshProxyRetryDone.Add(1)
+	go func() {
+		defer s.sshProxyRetryDone.Done()
+		for {
+			listener, err := net.Listen("tcp", listenAddr)
+			if err == nil {
+				s.sshProxyListener = listener
+				log.Info().Str("listen", listener.Addr().String()).Str("upstream", upstreamAddr).
+					Msg("Sandbox SSH proxy started")
+				s.serveSandboxSSHProxy(retryCtx, listener, upstreamAddr)
+				return
+			}
+			log.Warn().Err(err).Dur("retry_in", retryInterval).Msg("Sandbox SSH proxy listener unavailable")
+			timer := time.NewTimer(retryInterval)
+			select {
+			case <-retryCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+	}()
+	return nil
+}
+
+func (s *Server) serveSandboxSSHProxy(ctx context.Context, listener net.Listener, upstreamAddr string) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			log.Warn().Err(err).Msg("Sandbox SSH proxy accept failed")
+			continue
+		}
+		go forwardTCP(ctx, conn, upstreamAddr)
+	}
+}
+
+func forwardTCP(ctx context.Context, client net.Conn, upstreamAddr string) {
+	defer client.Close()
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	upstream, err := dialer.DialContext(ctx, "tcp", upstreamAddr)
+	if err != nil {
+		log.Warn().Err(err).Str("upstream", upstreamAddr).Str("client", client.RemoteAddr().String()).
+			Msg("Sandbox SSH proxy could not reach the control plane")
+		return
+	}
+	defer upstream.Close()
+	done := make(chan struct{}, 2)
+	pipe := func(dst, src net.Conn) {
+		_, _ = io.Copy(dst, src)
+		if tcp, ok := dst.(*net.TCPConn); ok {
+			_ = tcp.CloseWrite()
+		}
+		done <- struct{}{}
+	}
+	go pipe(upstream, client)
+	go pipe(client, upstream)
+	select {
+	case <-done:
+		// Wait for the other direction to drain, or the context to end.
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+	case <-ctx.Done():
+	}
+}
+
+func (s *Server) stopSandboxSSHProxy() {
+	// The accept loop runs on the retry goroutine, so the listener must close
+	// before waiting for it — cancelling the context alone never unblocks Accept.
+	if s.sshProxyRetryCancel != nil {
+		s.sshProxyRetryCancel()
+	}
+	if s.sshProxyListener != nil {
+		s.sshProxyListener.Close()
+	}
+	if s.sshProxyRetryCancel != nil {
+		s.sshProxyRetryDone.Wait()
+	}
+}

--- a/api/pkg/hydra/ssh_proxy_test.go
+++ b/api/pkg/hydra/ssh_proxy_test.go
@@ -1,0 +1,74 @@
+package hydra
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxSSHProxyUpstream(t *testing.T) {
+	upstream, err := SandboxSSHProxyUpstream("http://api:8080")
+	require.NoError(t, err)
+	require.Equal(t, "api:2224", upstream)
+
+	_, err = SandboxSSHProxyUpstream("://bad")
+	require.Error(t, err)
+}
+
+// The forwarder is a byte pipe to the control plane's SSH proxy: whatever the
+// session container sends must arrive unchanged, and the reply must come back.
+func TestSandboxSSHProxyForwardsBothWays(t *testing.T) {
+	echo, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer echo.Close()
+	go func() {
+		for {
+			conn, err := echo.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				line, err := bufio.NewReader(c).ReadString('\n')
+				if err != nil {
+					return
+				}
+				_, _ = c.Write([]byte("echo:" + line))
+			}(conn)
+		}
+	}()
+
+	server := &Server{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, server.StartSandboxSSHProxyWithRetry(ctx, "127.0.0.1:0", echo.Addr().String(), 10*time.Millisecond))
+	defer server.stopSandboxSSHProxy()
+
+	var addr string
+	require.Eventually(t, func() bool {
+		if server.sshProxyListener == nil {
+			return false
+		}
+		addr = server.sshProxyListener.Addr().String()
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte("SSH-2.0-test\n"))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	reply, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "echo:SSH-2.0-test\n", reply)
+}
+
+func TestSandboxSSHProxyRejectsBadUpstream(t *testing.T) {
+	server := &Server{}
+	require.Error(t, server.StartSandboxSSHProxyWithRetry(context.Background(), "127.0.0.1:0", "not-an-address", time.Millisecond))
+}

--- a/api/pkg/org/application/configregistry/default_sandbox.go
+++ b/api/pkg/org/application/configregistry/default_sandbox.go
@@ -1,0 +1,36 @@
+package configregistry
+
+import (
+	"context"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// Sandbox default keys. A Bot with no sandbox config of its own inherits
+// these; when they are unset too, the global spec-task defaults apply
+// (ubuntu-desktop, standard preset).
+const (
+	DefaultSandboxRuntimeKey = "worker.sandbox_runtime"
+	DefaultSandboxVCPUsKey   = "worker.sandbox_vcpus"
+)
+
+// GetDefaultSandboxConfig returns the org-level default sandbox runtime and
+// size preset for Bots. Empty runtime / nil resources mean "not configured".
+// An unknown vCPU count is ignored rather than propagated: the preset ladder
+// is validated on write, so a stale value here must not break every
+// activation in the org.
+func (r *Registry) GetDefaultSandboxConfig(ctx context.Context, orgID string) (types.SandboxRuntime, *types.SandboxResourceOverrides) {
+	runtime := ""
+	if r.IsConfigured(ctx, orgID, DefaultSandboxRuntimeKey) {
+		runtime, _ = r.GetString(ctx, orgID, DefaultSandboxRuntimeKey)
+	}
+	var resources *types.SandboxResourceOverrides
+	if r.IsConfigured(ctx, orgID, DefaultSandboxVCPUsKey) {
+		if vcpus, err := r.GetInt(ctx, orgID, DefaultSandboxVCPUsKey); err == nil && vcpus > 0 {
+			if preset, ok := types.SpecTaskSandboxPresetForVCPUs(int(vcpus)); ok {
+				resources = preset
+			}
+		}
+	}
+	return types.SandboxRuntime(runtime), resources
+}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -175,6 +175,8 @@ type CreateParams struct {
 	Sources         []eventsource.SourceRef
 	ParentID        orgchart.NodeID
 	PreserveContext bool
+	SandboxRuntime  string
+	SandboxVCPUs    int
 	AgentConfig     AgentConfig
 	// DeferActivation creates the Agent and org topology without starting
 	// its runtime. Settings activation provisions it after the org default
@@ -254,6 +256,8 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		AgentID:         agentAppID,
 		Tools:           p.Tools,
 		PreserveContext: p.PreserveContext,
+		SandboxRuntime:  p.SandboxRuntime,
+		SandboxVCPUs:    p.SandboxVCPUs,
 	})
 	if err != nil {
 		if s.Helix != nil && agentAppID != "" {

--- a/api/pkg/org/application/nodes/nodes.go
+++ b/api/pkg/org/application/nodes/nodes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // ErrReportingCycle is returned by AddParent when the proposed edge
@@ -116,6 +117,10 @@ type CreateParams struct {
 	AgentID         string
 	Tools           []tool.Name
 	PreserveContext bool
+	// SandboxRuntime / SandboxVCPUs are the node's own sandbox config; empty
+	// / 0 inherit the org default. VCPUs must be a spec-task preset rung.
+	SandboxRuntime string
+	SandboxVCPUs   int
 	// Kind, HelixUserID, Identity create a human placeholder when Kind ==
 	// orgchart.NodeKindHuman. A human gets no base tools (it never makes an
 	// MCP request) and is never spawned.
@@ -163,6 +168,13 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 	if p.PreserveContext {
 		node = node.WithPreserveContext(true)
 	}
+	if p.SandboxRuntime != "" || p.SandboxVCPUs != 0 {
+		runtime, vcpus, memoryMB, err := ValidateSandboxConfig(p.SandboxRuntime, p.SandboxVCPUs)
+		if err != nil {
+			return orgchart.Node{}, err
+		}
+		node = node.WithSandboxRuntime(runtime).WithSandboxResources(vcpus, memoryMB)
+	}
 	if p.Kind != "" {
 		node = node.WithKind(p.Kind)
 	}
@@ -188,6 +200,10 @@ type UpdateParams struct {
 	Tools           *[]tool.Name
 	ProjectIDs      *[]string
 	PreserveContext *bool
+	// SandboxRuntime / SandboxVCPUs patch the node's sandbox config. A
+	// non-nil empty runtime or zero vCPUs resets that field to "inherit".
+	SandboxRuntime *string
+	SandboxVCPUs   *int
 	// Identity, when non-nil, replaces the node's per-channel handle map
 	// (human nodes only). nil leaves it unchanged.
 	Identity *map[string]string
@@ -224,6 +240,21 @@ func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p 
 	}
 	if p.PreserveContext != nil {
 		updated = updated.WithPreserveContext(*p.PreserveContext)
+	}
+	if p.SandboxRuntime != nil || p.SandboxVCPUs != nil {
+		runtime := updated.SandboxRuntime
+		if p.SandboxRuntime != nil {
+			runtime = *p.SandboxRuntime
+		}
+		vcpus := updated.SandboxVCPUs
+		if p.SandboxVCPUs != nil {
+			vcpus = *p.SandboxVCPUs
+		}
+		runtime, vcpus, memoryMB, err := ValidateSandboxConfig(runtime, vcpus)
+		if err != nil {
+			return orgchart.Node{}, err
+		}
+		updated = updated.WithSandboxRuntime(runtime).WithSandboxResources(vcpus, memoryMB)
 	}
 	if p.Identity != nil {
 		updated = updated.WithIdentity(*p.Identity)
@@ -567,4 +598,27 @@ func MergeTools(existing, base []tool.Name) []tool.Name {
 		out = append(out, name)
 	}
 	return out
+}
+
+// ValidateSandboxConfig normalises a node's sandbox config against the
+// spec-task vocabulary: runtime must be "", ubuntu-desktop or
+// headless-ubuntu; vcpus must be 0 (inherit) or a preset rung, whose memory
+// is returned so the pair is always a valid preset.
+func ValidateSandboxConfig(runtime string, vcpus int) (string, int, int, error) {
+	runtime = strings.TrimSpace(runtime)
+	if !types.ValidSpecTaskSandboxRuntime(types.SandboxRuntime(runtime)) {
+		return "", 0, 0, fmt.Errorf("sandbox_runtime must be %q or %q (got %q)",
+			types.SandboxRuntimeUbuntuDesktop, types.SandboxRuntimeHeadlessUbuntu, runtime)
+	}
+	if vcpus < 0 {
+		return "", 0, 0, fmt.Errorf("sandbox vcpus must be positive (got %d)", vcpus)
+	}
+	if vcpus == 0 {
+		return runtime, 0, 0, nil
+	}
+	preset, ok := types.SpecTaskSandboxPresetForVCPUs(vcpus)
+	if !ok {
+		return "", 0, 0, fmt.Errorf("sandbox vcpus must be one of %s (got %d)", types.SpecTaskSandboxVCPUList(), vcpus)
+	}
+	return runtime, preset.VCPUs, preset.MemoryMB, nil
 }

--- a/api/pkg/org/application/nodes/restart_required_test.go
+++ b/api/pkg/org/application/nodes/restart_required_test.go
@@ -147,3 +147,42 @@ func TestUpdate_NilHookIsSafe(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func ptrInt(i int) *int { return &i }
+
+// Sandbox runtime/size is baked into the container at create time, so a
+// change must raise the restart banner like a tool or content edit.
+func TestUpdate_FiresRestartRequiredOnSandboxConfigChange(t *testing.T) {
+	st := memory.New()
+	seed(t, st, "b-four", []tool.Name{"chat"})
+	spy := &restartSpy{}
+	svc := restartSvc(st, spy)
+
+	updated, err := svc.Update(context.Background(), org, "b-four", nodes.UpdateParams{
+		SandboxRuntime: ptrStr("headless-ubuntu"),
+		SandboxVCPUs:   ptrInt(4),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "headless-ubuntu", updated.SandboxRuntime)
+	require.Equal(t, 4, updated.SandboxVCPUs)
+	require.Equal(t, 8192, updated.SandboxMemoryMB, "memory follows the preset, never independently")
+	require.Equal(t, []orgchart.NodeID{"b-four"}, spy.calls)
+
+	// Resetting vcpus to 0 means "inherit" and clears memory with it.
+	updated, err = svc.Update(context.Background(), org, "b-four", nodes.UpdateParams{SandboxVCPUs: ptrInt(0)})
+	require.NoError(t, err)
+	require.Equal(t, 0, updated.SandboxVCPUs)
+	require.Equal(t, 0, updated.SandboxMemoryMB)
+}
+
+func TestUpdate_RejectsInvalidSandboxConfig(t *testing.T) {
+	st := memory.New()
+	seed(t, st, "b-five", []tool.Name{"chat"})
+	svc := restartSvc(st, &restartSpy{})
+
+	_, err := svc.Update(context.Background(), org, "b-five", nodes.UpdateParams{SandboxRuntime: ptrStr("windows")})
+	require.ErrorContains(t, err, "sandbox_runtime must be")
+
+	_, err = svc.Update(context.Background(), org, "b-five", nodes.UpdateParams{SandboxVCPUs: ptrInt(3)})
+	require.ErrorContains(t, err, "sandbox vcpus must be one of")
+}

--- a/api/pkg/org/domain/orgchart/node.go
+++ b/api/pkg/org/domain/orgchart/node.go
@@ -77,6 +77,16 @@ type Node struct {
 	// Slack), at the cost of the session growing toward the model's
 	// context limit. See infrastructure/runtime/helix/spawner.go.
 	PreserveContext bool
+	// SandboxRuntime is the container runtime the Node's session is launched
+	// with: "" (inherit the org default, then the global default),
+	// "ubuntu-desktop" or "headless-ubuntu" — the same vocabulary spec tasks
+	// use. SandboxVCPUs/SandboxMemoryMB are the size preset; 0 inherits. The
+	// runtime spawner resolves the effective values on every activation and
+	// stamps them on the session, so a change here takes effect on the next
+	// container start (restart-agent), never on a live container.
+	SandboxRuntime  string
+	SandboxVCPUs    int
+	SandboxMemoryMB int
 	// Kind is "" (agent, the default) or NodeKindHuman. A human Node is
 	// never spawned — the dispatcher delivers to it instead of activating.
 	Kind NodeKind
@@ -163,6 +173,20 @@ func (n Node) WithUpdatedAt(t time.Time) Node {
 // replaced.
 func (n Node) WithPreserveContext(preserve bool) Node {
 	n.PreserveContext = preserve
+	return n
+}
+
+// WithSandboxRuntime returns a copy of the Node with SandboxRuntime replaced.
+func (n Node) WithSandboxRuntime(runtime string) Node {
+	n.SandboxRuntime = runtime
+	return n
+}
+
+// WithSandboxResources returns a copy of the Node with its sandbox size
+// preset replaced. (0, 0) means inherit.
+func (n Node) WithSandboxResources(vcpus, memoryMB int) Node {
+	n.SandboxVCPUs = vcpus
+	n.SandboxMemoryMB = memoryMB
 	return n
 }
 

--- a/api/pkg/org/domain/orgchart/restart.go
+++ b/api/pkg/org/domain/orgchart/restart.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"sort"
+	"strconv"
 )
 
 // RestartFingerprint hashes exactly the Node config a running sandbox
@@ -15,6 +16,9 @@ import (
 //   - Content — materialized into AGENTS.md/CLAUDE.md before the desktop
 //     starts. SyncAgentProfile rewrites them in a live container, but only
 //     during an activation, never on save.
+//   - SandboxRuntime / SandboxVCPUs / SandboxMemoryMB — the container is
+//     created headless-or-desktop at a fixed size; nothing resizes or
+//     re-images a live container, so a change only lands on the next start.
 //
 // Deliberately excluded, because each already reaches a running sandbox
 // without a restart: runtime/model/provider/effort (hot-switched through
@@ -41,5 +45,11 @@ func RestartFingerprint(n Node) string {
 	}
 	h.Write([]byte{0x01})
 	h.Write([]byte(n.Content))
+	h.Write([]byte{0x02})
+	h.Write([]byte(n.SandboxRuntime))
+	h.Write([]byte{0x00})
+	h.Write([]byte(strconv.Itoa(n.SandboxVCPUs)))
+	h.Write([]byte{0x00})
+	h.Write([]byte(strconv.Itoa(n.SandboxMemoryMB)))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/api/pkg/org/domain/orgchart/restart_test.go
+++ b/api/pkg/org/domain/orgchart/restart_test.go
@@ -79,3 +79,10 @@ func TestRestartFingerprint_ToolsCannotRunIntoContent(t *testing.T) {
 
 	require.NotEqual(t, RestartFingerprint(a), RestartFingerprint(b))
 }
+
+func TestRestartFingerprint_ChangesOnSandboxConfig(t *testing.T) {
+	before := fpNode(t, "# bot", []tool.Name{"chat"})
+
+	require.NotEqual(t, RestartFingerprint(before), RestartFingerprint(before.WithSandboxRuntime("headless-ubuntu")))
+	require.NotEqual(t, RestartFingerprint(before), RestartFingerprint(before.WithSandboxResources(4, 8192)))
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/node.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/node.go
@@ -35,6 +35,9 @@ type nodeRow struct {
 	Tools           []string `gorm:"serializer:json"`
 	ProjectIDs      []string `gorm:"serializer:json"`
 	PreserveContext bool     `gorm:"not null;default:false"`
+	SandboxRuntime  string   `gorm:"not null;default:''"`
+	SandboxVCPUs    int      `gorm:"column:sandbox_vcpus;not null;default:0"`
+	SandboxMemoryMB int      `gorm:"column:sandbox_memory_mb;not null;default:0"`
 	// Kind is "" (agent) or "human". HelixUserID / Identity are only
 	// populated for human placeholder rows.
 	Kind        string            `gorm:"not null;default:'';index"`
@@ -70,6 +73,9 @@ func (nodeMapper) ToRow(node orgchart.Node) (nodeRow, error) {
 		Tools:           tools,
 		ProjectIDs:      node.ProjectIDs,
 		PreserveContext: node.PreserveContext,
+		SandboxRuntime:  node.SandboxRuntime,
+		SandboxVCPUs:    node.SandboxVCPUs,
+		SandboxMemoryMB: node.SandboxMemoryMB,
 		Kind:            node.Kind,
 		HelixUserID:     node.HelixUserID,
 		Identity:        node.Identity,
@@ -99,6 +105,9 @@ func (nodeMapper) ToDomain(row nodeRow) (orgchart.Node, error) {
 		Tools:           tools,
 		ProjectIDs:      row.ProjectIDs,
 		PreserveContext: row.PreserveContext,
+		SandboxRuntime:  row.SandboxRuntime,
+		SandboxVCPUs:    row.SandboxVCPUs,
+		SandboxMemoryMB: row.SandboxMemoryMB,
 		Kind:            row.Kind,
 		HelixUserID:     row.HelixUserID,
 		Identity:        row.Identity,
@@ -172,10 +181,16 @@ func (r *nodesRepo) Update(ctx context.Context, node orgchart.Node) error {
 			"tools":            string(toolsJSON),
 			"project_ids":      string(projectIDsJSON),
 			"preserve_context": row.PreserveContext,
-			"kind":             row.Kind,
-			"helix_user_id":    row.HelixUserID,
-			"identity":         string(identityJSON),
-			"updated_at":       row.UpdatedAt,
+			// Sandbox config columns. This map is the complete column list an
+			// Update writes; a field mapped in ToRow but missing here is
+			// silently dropped on every PATCH.
+			"sandbox_runtime":   row.SandboxRuntime,
+			"sandbox_vcpus":     row.SandboxVCPUs,
+			"sandbox_memory_mb": row.SandboxMemoryMB,
+			"kind":              row.Kind,
+			"helix_user_id":     row.HelixUserID,
+			"identity":          string(identityJSON),
+			"updated_at":        row.UpdatedAt,
 		}),
 	)
 }

--- a/api/pkg/org/infrastructure/runtime/helix/launch.go
+++ b/api/pkg/org/infrastructure/runtime/helix/launch.go
@@ -1,0 +1,43 @@
+package helix
+
+import (
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// SessionLaunchConfig is the sandbox runtime and size a bot session's
+// container is launched with. The spawner resolves it from the Bot on every
+// activation and persists it on the session, so every launch path — fresh
+// start, message auto-start, resume, auto-wake cold start, dead-container
+// reconcile — reads the same values. This is the org-bot analogue of the
+// spec task being the source of truth for its own container.
+type SessionLaunchConfig struct {
+	SandboxRuntime   types.SandboxRuntime
+	SandboxResources types.SandboxResourceOverrides
+}
+
+// Headless reports whether the config selects the agent-only runtime.
+func (c SessionLaunchConfig) Headless() bool {
+	return c.SandboxRuntime == types.SandboxRuntimeHeadlessUbuntu
+}
+
+// EffectiveLaunchConfig resolves bot → org default → global default, using
+// the same helpers spec tasks use so there is exactly one preset ladder and
+// one default runtime in the system.
+func EffectiveLaunchConfig(bot orgchart.Node, orgRuntime types.SandboxRuntime, orgResources *types.SandboxResourceOverrides) SessionLaunchConfig {
+	runtime := types.SandboxRuntime(bot.SandboxRuntime)
+	if runtime == "" {
+		runtime = orgRuntime
+	}
+	var resources *types.SandboxResourceOverrides
+	if bot.SandboxVCPUs > 0 && bot.SandboxMemoryMB > 0 {
+		resources = &types.SandboxResourceOverrides{VCPUs: bot.SandboxVCPUs, MemoryMB: bot.SandboxMemoryMB}
+	} else if orgResources != nil {
+		copied := *orgResources
+		resources = &copied
+	}
+	return SessionLaunchConfig{
+		SandboxRuntime:   types.EffectiveSpecTaskSandboxRuntime(runtime),
+		SandboxResources: types.EffectiveSpecTaskSandboxResources(resources),
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/launch_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/launch_test.go
@@ -1,0 +1,136 @@
+package helix
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestEffectiveLaunchConfigResolvesBotThenOrgThenGlobal(t *testing.T) {
+	t.Parallel()
+	base, _ := orgchart.NewNode("w-x", "# Role", nil, time.Now().UTC(), "org-test")
+
+	got := EffectiveLaunchConfig(base, "", nil)
+	if got.SandboxRuntime != types.SandboxRuntimeUbuntuDesktop {
+		t.Fatalf("global default runtime = %q, want ubuntu-desktop", got.SandboxRuntime)
+	}
+	if std := types.EffectiveSpecTaskSandboxResources(nil); got.SandboxResources != std {
+		t.Fatalf("global default resources = %+v, want %+v", got.SandboxResources, std)
+	}
+
+	got = EffectiveLaunchConfig(base, types.SandboxRuntimeHeadlessUbuntu, &types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384})
+	if got.SandboxRuntime != types.SandboxRuntimeHeadlessUbuntu || got.SandboxResources.VCPUs != 8 {
+		t.Fatalf("org default not applied: %+v", got)
+	}
+
+	bot := base.WithSandboxRuntime(string(types.SandboxRuntimeUbuntuDesktop)).WithSandboxResources(4, 8192)
+	got = EffectiveLaunchConfig(bot, types.SandboxRuntimeHeadlessUbuntu, &types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384})
+	if got.SandboxRuntime != types.SandboxRuntimeUbuntuDesktop || got.SandboxResources.VCPUs != 4 || got.SandboxResources.MemoryMB != 8192 {
+		t.Fatalf("bot config must win over org default: %+v", got)
+	}
+}
+
+func TestSpawnerStampsBotLaunchConfigOnFreshSession(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	bot, err := s.Nodes.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("get bot: %v", err)
+	}
+	bot = bot.WithSandboxRuntime(string(types.SandboxRuntimeHeadlessUbuntu)).WithSandboxResources(4, 8192)
+	if err := s.Nodes.Update(context.Background(), bot); err != nil {
+		t.Fatalf("update bot: %v", err)
+	}
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	sp := Spawner(newHelixCfg(t, fc, s))
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	fc.mu.Lock()
+	launch := fc.lastStartParams.Launch
+	fc.mu.Unlock()
+	if launch.SandboxRuntime != types.SandboxRuntimeHeadlessUbuntu {
+		t.Fatalf("fresh session runtime = %q, want headless-ubuntu", launch.SandboxRuntime)
+	}
+	if launch.SandboxResources.VCPUs != 4 || launch.SandboxResources.MemoryMB != 8192 {
+		t.Fatalf("fresh session resources = %+v, want 4/8192", launch.SandboxResources)
+	}
+}
+
+func TestSpawnerSyncsChangedLaunchConfigOntoExistingSession(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	// Org default is headless at 8 cores; the bot has no config of its own.
+	cfg.SandboxRuntime = types.SandboxRuntimeHeadlessUbuntu
+	cfg.SandboxResources = &types.SandboxResourceOverrides{VCPUs: 8, MemoryMB: 16384}
+	sp := Spawner(cfg)
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn 1: %v", err)
+	}
+	fc.mu.Lock()
+	first := fc.lastStartParams.Launch
+	fc.mu.Unlock()
+	if first.SandboxRuntime != types.SandboxRuntimeHeadlessUbuntu || first.SandboxResources.VCPUs != 8 {
+		t.Fatalf("org default not inherited on first start: %+v", first)
+	}
+
+	// Operator switches this bot to a 12-core desktop. The next activation
+	// must push that onto the existing session before anything restarts it.
+	bot, err := s.Nodes.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("get bot: %v", err)
+	}
+	bot = bot.WithSandboxRuntime(string(types.SandboxRuntimeUbuntuDesktop)).WithSandboxResources(12, 24576)
+	if err := s.Nodes.Update(context.Background(), bot); err != nil {
+		t.Fatalf("update bot: %v", err)
+	}
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent, EventID: "e-1"}}); err != nil {
+		t.Fatalf("spawn 2: %v", err)
+	}
+	fc.mu.Lock()
+	synced := fc.lastSyncLaunch
+	fc.mu.Unlock()
+	if synced.SandboxRuntime != types.SandboxRuntimeUbuntuDesktop || synced.SandboxResources.VCPUs != 12 || synced.SandboxResources.MemoryMB != 24576 {
+		t.Fatalf("existing session not synced with new bot config: %+v", synced)
+	}
+}
+
+func TestSpawnerHeadlessBotIgnoresDesktopQuota(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	bot, err := s.Nodes.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("get bot: %v", err)
+	}
+	if err := s.Nodes.Update(context.Background(), bot.WithSandboxRuntime(string(types.SandboxRuntimeHeadlessUbuntu))); err != nil {
+		t.Fatalf("update bot: %v", err)
+	}
+	fc := &quotaFullFakeClient{
+		fakeHelixClient: fakeHelixClient{
+			startSessionID: "ses_headless",
+			outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+		},
+	}
+	cfg := newHelixCfg(t, &fc.fakeHelixClient, s)
+	cfg.Client = fc
+	sp := Spawner(cfg)
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("headless bot must not be gated by the desktop quota: %v", err)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 1 {
+		t.Fatalf("StartSession calls = %d, want 1", got)
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sandboxes.go
@@ -167,7 +167,10 @@ func (s *Sandboxes) OpenTerminal(ctx context.Context, orgID, sandboxID, shell st
 	if err != nil {
 		return nil, fmt.Errorf("connect to sandbox host: %w", err)
 	}
-	terminal, err := client.OpenSandboxTerminal(ctx, value.ID, shell)
+	// Session-backed rows (org bot and spec-task containers) are filed in
+	// hydra under the session id, not the row id; HydraOpsID picks the right
+	// key for both kinds. Using value.ID here 404'd every bot sandbox.
+	terminal, err := client.OpenSandboxTerminal(ctx, value.HydraOpsID(), shell)
 	if err != nil {
 		return nil, fmt.Errorf("open sandbox terminal: %w", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/sessions.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sessions.go
@@ -43,6 +43,9 @@ type StartSessionParams struct {
 	Prompt         string
 	WorkerID       string
 	Instructions   string
+	// Launch is the resolved sandbox runtime + size for the worker's
+	// container, stored on the session so every launch path honours it.
+	Launch SessionLaunchConfig
 }
 
 // SpawnerClient is the chat-session surface the helix Spawner uses
@@ -73,12 +76,17 @@ type SpawnerClient interface {
 	// and its session-scoped worker identity/instructions. When the desktop is
 	// running it also refreshes the runtime-native files before a new ACP thread
 	// is created; a stopped desktop receives them from session state on restart.
-	SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string) error
+	SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string, launch SessionLaunchConfig) error
 }
 
 // checkDesktopQuota pre-flights the desktop quota gate before
-// opening a new session.
-func checkDesktopQuota(ctx context.Context, client SessionClient) error {
+// opening a new session. Headless containers are not desktops — they need
+// no display host and count against the headless cap, which the sandbox
+// meter enforces at StartDesktop — so the gate only applies to desktops.
+func checkDesktopQuota(ctx context.Context, client SessionClient, launch SessionLaunchConfig) error {
+	if launch.Headless() {
+		return nil
+	}
 	status, err := client.ServerStatus(ctx)
 	if err != nil {
 		// Server-status read failed — log via the caller and proceed.
@@ -121,6 +129,7 @@ type SendPromptParams struct {
 	Prompt         string
 	WorkerID       string
 	Instructions   string
+	Launch         SessionLaunchConfig
 	OnSessionID    func(sessionID string)
 }
 
@@ -153,7 +162,7 @@ func EnsureAndSend(ctx context.Context, client SessionClient, params SendPromptP
 		return params.SessionID, false, nil
 	}
 
-	if err := checkDesktopQuota(ctx, client); err != nil {
+	if err := checkDesktopQuota(ctx, client, params.Launch); err != nil {
 		return "", false, err
 	}
 	sid, err := client.StartSession(ctx, StartSessionParams{
@@ -167,6 +176,7 @@ func EnsureAndSend(ctx context.Context, client SessionClient, params SendPromptP
 		Prompt:         params.Prompt,
 		WorkerID:       params.WorkerID,
 		Instructions:   params.Instructions,
+		Launch:         params.Launch,
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("start helix session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -55,6 +55,11 @@ type SpawnerConfig struct {
 	Model    string
 	// Credentials forwards to WorkerProject.Credentials. See there.
 	Credentials string
+	// SandboxRuntime / SandboxResources are the org-level sandbox defaults a
+	// Bot inherits when it sets none of its own. Empty / nil fall through to
+	// the global spec-task defaults (ubuntu-desktop, standard preset).
+	SandboxRuntime   types.SandboxRuntime
+	SandboxResources *types.SandboxResourceOverrides
 	// SpecsMandate is an optional full activation mandate override.
 	// Empty uses the Bot's current Content.
 	SpecsMandate string
@@ -295,12 +300,13 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			sessionName = string(workerID)
 		}
 		instructions := briefing.BuildInstructions(workerID, mandate)
-		if err := cfg.prepareAgentInstructions(startupCtx, orgID, workerID, sessionName, instructions); err != nil {
+		launch := EffectiveLaunchConfig(bot, cfg.SandboxRuntime, cfg.SandboxResources)
+		if err := cfg.prepareAgentInstructions(startupCtx, orgID, workerID, sessionName, instructions, launch); err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
 		}
 		prompt := briefing.BuildPrompt(triggers)
-		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, instructions, prompt, bot.PreserveContext, publish)
+		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, instructions, prompt, bot.PreserveContext, launch, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
@@ -324,14 +330,16 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 // prepareAgentInstructions refreshes an existing session before its old ACP
 // thread is cleared. Fresh sessions receive the same content through
 // StartSessionParams, which stores it on the session for Hydra to materialize
-// before the desktop starts.
-func (c SpawnerConfig) prepareAgentInstructions(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions string) error {
+// before the desktop starts. The launch config rides along so a Bot whose
+// sandbox runtime/size changed since the session was created lands the new
+// values on the session before any path can auto-start its container.
+func (c SpawnerConfig) prepareAgentInstructions(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions string, launch SessionLaunchConfig) error {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return fmt.Errorf("prepare agent instructions: load worker state: %w", err)
 	}
 	if state.SessionID != "" {
-		if err := c.Client.SyncAgentProfile(ctx, state.SessionID, sessionName, string(workerID), instructions); err != nil {
+		if err := c.Client.SyncAgentProfile(ctx, state.SessionID, sessionName, string(workerID), instructions, launch); err != nil {
 			return fmt.Errorf("prepare agent instructions: sync existing session: %w", err)
 		}
 	}
@@ -415,7 +423,7 @@ func sanitizeLogValue(value string) string {
 //     connect; if it does (hadWSError) we immediately re-queue the
 //     same prompt via the durable /messages endpoint so it lands as
 //     soon as the agent dials home.
-func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
+func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions, prompt string, preserveContext bool, launch SessionLaunchConfig, _ func(string)) (string, string, error) {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return "", "", err
@@ -499,6 +507,7 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 		Prompt:         prompt,
 		WorkerID:       string(workerID),
 		Instructions:   instructions,
+		Launch:         launch,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("ensure session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -59,6 +59,10 @@ type fakeHelixClient struct {
 	// the spawner's SessionStartupTimeout actually bounds session
 	// creation. nil means StartSession returns immediately.
 	startBlock <-chan struct{}
+	// lastSyncLaunch records the launch config the spawner synced onto an
+	// existing session, so tests can assert the Bot's sandbox config reaches
+	// the session before the container is (re)started.
+	lastSyncLaunch SessionLaunchConfig
 }
 
 func (f *fakeHelixClient) StartSession(ctx context.Context, params StartSessionParams) (string, error) {
@@ -103,11 +107,12 @@ func (f *fakeHelixClient) ClearSession(_ context.Context, sessionID string) erro
 	return clearErr
 }
 
-func (f *fakeHelixClient) SyncAgentProfile(_ context.Context, sessionID, sessionName, workerID, instructions string) error {
+func (f *fakeHelixClient) SyncAgentProfile(_ context.Context, sessionID, sessionName, workerID, instructions string, launch SessionLaunchConfig) error {
 	atomic.AddInt32(&f.syncCalls, 1)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.lastSyncSID = sessionID
+	f.lastSyncLaunch = launch
 	f.lastSessionName = sessionName
 	f.lastWorkerID = workerID
 	f.lastInstructions = instructions
@@ -860,7 +865,7 @@ func (c *concurrencyClient) ClearSession(ctx context.Context, sessionID string) 
 	return c.inner.ClearSession(ctx, sessionID)
 }
 
-func (c *concurrencyClient) SyncAgentProfile(context.Context, string, string, string, string) error {
+func (c *concurrencyClient) SyncAgentProfile(context.Context, string, string, string, string, SessionLaunchConfig) error {
 	return nil
 }
 

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -262,6 +262,15 @@ type BotRuntimeInfo struct {
 	// instructions, or the agent's model/provider/runtime/effort, all of
 	// which the sandbox bakes in at start.
 	RestartRequired bool
+	// EffectiveSandboxRuntime / EffectiveSandboxResources are the resolved
+	// launch config (bot → org default → global default). SandboxID /
+	// SandboxStatus / SandboxStatusMessage mirror the session-backed
+	// sandboxes row; empty when the bot has never started a container.
+	EffectiveSandboxRuntime   types.SandboxRuntime
+	EffectiveSandboxResources *types.SandboxResourceOverrides
+	SandboxID                 string
+	SandboxStatus             string
+	SandboxStatusMessage      string
 }
 
 // BotRuntime resolves a Bot's runtime-state sidecar. Declared here

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -17,6 +17,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // ---- Nodes ---------------------------------------------------------------
@@ -75,6 +76,7 @@ func (a *apiHandler) listBots(w http.ResponseWriter, r *http.Request) {
 				dto.SessionID = info.SessionID
 				dto.AgentRuntime = info.Runtime
 				dto.AgentModel = info.Model
+				applySandboxInfo(&dto, info)
 			}
 		}
 		out = append(out, dto)
@@ -139,6 +141,8 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		Sources:         toTriggerSources(req.Triggers),
 		ParentID:        orgchart.NodeID(strings.TrimSpace(req.ParentID)),
 		PreserveContext: req.PreserveContext,
+		SandboxRuntime:  string(req.SandboxRuntime),
+		SandboxVCPUs:    sandboxVCPUs(req.SandboxResourceOverrides),
 		DeferActivation: deferActivation,
 		AgentConfig: lifecycle.AgentConfig{
 			CodeAgentRuntime:        req.CodeAgentRuntime,
@@ -216,6 +220,7 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 			detail.Bot.SessionID = info.SessionID
 			detail.Bot.AgentRuntime = info.Runtime
 			detail.Bot.AgentModel = info.Model
+			applySandboxInfo(&detail.Bot, info)
 			if strings.Contains(r.URL.Path, "/agents/") {
 				writeJSON(w, http.StatusOK, AgentDetailDTO{BotDTO: detail.Bot, ProjectID: detail.ProjectID})
 			} else {
@@ -318,12 +323,24 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, errors.New("canonical agent updater is not available"))
 		return
 	}
+	var sandboxRuntimePatch *string
+	if req.SandboxRuntime != nil {
+		runtime := string(*req.SandboxRuntime)
+		sandboxRuntimePatch = &runtime
+	}
+	var sandboxVCPUsPatch *int
+	if req.SandboxResourceOverrides != nil {
+		vcpus := req.SandboxResourceOverrides.VCPUs
+		sandboxVCPUsPatch = &vcpus
+	}
 	updated, err := a.deps.Nodes.Update(ctx, orgID, id, nodes.UpdateParams{
 		Name:            namePatch,
 		Content:         contentPatch,
 		Tools:           toolsPatch,
 		ProjectIDs:      stringSlicePatch(req.ProjectIDs),
 		PreserveContext: req.PreserveContext,
+		SandboxRuntime:  sandboxRuntimePatch,
+		SandboxVCPUs:    sandboxVCPUsPatch,
 		Identity:        identityPatch,
 	})
 	if err != nil {
@@ -339,12 +356,16 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 				identity[key] = value
 			}
 			preserveContext := existing.PreserveContext
+			sandboxRuntime := existing.SandboxRuntime
+			sandboxVCPUs := existing.SandboxVCPUs
 			_, rollbackErr := a.deps.Nodes.Update(ctx, orgID, id, nodes.UpdateParams{
 				Name:            &existing.Name,
 				Content:         &existing.Content,
 				Tools:           &tools,
 				ProjectIDs:      &projectIDs,
 				PreserveContext: &preserveContext,
+				SandboxRuntime:  &sandboxRuntime,
+				SandboxVCPUs:    &sandboxVCPUs,
 				Identity:        &identity,
 			})
 			if rollbackErr != nil {
@@ -729,9 +750,13 @@ func botDTO(b orgchart.Node, parentIDs []string) BotDTO {
 		ParentIDs:       parentIDs,
 		OrganizationID:  b.OrganizationID,
 		PreserveContext: b.PreserveContext,
+		SandboxRuntime:  types.SandboxRuntime(b.SandboxRuntime),
 		Kind:            b.Kind,
 		HelixUserID:     b.HelixUserID,
 		Identity:        b.Identity,
+	}
+	if b.SandboxVCPUs > 0 {
+		dto.SandboxResourceOverrides = &types.SandboxResourceOverrides{VCPUs: b.SandboxVCPUs, MemoryMB: b.SandboxMemoryMB}
 	}
 	if !b.CreatedAt.IsZero() {
 		dto.CreatedAt = b.CreatedAt.Format(time.RFC3339)
@@ -822,4 +847,24 @@ func (a *apiHandler) listTools(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// sandboxVCPUs reads the vCPU count out of an optional resource override;
+// memory is never accepted independently (the preset ladder fixes it).
+func sandboxVCPUs(overrides *types.SandboxResourceOverrides) int {
+	if overrides == nil {
+		return 0
+	}
+	return overrides.VCPUs
+}
+
+// applySandboxInfo copies the runtime sidecar's resolved sandbox view onto
+// the wire DTO. Shared by the list and detail handlers so the two never
+// disagree about which fields carry the effective launch config.
+func applySandboxInfo(dto *BotDTO, info BotRuntimeInfo) {
+	dto.EffectiveSandboxRuntime = info.EffectiveSandboxRuntime
+	dto.EffectiveSandboxResourceOverrides = info.EffectiveSandboxResources
+	dto.SandboxID = info.SandboxID
+	dto.SandboxStatus = info.SandboxStatus
+	dto.SandboxStatusMessage = info.SandboxStatusMessage
 }

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -71,6 +71,19 @@ type BotDTO struct {
 	// the tool list and instructions from before the last save. Drives the
 	// restart banner on the bot page and the org chat panel.
 	RestartRequired bool `json:"restart_required,omitempty"`
+	// SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+	// config in the spec-task vocabulary; empty means "inherit the org
+	// default". The Effective* fields are what the next container start will
+	// actually use once org and global defaults are applied. SandboxID /
+	// SandboxStatus come from the session-backed sandboxes row, when one
+	// exists (pending, running, stopping, stopped, failed).
+	SandboxRuntime                    types.SandboxRuntime            `json:"sandbox_runtime,omitempty"`
+	SandboxResourceOverrides          *types.SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
+	EffectiveSandboxRuntime           types.SandboxRuntime            `json:"effective_sandbox_runtime,omitempty"`
+	EffectiveSandboxResourceOverrides *types.SandboxResourceOverrides `json:"effective_sandbox_resource_overrides,omitempty"`
+	SandboxID                         string                          `json:"sandbox_id,omitempty"`
+	SandboxStatus                     string                          `json:"sandbox_status,omitempty"`
+	SandboxStatusMessage              string                          `json:"sandbox_status_message,omitempty"`
 	// ProjectID is the bot's own Helix project — the one whose exploratory
 	// session is the bot's chat. SessionID is that session, when the bot
 	// has been activated. Both come from runtime state and let the chat
@@ -191,17 +204,21 @@ type CreateBotRequest struct {
 	ID string `json:"id,omitempty"`
 	// Name is the human-readable display label (e.g. "Chief of Staff").
 	// Optional; the ID stays the immutable handle.
-	Name                    string                        `json:"name,omitempty"`
-	Content                 string                        `json:"content"`
-	Tools                   []string                      `json:"tools,omitempty"`
-	Triggers                []string                      `json:"triggers,omitempty"`
-	ParentID                string                        `json:"parent_id,omitempty"`
-	PreserveContext         bool                          `json:"preserve_context,omitempty"`
-	CodeAgentRuntime        types.CodeAgentRuntime        `json:"code_agent_runtime,omitempty"`
-	CodeAgentCredentialType types.CodeAgentCredentialType `json:"code_agent_credential_type,omitempty"`
-	Provider                string                        `json:"provider,omitempty"`
-	Model                   string                        `json:"model,omitempty"`
-	ReasoningEffort         string                        `json:"reasoning_effort,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Content         string   `json:"content"`
+	Tools           []string `json:"tools,omitempty"`
+	Triggers        []string `json:"triggers,omitempty"`
+	ParentID        string   `json:"parent_id,omitempty"`
+	PreserveContext bool     `json:"preserve_context,omitempty"`
+	// SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.
+	// Only vcpus is read from the overrides — memory follows the preset.
+	SandboxRuntime           types.SandboxRuntime            `json:"sandbox_runtime,omitempty"`
+	SandboxResourceOverrides *types.SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
+	CodeAgentRuntime         types.CodeAgentRuntime          `json:"code_agent_runtime,omitempty"`
+	CodeAgentCredentialType  types.CodeAgentCredentialType   `json:"code_agent_credential_type,omitempty"`
+	Provider                 string                          `json:"provider,omitempty"`
+	Model                    string                          `json:"model,omitempty"`
+	ReasoningEffort          string                          `json:"reasoning_effort,omitempty"`
 	// Owner makes this a manager Bot: it receives the canonical owner
 	// tool set (every org-graph mutation - create_bot, delete_bot,
 	// set_bot_content, subscribe, ... - plus the read baseline) so it can
@@ -227,6 +244,12 @@ type UpdateBotRequest struct {
 	Tools           []string `json:"tools,omitempty"`
 	ProjectIDs      []string `json:"project_ids,omitempty"`
 	PreserveContext *bool    `json:"preserve_context,omitempty"`
+	// SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox
+	// config. A present-but-empty runtime, or vcpus=0, resets that field to
+	// inherit. Takes effect on the next container start; a running sandbox
+	// gets restart_required.
+	SandboxRuntime           *types.SandboxRuntime           `json:"sandbox_runtime,omitempty"`
+	SandboxResourceOverrides *types.SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
 	// Identity is the per-channel handle map for a human node (slack/github/
 	// email/…). When present it replaces the stored map; absent leaves it
 	// unchanged. Only meaningful for kind=human bots.

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -13,11 +13,13 @@ import (
 )
 
 var agentProvisioningKeys = map[string]bool{
-	configregistry.DefaultAgentConfigKey: true,
-	"worker.runtime":                     true,
-	"worker.credentials":                 true,
-	"worker.provider":                    true,
-	"worker.model":                       true,
+	configregistry.DefaultAgentConfigKey:    true,
+	"worker.runtime":                        true,
+	"worker.credentials":                    true,
+	"worker.provider":                       true,
+	"worker.model":                          true,
+	configregistry.DefaultSandboxRuntimeKey: true,
+	configregistry.DefaultSandboxVCPUsKey:   true,
 }
 
 // ---- Settings -----------------------------------------------------------

--- a/api/pkg/sandbox/controller_session.go
+++ b/api/pkg/sandbox/controller_session.go
@@ -93,7 +93,15 @@ func (c *Controller) BeginSession(ctx context.Context, req *types.BeginSandboxSe
 		existing.VCPUs = vcpus
 		existing.MemoryMB = memoryMB
 		existing.SpecTaskID = req.SpecTaskID
+		existing.OrgBotID = req.OrgBotID
 		existing.ProjectID = req.ProjectID
+		// A restarted Bot may have changed runtime (desktop ↔ headless) since
+		// the row was opened; the row must follow so pricing type and the
+		// Sandboxes list describe the container that is actually running.
+		existing.Runtime = runtime
+		if req.Name != "" {
+			existing.Name = req.Name
+		}
 		existing.Status = types.SandboxStatusPending
 		existing.StatusMessage = ""
 		// Reopen the billing window at the restart: the gap while the desktop
@@ -115,6 +123,7 @@ func (c *Controller) BeginSession(ctx context.Context, req *types.BeginSandboxSe
 		Owner:          req.Owner,
 		SessionID:      req.SessionID,
 		SpecTaskID:     req.SpecTaskID,
+		OrgBotID:       req.OrgBotID,
 		Runtime:        runtime,
 		Status:         types.SandboxStatusPending,
 		VCPUs:          vcpus,

--- a/api/pkg/sandbox/controller_session_test.go
+++ b/api/pkg/sandbox/controller_session_test.go
@@ -320,3 +320,42 @@ func (s *ControllerSessionSuite) TestHydraOpsIDPrefersSessionForSessionBackedRow
 	s.Require().Equal("ses_1", sessionBacked.HydraOpsID())
 	s.Require().Equal("sbx_2", controllerManaged.HydraOpsID())
 }
+
+func (s *ControllerSessionSuite) TestBeginSessionReopenFollowsBotRuntimeChange() {
+	// An org bot switched from desktop to headless between runs. The reused
+	// row must describe the container that is about to start — runtime for
+	// pricing type, org_bot_id for the Sandboxes list link — not the old one.
+	stoppedAt := time.Now().Add(-time.Hour)
+	existing := &types.Sandbox{
+		ID:             "sbx_bot",
+		OrganizationID: "org_1",
+		SessionID:      "ses_1",
+		Name:           "Session 1",
+		Runtime:        types.SandboxRuntimeUbuntuDesktop,
+		Status:         types.SandboxStatusStopped,
+		VCPUs:          12,
+		MemoryMB:       24576,
+		StoppedAt:      &stoppedAt,
+	}
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{}, nil)
+	s.store.EXPECT().GetSandboxBySession(gomock.Any(), "ses_1").Return(existing, nil)
+	s.store.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.store.EXPECT().UpdateSandbox(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, sb *types.Sandbox) (*types.Sandbox, error) {
+			s.Require().Equal("b-eng", sb.OrgBotID)
+			s.Require().Equal(types.SandboxRuntimeHeadlessUbuntu, sb.Runtime)
+			s.Require().Equal("Engineer @ Acme", sb.Name)
+			s.Require().Equal(4, sb.VCPUs)
+			return sb, nil
+		},
+	)
+
+	req := s.beginRequest()
+	req.SpecTaskID = ""
+	req.OrgBotID = "b-eng"
+	req.Name = "Engineer @ Acme"
+	req.Runtime = types.SandboxRuntimeHeadlessUbuntu
+	sb, err := s.controller.BeginSession(s.ctx, req)
+	s.Require().NoError(err)
+	s.Require().Equal("sbx_bot", sb.ID)
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -23585,6 +23585,12 @@ const docTemplate = `{
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23639,6 +23645,26 @@ const docTemplate = `{
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -23858,6 +23884,12 @@ const docTemplate = `{
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23913,6 +23945,26 @@ const docTemplate = `{
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -24032,6 +24084,17 @@ const docTemplate = `{
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.\nOnly vcpus is read from the overrides — memory follows the preset.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -24624,6 +24687,17 @@ const docTemplate = `{
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox\nconfig. A present-but-empty runtime, or vcpus=0, resets that field to\ninherit. Takes effect on the next container start; a running sandbox\ngets restart_required.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -28546,24 +28620,24 @@ const docTemplate = `{
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "email",
-                "local",
-                "cron",
                 "webhook",
-                "github",
-                "gitlab",
                 "helix_events",
-                "slack"
+                "local",
+                "github",
+                "slack",
+                "gitlab",
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindEmail",
-                "KindLocal",
-                "KindCron",
                 "KindWebhook",
-                "KindGitHub",
-                "KindGitLab",
                 "KindHelixEvents",
-                "KindSlack"
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
+                "KindGitLab",
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {
@@ -36924,6 +36998,10 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "org_bot_id": {
+                    "description": "OrgBotID is the helix-org bot whose session owns this container, when\nthere is one. Denormalised from the session (org_worker_id) so the bot\ndetail and the Sandboxes list can link both ways without joining sessions.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -38201,6 +38279,17 @@ const docTemplate = `{
                 },
                 "runtime_instructions": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the container runtime and\nsize for an org-worker session. The org spawner writes them from the Bot\non every activation and StartDesktop reads them on every launch path\n(fresh start, message auto-start, resume, auto-wake, reconciler), so a\nheadless bot never comes back as a desktop. SpecTask sessions leave both\nempty — the task is authoritative there, as with CodeAgentConfig.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "session_rag_results": {
                     "type": "array",

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -173,7 +173,11 @@ type orgWorkerRuntime struct {
 	sessions interface {
 		GetSession(ctx context.Context, id string) (*types.Session, error)
 		GetApp(ctx context.Context, id string) (*types.App, error)
+		GetSandboxBySession(ctx context.Context, sessionID string) (*types.Sandbox, error)
 	}
+	// configs resolves the org's default sandbox config so the DTO can show
+	// what a Bot with no config of its own will actually launch with.
+	configs *configregistry.Registry
 }
 
 func (o orgWorkerRuntime) State(ctx context.Context, orgID string, workerID orgchart.NodeID) (helixorgapi.BotRuntimeInfo, error) {
@@ -192,6 +196,28 @@ func (o orgWorkerRuntime) State(ctx context.Context, orgID string, workerID orgc
 			assistant := app.Config.Helix.Assistants[0]
 			info.Runtime = string(assistant.CodeAgentRuntime)
 			info.Model = assistant.Model
+		}
+	}
+	if bot, err := o.st.Nodes.Get(ctx, orgID, workerID); err == nil {
+		var orgRuntime types.SandboxRuntime
+		var orgResources *types.SandboxResourceOverrides
+		if o.configs != nil {
+			orgRuntime, orgResources = o.configs.GetDefaultSandboxConfig(ctx, orgID)
+		}
+		launch := runtimehelix.EffectiveLaunchConfig(bot, orgRuntime, orgResources)
+		info.EffectiveSandboxRuntime = launch.SandboxRuntime
+		resources := launch.SandboxResources
+		info.EffectiveSandboxResources = &resources
+	}
+	// The session-backed sandboxes row is the container's lifecycle record
+	// (pending/running/stopping/stopped/failed + hydra's failure reason). A
+	// bot that never started has no row; a lookup failure leaves the fields
+	// empty rather than failing the whole read.
+	if s.SessionID != "" && o.sessions != nil {
+		if sb, err := o.sessions.GetSandboxBySession(ctx, s.SessionID); err == nil && sb != nil {
+			info.SandboxID = sb.ID
+			info.SandboxStatus = string(sb.Status)
+			info.SandboxStatusMessage = sb.StatusMessage
 		}
 	}
 	// Resolve sandbox online-ness from the session metadata the desktop
@@ -1147,7 +1173,7 @@ func initHelixOrgHandler(ctx context.Context, cfg helixOrgConfig, helixStore hel
 	// RegisterBuiltins so start_bot / stop_bot / restart_bot share the same
 	// service instance as POST /bots/{id}/activate|stop-agent|restart-agent.
 	sessionResetter := botSessionResetter{client: inProcClient, st: st}
-	workerRuntime := orgWorkerRuntime{st: st, sessions: helixStore}
+	workerRuntime := orgWorkerRuntime{st: st, sessions: helixStore, configs: configReg}
 	svc.Activations = activations.New(activations.Deps{
 		Repo:       st.Activations,
 		Now:        deps.Now,
@@ -1711,23 +1737,26 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 	}
 	runtime, credentials, provider, model := resolveWorkerAgentConfig(ctx, orgID, d.Cfg)
 	specsMandate, _ := d.Cfg.GetString(ctx, orgID, "worker.specs_mandate")
+	sandboxRuntime, sandboxResources := d.Cfg.GetDefaultSandboxConfig(ctx, orgID)
 	return runtimehelix.SpawnerConfig{
-		Client:         d.SpawnerClient,
-		ProjectService: d.ProjectSvc,
-		OrgID:          orgID,
-		OrgDisplayName: orgDisplayName(ctx, d.HelixStore, orgID),
-		Runtime:        runtime,
-		Credentials:    credentials,
-		Provider:       provider,
-		Model:          model,
-		SpecsMandate:   specsMandate,
-		Store:          d.OrgStore,
-		Hub:            d.Hub,
-		PubSub:         d.PubSub,
-		Snapshotter:    runtimehelix.NoopSessionPreamble{},
-		Logger:         d.Logger,
-		NewID:          d.NewID,
-		Now:            d.Now,
+		Client:           d.SpawnerClient,
+		ProjectService:   d.ProjectSvc,
+		OrgID:            orgID,
+		OrgDisplayName:   orgDisplayName(ctx, d.HelixStore, orgID),
+		Runtime:          runtime,
+		Credentials:      credentials,
+		Provider:         provider,
+		Model:            model,
+		SandboxRuntime:   sandboxRuntime,
+		SandboxResources: sandboxResources,
+		SpecsMandate:     specsMandate,
+		Store:            d.OrgStore,
+		Hub:              d.Hub,
+		PubSub:           d.PubSub,
+		Snapshotter:      runtimehelix.NoopSessionPreamble{},
+		Logger:           d.Logger,
+		NewID:            d.NewID,
+		Now:              d.Now,
 		BearerForUser: func(ctx context.Context, userID string) (string, error) {
 			return helixorg.NewHelixAPIKeys(d.HelixStore, d.Cfg).User(ctx, userID)
 		},

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -966,6 +966,12 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 		AutoRestartOnCrash:  true,
 		OrgWorkerID:         params.WorkerID,
 		RuntimeInstructions: params.Instructions,
+		SessionName:         params.Name,
+		SandboxRuntime:      params.Launch.SandboxRuntime,
+		SandboxResourceOverrides: &types.SandboxResourceOverrides{
+			VCPUs:    params.Launch.SandboxResources.VCPUs,
+			MemoryMB: params.Launch.SandboxResources.MemoryMB,
+		},
 		Messages: []*types.Message{{
 			Role:    "user",
 			Content: types.MessageContent{Parts: []any{params.Prompt}},
@@ -974,12 +980,6 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 	session, err := c.server.StartExternalAgentSession(ctx, req, user.ID)
 	if err != nil {
 		return "", fmt.Errorf("start external agent session: %w", err)
-	}
-	if params.Name != "" && session.Name != params.Name {
-		session.Name = params.Name
-		if _, err := c.server.Store.UpdateSession(ctx, *session); err != nil {
-			return "", fmt.Errorf("name external agent session: %w", err)
-		}
 	}
 	return session.ID, nil
 }
@@ -1027,7 +1027,7 @@ func (c *inProcHelixClient) ClearSession(ctx context.Context, sessionID string) 
 // SyncAgentProfile refreshes the display name on every existing session and
 // the instruction files read natively by Codex and Claude on running desktops.
 // The spawner calls this before clearing the existing ACP thread.
-func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string) error {
+func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, sessionName, workerID, instructions string, launch runtimehelix.SessionLaunchConfig) error {
 	if sessionID == "" {
 		return errors.New("SyncAgentProfile: sessionID is required")
 	}
@@ -1043,6 +1043,22 @@ func (c *inProcHelixClient) SyncAgentProfile(ctx context.Context, sessionID, ses
 	if session.Metadata.OrgWorkerID != workerID || session.Metadata.RuntimeInstructions != instructions {
 		session.Metadata.OrgWorkerID = workerID
 		session.Metadata.RuntimeInstructions = instructions
+		changed = true
+	}
+	// The Bot's sandbox runtime/size is session state for the same reason the
+	// instructions are: every container start path rebuilds the DesktopAgent
+	// from the session, so a changed Bot config must land here before the
+	// next start — including the auto-start a queued message triggers.
+	resources := session.Metadata.SandboxResourceOverrides
+	if session.Metadata.SandboxRuntime != launch.SandboxRuntime ||
+		resources == nil ||
+		resources.VCPUs != launch.SandboxResources.VCPUs ||
+		resources.MemoryMB != launch.SandboxResources.MemoryMB {
+		session.Metadata.SandboxRuntime = launch.SandboxRuntime
+		session.Metadata.SandboxResourceOverrides = &types.SandboxResourceOverrides{
+			VCPUs:    launch.SandboxResources.VCPUs,
+			MemoryMB: launch.SandboxResources.MemoryMB,
+		}
 		changed = true
 	}
 	if session.ParentApp != "" {

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -596,13 +596,23 @@ func TestInProcSpawnerClient_SyncAgentProfileRenamesStoppedSession(t *testing.T)
 	_, err := store.CreateSession(ctx, types.Session{ID: "ses_profile", Name: "You are Bot old"})
 	require.NoError(t, err)
 
-	err = client.SyncAgentProfile(ctx, "ses_profile", "Build Engineer", "w-build", "instructions")
+	launch := runtimehelix.SessionLaunchConfig{
+		SandboxRuntime:   types.SandboxRuntimeHeadlessUbuntu,
+		SandboxResources: types.SandboxResourceOverrides{VCPUs: 4, MemoryMB: 8192},
+	}
+	err = client.SyncAgentProfile(ctx, "ses_profile", "Build Engineer", "w-build", "instructions", launch)
 	require.ErrorContains(t, err, "external agent executor is not configured")
 
 	got, err := store.GetSession(ctx, "ses_profile")
 	require.NoError(t, err)
 	require.Equal(t, "Build Engineer", got.Name)
 	require.Equal(t, "w-build", got.Metadata.OrgWorkerID)
+	// The Bot's sandbox config must land on the session so the next
+	// container start (any path) launches headless at the chosen preset.
+	require.Equal(t, types.SandboxRuntimeHeadlessUbuntu, got.Metadata.SandboxRuntime)
+	require.NotNil(t, got.Metadata.SandboxResourceOverrides)
+	require.Equal(t, 4, got.Metadata.SandboxResourceOverrides.VCPUs)
+	require.Equal(t, 8192, got.Metadata.SandboxResourceOverrides.MemoryMB)
 	require.Equal(t, "instructions", got.Metadata.RuntimeInstructions)
 }
 

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -37,6 +37,16 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 		Description: "Model ID for the chosen provider or Codex subscription (e.g. `claude-sonnet-4-5`, `gpt-5.6-sol`). Required alongside `worker.provider` whenever inference routes through Helix. For subscription-backed `codex_cli`, selects the Codex default model; ignored for subscription-backed `claude_code`.",
 	})
 	r.Register(configregistry.Spec{
+		Key:         configregistry.DefaultSandboxRuntimeKey,
+		Type:        configregistry.TypeString,
+		Description: "Default sandbox environment for Bots that do not set their own: `ubuntu-desktop` (full streamed desktop) or `headless-ubuntu` (agent toolchain only, no compositor). Unset means ubuntu-desktop. Changing it affects Bots on their next restart.",
+	})
+	r.Register(configregistry.Spec{
+		Key:         configregistry.DefaultSandboxVCPUsKey,
+		Type:        configregistry.TypeInt,
+		Description: "Default sandbox size (vCPU count from the spec-task preset ladder) for Bots that do not set their own. Unset means the standard preset.",
+	})
+	r.Register(configregistry.Spec{
 		Key:         "worker.specs_mandate",
 		Type:        configregistry.TypeString,
 		Description: "Optional full activation mandate override. When empty, every activation embeds the Worker's current role content.",

--- a/api/pkg/server/org_restart_required_test.go
+++ b/api/pkg/server/org_restart_required_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	helixorgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +22,9 @@ func (f fakeSessionReader) GetSession(_ context.Context, _ string) (*types.Sessi
 }
 func (f fakeSessionReader) GetApp(_ context.Context, _ string) (*types.App, error) {
 	return nil, nil
+}
+func (f fakeSessionReader) GetSandboxBySession(_ context.Context, _ string) (*types.Sandbox, error) {
+	return nil, store.ErrNotFound
 }
 
 func runtimeFor(t *testing.T, stamp, containerID, agentStatus string) helixorgapi.BotRuntimeInfo {

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -371,7 +371,6 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 		Provider: "ep_123",
 		Owner:    "user_id",
 	}).DoAndReturn(func(_ context.Context, req *manager.GetClientRequest) (openai.Client, error) {
-		defer close(warmDone)
 		// The warm goroutine shouldn't see "*****" — it should use the copy with the real key.
 		// We can't directly observe the API key from GetClientRequest, but we can verify
 		// the goroutine completed without error.
@@ -380,7 +379,15 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 	})
 
 	s.openAiClient.EXPECT().ListModels(gomock.Any()).Return([]types.OpenAIModel{{ID: "llama3"}}, nil)
-	s.modelInfoProvider.EXPECT().GetModelInfo(gomock.Any(), gomock.Any()).Return(nil, errors.New("not found"))
+	// Signal from the LAST mocked call in the warm path, not the first: releasing
+	// the test after GetClient lets TearDownTest run ctrl.Finish() while the
+	// goroutine is still on its way to ListModels/GetModelInfo, which fails as
+	// "missing call(s) to GetModelInfo" whenever CI is loaded enough to lose the race.
+	s.modelInfoProvider.EXPECT().GetModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *model.ModelInfoRequest) (*types.ModelInfo, error) {
+			close(warmDone)
+			return nil, errors.New("not found")
+		})
 
 	req, err := http.NewRequest("POST", "/v1/provider-endpoints", bytes.NewReader(body))
 	s.Require().NoError(err)

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -3166,6 +3166,13 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		}
 	}
 
+	// Name the session before the desktop starts: StartDesktop labels the
+	// sandbox billing row after the session, so a name applied afterwards
+	// would leave the row carrying the first-prompt placeholder.
+	if req.SessionName != "" && session.Name != req.SessionName {
+		session.Name = req.SessionName
+	}
+
 	// Autonomous surfaces (org workers) ask for crash auto-recovery. Set it on
 	// the metadata after the build/reuse branch so it sticks on the reused
 	// exploratory singleton too, not only on a freshly minted row.
@@ -3178,6 +3185,10 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		}
 		session.Metadata.OrgWorkerID = req.OrgWorkerID
 		session.Metadata.RuntimeInstructions = req.RuntimeInstructions
+		// Sandbox launch config travels with the worker identity: the
+		// executor reads it on every StartDesktop for this session.
+		session.Metadata.SandboxRuntime = req.SandboxRuntime
+		session.Metadata.SandboxResourceOverrides = req.SandboxResourceOverrides
 	}
 
 	if req.AppID != "" {

--- a/api/pkg/server/session_workspace_handlers.go
+++ b/api/pkg/server/session_workspace_handlers.go
@@ -71,6 +71,28 @@ func resolveExpectedBranch(specTask *types.SpecTask) string {
 	return services.GenerateFeatureBranchName(specTask)
 }
 
+// orgWorkerDefaultBranch resolves the branch an org bot's session commits to:
+// the default branch of its project's primary repository. Empty when the
+// project or repo cannot be resolved, which leaves the caller's "no branch"
+// handling in charge.
+func (apiServer *HelixAPIServer) orgWorkerDefaultBranch(ctx context.Context, projectID string) string {
+	if projectID == "" {
+		return ""
+	}
+	project, err := apiServer.Store.GetProject(ctx, projectID)
+	if err != nil || project == nil || project.DefaultRepoID == "" {
+		return ""
+	}
+	repo, err := apiServer.Store.GetGitRepository(ctx, project.DefaultRepoID)
+	if err != nil || repo == nil {
+		return ""
+	}
+	if repo.DefaultBranch != "" {
+		return repo.DefaultBranch
+	}
+	return "main"
+}
+
 // Wire types mirroring api/pkg/desktop/workspace.go. Duplicated
 // rather than imported because the desktop package pulls in
 // gstreamer/CGo via its video pipeline, which would balloon this
@@ -341,6 +363,16 @@ func (apiServer *HelixAPIServer) workspaceStatus(_ http.ResponseWriter, req *htt
 			resp.ExpectedBranch = resolveExpectedBranch(specTask)
 		}
 	}
+	// An org bot works directly on the default branch of its own per-bot
+	// repository — there is no feature branch and nothing protects main
+	// there — so the safety net commits to that branch instead of refusing.
+	orgWorkerBranch := false
+	if resp.ExpectedBranch == "" && session.Metadata.OrgWorkerID != "" {
+		if branch := apiServer.orgWorkerDefaultBranch(ctx, projectID); branch != "" {
+			resp.ExpectedBranch = branch
+			orgWorkerBranch = true
+		}
+	}
 
 	// Decide whether the pre-fork commit can actually save changes.
 	// Default to "can save" — only flip false when there ARE dirty
@@ -351,6 +383,8 @@ func (apiServer *HelixAPIServer) workspaceStatus(_ http.ResponseWriter, req *htt
 		case resp.ExpectedBranch == "":
 			resp.CanSaveChanges = false
 			resp.CannotSaveReason = "This session isn't linked to a feature branch — the safety net can't decide where to commit your changes. Commit and push them from the desktop terminal first, then try switching agent."
+		case orgWorkerBranch:
+			// Bot repo default branch: pushable by design.
 		case resp.ExpectedBranch == "main" || resp.ExpectedBranch == "master":
 			resp.CanSaveChanges = false
 			resp.CannotSaveReason = fmt.Sprintf("The branch for this session is %q, which the repository protects from direct pushes. Commit your changes to a feature branch from the desktop terminal first, then try switching agent.", resp.ExpectedBranch)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -23581,6 +23581,12 @@
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23635,6 +23641,26 @@
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -23854,6 +23880,12 @@
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23909,6 +23941,26 @@
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -24028,6 +24080,17 @@
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.\nOnly vcpus is read from the overrides — memory follows the preset.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -24620,6 +24683,17 @@
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox\nconfig. A present-but-empty runtime, or vcpus=0, resets that field to\ninherit. Takes effect on the next container start; a running sandbox\ngets restart_required.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -28542,24 +28616,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "email",
-                "local",
-                "cron",
                 "webhook",
-                "github",
-                "gitlab",
                 "helix_events",
-                "slack"
+                "local",
+                "github",
+                "slack",
+                "gitlab",
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindEmail",
-                "KindLocal",
-                "KindCron",
                 "KindWebhook",
-                "KindGitHub",
-                "KindGitLab",
                 "KindHelixEvents",
-                "KindSlack"
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
+                "KindGitLab",
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {
@@ -36920,6 +36994,10 @@
                 "name": {
                     "type": "string"
                 },
+                "org_bot_id": {
+                    "description": "OrgBotID is the helix-org bot whose session owns this container, when\nthere is one. Denormalised from the session (org_worker_id) so the bot\ndetail and the Sandboxes list can link both ways without joining sessions.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -38197,6 +38275,17 @@
                 },
                 "runtime_instructions": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the container runtime and\nsize for an org-worker session. The org spawner writes them from the Bot\non every activation and StartDesktop reads them on every launch path\n(fresh start, message auto-start, resume, auto-wake, reconciler), so a\nheadless bot never comes back as a desktop. SpecTask sessions leave both\nempty — the task is authoritative there, as with CodeAgentConfig.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "session_rag_results": {
                     "type": "array",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -51,6 +51,10 @@ definitions:
           reset to. Detail-only: GET /bots/{id} populates it, the list does
           not (it would repeat kilobytes of prompt per row).
         type: string
+      effective_sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      effective_sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       helix_user_id:
         type: string
       id:
@@ -101,6 +105,24 @@ definitions:
           the tool list and instructions from before the last save. Drives the
           restart banner on the bot page and the org chat panel.
         type: boolean
+      sandbox_id:
+        type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+          config in the spec-task vocabulary; empty means "inherit the org
+          default". The Effective* fields are what the next container start will
+          actually use once org and global defaults are applied. SandboxID /
+          SandboxStatus come from the session-backed sandboxes row, when one
+          exists (pending, running, stopping, stopped, failed).
+      sandbox_status:
+        type: string
+      sandbox_status_message:
+        type: string
       session_id:
         type: string
       tools:
@@ -252,6 +274,10 @@ definitions:
           reset to. Detail-only: GET /bots/{id} populates it, the list does
           not (it would repeat kilobytes of prompt per row).
         type: string
+      effective_sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      effective_sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       helix_user_id:
         type: string
       id:
@@ -308,6 +334,24 @@ definitions:
           the tool list and instructions from before the last save. Drives the
           restart banner on the bot page and the org chat panel.
         type: boolean
+      sandbox_id:
+        type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+          config in the spec-task vocabulary; empty means "inherit the org
+          default". The Effective* fields are what the next container start will
+          actually use once org and global defaults are applied. SandboxID /
+          SandboxStatus come from the session-backed sandboxes row, when one
+          exists (pending, running, stopping, stopped, failed).
+      sandbox_status:
+        type: string
+      sandbox_status_message:
+        type: string
       session_id:
         type: string
       tools:
@@ -395,6 +439,14 @@ definitions:
         type: string
       reasoning_effort:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.
+          Only vcpus is read from the overrides — memory follows the preset.
       tools:
         items:
           type: string
@@ -821,6 +873,16 @@ definitions:
         type: string
       reasoning_effort:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox
+          config. A present-but-empty runtime, or vcpus=0, resets that field to
+          inherit. Takes effect on the next container start; a running sandbox
+          gets restart_required.
       tools:
         items:
           type: string
@@ -3607,24 +3669,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - email
-    - local
-    - cron
     - webhook
-    - github
-    - gitlab
     - helix_events
+    - local
+    - github
     - slack
+    - gitlab
+    - email
+    - cron
     type: string
     x-enum-varnames:
-    - KindEmail
-    - KindLocal
-    - KindCron
     - KindWebhook
-    - KindGitHub
-    - KindGitLab
     - KindHelixEvents
+    - KindLocal
+    - KindGitHub
     - KindSlack
+    - KindGitLab
+    - KindEmail
+    - KindCron
   transport.ResolvedActivation:
     properties:
       address:
@@ -9748,6 +9810,12 @@ definitions:
         type: integer
       name:
         type: string
+      org_bot_id:
+        description: |-
+          OrgBotID is the helix-org bot whose session owns this container, when
+          there is one. Denormalised from the session (org_worker_id) so the bot
+          detail and the Sandboxes list can link both ways without joining sessions.
+        type: string
       organization_id:
         type: string
       owner:
@@ -10820,6 +10888,18 @@ definitions:
         type: string
       runtime_instructions:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the container runtime and
+          size for an org-worker session. The org spawner writes them from the Bot
+          on every activation and StartDesktop reads them on every launch path
+          (fresh start, message auto-start, resume, auto-wake, reconciler), so a
+          headless bot never comes back as a desktop. SpecTask sessions leave both
+          empty — the task is authoritative there, as with CodeAgentConfig.
       session_rag_results:
         items:
           $ref: '#/definitions/types.SessionRAGResult'

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -4279,10 +4279,15 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 				target = nil
 			}
 			if target != nil && target.State == types.InteractionStateWaiting {
-				// A delivery failure against a turn that is still producing
-				// output is proof the delivery was a duplicate, not that the
-				// turn failed. Ignore it outright (unlike an abort, it can never
-				// become true later — the turn is demonstrably reachable).
+				// A delivery failure against a turn that is still producing output
+				// is usually a rejected duplicate delivery, not a failed turn. But it
+				// is not proof: the send itself publishes to the streaming context, so
+				// an agent that rejects the very first delivery (OpenCode with a dead
+				// persisted session, for one) reports the error inside the evidence
+				// window too. Discarding it stranded the turn in state=waiting with a
+				// connected agent, which no watchdog reaps. So defer and re-examine,
+				// exactly like applyTurnError: a live turn keeps producing content and
+				// the error is dropped; a dead one goes silent and the error lands.
 				lastPublish, streaming := apiServer.streamingEvidence(helixSessionID, target.ID)
 				if streaming && time.Since(lastPublish) < liveTurnEvidenceWindow {
 					log.Warn().
@@ -4290,82 +4295,10 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 						Str("interaction_id", target.ID).
 						Str("request_id", requestID).
 						Time("last_publish", lastPublish).
-						Msg("⏸️ [HELIX] thread_load_error names a turn that is still streaming — ignoring rejected duplicate delivery")
+						Msg("⏸️ [HELIX] thread_load_error names a turn that is still streaming — deferring; likely a rejected duplicate delivery")
+					go apiServer.reapplyThreadLoadErrorAfterSilence(helixSessionID, target.ID, acpThreadID, errorMsg)
 				} else {
-					target.State = types.InteractionStateError
-					target.Error = fmt.Sprintf("Thread load failed: %s", errorMsg)
-					target.Updated = time.Now()
-					target.Completed = time.Now()
-					apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), target)
-
-					// If this interaction came from a queue prompt that's still
-					// in 'sending' state (deferred MarkPromptAsSent flow), mark
-					// the prompt as failed so the user sees retry, not a
-					// stuck "queued" entry.
-					//
-					// Distinguish terminal Claude Agent crashes (process exit,
-					// "Session not found") from transient errors. For crashes,
-					// auto-retry is futile — every subsequent send hits the same
-					// dead process and rebounds. We pin next_retry_at far in the
-					// future via MarkPromptAsCrashed so the queue stops looping,
-					// and the frontend's crash detector renders a Restart button.
-					// Read the prompt_id directly from the interaction column so this
-					// works after API restart too (the in-memory map used to be the
-					// only source of this link).
-					if target.PromptID != "" {
-						failureMsg := fmt.Sprintf("Thread load failed: %s", errorMsg)
-						var markErr error
-						// A thread_load_error that RECURS is terminal: it means Zed
-						// cannot deliver the follow-up to the agent (wedged ACP thread,
-						// dead connection, …) and re-sending to the same thread can
-						// never succeed. The exact wrapper/transport wording varies
-						// ("ede_diagnostic …", "response channel cancelled", "send
-						// failed because receiver is gone", …) so we do NOT match on
-						// the string — recurrence is the signal. After a couple of
-						// normal backoff retries (acpWedgeCrashThreshold) we crash-mark
-						// the prompt (pins next_retry_at to the far-future sentinel,
-						// surfacing Restart) instead of looping forever. The first
-						// occurrence still gets normal retries in case it was a genuinely
-						// transient drain that Zed's own retry just missed.
-						recurringThreadLoadFailure := false
-						if !isAgentCrashError(errorMsg) {
-							// Only the recurrence gate needs the prior retry_count; a
-							// hard crash is terminal immediately and short-circuits.
-							if p, gErr := apiServer.Controller.Options.Store.GetPromptHistoryEntry(context.Background(), target.PromptID); gErr == nil && p != nil && p.RetryCount >= acpWedgeCrashThreshold {
-								recurringThreadLoadFailure = true
-							}
-						}
-						if isAgentCrashError(errorMsg) || recurringThreadLoadFailure {
-							log.Warn().
-								Str("prompt_id", target.PromptID).
-								Str("interaction_id", target.ID).
-								Str("acp_thread_id", acpThreadID).
-								Bool("recurring_thread_load_failure", recurringThreadLoadFailure).
-								Msg("💥 [HELIX] Agent thread terminal (hard crash or recurring thread_load_error) — marking prompt crashed (suppress auto-retry, awaits user Restart)")
-							markErr = apiServer.Controller.Options.Store.MarkPromptAsCrashed(context.Background(), target.PromptID, failureMsg)
-							// The hard-crash case already triggered auto-restart above
-							// (outside this loop, PromptID-independent). Here we also
-							// cover the RECURRING thread_load_error case — a wedged queue
-							// prompt that isn't a hard-crash marker — which only reaches
-							// terminal after retries and so always has a PromptID.
-							if recurringThreadLoadFailure && helixSession.Metadata.AutoRestartOnCrash {
-								go apiServer.maybeAutoRestartCrashedAgent(helixSessionID)
-							}
-						} else {
-							markErr = apiServer.Controller.Options.Store.MarkPromptAsFailed(context.Background(), target.PromptID, failureMsg)
-						}
-						if markErr != nil {
-							log.Error().Err(markErr).
-								Str("prompt_id", target.PromptID).
-								Str("interaction_id", target.ID).
-								Msg("Failed to mark prompt after thread load error")
-						}
-					}
-
-					log.Info().
-						Str("helix_session_id", helixSessionID).
-						Str("interaction_id", target.ID).
-						Msg("✅ [HELIX] Marked interaction as error due to thread load failure")
+					apiServer.commitThreadLoadFailure(context.Background(), helixSession, target, acpThreadID, errorMsg)
 				}
 			}
 		}
@@ -4410,13 +4343,30 @@ func (apiServer *HelixAPIServer) maybeExplainProviderFailure(ctx context.Context
 	if !strings.Contains(errorMsg, genericACPAbortMarker) || helixSessionID == "" {
 		return errorMsg
 	}
+	detail, ok := apiServer.recentProviderFailure(ctx, helixSessionID)
+	if !ok {
+		return errorMsg
+	}
+	return fmt.Sprintf("Agent turn aborted: the model provider failed and the coding agent gave up retrying. "+
+		"Last provider error: %s.", detail)
+}
+
+// recentProviderFailure returns a one-line description of the session's most
+// recent model-provider failure — "<error> (model X). N consecutive requests
+// failed" — when one happened within providerFailureLookback. Both the turn
+// abort and thread-load failure paths attach it, because the agent only ever
+// reports a generic service failure while llm_calls holds the actual reason.
+func (apiServer *HelixAPIServer) recentProviderFailure(ctx context.Context, helixSessionID string) (string, bool) {
+	if helixSessionID == "" {
+		return "", false
+	}
 	calls, _, err := apiServer.Store.ListLLMCalls(ctx, &store.ListLLMCallsQuery{
 		SessionID: helixSessionID,
 		Page:      1,
 		PerPage:   10,
 	})
 	if err != nil || len(calls) == 0 {
-		return errorMsg
+		return "", false
 	}
 	// ListLLMCalls orders by created DESC, so the first failure we meet is the
 	// most recent one.
@@ -4431,7 +4381,7 @@ func (apiServer *HelixAPIServer) maybeExplainProviderFailure(ctx context.Context
 		}
 	}
 	if failure == nil || time.Since(failure.Created) > providerFailureLookback {
-		return errorMsg
+		return "", false
 	}
 
 	// Count how many consecutive recent calls failed the same way. One failure
@@ -4450,16 +4400,13 @@ func (apiServer *HelixAPIServer) maybeExplainProviderFailure(ctx context.Context
 	if len(detail) > 300 {
 		detail = detail[:300] + "…"
 	}
-	msg := fmt.Sprintf("Agent turn aborted: the model provider failed and the coding agent gave up retrying. "+
-		"Last provider error: %s", detail)
 	if failure.Model != "" {
-		msg += fmt.Sprintf(" (model %s)", failure.Model)
+		detail += fmt.Sprintf(" (model %s)", failure.Model)
 	}
 	if attempts > 1 {
-		msg += fmt.Sprintf(". %d consecutive requests failed", attempts)
+		detail += fmt.Sprintf(". %d consecutive requests failed", attempts)
 	}
-	msg += "."
-	return msg
+	return detail, true
 }
 
 // maybeReclassifySubscriptionAuthError rewrites the generic ACP mid-turn abort
@@ -4542,6 +4489,128 @@ func (apiServer *HelixAPIServer) handleChatResponseError(sessionID string, syncM
 // durable ExternalAgentRequestID column — which is the whole reason that column
 // exists. Without this, an agent that keeps talking across a restart addresses
 // turns Helix can no longer name.
+// reapplyThreadLoadErrorAfterSilence re-examines a deferred thread_load_error
+// once the evidence window has passed. Fresh content means the turn outlived
+// the rejected delivery and the error is dropped; silence means the delivery
+// really failed and the turn is failed now. Mirrors reapplyTurnErrorAfterSilence.
+func (apiServer *HelixAPIServer) reapplyThreadLoadErrorAfterSilence(helixSessionID, interactionID, acpThreadID, errorMsg string) {
+	time.Sleep(liveTurnEvidenceWindow)
+
+	ctx := context.Background()
+	logger := log.With().
+		Str("helix_session_id", helixSessionID).
+		Str("interaction_id", interactionID).
+		Logger()
+
+	if lastPublish, streaming := apiServer.streamingEvidence(helixSessionID, interactionID); streaming && time.Since(lastPublish) < liveTurnEvidenceWindow {
+		logger.Info().Time("last_publish", lastPublish).Msg("✅ [HELIX] Deferred thread_load_error discarded — turn is still producing output")
+		return
+	}
+	interaction, err := apiServer.Store.GetInteraction(ctx, interactionID)
+	if err != nil || interaction == nil {
+		logger.Warn().Err(err).Msg("[HELIX] Could not reload interaction to re-apply deferred thread_load_error")
+		return
+	}
+	if interaction.State != types.InteractionStateWaiting {
+		logger.Debug().Str("state", string(interaction.State)).Msg("[HELIX] Deferred thread_load_error dropped — turn already reached a terminal state")
+		return
+	}
+	session, err := apiServer.Store.GetSession(ctx, helixSessionID)
+	if err != nil || session == nil {
+		logger.Warn().Err(err).Msg("[HELIX] Could not reload session to re-apply deferred thread_load_error")
+		return
+	}
+	logger.Warn().Str("error", errorMsg).Msg("[HELIX] Turn went silent after deferred thread_load_error — applying it now")
+	apiServer.commitThreadLoadFailure(ctx, session, interaction, acpThreadID, errorMsg)
+}
+
+// commitThreadLoadFailure fails the turn a thread_load_error names and settles
+// its queue prompt (retry, or crash-mark when the failure is terminal). The
+// message carries the most recent model-provider error for the session when
+// there is one: the agent only reports "service failure", while the reason
+// (a model the endpoint does not serve, an auth failure, a down provider) is
+// in llm_calls and is what the operator actually needs to see.
+func (apiServer *HelixAPIServer) commitThreadLoadFailure(ctx context.Context, helixSession *types.Session, target *types.Interaction, acpThreadID, errorMsg string) {
+	helixSessionID := helixSession.ID
+	if detail, ok := apiServer.recentProviderFailure(ctx, helixSessionID); ok {
+		errorMsg = fmt.Sprintf("%s. Last model provider error: %s", errorMsg, detail)
+	}
+	target.State = types.InteractionStateError
+	target.Error = fmt.Sprintf("Thread load failed: %s", errorMsg)
+	target.Updated = time.Now()
+	target.Completed = time.Now()
+	apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), target)
+
+	// If this interaction came from a queue prompt that's still
+	// in 'sending' state (deferred MarkPromptAsSent flow), mark
+	// the prompt as failed so the user sees retry, not a
+	// stuck "queued" entry.
+	//
+	// Distinguish terminal Claude Agent crashes (process exit,
+	// "Session not found") from transient errors. For crashes,
+	// auto-retry is futile — every subsequent send hits the same
+	// dead process and rebounds. We pin next_retry_at far in the
+	// future via MarkPromptAsCrashed so the queue stops looping,
+	// and the frontend's crash detector renders a Restart button.
+	// Read the prompt_id directly from the interaction column so this
+	// works after API restart too (the in-memory map used to be the
+	// only source of this link).
+	if target.PromptID != "" {
+		failureMsg := fmt.Sprintf("Thread load failed: %s", errorMsg)
+		var markErr error
+		// A thread_load_error that RECURS is terminal: it means Zed
+		// cannot deliver the follow-up to the agent (wedged ACP thread,
+		// dead connection, …) and re-sending to the same thread can
+		// never succeed. The exact wrapper/transport wording varies
+		// ("ede_diagnostic …", "response channel cancelled", "send
+		// failed because receiver is gone", …) so we do NOT match on
+		// the string — recurrence is the signal. After a couple of
+		// normal backoff retries (acpWedgeCrashThreshold) we crash-mark
+		// the prompt (pins next_retry_at to the far-future sentinel,
+		// surfacing Restart) instead of looping forever. The first
+		// occurrence still gets normal retries in case it was a genuinely
+		// transient drain that Zed's own retry just missed.
+		recurringThreadLoadFailure := false
+		if !isAgentCrashError(errorMsg) {
+			// Only the recurrence gate needs the prior retry_count; a
+			// hard crash is terminal immediately and short-circuits.
+			if p, gErr := apiServer.Controller.Options.Store.GetPromptHistoryEntry(context.Background(), target.PromptID); gErr == nil && p != nil && p.RetryCount >= acpWedgeCrashThreshold {
+				recurringThreadLoadFailure = true
+			}
+		}
+		if isAgentCrashError(errorMsg) || recurringThreadLoadFailure {
+			log.Warn().
+				Str("prompt_id", target.PromptID).
+				Str("interaction_id", target.ID).
+				Str("acp_thread_id", acpThreadID).
+				Bool("recurring_thread_load_failure", recurringThreadLoadFailure).
+				Msg("💥 [HELIX] Agent thread terminal (hard crash or recurring thread_load_error) — marking prompt crashed (suppress auto-retry, awaits user Restart)")
+			markErr = apiServer.Controller.Options.Store.MarkPromptAsCrashed(context.Background(), target.PromptID, failureMsg)
+			// The hard-crash case already triggered auto-restart above
+			// (outside this loop, PromptID-independent). Here we also
+			// cover the RECURRING thread_load_error case — a wedged queue
+			// prompt that isn't a hard-crash marker — which only reaches
+			// terminal after retries and so always has a PromptID.
+			if recurringThreadLoadFailure && helixSession.Metadata.AutoRestartOnCrash {
+				go apiServer.maybeAutoRestartCrashedAgent(helixSessionID)
+			}
+		} else {
+			markErr = apiServer.Controller.Options.Store.MarkPromptAsFailed(context.Background(), target.PromptID, failureMsg)
+		}
+		if markErr != nil {
+			log.Error().Err(markErr).
+				Str("prompt_id", target.PromptID).
+				Str("interaction_id", target.ID).
+				Msg("Failed to mark prompt after thread load error")
+		}
+	}
+
+	log.Info().
+		Str("helix_session_id", helixSessionID).
+		Str("interaction_id", target.ID).
+		Msg("✅ [HELIX] Marked interaction as error due to thread load failure")
+}
+
 func (apiServer *HelixAPIServer) interactionForRequest(ctx context.Context, requestID string) *types.Interaction {
 	if requestID == "" {
 		return nil

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -27,6 +27,11 @@ type WebSocketSyncSuite struct {
 	ctrl   *gomock.Controller
 	store  *store.MockStore
 	server *HelixAPIServer
+	// llmCalls is what ListLLMCalls returns for any session: the recent
+	// provider-failure lookup runs on every terminal turn error, and most
+	// tests want it to find nothing. Tests that assert the provider detail
+	// set it before firing the event.
+	llmCalls []*types.LLMCall
 }
 
 type recordingPubSub struct {
@@ -46,6 +51,12 @@ func TestWebSocketSyncSuite(t *testing.T) {
 func (s *WebSocketSyncSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.store = store.NewMockStore(s.ctrl)
+	s.llmCalls = nil
+	s.store.EXPECT().ListLLMCalls(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *store.ListLLMCallsQuery) ([]*types.LLMCall, int64, error) {
+			return s.llmCalls, int64(len(s.llmCalls)), nil
+		},
+	).AnyTimes()
 
 	// TouchSession is called as a fire-and-forget side effect in
 	// handleMessageCompleted and handleMessageAdded (user messages).
@@ -2230,6 +2241,85 @@ func (s *WebSocketSyncSuite) TestThreadLoadError_TransientError_StillUsesMarkAsF
 	}
 	err := s.server.handleThreadLoadError("ses_transient", syncMsg)
 	s.NoError(err)
+}
+
+// A thread_load_error that lands while the turn shows fresh streaming evidence
+// must be deferred, not discarded: the send itself publishes to the streaming
+// context, so an agent that rejects the very first delivery (a dead persisted
+// OpenCode session, for one) reports inside the evidence window too. Dropping
+// it stranded the turn in state=waiting with a connected agent.
+func (s *WebSocketSyncSuite) TestThreadLoadError_StreamingEvidence_DefersInsteadOfDiscarding() {
+	s.server.contextMappings["thread-live"] = "ses_live"
+
+	session := &types.Session{ID: "ses_live", GenerationID: 1, Metadata: types.SessionMetadata{ZedThreadID: "thread-live"}}
+	interaction := &types.Interaction{ID: "int-live", SessionID: "ses_live", State: types.InteractionStateWaiting, PromptID: "prompt-live", ExternalAgentRequestID: "int-live"}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_live").Return(session, nil)
+	s.store.EXPECT().GetInteractionByExternalAgentRequestID(gomock.Any(), "int-live").Return(interaction, nil)
+	s.server.streamingContexts["ses_live"] = &streamingContext{
+		session:       session,
+		interaction:   interaction,
+		interactionID: "int-live",
+		lastPublish:   time.Now(),
+	}
+
+	// No UpdateInteraction / MarkPromptAs* expectations: the failure is
+	// deferred to reapplyThreadLoadErrorAfterSilence, which re-examines the
+	// turn after the evidence window rather than failing it now.
+	err := s.server.handleThreadLoadError("ses_live", &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-live",
+			"request_id":    "int-live",
+			"error":         "Failed to send follow-up: Internal error: OpenCode service failure",
+		},
+	})
+	s.NoError(err)
+}
+
+// The agent only reports a generic service failure; the reason (a model the
+// endpoint does not serve, an auth failure, a down provider) is in llm_calls.
+// A thread-load failure must carry it so the operator can act on it.
+func (s *WebSocketSyncSuite) TestThreadLoadError_AttachesRecentProviderFailure() {
+	s.server.contextMappings["thread-prov"] = "ses_prov"
+	s.llmCalls = []*types.LLMCall{{
+		SessionID: "ses_prov", Model: "qwen3.8-27b", Created: time.Now().Add(-20 * time.Second),
+		Error: "model qwen3.8-27b is not in the list of allowed models",
+	}}
+
+	session := &types.Session{ID: "ses_prov", GenerationID: 1, Metadata: types.SessionMetadata{ZedThreadID: "thread-prov"}}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_prov").Return(session, nil)
+	s.store.EXPECT().GetInteractionByExternalAgentRequestID(gomock.Any(), "int-prov").Return(
+		&types.Interaction{ID: "int-prov", SessionID: "ses_prov", State: types.InteractionStateWaiting, PromptID: "prompt-prov", ExternalAgentRequestID: "int-prov"}, nil,
+	)
+	var persisted string
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, in *types.Interaction) (*types.Interaction, error) {
+			persisted = in.Error
+			return in, nil
+		},
+	)
+	s.store.EXPECT().GetPromptHistoryEntry(gomock.Any(), "prompt-prov").
+		Return(&types.PromptHistoryEntry{ID: "prompt-prov", RetryCount: 0}, nil)
+	var promptFailure string
+	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-prov", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, msg string) error {
+			promptFailure = msg
+			return nil
+		},
+	)
+
+	err := s.server.handleThreadLoadError("ses_prov", &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-prov",
+			"request_id":    "int-prov",
+			"error":         "Failed to send follow-up: Internal error: OpenCode service failure: {\"service\": \"session\"}",
+		},
+	})
+	s.NoError(err)
+	s.Contains(persisted, "OpenCode service failure")
+	s.Contains(persisted, "Last model provider error: model qwen3.8-27b is not in the list of allowed models (model qwen3.8-27b)")
+	s.Contains(promptFailure, "not in the list of allowed models")
 }
 
 func (s *WebSocketSyncSuite) TestThreadLoadError_MissingCodexRolloutClearsThreadForRetry() {

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -284,6 +284,22 @@ func (s *PostgresStore) runMigrations() error {
 		}
 	}
 
+	// One-time backfill: link pre-existing session-backed sandbox rows to the
+	// helix-org bot whose session owns them. New rows get org_bot_id from the
+	// executor at BeginSession; idempotent because the WHERE excludes rows
+	// already linked.
+	if s.gdb.Migrator().HasTable(&types.Sandbox{}) && s.gdb.Migrator().HasTable(&types.Session{}) {
+		if err := s.gdb.WithContext(context.Background()).Exec(
+			`UPDATE sandboxes SET org_bot_id = s.config->>'org_worker_id'
+			 FROM sessions s
+			 WHERE sandboxes.session_id = s.id
+			   AND COALESCE(sandboxes.org_bot_id, '') = ''
+			   AND COALESCE(s.config->>'org_worker_id', '') <> ''`,
+		).Error; err != nil {
+			return fmt.Errorf("failed to backfill sandboxes.org_bot_id: %w", err)
+		}
+	}
+
 	err = s.AutoMigrateRoleConfig(context.Background())
 	if err != nil {
 		return err

--- a/api/pkg/types/sandbox.go
+++ b/api/pkg/types/sandbox.go
@@ -90,6 +90,11 @@ type Sandbox struct {
 	// to the task without joining through sessions.
 	SpecTaskID string `json:"spec_task_id,omitempty" gorm:"size:64;index"`
 
+	// OrgBotID is the helix-org bot whose session owns this container, when
+	// there is one. Denormalised from the session (org_worker_id) so the bot
+	// detail and the Sandboxes list can link both ways without joining sessions.
+	OrgBotID string `json:"org_bot_id,omitempty" gorm:"size:128;index"`
+
 	// Display fields apply to desktop runtimes.
 	DisplayWidth  int `json:"display_width,omitempty"`
 	DisplayHeight int `json:"display_height,omitempty"`
@@ -180,6 +185,7 @@ type BeginSandboxSessionRequest struct {
 	Owner          string
 	ProjectID      string
 	SpecTaskID     string
+	OrgBotID       string
 	Name           string
 	Runtime        SandboxRuntime
 	VCPUs          int

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -519,6 +519,15 @@ type SessionMetadata struct {
 	// and reasoning. SpecTask sessions keep this nil and read the task instead.
 	CodeAgentConfig *CodeAgentExecutionConfig `json:"code_agent_config,omitempty"`
 
+	// SandboxRuntime and SandboxResourceOverrides are the container runtime and
+	// size for an org-worker session. The org spawner writes them from the Bot
+	// on every activation and StartDesktop reads them on every launch path
+	// (fresh start, message auto-start, resume, auto-wake, reconciler), so a
+	// headless bot never comes back as a desktop. SpecTask sessions leave both
+	// empty — the task is authoritative there, as with CodeAgentConfig.
+	SandboxRuntime           SandboxRuntime            `json:"sandbox_runtime,omitempty"`
+	SandboxResourceOverrides *SandboxResourceOverrides `json:"sandbox_resource_overrides,omitempty"`
+
 	// Container fields (Hydra executor)
 	ContainerName string `json:"container_name,omitempty"` // Docker container name
 	ContainerID   string `json:"container_id,omitempty"`   // Docker container ID
@@ -623,6 +632,15 @@ type SessionChatRequest struct {
 	// a Worker's identity.
 	OrgWorkerID         string `json:"-"`
 	RuntimeInstructions string `json:"-"`
+	// SessionName, when set, names a freshly created session up front so the
+	// container start that follows (and the sandbox row it opens) sees the
+	// final name rather than the placeholder derived from the first prompt.
+	SessionName string `json:"-"`
+	// SandboxRuntime / SandboxResourceOverrides are the org worker's resolved
+	// container runtime and size, persisted onto the session metadata. Internal
+	// for the same reason as OrgWorkerID.
+	SandboxRuntime           SandboxRuntime            `json:"-"`
+	SandboxResourceOverrides *SandboxResourceOverrides `json:"-"`
 }
 
 // ExternalAgentConfig holds display configuration for external agent sessions
@@ -2086,6 +2104,11 @@ type DesktopAgent struct {
 	ProjectID           string   `json:"project_id,omitempty"`            // Project ID for exploratory sessions (when no SpecTask)
 	RepositoryIDs       []string `json:"repository_ids,omitempty"`        // Git repository IDs to checkout
 	PrimaryRepositoryID string   `json:"primary_repository_id,omitempty"` // Primary git repository (opened in Zed by default)
+	// OrgWorkerID / OrgWorkerName identify a helix-org bot session. Filled from
+	// the session metadata by the executor's bootstrap step; they name and link
+	// the sandbox billing row to the bot. Never accepted from callers.
+	OrgWorkerID   string `json:"-"`
+	OrgWorkerName string `json:"-"`
 
 	// Branch configuration (for starting on correct branch)
 	BranchMode    string `json:"branch_mode,omitempty"`    // "new" or "existing"

--- a/design/2026-09-07-org-agent-sandbox-migration.md
+++ b/design/2026-09-07-org-agent-sandbox-migration.md
@@ -1,0 +1,461 @@
+# Org agents: migrate the PoC desktop runtime onto the spec-task sandbox model
+
+**Date:** 2026-09-07
+**Status:** Implemented on branch `feature/org-agent-sandbox-runtime` (2026-09-07); see §7 for what was verified live
+**Scope:** `api/pkg/org/**`, `api/pkg/server/helix_org*.go`, `api/pkg/external-agent/hydra_executor.go`,
+`api/pkg/sandbox/controller_session.go`, `frontend/src/components/helix-org/**`, `frontend/src/pages/App.tsx`
+
+## Decisions (2026-09-07)
+
+- Default stays **full desktop**. Headless is opt-in per bot (or per org default).
+- `restart-agent` keeps its current semantics (stop, delete session, fresh session).
+- **One PR.** No billing/usage work; no new lifecycle verbs. There are no org-agent
+  users yet, so compatibility means: existing bots keep working unchanged, and at most
+  a restart is needed to pick up a changed sandbox config.
+- The bot UI gets the full spec-task workspace (desktop, chat, diff, files, terminal,
+  reverse-tunnel browser, share links, controls) — everything except task-only panels.
+
+## 1. Why
+
+Org agents (helix-org Bots) run inside a per-bot Helix project's *exploratory session*
+whose container is started by the same `HydraExecutor.StartDesktop` path spec tasks
+use — but with none of the knobs spec tasks have. Every bot gets an uncapped, full
+GNOME `helix-ubuntu` desktop, billed at the standard 12 vCPU desktop rate, that nobody
+can size, make headless, or find in the Sandboxes list. Status is a two-state boolean
+derived from session metadata.
+
+Spec tasks already solved this (`design/2026-08-14-headless-spec-tasks.md`,
+`design/2026-08-10-spec-task-desktop-billing.md`). This doc maps the current bot
+runtime, contrasts it with spec tasks, and proposes converging bots onto the same
+model: the owning entity (the Bot) is the source of truth for sandbox runtime and size
+on every launch path, and the `sandboxes` row is named and linked.
+
+## 2. Current implementation (as of `main` @ 53f68a160)
+
+### 2.1 Entities
+
+| Entity | Table / type | Owns |
+|---|---|---|
+| Bot (graph node) | `org_bots` → `orgchart.Node` (`api/pkg/org/domain/orgchart/node.go:56`) | id, name, content, tools, project allowlist, `PreserveContext`, `AgentID` (link to App), parents via `org_reporting_lines` |
+| Canonical agent | `types.App` (one Assistant) | system prompt, `CodeAgentRuntime`, credential type, provider, model, reasoning effort, MCP servers |
+| Runtime sidecar | `org_bot_runtime_state` KV (`api/pkg/org/infrastructure/runtime/helix/state.go`) | `project_id`, `agent_app_id`, `repo_id`, `session_id`, `hiring_user_id`, `restart_required_container` |
+| Per-bot project | `projects` row named `<Bot> @ <Org>` + one git repo (`project.go:184 Ensure`) | startup script, secrets, `DefaultHelixAppID` = the App |
+| Bot session | `sessions` row, `session_role=exploratory`, `agent_type=zed_external`, `Metadata.OrgWorkerID`, `RuntimeInstructions`, `AutoRestartOnCrash=true` (`helix_org_inproc.go:948`) | chat history, Zed thread, container pointers (`ContainerID`, `DevContainerID`, `SandboxID`, `ExternalAgentStatus`) |
+| Sandbox meter row | `sandboxes` row, session-backed (`SessionID` set, `TimeoutSeconds=-1`), created by `beginSandboxMetering` (`hydra_executor.go:703`) | billing window, quota slot, host/container ids |
+| Activation audit | `org_activations` | trigger kind, started/ended, outcome |
+
+There is **no bot-level sandbox configuration anywhere**. The only runtime axis a bot
+has is the agent harness on its App.
+
+### 2.2 How a bot is woken (event → activation)
+
+```
+Trigger (GitHub/GitLab/Slack/Postmark webhook, cron via streamcron, manual publish)
+  └─ publishing.Publish            append org_events, wakebus.Notify (NATS wake for live UI)
+       └─ dispatch.Route           org_worker_attachments for that source → one Trigger per bot
+            └─ agentdelivery.Queue NATS JetStream stream HELIX_ORG_AGENT_ACTIVATIONS,
+                                   one durable pull consumer per (org, bot), 1 outstanding msg
+                 └─ Spawner        blocks for the whole activation; Ack on success,
+                                   NakWithDelay(1s…30m backoff) on error; InProgress every 10m
+```
+
+Other entry points into the same queue: `DispatchHire` (bot created), `DispatchManual`
+(REST `/activate`, MCP `start_bot`). Processors fan out from `Route` and publish back
+through `Publish`, so chains recurse through the same path.
+
+Key properties: per-bot FIFO, restart-safe (consumers resume on API boot,
+`queue.go:59`), no coalescing (one trigger per activation), global inflight cap of 8
+(`spawner.go:34`), `CancelOutstanding` drains the consumer on stop/restart.
+
+### 2.3 The activation loop (`spawner.go:117`)
+
+1. Acquire global semaphore slot; create/adopt `org_activations` row.
+2. Resolve the hiring user and put their bearer on the context (all Helix resources are
+   owned by the human who hired the bot).
+3. `ensureProject` → `WorkerProject.Ensure`: upsert project + App + repo, sync the
+   project's `CodeAgentExecutionConfig` from the App, sync runtime secrets, attach the
+   helix-org MCP.
+4. `Mirror.Ensure` — transcript mirror subscribes to the session's pubsub topic and
+   republishes settled entries onto `s-transcript-<bot>`.
+5. Build the mandate from the App's assistant system prompt, render `AGENTS.md` /
+   `CLAUDE.md` instructions, `SyncAgentProfile` onto the existing session.
+6. `ensureSession`:
+   - existing session and `!PreserveContext` → `ClearSession` (wipes interactions and
+     the Zed thread; every activation starts on a fresh context window);
+   - `EnsureAndSend`: existing session → `POST /sessions/{id}/messages` (prompt queue;
+     if the desktop is down `autoStartDevContainerForSession` boots it); no session →
+     `checkDesktopQuota` then `StartExternalAgentSession` → `StartDesktop`.
+7. `pollUntilDone`: poll `GetOutput` with backoff until the *new* interaction reaches a
+   terminal state. Bounded only by the 24h runaway guard. Session-level watchdogs own
+   "is it stuck": `auto_wake_stuck_interactions.go`, `AutoRestartOnCrash`, the dead
+   container reconciler, the orphan reaper.
+8. Return → queue Ack/Nak → `org_activations.Complete`.
+
+Between activations the desktop stays up until the global idle checker stops it
+(`HELIX_DESKTOP_IDLE_TIMEOUT`, default 1h, `idle_checker.go:16`), which sets
+`external_agent_status=terminated_idle`. The next trigger cold-starts it again
+(≈3 min for a GNOME desktop).
+
+### 2.4 What the container actually is
+
+`StartExternalAgentSession` (`session_handlers.go:3091`) builds a `DesktopAgent` with
+`OrganizationID`, `SessionID`, `UserID`, `ProjectPath`, repos — and nothing else. In
+`StartDesktop`:
+
+- `resolveSpecTaskLaunchConfig` (`hydra_executor.go:679`) is a no-op because
+  `SpecTaskID == ""` → `DesktopType` stays `""` → `parseContainerType` → `"ubuntu"` →
+  full GNOME + streaming, privileged isolation, display-capable host required.
+- `VCPUs/MemoryMB` are 0 → hydra runs the container **uncapped**;
+  `desktopBillingResources` bills it at the standard preset (12 vCPU / 24 GB) at the
+  *desktop* price (`hydra_executor.go:731`).
+- The `sandboxes` row is named `Session <id>` (`desktopSandboxName`, `:750`), has no
+  bot link, `Runtime=ubuntu-desktop`.
+- The org-worker bootstrap (`applySessionBootstrap`, `:820`) injects
+  `HELIX_WORKER_ID` and writes `AGENTS.md`/`CLAUDE.md` into the workspace.
+
+Resume paths (`autoStartDevContainerForSession`, `resumeSession`, auto-wake cold start,
+container reconciler) rebuild the `DesktopAgent` from session metadata. Since the
+session carries no runtime/size either, every path lands on the same uncapped desktop.
+
+### 2.5 Lifecycle HTTP API today
+
+Mounted under `/api/v1/orgs/{org}/` by `api/pkg/org/interfaces/server/api/api.go:323`.
+`/agents/*` is canonical; `/bots/*` is an alias with the legacy nested detail shape.
+
+| Verb | Handler | What it does |
+|---|---|---|
+| `POST /agents/{id}/chat` | `ensureBotChat` | ensure project + App, return ids (no container) |
+| `POST /agents/{id}/activate` → 202 | `Activations.Activate` | ensure project synchronously, pre-allocate activation row, enqueue `TriggerManual`. Boots the desktop *as a side effect* of the first prompt |
+| `POST /agents/{id}/stop-agent` | `Activations.Stop` | `CancelOutstanding` + `StopExternalAgent` (container down, session kept) |
+| `POST /agents/{id}/restart-agent` | `Activations.Restart` | cancel + stop + delete session row + clear pointer + `Activate` → brand-new session |
+| `GET /agents`, `GET /agents/{id}` | `listBots`/`getBot` | `agent_status ∈ {running, stopped}` from `session.Metadata.ExternalAgentStatus == "running"` (`helix_org.go:179`), one `GetSession` per bot on list |
+| `PATCH /agents/{id}` | `updateBot` | graph fields + App config (harness, credentials, provider, model, reasoning) in one call |
+
+MCP: `start_bot` / `stop_bot` / `restart_bot` call the same `Activations` service.
+
+### 2.6 UI today
+
+- Live surfaces: org chart (`HelixOrgChart.tsx`), chat panel
+  (`components/helix-org/HelixOrgChatPanel.tsx`), agent settings via the generic
+  `App.tsx` (`org_agent` route). `HelixOrgBots.tsx` and `HelixOrgBotDetail.tsx` are
+  orphaned — their routes redirect (`router.tsx:642-661`).
+- Status: green/grey dot, `Running`/`Stopped`, polled through the bots list.
+- Desktop tab: `ExternalAgentDesktopViewer` with `sandboxId={sessionId}` — the session
+  id stands in for a sandbox identity.
+- Runtime form (`BotRuntimeForm.tsx`): harness, credential source, model, reasoning
+  effort. No environment, no size.
+- `AgentRestartRequiredBanner` already exists, driven by `restart_required`
+  (`RestartFingerprint`, `orgchart/restart.go`) and `restart_required_container`.
+
+### 2.7 What spec tasks do instead
+
+| Concern | Spec task | Org bot |
+|---|---|---|
+| Runtime choice | `SpecTask.SandboxRuntime` (`ubuntu-desktop` / `headless-ubuntu`), immutable after launch, project default, browser-stored personal default | none — always desktop |
+| Size | `SpecTask.SandboxResourceOverrides`, preset ladder 1/4/8/12/16 vCPU, live resize, operator default | none — uncapped, billed as 12 vCPU |
+| Source of truth on every launch path | `resolveSpecTaskLaunchConfig` reloads the task on start / resume / fork / reconcile | nothing; whatever `DesktopAgent` defaults give |
+| Sandbox row | named after the task, `SpecTaskID` set, visible in Sandboxes list with a link back | `Session ses_…`, unlinked |
+| Status | `SandboxState` absent/starting/running + `SandboxStatusIndicator` | running/stopped |
+| Idle | `keep_alive` excludes the task from the idle checker | always idle-stopped after 1h |
+| Restart | `restartSessionContainer` keeps the session and threads | deletes the session |
+| Picker UI | `SpecTaskExecutionControls` (Compute + Environment), locked after start | harness only |
+
+## 3. API: how the spec-task surface is shaped, and what the bot surface becomes
+
+### 3.1 Spec-task API surface (for comparison)
+
+Spec tasks spread their runtime control across three layers. Bots already sit on the
+bottom two; only the top layer is missing.
+
+**Task layer** (`/api/v1/spec-tasks/{id}…`, `server.go:1636-1682`)
+
+| Route | Purpose |
+|---|---|
+| `POST /spec-tasks` (`CreateTaskRequest`) | `sandbox_runtime` and `sandbox_resource_overrides` are set **here only**; runtime is immutable afterwards |
+| `GET /spec-tasks/{id}` | returns `sandbox_runtime`, `sandbox_resource_overrides`, `keep_alive`, derived `sandbox_state` (`absent/starting/running`) |
+| `PUT /spec-tasks/{id}` (`SpecTaskUpdateRequest`) | `keep_alive` and other metadata; not runtime/size |
+| `PATCH /spec-tasks/{id}/execution-config` | `code_agent_config` and/or `sandbox_resource_overrides`; resizes a **running** container via `UpdateDesktopResources` and reports `sandbox_resources_applied` |
+| `POST /spec-tasks/{id}/start-planning` | starts the workflow (creates the planning session, boots the container) |
+| `POST /spec-tasks/{id}/stop-agent` | `StopDesktop` on the planning session; session kept |
+| `GET/DELETE /spec-tasks/{id}/zed-instance` | legacy status/shutdown of the Zed instance |
+
+**Session layer** (`/api/v1/sessions/{id}…`, `server.go:1080-1099`) — shared by spec
+tasks, human desktops and bots already:
+`POST /resume` (rebuilds `DesktopAgent` from session metadata), `DELETE
+/stop-external-agent`, `POST /restart-agent` (`restartSessionContainer`: recreate the
+container, keep session + thread), `POST /messages`, `/cancel`, `/clear`,
+`/switch-agent`, `GET /sandbox-state` (thin: `absent|running` from `Session.SandboxID`).
+
+**Sandbox layer** (`/api/v1/organizations/{org}/sandboxes/{id}`, `/billing`) — the
+metering row. Spec-task rows show up here named after the task with `spec_task_id`.
+
+The pattern: **the owning entity holds the config; the executor reloads it from the
+owning entity on every launch; the session and sandbox layers are generic.**
+
+### 3.2 Bot API after this change
+
+Same pattern, same field names, mounted on the existing org-graph router. No new verbs.
+
+| Route | Change |
+|---|---|
+| `PATCH /orgs/{org}/agents/{id}` | accepts `sandbox_runtime` (`""`, `ubuntu-desktop`, `headless-ubuntu`) and `sandbox_resource_overrides` (`{vcpus, memory_mb}`, must be a preset). Validation reuses `ValidSpecTaskSandboxRuntime` / `ValidPreset`, and the same "no display-capable host" check spec-task create uses (`spec_driven_task_handlers.go:188`). Stored on `org_bots`. Applied at the **next container start**; if a container is running, `restart_required` is stamped (both fields join `RestartFingerprint`) |
+| `POST /orgs/{org}/agents` | same two optional fields at create |
+| `GET /orgs/{org}/agents`, `GET …/{id}` | add `sandbox_runtime`, `sandbox_resource_overrides` (effective values, defaults resolved), `sandbox_id`, `sandbox_status` (`pending/running/stopping/stopped/failed` from the `sandboxes` row, `status_message` on failure). `agent_status` stays `running/stopped` so nothing in the UI breaks |
+| `POST …/activate`, `…/stop-agent`, `…/restart-agent`, `…/chat` | **unchanged**. `restart-agent` is the way to apply a changed runtime |
+| MCP `start_bot` / `stop_bot` / `restart_bot` | unchanged; `create_bot` / `set_bot_*` may take the two fields (optional, cheap) |
+| CLI `helix org agents create/update` | `--sandbox-runtime`, `--sandbox-vcpus` |
+
+Mapping onto spec-task verbs:
+
+| Bot | Spec task equivalent | Difference |
+|---|---|---|
+| `PATCH agents/{id}` with runtime | `POST /spec-tasks` only | bots are long-lived, so runtime is **mutable**, applied on restart. Spec tasks lock it because the workspace/branch state is tied to one container |
+| `PATCH agents/{id}` with size | `PATCH /execution-config` | spec tasks resize live; bots apply on restart in this PR. Live resize is a follow-up: call `UpdateDesktopResources` when a container is running, exactly as the execution-config handler does |
+| `activate` | `start-planning` + first message | same: boots the container as a side effect of the first prompt |
+| `stop-agent` | `stop-agent` | identical semantics (`StopDesktop`, session kept) |
+| `restart-agent` | none at task level; `POST /sessions/{id}/restart-agent` at session level | bot restart deletes the session. Kept as-is per decision |
+| `GET agents/{id}.sandbox_status` | `GET spec-tasks/{id}.sandbox_state` | bot uses the `sandboxes` row (5 states); task derives 3 states from session config. Either is fine; the row is already there and cheaper on list |
+
+What is deliberately **not** added: a `/sandbox` sub-resource, `keep_alive`, a
+session-preserving restart, billing endpoints. All three layers remain reachable for a
+bot through the session and sandbox APIs already (`session_id` and `sandbox_id` are
+on the DTO).
+
+### 3.3 Org-level defaults
+
+`worker.sandbox_runtime` and `worker.sandbox_vcpus` in the config registry next to the
+default agent config, resolved in `resolveWorkerAgentConfig` (`helix_org.go:1614`).
+Resolution order: bot → org default → `EffectiveSpecTaskSandboxRuntime` /
+`DefaultSpecTaskSandboxResources` (the same helpers spec tasks use; no second ladder).
+Global default remains `ubuntu-desktop`.
+
+## 4. Implementation (single PR)
+
+### 4.1 Data
+
+- `org_bots`: `sandbox_runtime varchar(64)`, `sandbox_resource_overrides jsonb`
+  (nullable = inherit). `orgchart.Node` gains the two fields; `RestartFingerprint`
+  includes them.
+- `sandboxes.org_bot_id` (indexed), populated by `BeginSession` via a new
+  `BeginSandboxSessionRequest.OrgBotID`. Row name becomes `<Bot name> @ <Org>` in
+  `desktopSandboxName` when `Metadata.OrgWorkerID` is set. One-off backfill in the
+  migration: join `sessions.config->>'org_worker_id'` for existing session-backed rows.
+- `types.SessionMetadata`: `SandboxRuntime`, `SandboxResourceOverrides`. Set only on
+  sessions with `OrgWorkerID`; spec-task sessions leave them empty (the task is
+  authoritative there, same rule as `CodeAgentConfig`).
+- Org config keys `worker.sandbox_runtime`, `worker.sandbox_vcpus`.
+
+### 4.2 Launch path
+
+- Spawner: on every activation, write the bot's effective runtime/size to the session —
+  through `StartSessionParams` for a fresh session and through `SyncAgentProfile` for an
+  existing one (it already updates session-scoped worker state before each turn).
+- Executor: rename `resolveSpecTaskLaunchConfig` → `resolveLaunchConfig`. Branch:
+  `SpecTaskID != ""` → task (unchanged); else `Metadata.OrgWorkerID != ""` → session
+  metadata (`headless-ubuntu` → `DesktopType="headless"`; preset → `VCPUs/MemoryMB`).
+  Every resume path already goes through `StartDesktop`, so
+  `autoStartDevContainerForSession`, `resumeSession`, auto-wake cold start and the
+  reconciler inherit it. This is the invariant from the headless spec-task doc: "the
+  owning entity is the source of truth on every launch path".
+- `EnsureAndSend.checkDesktopQuota` (`sessions.go:79`) must skip when the bot is
+  headless; `beginSandboxMetering` already enforces the headless cap by pricing type.
+- Status: `orgWorkerRuntime.State` reads the bot's `sandboxes` row (`org_bot_id`) for
+  `sandbox_id` / `sandbox_status`; list does one `ListSandboxes` per org instead of a
+  `GetSession` per bot.
+
+### 4.3 UI: the bot gets the spec-task workspace
+
+Goal: a bot session gets every workspace surface a spec task has — desktop stream, chat,
+changes (diff), files, terminal, reverse-tunnel browser, share-preview links, execution
+controls, sandbox status, start/stop/restart — minus the things a bot does not have
+(specs, design-doc review, approval, PR, attachments, clone groups, thread selector).
+
+**Why this is mostly plumbing.** `SpecTaskDetailContent.tsx` is task-bound only at the
+top: it resolves one `activeSessionId` (`:661`) and hands that to every workspace
+panel. Each panel calls session-keyed endpoints and none of the handlers consult the
+spec task:
+
+| Panel | Component | Endpoint family | Task dependency |
+|---|---|---|---|
+| Desktop stream / screenshots / drop-zone | `external-agent/ExternalAgentDesktopViewer.tsx` | `/external-agents/{sessionId}/ws/stream`, `/ws/input`, `/screenshot`, `/upload`; `/sessions/{id}/resume`, `/stop-external-agent`, `/cancel` | none |
+| Chat | `session/AgentChat.tsx` | `/sessions/{id}/interactions`, `/messages`, `/cancel` | `specTaskId`/`projectId` optional |
+| Changes + Files | `tasks/DiffViewer.tsx` → `workspace-inspector/WorkspaceInspector.tsx` | `/external-agents/{sessionId}/workspaces`, `/workspace-review`, `/workspace-files`, `/workspace-file` (`workspace_review_handlers.go`) | none; `baseBranch` is a prop |
+| Terminal drawer | `tasks/SpecTaskTerminalDrawer.tsx` → `session/SessionTerminal.tsx` | WS `/sessions/{id}/terminal`, `/terminal-sessions` (`session_terminal_handlers.go`, hydra exec) | none |
+| Browser (reverse tunnel) | `tasks/SandboxBrowser.tsx` | `/sessions/{id}/preview-tokens` (`session_preview_handlers.go`), `vhost_routes` → RevDial → hydra dev-container proxy | none; needs `DEV_SUBDOMAIN` |
+| Share preview URLs | `tasks/SharePreviewSection.tsx` | same preview-token hooks + rotate/delete | none |
+| Sandbox status dot | `tasks/SandboxStatusIndicator.tsx` | pure prop | none |
+| Execution controls | `agent/CodeAgentExecutionControls.tsx` | pure value/onChange | none; persistence is the caller's |
+| View toolbar | `tasks/SpecTaskViewToolbar.tsx` | pure props: `TaskView` (`chat\|desktop\|browser\|changes\|files\|details`), `hasSession`, `showDesktop`, start/stop/restart, terminal toggle | none |
+
+Session-backed `sandboxes` rows route hydra ops by the **session id**
+(`Sandbox.HydraOpsID()`), so a bot session already drives the whole
+`/external-agents/{sessionId}/*` surface with no spec task involved.
+
+**What to build.** Extend `components/helix-org/OrgAgentSessionWorkspace.tsx` (today:
+chat + desktop split only, used from `pages/Session.tsx:1607` for sessions with
+`org_worker_id`) into the bot equivalent of `SpecTaskDetailContent`:
+
+- `SpecTaskViewToolbar` with the same `TaskView` set. `hasSession` = bot has a
+  `session_id`; `showDesktop` = effective runtime is `ubuntu-desktop`; start / stop /
+  restart wired to `useActivateBot` / `useStopBotAgent` / `useRestartBotAgent`;
+  terminal toggle opens `SpecTaskTerminalDrawer` on the bot session. `showKeepAlive`
+  stays off (deferred).
+- Views: `chat` → `AgentChat` (no task id); `desktop` → `ExternalAgentDesktopViewer`
+  (already there); `browser` → `SandboxBrowser`; `changes` / `files` → `DiffViewer`
+  with `baseBranch` = the bot repo's default branch; `details` → a bot details pane
+  (below).
+- Details pane (replaces the task's Details view): sandbox runtime + preset picker
+  (`CodeAgentExecutionControls` Compute + Environment, never locked, "takes effect on
+  restart"), harness/model (`BotRuntimeForm`), sandbox status / id / host, project and
+  repo links, `SharePreviewSection`, `AgentRestartRequiredBanner`, and the activation
+  history from `org_activations` (the transcript already exists as
+  `s-transcript-<bot>`). Saving the picker calls `PATCH /orgs/{org}/agents/{id}`.
+- Mount points: `pages/Session.tsx` (org chat → bot row → session) keeps using this
+  component; the `helix_org_bot_detail` route mounts the same workspace so the
+  orphaned `HelixOrgBotDetail.tsx` / `HelixOrgBots.tsx` can go. `HelixOrgChatPanel`
+  keeps its bot picker and lifecycle menu but delegates the body to the workspace.
+- `SandboxStatusIndicator` replaces the local green/grey dot on the chart and chat
+  panel; it maps `sandbox_status` → `running/starting/stopped`.
+- Org settings: the two sandbox defaults next to the default agent config.
+- Sandboxes list: link column to the org agent via `org_bot_id`, mirroring the
+  spec-task link.
+
+**Headless bots.** Desktop tab hidden (same `isHeadless` routing as
+`SpecTaskDetailContent.tsx:767`). Files/diff work through the workspace-only desktop
+bridge, the terminal through hydra exec, and the browser preview through the hydra
+dev-container proxy — none need a compositor. Screenshots do not exist.
+
+**One backend nit.** `GET /external-agents/{sessionId}/workspaces` fills
+`ExpectedBranch` only from the spec task (`session_workspace_handlers.go:339`); without
+one the switch-agent safety net reports "can't save changes". For bot sessions resolve
+it from the bot repo's default branch (the session has `OrgWorkerID`), or the
+switch-agent dialog on a bot will always refuse to auto-commit.
+
+### 4.4 Compatibility
+
+Existing bots have NULL config → resolve to org default → global default
+`ubuntu-desktop` + standard preset. Behaviour is identical to today except the
+container is now capped at the preset (12 vCPU / 24 GB) instead of uncapped; that
+matches what it is already billed as. Sessions created before the change carry no
+metadata until their next activation stamps it, and a restart is the only thing needed
+to pick up a changed runtime.
+
+## 5. What must be validated
+
+Live, in the inner Helix at `localhost:8080`, against a connected Zed. Seeded rows do
+not exercise the resume paths. Per `CLAUDE.md`, test the operation *after* each state
+change, not just the state change.
+
+**Launch config on every path**
+1. Create a bot with `headless-ubuntu` / 4 vCPU → first activation: container has
+   `HELIX_HEADLESS=1`, rootless isolation, `sandboxes` row `runtime=headless-ubuntu`,
+   `vcpus=4`, `org_bot_id` set, name `<Bot> @ <Org>`.
+2. Let the idle checker stop it (set `HELIX_DESKTOP_IDLE_TIMEOUT` low) → fire a cron
+   trigger → the auto-start path boots it headless at 4 vCPU again. Repeat for
+   `POST /sessions/{id}/resume`, the auto-wake cold-start retry, and the container
+   reconciler after a `docker kill`.
+3. Same bot, switch to `ubuntu-desktop` / 12 vCPU → `restart_required=true`, running
+   container untouched → `restart-agent` → new container is a desktop at 12 vCPU, and
+   the next trigger produces a reply.
+4. Desktop bot on a host with `RenderNode=SOFTWARE` → PATCH to desktop rejected;
+   headless placement succeeds on that host.
+5. Pre-existing bot with NULL config → activation still boots a desktop; it is now
+   capped at the standard preset; org default set to headless → *new* bots inherit,
+   existing bots do not.
+
+**Wake loop unchanged**
+6. Publish 5 events in a burst → 5 sequential activations, FIFO, one `org_activations`
+   row each; `stop-agent` mid-burst drains the consumer and nothing fires after.
+7. `PreserveContext=false` → each activation clears the thread; `true` → thread persists
+   across an idle stop + wake.
+8. Kill the API mid-activation → consumer resumes on boot and redelivers.
+
+**Status and API**
+9. `sandbox_status` walks `pending → running → stopped` from the chart and chat panel;
+   a failed boot (bad image tag) yields `failed` with the hydra reason in
+   `status_message`; the queue Naks with backoff.
+10. `activate` / `stop-agent` / `restart-agent` behave exactly as before for a bot that
+    never had sandbox config set.
+11. MCP `start_bot` / `stop_bot` / `restart_bot` and the CLI produce the same
+    transitions; `create_bot` with `sandbox_runtime` lands on the row.
+12. Cross-org: bot ids collide across orgs (`b-root`); the Sandboxes list and the bot
+    DTO never leak another org's row.
+
+**Workspace UI (bot session, desktop and headless variants)**
+13. Chat, Changes, Files, Browser and the terminal drawer all work on a running bot
+    session from the org chat and from the bot detail route; Files shows the bot repo,
+    Changes diffs against its default branch after the bot commits something.
+14. Browser: navigate to a port the bot is serving → a `share-<random>` preview token
+    is minted, the iframe loads, the token is listed and revocable under Details.
+15. Headless bot: Desktop tab absent, everything in 13–14 still works; desktop bot:
+    Desktop tab streams.
+16. Toolbar start/stop/restart change `sandbox_status` and the status dot on the chart
+    and chat panel within one poll; the restart-required banner appears after changing
+    the runtime in Details and disappears after restart.
+17. Switch-agent from a bot session with uncommitted changes offers to commit to the
+    bot repo branch rather than refusing (the `ExpectedBranch` fix).
+18. Mobile width: the toolbar folds like the task page and each view is reachable.
+
+**Regression**
+19. A headless bot can still `create_spectask`, `send_spectask_agent_message`, read
+    files via the desktop bridge's workspace-only API, and use `sandbox_ssh_access`;
+    the org chat Desktop tab is hidden for it and present for a desktop bot.
+20. Org delete tears down bot sandboxes and closes their rows. The org-delete sweep
+    (`0087ceaeb`) walks the org's external-agent sessions, which includes bot sessions,
+    but confirm the session-backed `sandboxes` row is closed too, not just the container.
+21. Migration backfill on a Postgres copy with: bots with and without sessions,
+    sessions whose sandbox row is already closed, two orgs sharing a bot id.
+22. Go: `resolveLaunchConfig` table test covering task / org-worker / plain session on
+    each caller; `BeginSession` reuse with `OrgBotID`; status derivation;
+    `go test ./pkg/server/ ./pkg/sandbox/ ./pkg/external-agent/ ./pkg/org/...`.
+    Frontend: `yarn build`. E2E (`run_docker_e2e.sh`) if the executor change touches
+    the WS sync path.
+
+## 6. Deferred (not in this PR)
+
+- Billing block on the bot page, `org_bot_id` in `OrgComputeUsage`, price hints.
+- `keep_alive` on bots (idle-checker exclusion).
+- Session-preserving restart (`restartSessionContainer`) and a `reset` verb.
+- Live resize via `UpdateDesktopResources` on PATCH while running.
+- A `/agents/{id}/sandbox` sub-resource; removing the `/bots/*` alias.
+- Task-only surfaces that have no bot equivalent: specs / design-doc review, approval
+  and PR actions, attachments, clone groups, the Zed thread selector (a bot has one
+  session). Multi-session bots would need the thread selector back.
+
+## 7. Implementation notes and verification (2026-09-07)
+
+Implemented as designed in §3–4, with these deviations discovered while building:
+
+- **Sandbox row naming.** `StartExternalAgentSession` named a fresh session from its
+  first prompt and the in-proc client renamed it only *after* `StartDesktop`, so the
+  sandbox row (named at `BeginSession`) carried the prompt text. `SessionChatRequest`
+  now takes an internal `SessionName`, applied before the desktop starts.
+- **Org nodes repo update map.** `nodesRepo.Update` writes an explicit column map, so
+  new Node fields silently don't persist unless added there. The gorm org tests run on
+  the in-memory store and would not have caught it; the live PATCH did.
+- **GORM naming.** `SandboxVCPUs` needs an explicit `column:sandbox_vcpus` tag; GORM's
+  default produced `sandbox_v_cpus`.
+- **Display-host check on PATCH** is not enforced (the org API adapter has no host
+  store); a desktop bot on a display-less host fails at start with hydra's placement
+  error in `sandbox_status_message` instead.
+
+Verified live in the dev stack (`unmanned-org`, bot `b-mira`):
+
+| Check | Result |
+|---|---|
+| `PATCH` invalid runtime / off-ladder vCPU | 400 with the ladder in the message |
+| `PATCH` headless / 4 vCPU → `GET` | stored + effective values; `sandbox_resource_overrides` reset to inherit with `vcpus: 0` |
+| activate stopped bot | container `headless-external-…`, `HELIX_HEADLESS=1`, `HELIX_WORKER_ID=b-mira`, 4 vCPU / 8 GB, rootless; session metadata carries runtime + resources; sandbox row `Software Engineer`, `headless-ubuntu`, `org_bot_id=b-mira`; agent turn completed |
+| stop-agent → activate (resume path) | same sandbox row reused, container headless at 4 vCPU again |
+| switch to desktop / 8 vCPU while running | `restart_required=true`; container untouched |
+| restart-agent | new session, `ubuntu-external-…` container, 8 vCPU / 16 GB, privileged; `restart_required` cleared; sandbox row `ubuntu-desktop` |
+| restart-agent after the naming fix | new sandbox row named after the bot |
+| org chat → bot session | toolbar Desktop / Browser / Diff / Files / Details, Terminal, Stop, Restart; desktop streams; Diff and Files load the workspace; Details shows sandbox status, environment, compute, sandbox/session/project links, share-preview URLs; terminal drawer opens |
+| agent settings | Environment + Compute picker with "Org default (currently …)" and Save sandbox |
+| org settings | Default sandbox panel (Helix default hints) |
+| Sandboxes list | rows show "Org agent" source linking to the bot |
+| Go | `go test ./pkg/org/... ./pkg/sandbox/ ./pkg/external-agent/` and the org/inproc/workspace server tests pass |
+| Frontend | `tsc` clean, `yarn build` passes, `vitest` for helix-org / sandboxes / app folders passes |
+
+NOT tested: headless placement on a display-less host, quota caps, org delete sweep,
+the migration backfill on a production copy, and mobile layout.

--- a/design/2026-09-07-org-agent-sandbox-migration.md
+++ b/design/2026-09-07-org-agent-sandbox-migration.md
@@ -464,3 +464,30 @@ Verified live in the dev stack (`unmanned-org`, bot `b-mira`):
 NOT tested: headless placement on a display-less host, quota caps, org delete sweep,
 the migration backfill on a production copy, mobile layout, and native SSH against a
 desktop bot (same docker-exec path; only the id routing differed).
+
+## 8. Follow-up fixes (2026-09-08)
+
+- **Agent-side SSH was unreachable.** `sandbox_ssh_access` advertised the proxy as
+  `api:2224` (inferred from `SANDBOX_API_URL`), a name that does not resolve on the
+  isolated sandbox bridge, where only `helix-api.internal` (the Hydra gateway) is
+  routable and only :18080 was forwarded. Hydra now mirrors the control plane's SSH
+  proxy on the gateway (`hydra.SandboxSSHProxyListenAddress`, a raw TCP pipe; the
+  control plane still authenticates every connection), the sandbox network policy
+  admits gateway:2224, and `ASSET_SSH_PROXY_ADDRESS` defaults to
+  `helix-api.internal:2224`. Verified from inside a desktop bot container with a
+  minted cert: `ssh sandbox@helix-api.internal -p 2224` lands in the bot's own
+  container. Existing sandboxes need the new hydra binary and a network-policy
+  re-run (or a sandbox restart) to pick up the rule.
+- **Files / Diff stayed on the start placeholder after the sandbox came up.** The
+  session page fetched the bot once; the workspace gates those surfaces on
+  `agent_status`, so it never noticed the start. The bot is now polled every 5 s
+  while the page is open.
+- **Diff base branch.** The workspace inspector sent `base=main` for every session.
+  Org agents' repos are not necessarily on main (keel is on master); `base` is now
+  omitted unless the caller knows a task branch, so the desktop resolves the
+  repository's own default.
+- **Prompt queue parity.** The org session queue now uses the same attached-header
+  chrome and rows as the spec-task composer queue, and hides prompts already handed
+  to the agent (`sending`) like the task queue does.
+- The trailing status dot on the view toolbar is gone; status lives on the Details
+  pane, which was redesigned as a stat strip plus copyable ids.

--- a/design/2026-09-07-org-agent-sandbox-migration.md
+++ b/design/2026-09-07-org-agent-sandbox-migration.md
@@ -457,5 +457,10 @@ Verified live in the dev stack (`unmanned-org`, bot `b-mira`):
 | Go | `go test ./pkg/org/... ./pkg/sandbox/ ./pkg/external-agent/` and the org/inproc/workspace server tests pass |
 | Frontend | `tsc` clean, `yarn build` passes, `vitest` for helix-org / sandboxes / app folders passes |
 
+| chat parity | the bot session page now renders `AgentChat` (the spec-task chat) instead of the legacy Session composer: sandbox file/image attachments via upload, prompt queue, plan progress, cancel, execution controls |
+| native SSH (`sandbox_ssh_access` → proxy on :2224) | fixed: `helix/sandboxes.go` opened the hydra terminal with the row id, which 404s for every session-backed row; now `HydraOpsID()`. Verified with a minted user cert: `ssh sandbox@localhost -p 2224` lands in the headless bot container (`HELIX_WORKER_ID=b-mira`, `HELIX_HEADLESS=1`) |
+| Sandboxes UI terminal on the bot's row | Terminal tab on `/orgs/…/sandboxes/<id>` opens a shell in the bot container |
+
 NOT tested: headless placement on a display-less host, quota caps, org delete sweep,
-the migration backfill on a production copy, and mobile layout.
+the migration backfill on a production copy, mobile layout, and native SSH against a
+desktop bot (same docker-exec path; only the id routing differed).

--- a/design/2026-09-07-org-agent-sandbox-migration.md
+++ b/design/2026-09-07-org-agent-sandbox-migration.md
@@ -465,6 +465,28 @@ NOT tested: headless placement on a display-less host, quota caps, org delete sw
 the migration backfill on a production copy, mobile layout, and native SSH against a
 desktop bot (same docker-exec path; only the id routing differed).
 
+### 2026-09-08: "agent not starting" on chief-of-staff
+
+Not caused by this change. The bot's App was pinned to `qwen3.8-27b` on the
+`ds4-flash-node06` endpoint, which only serves `qwen3.8-flash-next`; every LLM call had
+failed for days (last completed turn 2026-08-08). OpenCode surfaces that as
+`OpenCode service failure: {"service": "session"}` and the real reason only lived in
+`llm_calls`. Two server bugs made it worse and are fixed here:
+
+- `handleThreadLoadError` discarded a thread-load error that arrived within the
+  10 s streaming-evidence window as a "rejected duplicate delivery". The send itself
+  publishes to the streaming context, so an agent that rejects the *first* delivery
+  (OpenCode with a dead persisted session) always lands inside the window, and the
+  turn stayed `waiting` forever with a connected agent that no watchdog reaps. It now
+  defers and re-examines after the window, exactly like `applyTurnError`.
+- Thread-load failures now carry the session's most recent provider error
+  (`recentProviderFailure`, shared with the turn-abort path), so the UI shows
+  "model X is not in the list of allowed models" instead of an opaque service failure.
+
+Recovery for the bot itself was config: model switched to `qwen3.8-flash-next`, then a
+bot restart to discard the OpenCode session created under the bad model. Verified: a
+manual activation completes in ~40 s with successful LLM calls.
+
 ## 8. Follow-up fixes (2026-09-08)
 
 - **Agent-side SSH was unreachable.** `sandbox_ssh_access` advertised the proxy as

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -45,6 +45,8 @@ export interface ApiAgentDetailDTO {
    * not (it would repeat kilobytes of prompt per row).
    */
   default_instructions?: string;
+  effective_sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  effective_sandbox_runtime?: TypesSandboxRuntime;
   helix_user_id?: string;
   id?: string;
   identity?: Record<string, string>;
@@ -79,6 +81,19 @@ export interface ApiAgentDetailDTO {
    * restart banner on the bot page and the org chat panel.
    */
   restart_required?: boolean;
+  sandbox_id?: string;
+  sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  /**
+   * SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+   * config in the spec-task vocabulary; empty means "inherit the org
+   * default". The Effective* fields are what the next container start will
+   * actually use once org and global defaults are applied. SandboxID /
+   * SandboxStatus come from the session-backed sandboxes row, when one
+   * exists (pending, running, stopping, stopped, failed).
+   */
+  sandbox_runtime?: TypesSandboxRuntime;
+  sandbox_status?: string;
+  sandbox_status_message?: string;
   session_id?: string;
   tools?: string[];
   updated_at?: string;
@@ -175,6 +190,8 @@ export interface ApiBotDTO {
    * not (it would repeat kilobytes of prompt per row).
    */
   default_instructions?: string;
+  effective_sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  effective_sandbox_runtime?: TypesSandboxRuntime;
   helix_user_id?: string;
   id?: string;
   identity?: Record<string, string>;
@@ -216,6 +233,19 @@ export interface ApiBotDTO {
    * restart banner on the bot page and the org chat panel.
    */
   restart_required?: boolean;
+  sandbox_id?: string;
+  sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  /**
+   * SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+   * config in the spec-task vocabulary; empty means "inherit the org
+   * default". The Effective* fields are what the next container start will
+   * actually use once org and global defaults are applied. SandboxID /
+   * SandboxStatus come from the session-backed sandboxes row, when one
+   * exists (pending, running, stopping, stopped, failed).
+   */
+  sandbox_runtime?: TypesSandboxRuntime;
+  sandbox_status?: string;
+  sandbox_status_message?: string;
   session_id?: string;
   tools?: string[];
   updated_at?: string;
@@ -272,6 +302,12 @@ export interface ApiCreateBotRequest {
   preserve_context?: boolean;
   provider?: string;
   reasoning_effort?: string;
+  sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  /**
+   * SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.
+   * Only vcpus is read from the overrides — memory follows the preset.
+   */
+  sandbox_runtime?: TypesSandboxRuntime;
   tools?: string[];
   triggers?: string[];
 }
@@ -552,6 +588,14 @@ export interface ApiUpdateBotRequest {
   project_ids?: string[];
   provider?: string;
   reasoning_effort?: string;
+  sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  /**
+   * SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox
+   * config. A present-but-empty runtime, or vcpus=0, resets that field to
+   * inherit. Takes effect on the next container start; a running sandbox
+   * gets restart_required.
+   */
+  sandbox_runtime?: TypesSandboxRuntime;
   tools?: string[];
 }
 
@@ -2329,14 +2373,14 @@ export enum TransportFieldType {
 }
 
 export enum TransportKind {
-  KindEmail = "email",
-  KindLocal = "local",
-  KindCron = "cron",
   KindWebhook = "webhook",
-  KindGitHub = "github",
-  KindGitLab = "gitlab",
   KindHelixEvents = "helix_events",
+  KindLocal = "local",
+  KindGitHub = "github",
   KindSlack = "slack",
+  KindGitLab = "gitlab",
+  KindEmail = "email",
+  KindCron = "cron",
 }
 
 export interface TransportResolvedActivation {
@@ -6141,6 +6185,12 @@ export interface TypesSandbox {
   image?: string;
   memory_mb?: number;
   name?: string;
+  /**
+   * OrgBotID is the helix-org bot whose session owns this container, when
+   * there is one. Denormalised from the session (org_worker_id) so the bot
+   * detail and the Sandboxes list can link both ways without joining sessions.
+   */
+  org_bot_id?: string;
   organization_id?: string;
   owner?: string;
   /**
@@ -6893,6 +6943,16 @@ export interface TypesSessionMetadata {
   /** GPU render node of sandbox (/dev/dri/renderD128 or SOFTWARE) */
   render_node?: string;
   runtime_instructions?: string;
+  sandbox_resource_overrides?: TypesSandboxResourceOverrides;
+  /**
+   * SandboxRuntime and SandboxResourceOverrides are the container runtime and
+   * size for an org-worker session. The org spawner writes them from the Bot
+   * on every activation and StartDesktop reads them on every launch path
+   * (fresh start, message auto-start, resume, auto-wake, reconciler), so a
+   * headless bot never comes back as a desktop. SpecTask sessions leave both
+   * empty — the task is authoritative there, as with CodeAgentConfig.
+   */
+  sandbox_runtime?: TypesSandboxRuntime;
   session_rag_results?: TypesSessionRAGResult[];
   /** "planning", "implementation", "coordination", "exploratory" */
   session_role?: string;

--- a/frontend/src/components/app/OrgAgentSettings.tsx
+++ b/frontend/src/components/app/OrgAgentSettings.tsx
@@ -12,6 +12,7 @@ import { Pencil, Square, SquareCheck } from 'lucide-react'
 
 import ToolPickerDialog from '../helix-org/ToolPickerDialog'
 import AgentConfigForm, { AgentConfigValue } from '../helix-org/BotRuntimeForm'
+import BotSandboxForm, { BotSandboxValue } from '../helix-org/BotSandboxForm'
 import MonacoEditor from '../widgets/MonacoEditor'
 import useSnackbar from '../../hooks/useSnackbar'
 import { useListProjects } from '../../services/projectService'
@@ -64,6 +65,18 @@ const OrgAgentSettings: FC<{
     model: '',
     reasoning_effort: 'none',
   })
+
+  const [sandbox, setSandbox] = useState<BotSandboxValue>({ runtime: '', vcpus: 0 })
+  useEffect(() => {
+    setSandbox({
+      runtime: agent?.sandbox_runtime ?? '',
+      vcpus: agent?.sandbox_resource_overrides?.vcpus ?? 0,
+    })
+  }, [agent?.sandbox_runtime, agent?.sandbox_resource_overrides?.vcpus])
+  const sandboxDirty = !!agent && (
+    sandbox.runtime !== (agent.sandbox_runtime ?? '')
+    || sandbox.vcpus !== (agent.sandbox_resource_overrides?.vcpus ?? 0)
+  )
 
   useEffect(() => {
     setName(agent?.name ?? '')
@@ -192,6 +205,35 @@ const OrgAgentSettings: FC<{
   if (section === 'runtime') {
     return (
       <Box sx={{ mt: embedded ? 0 : 3 }}>
+        {!embedded && <Typography variant="subtitle1">Sandbox</Typography>}
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          The container this agent runs in. Changes apply the next time the agent starts;
+          a running sandbox shows a restart prompt.
+        </Typography>
+        <BotSandboxForm
+          value={sandbox}
+          onChange={(patch) => setSandbox((current) => ({ ...current, ...patch }))}
+          disabled={readOnly || updateAgent.isPending}
+          inheritLabel="Org default"
+          effective={{
+            runtime: agent.effective_sandbox_runtime,
+            vcpus: agent.effective_sandbox_resource_overrides?.vcpus,
+            memory_mb: agent.effective_sandbox_resource_overrides?.memory_mb,
+          }}
+        />
+        <Box sx={{ mt: 2, mb: 3 }}>
+          <Button
+            variant="contained"
+            size="small"
+            disabled={readOnly || updateAgent.isPending || !sandboxDirty}
+            onClick={() => void update({
+              sandbox_runtime: sandbox.runtime as NonNullable<typeof agent.sandbox_runtime>,
+              sandbox_resource_overrides: { vcpus: sandbox.vcpus },
+            })}
+          >
+            Save sandbox
+          </Button>
+        </Box>
         {!embedded && <Typography variant="subtitle1">Context</Typography>}
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
           <Typography variant="body1">Preserve context</Typography>

--- a/frontend/src/components/app/OrgAgentSettings.tsx
+++ b/frontend/src/components/app/OrgAgentSettings.tsx
@@ -1,4 +1,4 @@
-import { FC, Key, useEffect, useMemo, useState } from 'react'
+import { FC, Key, useEffect, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -90,16 +90,6 @@ const OrgAgentSettings: FC<{
     })
   }, [agent?.name, agent?.content, agent?.code_agent_runtime, agent?.code_agent_credential_type, agent?.provider, agent?.model, agent?.reasoning_effort])
 
-  const basicsDirty = useMemo(() => {
-    if (!agent) return false
-    return name !== (agent.name ?? '')
-      || runtimeConfig.runtime !== (agent.code_agent_runtime ?? '')
-      || runtimeConfig.credentials !== (agent.code_agent_credential_type ?? 'api_key')
-      || runtimeConfig.provider !== (agent.provider ?? '')
-      || runtimeConfig.model !== (agent.model ?? '')
-      || (runtimeConfig.reasoning_effort ?? 'none') !== (agent.reasoning_effort ?? 'none')
-  }, [agent, name, runtimeConfig])
-
   if (!agent?.id) return null
 
   const update = async (patch: UpdateBotRequest) => {
@@ -113,12 +103,39 @@ const OrgAgentSettings: FC<{
   }
 
   if (section === 'basics') {
+    // No save button: harness, model and effort persist the moment they change,
+    // the name when its field loses focus. A config change carries an
+    // uncommitted name with it, so the refetch that follows cannot discard it.
+    const nameDirty = !!name.trim() && name.trim() !== (agent.name ?? '')
+    const saveBasics = (config: AgentConfigValue, nextName?: string) => {
+      if (!config.runtime) return
+      void update({
+        ...(nextName ? { name: nextName } : {}),
+        code_agent_runtime: config.runtime as NonNullable<typeof agent.code_agent_runtime>,
+        code_agent_credential_type: config.credentials as NonNullable<typeof agent.code_agent_credential_type>,
+        provider: config.provider,
+        model: config.model,
+        reasoning_effort: config.reasoning_effort ?? 'none',
+      })
+    }
+    const commitName = () => {
+      // A config save disables the field, which blurs it; that patch already
+      // carried the name, so don't PATCH it a second time.
+      if (readOnly || updateAgent.isPending) return
+      // An emptied field is a mistake, not a request to clear the name.
+      if (!name.trim()) {
+        setName(agent.name ?? '')
+        return
+      }
+      if (!nameDirty) return
+      void update({ name: name.trim() })
+    }
     return (
       <Box sx={{ mb: embedded ? 0 : 3 }}>
         {!embedded && (<>
-        <Typography variant="h5" sx={{ mb: 0.5 }}>Basics</Typography>
+        <Typography variant="h5" sx={{ mb: 0.5 }}>Agent</Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Configure the org agent's name, coding runtime, model, and reasoning effort.
+          The org agent's name, coding harness, model, and reasoning effort. Changes save as you make them.
         </Typography>
         </>)}
         <Stack spacing={3}>
@@ -126,32 +143,24 @@ const OrgAgentSettings: FC<{
             label="Agent name"
             value={name}
             onChange={(event) => setName(event.target.value)}
+            onBlur={commitName}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') (event.target as HTMLInputElement).blur()
+            }}
             disabled={readOnly || updateAgent.isPending}
-            helperText="Use a name that makes this agent easy to identify."
+            helperText="Use a name that makes this agent easy to identify. Saved when you click away."
             fullWidth
           />
           <AgentConfigForm
             value={runtimeConfig}
-            onChange={(patch) => setRuntimeConfig((current) => ({ ...current, ...patch }))}
+            onChange={(patch) => {
+              const next = { ...runtimeConfig, ...patch }
+              setRuntimeConfig(next)
+              saveBasics(next, nameDirty ? name.trim() : undefined)
+            }}
             showReasoningEffort
             disabled={readOnly || updateAgent.isPending}
           />
-          <Box>
-            <Button
-              variant="contained"
-              disabled={readOnly || updateAgent.isPending || !basicsDirty || !name.trim() || !runtimeConfig.runtime}
-              onClick={() => void update({
-                name: name.trim(),
-                code_agent_runtime: runtimeConfig.runtime as NonNullable<typeof agent.code_agent_runtime>,
-                code_agent_credential_type: runtimeConfig.credentials as NonNullable<typeof agent.code_agent_credential_type>,
-                provider: runtimeConfig.provider,
-                model: runtimeConfig.model,
-                reasoning_effort: runtimeConfig.reasoning_effort ?? 'none',
-              })}
-            >
-              Save basics
-            </Button>
-          </Box>
         </Stack>
       </Box>
     )
@@ -195,7 +204,7 @@ const OrgAgentSettings: FC<{
             disabled={readOnly || updateAgent.isPending || !instructionsDirty}
             onClick={() => void update({ content })}
           >
-            Save instructions
+            Save
           </Button>
         </Stack>
       </Stack>
@@ -231,7 +240,7 @@ const OrgAgentSettings: FC<{
               sandbox_resource_overrides: { vcpus: sandbox.vcpus },
             })}
           >
-            Save sandbox
+            Save
           </Button>
         </Box>
         {!embedded && <Typography variant="subtitle1">Context</Typography>}

--- a/frontend/src/components/helix-org/AgentRestartRequiredBanner.test.tsx
+++ b/frontend/src/components/helix-org/AgentRestartRequiredBanner.test.tsx
@@ -20,7 +20,7 @@ describe('AgentRestartRequiredBanner', () => {
     const onRestart = vi.fn()
     render(<AgentRestartRequiredBanner visible onRestart={onRestart} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /restart sandbox/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^restart$/i }))
     expect(onRestart).not.toHaveBeenCalled()
     expect(screen.getByText(/current chat history is discarded/i)).toBeInTheDocument()
   })
@@ -29,7 +29,7 @@ describe('AgentRestartRequiredBanner', () => {
     const onRestart = vi.fn()
     render(<AgentRestartRequiredBanner visible onRestart={onRestart} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /restart sandbox/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^restart$/i }))
     fireEvent.click(screen.getByTestId('agent-restart-confirm'))
     expect(onRestart).toHaveBeenCalledTimes(1)
   })
@@ -38,7 +38,7 @@ describe('AgentRestartRequiredBanner', () => {
     const onRestart = vi.fn()
     render(<AgentRestartRequiredBanner visible onRestart={onRestart} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /restart sandbox/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^restart$/i }))
     fireEvent.click(screen.getByTestId('agent-restart-cancel'))
     expect(onRestart).not.toHaveBeenCalled()
     expect(screen.getByTestId('agent-restart-required-banner')).toBeInTheDocument()
@@ -54,12 +54,12 @@ describe('AgentRestartRequiredBanner', () => {
   // Live work in progress is the one thing a restart genuinely destroys.
   it('gates the restart while the agent is mid-turn', () => {
     render(<AgentRestartRequiredBanner visible working onRestart={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /restart sandbox/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^restart$/i })).toBeDisabled()
   })
 
   it('gates the restart while a lifecycle action is in flight', () => {
     render(<AgentRestartRequiredBanner visible busy onRestart={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /restart sandbox/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^restart$/i })).toBeDisabled()
   })
 
   it('pins to the top of its scrolling ancestor when sticky', () => {

--- a/frontend/src/components/helix-org/AgentRestartRequiredBanner.tsx
+++ b/frontend/src/components/helix-org/AgentRestartRequiredBanner.tsx
@@ -26,6 +26,16 @@ import { RotateCcw } from 'lucide-react'
 
 import { APP_FONT_FAMILY } from '../../styles/typography'
 
+// The banner is a notice, not a toolbar: its buttons sit shorter than the
+// default so the warning strip keeps breathing room above and below them.
+const COMPACT_BUTTON_SX = {
+  minHeight: 24,
+  py: 0.125,
+  px: 1.25,
+  fontSize: '0.75rem',
+  lineHeight: 1.5,
+} as const
+
 export interface AgentRestartRequiredBannerProps {
   visible: boolean
   working?: boolean
@@ -81,34 +91,35 @@ const AgentRestartRequiredBanner: FC<AgentRestartRequiredBannerProps> = ({
         alignItems: 'center',
         gap: 1,
         px: 1.5,
-        py: 1,
+        py: 0.75,
         mb: 1,
         borderRadius: 1,
         border: `1px solid ${alpha(theme.palette.warning.main, 0.35)}`,
         backgroundColor: alpha(theme.palette.warning.main, 0.08),
       }}
     >
-      <RotateCcw size={18} strokeWidth={1.8} />
+      <RotateCcw size={16} strokeWidth={1.8} />
       <Typography
         variant="body2"
         sx={{ flexGrow: 1, fontSize: '0.8rem', fontFamily: APP_FONT_FAMILY }}
       >
-        Tool and instruction changes apply after a restart.
+        Restart the agent to apply latest changes.
       </Typography>
       <Stack direction="row" alignItems="center" spacing={0.75}>
-        <Button size="small" onClick={() => setDismissed(true)}>
+        <Button size="small" sx={COMPACT_BUTTON_SX} onClick={() => setDismissed(true)}>
           Not now
         </Button>
         <Tooltip title={gateReason}>
           <span>
             <Button
               size="small"
+              sx={COMPACT_BUTTON_SX}
               variant="contained"
               color="secondary"
               disabled={gated}
               onClick={() => setConfirming(true)}
             >
-              Restart sandbox
+              Restart
             </Button>
           </span>
         </Tooltip>
@@ -137,10 +148,10 @@ const AgentRestartRequiredBanner: FC<AgentRestartRequiredBannerProps> = ({
       ) : banner}
 
       <Dialog open={confirming} onClose={() => setConfirming(false)}>
-        <DialogTitle>Restart sandbox?</DialogTitle>
+        <DialogTitle>Restart the agent?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Restarts the sandbox with a fresh conversation. The workspace and
+            The agent starts again with a fresh conversation. The workspace and
             committed work are kept; the current chat history is discarded.
           </DialogContentText>
         </DialogContent>

--- a/frontend/src/components/helix-org/BotSandboxForm.tsx
+++ b/frontend/src/components/helix-org/BotSandboxForm.tsx
@@ -1,0 +1,152 @@
+// BotSandboxForm is the controlled picker for an org agent's sandbox: the
+// environment (full desktop vs headless) and the compute preset. It uses the
+// same vocabulary and ladder as spec tasks (SpecTaskExecutionControls), but
+// as plain selects because it lives on a settings page, not in a chat
+// composer. The parent owns the value and persists it.
+
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import FormControl from '@mui/material/FormControl'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { Cpu, Monitor, Server } from 'lucide-react'
+
+import { TypesSandboxRuntime } from '../../api/api'
+import { SANDBOX_PRESETS, sandboxPresetsFor } from '../../constants/sandboxPresets'
+
+/** '' / 0 mean "inherit" (the org default, or the Helix default for an org). */
+export interface BotSandboxValue {
+  runtime: string
+  vcpus: number
+}
+
+export interface EffectiveSandbox {
+  runtime?: string
+  vcpus?: number
+  memory_mb?: number
+}
+
+export const sandboxRuntimeLabel = (runtime?: string): string => {
+  switch (runtime) {
+    case TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu:
+      return 'Headless'
+    case TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop:
+      return 'Full Desktop'
+    default:
+      return ''
+  }
+}
+
+export const sandboxSizeLabel = (vcpus?: number, memoryMB?: number): string => {
+  if (!vcpus) return ''
+  const preset = SANDBOX_PRESETS.find((p) => p.vcpus === vcpus)
+  if (preset) return `${preset.label} · ${preset.description}`
+  const memory = memoryMB ? ` · ${Math.round(memoryMB / 1024)} GB RAM` : ''
+  return `${vcpus} CPU${memory}`
+}
+
+const INHERIT = '__inherit__'
+
+const BotSandboxForm: FC<{
+  value: BotSandboxValue
+  onChange: (patch: Partial<BotSandboxValue>) => void
+  disabled?: boolean
+  /** Label for the inherit option, e.g. "Org default" or "Helix default". */
+  inheritLabel: string
+  /** What inherit currently resolves to, shown next to the inherit option. */
+  effective?: EffectiveSandbox
+}> = ({ value, onChange, disabled = false, inheritLabel, effective }) => {
+  const presets = sandboxPresetsFor(value.vcpus || undefined)
+  const inheritRuntimeHint = sandboxRuntimeLabel(effective?.runtime)
+  const inheritSizeHint = sandboxSizeLabel(effective?.vcpus, effective?.memory_mb)
+
+  return (
+    <Stack spacing={2}>
+      <Box>
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+          Environment
+        </Typography>
+        <FormControl fullWidth size="small">
+          <Select
+            value={value.runtime || INHERIT}
+            onChange={(e) => onChange({ runtime: e.target.value === INHERIT ? '' : e.target.value })}
+            disabled={disabled}
+            inputProps={{ 'aria-label': 'Sandbox environment' }}
+          >
+            <MenuItem value={INHERIT}>
+              <Stack direction="row" spacing={1.25} alignItems="center">
+                <Server size={18} />
+                <Box>
+                  <Typography variant="body2">{inheritLabel}</Typography>
+                  {inheritRuntimeHint && (
+                    <Typography variant="caption" color="text.secondary">
+                      Currently {inheritRuntimeHint}
+                    </Typography>
+                  )}
+                </Box>
+              </Stack>
+            </MenuItem>
+            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop}>
+              <Stack direction="row" spacing={1.25} alignItems="center">
+                <Monitor size={18} />
+                <Box>
+                  <Typography variant="body2">Full Desktop</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Streamed GNOME desktop with a browser; needs a display-capable host
+                  </Typography>
+                </Box>
+              </Stack>
+            </MenuItem>
+            <MenuItem value={TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu}>
+              <Stack direction="row" spacing={1.25} alignItems="center">
+                <Cpu size={18} />
+                <Box>
+                  <Typography variant="body2">Headless</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Agent toolchain only: files, diff, terminal and web preview, no desktop stream
+                  </Typography>
+                </Box>
+              </Stack>
+            </MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+      <Box>
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+          Compute
+        </Typography>
+        <FormControl fullWidth size="small">
+          <Select
+            value={value.vcpus ? String(value.vcpus) : INHERIT}
+            onChange={(e) => onChange({ vcpus: e.target.value === INHERIT ? 0 : parseInt(e.target.value, 10) })}
+            disabled={disabled}
+            inputProps={{ 'aria-label': 'Sandbox compute' }}
+          >
+            <MenuItem value={INHERIT}>
+              <Box>
+                <Typography variant="body2">{inheritLabel}</Typography>
+                {inheritSizeHint && (
+                  <Typography variant="caption" color="text.secondary">
+                    Currently {inheritSizeHint}
+                  </Typography>
+                )}
+              </Box>
+            </MenuItem>
+            {presets.map((preset) => (
+              <MenuItem key={preset.vcpus} value={String(preset.vcpus)}>
+                <Box>
+                  <Typography variant="body2">{preset.label}</Typography>
+                  <Typography variant="caption" color="text.secondary">{preset.description}</Typography>
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+    </Stack>
+  )
+}
+
+export default BotSandboxForm

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -121,6 +121,8 @@ const HelixOrgChatPanel: FC = () => {
 
   const selectedBot = agents.find((b) => b.id === selectedBotId)
   const agentOnline = selectedBot?.agent_status === 'running'
+  const agentStarting = !agentOnline && selectedBot?.sandbox_status === 'pending'
+  const agentHeadless = selectedBot?.effective_sandbox_runtime === 'headless-ubuntu'
 
   // Project + session for the selected bot (detail endpoint carries project_id).
   const { data: botDetail, refetch: refetchBot } = useHelixOrgBot(selectedBotId || undefined, {
@@ -155,6 +157,10 @@ const HelixOrgChatPanel: FC = () => {
       .catch(() => { if (!cancelled) setChatSessionId(null) })
     return () => { cancelled = true }
   }, [projectID, selectedBotId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (agentHeadless && view === 'desktop') setView('chat')
+  }, [agentHeadless, view])
 
   useEffect(() => {
     streaming.setCurrentSessionId(chatSessionId)
@@ -232,7 +238,11 @@ const HelixOrgChatPanel: FC = () => {
 
   const busy = activateAgent.isPending || stopAgent.isPending || restartAgent.isPending
   const border = lightTheme.isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'
-  const statusColor = agentOnline ? 'rgb(46, 160, 67)' : (lightTheme.isLight ? 'rgba(0,0,0,0.28)' : 'rgba(255,255,255,0.28)')
+  const statusColor = agentOnline
+    ? 'rgb(46, 160, 67)'
+    : agentStarting
+      ? 'rgb(214, 158, 46)'
+      : (lightTheme.isLight ? 'rgba(0,0,0,0.28)' : 'rgba(255,255,255,0.28)')
   const menuIconSx = { mr: 1, fontSize: 20 }
 
   return (
@@ -352,11 +362,12 @@ const HelixOrgChatPanel: FC = () => {
           )}
         </Stack>
         <Stack direction="row" alignItems="center" spacing={0.75} sx={{ pl: 3.5 }}>
-          <Tooltip title={agentOnline ? 'Agent sandbox online' : 'Agent sandbox stopped'}>
+          <Tooltip title={selectedBot?.sandbox_status_message || (agentOnline ? 'Agent sandbox online' : agentStarting ? 'Agent sandbox starting' : 'Agent sandbox stopped')}>
             <Box sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: statusColor, flexShrink: 0 }} />
           </Tooltip>
           <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2 }}>
-            {agentOnline ? 'Running' : 'Stopped'}
+            {agentOnline ? 'Running' : agentStarting ? 'Starting' : selectedBot?.sandbox_status === 'failed' ? 'Failed' : 'Stopped'}
+            {agentHeadless ? ' · headless' : ''}
             {selectedBotId ? ` · ${selectedBotId}` : ''}
           </Typography>
         </Stack>
@@ -372,7 +383,7 @@ const HelixOrgChatPanel: FC = () => {
           ['chat', 'Chat'],
           ['desktop', 'Desktop'],
           ['tasks', 'Tasks'],
-        ] as const).map(([value, label]) => (
+        ] as const).filter(([value]) => value !== 'desktop' || !agentHeadless).map(([value, label]) => (
           <Button
             key={value}
             size="small"

--- a/frontend/src/components/helix-org/OrgAgentDetailsPane.tsx
+++ b/frontend/src/components/helix-org/OrgAgentDetailsPane.tsx
@@ -1,0 +1,139 @@
+// OrgAgentDetailsPane is the "Details" view of the org agent workspace — the
+// bot's counterpart of the spec task Details view. It shows the sandbox the
+// agent runs in (status, environment, size, host row), the session and
+// project it is attached to, and the shareable preview URLs. Editing lives
+// on the agent settings page; this pane links there.
+
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Link from '@mui/material/Link'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { Settings2 } from 'lucide-react'
+
+import useRouter from '../../hooks/useRouter'
+import { BotDTO } from '../../services/helixOrgService'
+import SandboxStatusIndicator, { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
+import SharePreviewSection from '../tasks/SharePreviewSection'
+import { sandboxRuntimeLabel, sandboxSizeLabel } from './BotSandboxForm'
+
+interface OrgAgentDetailsPaneProps {
+  bot: BotDTO
+  sessionId: string
+  organizationId: string
+  indicatorState: SandboxIndicatorState
+}
+
+const Row: FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <Stack direction="row" spacing={2} alignItems="baseline" sx={{ minWidth: 0 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ width: 120, flexShrink: 0 }}>
+      {label}
+    </Typography>
+    <Box sx={{ minWidth: 0, flex: 1 }}>{children}</Box>
+  </Stack>
+)
+
+const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, organizationId, indicatorState }) => {
+  const router = useRouter()
+  const agentID = bot.agent_id ?? bot.agent_app_id
+  const runtime = sandboxRuntimeLabel(bot.effective_sandbox_runtime) || 'Full Desktop'
+  const size = sandboxSizeLabel(
+    bot.effective_sandbox_resource_overrides?.vcpus,
+    bot.effective_sandbox_resource_overrides?.memory_mb,
+  )
+  const ownRuntime = !!bot.sandbox_runtime
+  const ownSize = !!bot.sandbox_resource_overrides?.vcpus
+  const statusLabel = bot.sandbox_status
+    ? bot.sandbox_status.charAt(0).toUpperCase() + bot.sandbox_status.slice(1)
+    : indicatorState === 'running' ? 'Running' : 'Stopped'
+
+  const openSettings = () => {
+    if (!agentID) return
+    router.navigate('org_agent', { org_id: organizationId, app_id: agentID })
+  }
+  const openSandbox = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!bot.sandbox_id) return
+    router.navigate('org_sandbox_detail', { org_id: organizationId, sandbox_id: bot.sandbox_id })
+  }
+  const openProject = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!bot.project_id) return
+    router.navigate('org_project-specs', { org_id: organizationId, id: bot.project_id })
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <SandboxStatusIndicator state={indicatorState} />
+            <Typography variant="subtitle1">Sandbox</Typography>
+          </Stack>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<Settings2 size={16} />}
+            onClick={openSettings}
+            disabled={!agentID}
+          >
+            Agent settings
+          </Button>
+        </Stack>
+        <Stack spacing={1}>
+          <Row label="Status">
+            <Typography variant="body2">{statusLabel}</Typography>
+            {bot.sandbox_status_message && (
+              <Typography variant="caption" color="error.main" sx={{ display: 'block' }}>
+                {bot.sandbox_status_message}
+              </Typography>
+            )}
+          </Row>
+          <Row label="Environment">
+            <Typography variant="body2">
+              {runtime}
+              {!ownRuntime && (
+                <Typography component="span" variant="caption" color="text.secondary"> · org default</Typography>
+              )}
+            </Typography>
+          </Row>
+          <Row label="Compute">
+            <Typography variant="body2">
+              {size || 'Standard'}
+              {!ownSize && (
+                <Typography component="span" variant="caption" color="text.secondary"> · org default</Typography>
+              )}
+            </Typography>
+          </Row>
+          {bot.restart_required && (
+            <Typography variant="caption" color="warning.main">
+              The running sandbox predates the latest settings. Restart the agent to apply them.
+            </Typography>
+          )}
+          {bot.sandbox_id && (
+            <Row label="Sandbox">
+              <Link href="#" onClick={openSandbox} variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>
+                {bot.sandbox_id}
+              </Link>
+            </Row>
+          )}
+          <Row label="Session">
+            <Typography variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>{sessionId}</Typography>
+          </Row>
+          {bot.project_id && (
+            <Row label="Project">
+              <Link href="#" onClick={openProject} variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>
+                {bot.project_id}
+              </Link>
+            </Row>
+          )}
+        </Stack>
+      </Paper>
+      <SharePreviewSection sessionId={sessionId} />
+    </Stack>
+  )
+}
+
+export default OrgAgentDetailsPane

--- a/frontend/src/components/helix-org/OrgAgentDetailsPane.tsx
+++ b/frontend/src/components/helix-org/OrgAgentDetailsPane.tsx
@@ -1,22 +1,26 @@
 // OrgAgentDetailsPane is the "Details" view of the org agent workspace — the
-// bot's counterpart of the spec task Details view. It shows the sandbox the
-// agent runs in (status, environment, size, host row), the session and
-// project it is attached to, and the shareable preview URLs. Editing lives
-// on the agent settings page; this pane links there.
+// bot's counterpart of the spec task Details view: what the agent runs in
+// (environment, size, status), where it lives (sandbox, session, project),
+// and the shareable preview URLs. Editing lives on the agent settings page;
+// this pane links there.
 
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Link from '@mui/material/Link'
-import Paper from '@mui/material/Paper'
+import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { Settings2 } from 'lucide-react'
+import { Box as BoxIcon, Cpu, FolderKanban, MessageSquare, Monitor, Settings2, SquareTerminal } from 'lucide-react'
 
+import useLightTheme from '../../hooks/useLightTheme'
 import useRouter from '../../hooks/useRouter'
 import { BotDTO } from '../../services/helixOrgService'
-import SandboxStatusIndicator, { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
+import { TypesSandboxRuntime } from '../../api/api'
+import CopyButton from '../common/CopyButton'
+import { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
 import SharePreviewSection from '../tasks/SharePreviewSection'
+import { PRESENCE_OFFLINE_COLOR, PRESENCE_ONLINE_COLOR } from '../widgets/PresenceDot'
 import { sandboxRuntimeLabel, sandboxSizeLabel } from './BotSandboxForm'
 
 interface OrgAgentDetailsPaneProps {
@@ -26,112 +30,215 @@ interface OrgAgentDetailsPaneProps {
   indicatorState: SandboxIndicatorState
 }
 
-const Row: FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-  <Stack direction="row" spacing={2} alignItems="baseline" sx={{ minWidth: 0 }}>
-    <Typography variant="body2" color="text.secondary" sx={{ width: 120, flexShrink: 0 }}>
+const STATUS_LABEL: Record<SandboxIndicatorState, string> = {
+  running: 'Running',
+  starting: 'Starting',
+  stopped: 'Stopped',
+}
+
+// One fact of the sandbox: a label, a value, and an optional "org default"
+// note. The stat strip is the same dense treatment cards use elsewhere.
+const Stat: FC<{ icon: ReactNode; label: string; value: string; note?: string }> = ({ icon, label, value, note }) => {
+  const lightTheme = useLightTheme()
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ color: 'text.secondary', mb: 0.25 }}>
+        {icon}
+        <Typography variant="caption" sx={{ fontSize: '0.65rem', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+          {label}
+        </Typography>
+      </Stack>
+      <Typography variant="body2" sx={{ fontSize: '0.85rem', fontWeight: 600, lineHeight: 1.3 }} noWrap>
+        {value}
+      </Typography>
+      {note && (
+        <Typography variant="caption" sx={{ color: lightTheme.isLight ? 'rgba(113,113,122,0.9)' : 'rgba(163,163,163,0.7)' }}>
+          {note}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+// An identifier with its own copy control, optionally opening the thing it
+// names. Kept monospace and single-line so ids never wrap.
+const IdRow: FC<{ label: string; value: string; onOpen?: () => void; openLabel?: string }> = ({ label, value, onOpen, openLabel }) => (
+  <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0, minHeight: 30 }}>
+    <Typography variant="body2" color="text.secondary" sx={{ width: 72, flexShrink: 0 }}>
       {label}
     </Typography>
-    <Box sx={{ minWidth: 0, flex: 1 }}>{children}</Box>
+    {onOpen ? (
+      <Typography
+        component="button"
+        type="button"
+        variant="body2"
+        onClick={onOpen}
+        aria-label={openLabel}
+        sx={{
+          appearance: 'none',
+          border: 0,
+          p: 0,
+          background: 'none',
+          color: 'primary.main',
+          cursor: 'pointer',
+          fontFamily: 'monospace',
+          fontSize: '0.8rem',
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          textAlign: 'left',
+          '&:hover': { textDecoration: 'underline' },
+        }}
+      >
+        {value}
+      </Typography>
+    ) : (
+      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem', minWidth: 0 }} noWrap>
+        {value}
+      </Typography>
+    )}
+    <Box sx={{ flexShrink: 0, ml: 'auto' }}>
+      <CopyButton content={value} size="small" />
+    </Box>
   </Stack>
 )
 
 const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, organizationId, indicatorState }) => {
   const router = useRouter()
+  const lightTheme = useLightTheme()
   const agentID = bot.agent_id ?? bot.agent_app_id
+  const headless = bot.effective_sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
   const runtime = sandboxRuntimeLabel(bot.effective_sandbox_runtime) || 'Full Desktop'
   const size = sandboxSizeLabel(
     bot.effective_sandbox_resource_overrides?.vcpus,
     bot.effective_sandbox_resource_overrides?.memory_mb,
-  )
+  ) || 'Standard'
   const ownRuntime = !!bot.sandbox_runtime
   const ownSize = !!bot.sandbox_resource_overrides?.vcpus
   const statusLabel = bot.sandbox_status
     ? bot.sandbox_status.charAt(0).toUpperCase() + bot.sandbox_status.slice(1)
-    : indicatorState === 'running' ? 'Running' : 'Stopped'
+    : STATUS_LABEL[indicatorState]
+  const statusColor = indicatorState === 'running'
+    ? PRESENCE_ONLINE_COLOR
+    : indicatorState === 'starting' ? '#fbbf24' : PRESENCE_OFFLINE_COLOR
+  const panelSx = {
+    border: '1px solid',
+    borderColor: lightTheme.isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)',
+    borderRadius: 2,
+    backgroundColor: 'background.paper',
+    p: 2,
+  } as const
 
   const openSettings = () => {
     if (!agentID) return
     router.navigate('org_agent', { org_id: organizationId, app_id: agentID })
   }
-  const openSandbox = (e: React.MouseEvent) => {
-    e.preventDefault()
-    if (!bot.sandbox_id) return
-    router.navigate('org_sandbox_detail', { org_id: organizationId, sandbox_id: bot.sandbox_id })
-  }
-  const openProject = (e: React.MouseEvent) => {
-    e.preventDefault()
-    if (!bot.project_id) return
-    router.navigate('org_project-specs', { org_id: organizationId, id: bot.project_id })
-  }
 
   return (
-    <Stack spacing={2}>
-      <Paper variant="outlined" sx={{ p: 2 }}>
-        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
-          <Stack direction="row" alignItems="center" spacing={0.5}>
-            <SandboxStatusIndicator state={indicatorState} />
-            <Typography variant="subtitle1">Sandbox</Typography>
-          </Stack>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<Settings2 size={16} />}
-            onClick={openSettings}
-            disabled={!agentID}
-          >
+    <Stack spacing={2} sx={{ maxWidth: 760 }}>
+      <Box sx={panelSx}>
+        <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 2 }}>
+          <Box
+            component="span"
+            sx={{ width: 9, height: 9, borderRadius: '50%', backgroundColor: statusColor, flexShrink: 0 }}
+          />
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
+            {bot.name || bot.id}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {statusLabel}
+          </Typography>
+          <Tooltip title="Agent settings">
+            <span>
+              <IconButton size="small" aria-label="Agent settings" onClick={openSettings} disabled={!agentID}>
+                <Settings2 size={18} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+
+        {bot.sandbox_status_message && (
+          <Typography variant="body2" color="error.main" sx={{ mb: 1.5 }}>
+            {bot.sandbox_status_message}
+          </Typography>
+        )}
+        {bot.restart_required && (
+          <Typography variant="body2" color="warning.main" sx={{ mb: 1.5 }}>
+            The running sandbox predates the latest settings. Restart the agent to apply them.
+          </Typography>
+        )}
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr 1fr', sm: '1fr 1fr 1fr' },
+            gap: 2,
+            p: 1.5,
+            borderRadius: 2,
+            background: 'linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
+          <Stat
+            icon={headless ? <SquareTerminal size={13} /> : <Monitor size={13} />}
+            label="Environment"
+            value={runtime}
+            note={ownRuntime ? undefined : 'Org default'}
+          />
+          <Stat icon={<Cpu size={13} />} label="Compute" value={size} note={ownSize ? undefined : 'Org default'} />
+          <Stat icon={<BoxIcon size={13} />} label="Status" value={statusLabel} />
+        </Box>
+
+        <Stack spacing={0} sx={{ mt: 2 }}>
+          {bot.sandbox_id && (
+            <IdRow
+              label="Sandbox"
+              value={bot.sandbox_id}
+              openLabel="Open sandbox"
+              onOpen={() => router.navigate('org_sandbox_detail', { org_id: organizationId, sandbox_id: bot.sandbox_id! })}
+            />
+          )}
+          <IdRow label="Session" value={sessionId} />
+          {bot.project_id && (
+            <IdRow
+              label="Project"
+              value={bot.project_id}
+              openLabel="Open project"
+              onOpen={() => router.navigate('org_project-specs', { org_id: organizationId, id: bot.project_id! })}
+            />
+          )}
+        </Stack>
+
+        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+          <Button size="small" variant="outlined" startIcon={<Settings2 size={15} />} onClick={openSettings} disabled={!agentID}>
             Agent settings
           </Button>
-        </Stack>
-        <Stack spacing={1}>
-          <Row label="Status">
-            <Typography variant="body2">{statusLabel}</Typography>
-            {bot.sandbox_status_message && (
-              <Typography variant="caption" color="error.main" sx={{ display: 'block' }}>
-                {bot.sandbox_status_message}
-              </Typography>
-            )}
-          </Row>
-          <Row label="Environment">
-            <Typography variant="body2">
-              {runtime}
-              {!ownRuntime && (
-                <Typography component="span" variant="caption" color="text.secondary"> · org default</Typography>
-              )}
-            </Typography>
-          </Row>
-          <Row label="Compute">
-            <Typography variant="body2">
-              {size || 'Standard'}
-              {!ownSize && (
-                <Typography component="span" variant="caption" color="text.secondary"> · org default</Typography>
-              )}
-            </Typography>
-          </Row>
-          {bot.restart_required && (
-            <Typography variant="caption" color="warning.main">
-              The running sandbox predates the latest settings. Restart the agent to apply them.
-            </Typography>
-          )}
-          {bot.sandbox_id && (
-            <Row label="Sandbox">
-              <Link href="#" onClick={openSandbox} variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>
-                {bot.sandbox_id}
-              </Link>
-            </Row>
-          )}
-          <Row label="Session">
-            <Typography variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>{sessionId}</Typography>
-          </Row>
           {bot.project_id && (
-            <Row label="Project">
-              <Link href="#" onClick={openProject} variant="body2" sx={{ fontFamily: 'monospace' }} noWrap>
-                {bot.project_id}
-              </Link>
-            </Row>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<FolderKanban size={15} />}
+              onClick={() => router.navigate('org_project-specs', { org_id: organizationId, id: bot.project_id! })}
+            >
+              Project board
+            </Button>
           )}
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<MessageSquare size={15} />}
+            onClick={() => router.navigate('helix_org_bot_detail', { org_id: organizationId, bot_id: bot.id! })}
+            disabled={!bot.id}
+          >
+            Agent page
+          </Button>
         </Stack>
-      </Paper>
-      <SharePreviewSection sessionId={sessionId} />
+      </Box>
+
+      <Box sx={{ ...panelSx, '& > .MuiBox-root': { mb: 0 } }}>
+        <SharePreviewSection sessionId={sessionId} />
+      </Box>
     </Stack>
   )
 }

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import OrgAgentSessionWorkspace from './OrgAgentSessionWorkspace'
+import OrgAgentSessionWorkspace, { botSandboxIndicatorState } from './OrgAgentSessionWorkspace'
 
 const mocks = vi.hoisted(() => ({
   isBigScreen: true,
@@ -10,14 +10,37 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../hooks/useIsBigScreen', () => ({ default: () => mocks.isBigScreen }))
 vi.mock('../../hooks/useLightTheme', () => ({ default: () => ({ isLight: true }) }))
+vi.mock('../../hooks/useIsPhone', () => ({ default: () => false }))
+vi.mock('../../hooks/useElementWidth', () => ({ useElementWidth: () => [{ current: null }, 900] }))
 vi.mock('../external-agent/ExternalAgentDesktopViewer', () => ({
   default: ({ sessionId }: { sessionId: string }) => <div>Desktop for {sessionId}</div>,
+}))
+vi.mock('../tasks/DiffViewer', () => ({
+  default: ({ sessionId, primarySurface }: { sessionId: string; primarySurface: string }) => (
+    <div>{primarySurface} for {sessionId}</div>
+  ),
+}))
+vi.mock('../tasks/SandboxBrowser', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div>Browser for {sessionId}</div>,
+}))
+vi.mock('../tasks/SpecTaskTerminalDrawer', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div>Terminal for {sessionId}</div>,
+}))
+vi.mock('./OrgAgentDetailsPane', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div>Details for {sessionId}</div>,
 }))
 vi.mock('react-resizable-panels', () => ({
   Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Separator: () => <div />,
 }))
+
+const runningBot = {
+  id: 'b-eng',
+  agent_status: 'running',
+  sandbox_status: 'running',
+  effective_sandbox_runtime: 'ubuntu-desktop',
+} as const
 
 describe('OrgAgentSessionWorkspace', () => {
   beforeEach(() => {
@@ -44,12 +67,99 @@ describe('OrgAgentSessionWorkspace', () => {
       </OrgAgentSessionWorkspace>,
     )
 
-    expect(screen.getByText('Session chat')).toBeInTheDocument()
-    expect(screen.queryByText('Desktop for session-two')).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /desktop/i }))
-
+    // Chat is a tab on a phone-width layout; the default view is desktop.
     expect(screen.getByText('Desktop for session-two')).toBeInTheDocument()
     expect(screen.queryByText('Session chat')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /chat view/i }))
+
+    expect(screen.getByText('Session chat')).toBeInTheDocument()
+    expect(screen.queryByText('Desktop for session-two')).not.toBeInTheDocument()
+  })
+
+  it('switches between the diff, files, browser and details surfaces', () => {
+    render(
+      <OrgAgentSessionWorkspace sessionId="session-three" organizationId="acme" bot={runningBot as any}>
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /diff view/i }))
+    expect(screen.getByText('changes for session-three')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /files view/i }))
+    expect(screen.getByText('files for session-three')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /browser view/i }))
+    expect(screen.getByText('Browser for session-three')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /details view/i }))
+    expect(screen.getByText('Details for session-three')).toBeInTheDocument()
+  })
+
+  it('hides the desktop for a headless bot and opens on the diff view', () => {
+    render(
+      <OrgAgentSessionWorkspace
+        sessionId="session-four"
+        organizationId="acme"
+        bot={{ ...runningBot, effective_sandbox_runtime: 'headless-ubuntu' } as any}
+      >
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+
+    expect(screen.queryByRole('button', { name: /desktop view/i })).not.toBeInTheDocument()
+    expect(screen.getByText('changes for session-four')).toBeInTheDocument()
+  })
+
+  it('offers start for a stopped bot and stop for a running one', () => {
+    const onStart = vi.fn()
+    const onStop = vi.fn()
+    const { rerender } = render(
+      <OrgAgentSessionWorkspace
+        sessionId="session-five"
+        organizationId="acme"
+        bot={{ ...runningBot, agent_status: 'stopped', sandbox_status: 'stopped' } as any}
+        onStart={onStart}
+        onStop={onStop}
+      >
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /^start/i }))
+    expect(onStart).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <OrgAgentSessionWorkspace
+        sessionId="session-five"
+        organizationId="acme"
+        bot={runningBot as any}
+        onStart={onStart}
+        onStop={onStop}
+      >
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /^stop/i }))
+    expect(onStop).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the terminal drawer from the toolbar', () => {
+    render(
+      <OrgAgentSessionWorkspace sessionId="session-six" organizationId="acme" bot={runningBot as any}>
+        <div>Session chat</div>
+      </OrgAgentSessionWorkspace>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /terminal/i }))
+    expect(screen.getByText('Terminal for session-six')).toBeInTheDocument()
+  })
+})
+
+describe('botSandboxIndicatorState', () => {
+  it('maps agent and sandbox status onto the indicator', () => {
+    expect(botSandboxIndicatorState(undefined)).toBe('running')
+    expect(botSandboxIndicatorState({ agent_status: 'running' } as any)).toBe('running')
+    expect(botSandboxIndicatorState({ agent_status: 'stopped', sandbox_status: 'pending' } as any)).toBe('starting')
+    expect(botSandboxIndicatorState({ agent_status: 'stopped', sandbox_status: 'stopped' } as any)).toBe('stopped')
   })
 })

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.test.tsx
@@ -26,8 +26,8 @@ vi.mock('../tasks/SandboxBrowser', () => ({
 vi.mock('../tasks/SpecTaskTerminalDrawer', () => ({
   default: ({ sessionId }: { sessionId: string }) => <div>Terminal for {sessionId}</div>,
 }))
-vi.mock('./OrgAgentDetailsPane', () => ({
-  default: ({ sessionId }: { sessionId: string }) => <div>Details for {sessionId}</div>,
+vi.mock('./OrgAgentSettingsPane', () => ({
+  default: ({ sessionId }: { sessionId: string }) => <div>Settings for {sessionId}</div>,
 }))
 vi.mock('react-resizable-panels', () => ({
   Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -93,8 +93,8 @@ describe('OrgAgentSessionWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: /browser view/i }))
     expect(screen.getByText('Browser for session-three')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /details view/i }))
-    expect(screen.getByText('Details for session-three')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /settings view/i }))
+    expect(screen.getByText('Settings for session-three')).toBeInTheDocument()
   })
 
   it('hides the desktop for a headless bot and opens on the diff view', () => {

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
@@ -28,7 +28,7 @@ import { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
 import SpecTaskTerminalDrawer from '../tasks/SpecTaskTerminalDrawer'
 import SpecTaskViewToolbar, { TaskView } from '../tasks/SpecTaskViewToolbar'
 import TaskSessionPlaceholder from '../tasks/TaskSessionPlaceholder'
-import OrgAgentDetailsPane from './OrgAgentDetailsPane'
+import OrgAgentSettingsPane from './OrgAgentSettingsPane'
 
 export interface OrgAgentSessionWorkspaceProps {
   sessionId: string
@@ -147,6 +147,7 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
       showRestart={!!bot && !!onRestart}
       onRestart={onRestart}
       restartBusy={lifecycleBusy}
+      detailsLabel="Settings"
     />
   )
 
@@ -185,7 +186,7 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
         )
       case 'details':
         return bot
-          ? <OrgAgentDetailsPane bot={bot} sessionId={sessionId} organizationId={organizationId} indicatorState={indicatorState} />
+          ? <OrgAgentSettingsPane bot={bot} sessionId={sessionId} organizationId={organizationId} indicatorState={indicatorState} />
           : null
       case 'desktop':
       default:
@@ -221,24 +222,35 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
       >
         {surface}
       </Box>
-      {terminalOpen && sessionId && (
-        <SpecTaskTerminalDrawer
-          sessionId={sessionId}
-          running={desktopRunning}
-          height={terminalHeight}
-          onHeightChange={handleTerminalHeight}
-          onClose={() => setTerminalOpen(false)}
-          onCopyToChat={(text) => onAppendToChat?.(text)}
-        />
-      )}
     </Box>
   )
 
+  // The terminal drawer sits under the whole workspace — chat and content
+  // alike — exactly as on the spec task page, not inside the right panel.
+  const terminalDrawer = terminalOpen && sessionId ? (
+    <SpecTaskTerminalDrawer
+      sessionId={sessionId}
+      running={desktopRunning}
+      height={terminalHeight}
+      onHeightChange={handleTerminalHeight}
+      onClose={() => setTerminalOpen(false)}
+      onCopyToChat={(text) => onAppendToChat?.(text)}
+    />
+  ) : null
+
   if (!isBigScreen) {
-    return content
+    return (
+      <Box sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {content}
+        </Box>
+        {terminalDrawer}
+      </Box>
+    )
   }
 
   return (
+    <Box sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
     <PanelGroup
       id="org-agent-session-workspace"
       orientation="horizontal"
@@ -247,7 +259,7 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
         'org-agent-session-desktop': 62,
       }}
       onLayoutChange={(layout) => savePanelLayout(layoutKey, layout, panelIds)}
-      style={{ height: '100%', width: '100%' }}
+      style={{ flex: 1, minHeight: 0, width: '100%' }}
     >
       <Panel
         id="org-agent-session-chat"
@@ -277,6 +289,8 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
         {content}
       </Panel>
     </PanelGroup>
+    {terminalDrawer}
+    </Box>
   )
 }
 

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
@@ -24,7 +24,7 @@ import { TypesSandboxRuntime } from '../../api/api'
 import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
 import DiffViewer from '../tasks/DiffViewer'
 import SandboxBrowser from '../tasks/SandboxBrowser'
-import SandboxStatusIndicator, { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
+import { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
 import SpecTaskTerminalDrawer from '../tasks/SpecTaskTerminalDrawer'
 import SpecTaskViewToolbar, { TaskView } from '../tasks/SpecTaskViewToolbar'
 import TaskSessionPlaceholder from '../tasks/TaskSessionPlaceholder'
@@ -136,7 +136,6 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
       hasSession={!!sessionId}
       showChatTab={!isBigScreen}
       showDesktop={!isHeadless}
-      renderActions={() => <SandboxStatusIndicator state={indicatorState} />}
       onToggleTerminal={() => setTerminalOpen((open) => !open)}
       terminalOpen={terminalOpen}
       showStart={!!bot && !!onStart && !desktopRunning && !starting}

--- a/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSessionWorkspace.tsx
@@ -1,9 +1,15 @@
-import { FC, ReactNode, useState } from 'react'
+// OrgAgentSessionWorkspace is the bot-session counterpart of the spec task
+// detail page: chat on the left, and on the right the same view toolbar and
+// surfaces a task has — desktop stream, reverse-tunnel browser, diff, files,
+// details — plus the terminal drawer. Every surface is keyed by the session
+// id (the container is session-backed), so nothing here needs a spec task.
+//
+// `children` is the chat (rendered by pages/Session.tsx). `bot` is optional:
+// without it the workspace degrades to a plain session viewer, which is what
+// non-org external-agent sessions get.
+
+import { FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
-import Stack from '@mui/material/Stack'
-import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined'
-import DesktopWindowsOutlinedIcon from '@mui/icons-material/DesktopWindowsOutlined'
 import {
   Group as PanelGroup,
   Panel,
@@ -13,71 +19,224 @@ import {
 import useIsBigScreen from '../../hooks/useIsBigScreen'
 import useLightTheme from '../../hooks/useLightTheme'
 import { loadPanelLayout, savePanelLayout } from '../../lib/panelLayoutStorage'
+import { BotDTO } from '../../services/helixOrgService'
+import { TypesSandboxRuntime } from '../../api/api'
 import ExternalAgentDesktopViewer from '../external-agent/ExternalAgentDesktopViewer'
+import DiffViewer from '../tasks/DiffViewer'
+import SandboxBrowser from '../tasks/SandboxBrowser'
+import SandboxStatusIndicator, { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
+import SpecTaskTerminalDrawer from '../tasks/SpecTaskTerminalDrawer'
+import SpecTaskViewToolbar, { TaskView } from '../tasks/SpecTaskViewToolbar'
+import TaskSessionPlaceholder from '../tasks/TaskSessionPlaceholder'
+import OrgAgentDetailsPane from './OrgAgentDetailsPane'
 
-interface OrgAgentSessionWorkspaceProps {
+export interface OrgAgentSessionWorkspaceProps {
   sessionId: string
   organizationId: string
+  bot?: BotDTO
+  onStart?: () => void
+  onStop?: () => void
+  onRestart?: () => void
+  lifecycleBusy?: boolean
+  /** Terminal "copy to chat" lands here; the parent appends it to the composer. */
+  onAppendToChat?: (text: string) => void
   children: ReactNode
 }
 
-type MobileView = 'chat' | 'desktop'
+const VIEW_STORAGE_PREFIX = 'helix.orgAgentSession.view.'
+const TERMINAL_STORAGE_PREFIX = 'helix.orgAgentSession.terminal.'
+const DEFAULT_TERMINAL_HEIGHT = 280
+const VALID_VIEWS: TaskView[] = ['chat', 'desktop', 'browser', 'changes', 'files', 'details']
+
+const loadView = (key: string): TaskView | null => {
+  if (!key) return null
+  try {
+    const raw = localStorage.getItem(key)
+    return raw && (VALID_VIEWS as string[]).includes(raw) ? (raw as TaskView) : null
+  } catch {
+    return null
+  }
+}
+
+const loadTerminalHeight = (key: string): number => {
+  if (!key) return DEFAULT_TERMINAL_HEIGHT
+  try {
+    const raw = parseInt(localStorage.getItem(key) ?? '', 10)
+    return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TERMINAL_HEIGHT
+  } catch {
+    return DEFAULT_TERMINAL_HEIGHT
+  }
+}
+
+/** Maps the bot DTO onto the three-state indicator the task page uses. */
+export const botSandboxIndicatorState = (bot?: BotDTO): SandboxIndicatorState => {
+  if (!bot) return 'running'
+  if (bot.agent_status === 'running') return 'running'
+  if (bot.sandbox_status === 'pending') return 'starting'
+  return 'stopped'
+}
 
 const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
   sessionId,
   organizationId,
+  bot,
+  onStart,
+  onStop,
+  onRestart,
+  lifecycleBusy = false,
+  onAppendToChat,
   children,
 }) => {
   const isBigScreen = useIsBigScreen()
   const lightTheme = useLightTheme()
-  const [mobileView, setMobileView] = useState<MobileView>('chat')
   const panelIds = ['org-agent-session-chat', 'org-agent-session-desktop'] as const
   const layoutKey = organizationId ? `helix.orgAgentSession.layout.${organizationId}` : ''
+  const viewKey = organizationId ? `${VIEW_STORAGE_PREFIX}${organizationId}` : ''
+  const terminalKey = organizationId ? `${TERMINAL_STORAGE_PREFIX}${organizationId}` : ''
   const savedLayout = loadPanelLayout(layoutKey, panelIds)
   const dividerColor = lightTheme.isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'
 
-  const desktop = (
-    <Box sx={{ height: '100%', minHeight: 0, minWidth: 0, display: 'flex', overflow: 'hidden' }}>
-      <ExternalAgentDesktopViewer
-        sessionId={sessionId}
-        sandboxId={sessionId}
-        mode="stream"
-      />
+  const isHeadless = bot?.effective_sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
+  const indicatorState = botSandboxIndicatorState(bot)
+  const desktopRunning = indicatorState === 'running'
+  const starting = indicatorState === 'starting'
+  const defaultView: TaskView = isHeadless ? 'changes' : 'desktop'
+
+  const [view, setView] = useState<TaskView>(() => loadView(viewKey) ?? defaultView)
+  const [terminalOpen, setTerminalOpen] = useState(false)
+  const [terminalHeight, setTerminalHeight] = useState(() => loadTerminalHeight(terminalKey))
+
+  // A headless bot has no desktop; if the stored view is desktop, fall back.
+  // On a big screen chat has its own panel, so "chat" as a right-panel view
+  // falls through to the default surface too.
+  useEffect(() => {
+    if (isHeadless && view === 'desktop') setView('changes')
+    if (isBigScreen && view === 'chat') setView(defaultView)
+  }, [isHeadless, isBigScreen, view, defaultView])
+
+  const handleViewChange = useCallback((next: TaskView | null) => {
+    if (!next) return
+    setView(next)
+    if (viewKey) {
+      try { localStorage.setItem(viewKey, next) } catch { /* storage unavailable */ }
+    }
+  }, [viewKey])
+
+  const handleTerminalHeight = useCallback((height: number) => {
+    setTerminalHeight(height)
+    if (terminalKey) {
+      try { localStorage.setItem(terminalKey, String(height)) } catch { /* storage unavailable */ }
+    }
+  }, [terminalKey])
+
+  const toolbar = (
+    <SpecTaskViewToolbar
+      currentView={view}
+      onViewChange={handleViewChange}
+      hasSession={!!sessionId}
+      showChatTab={!isBigScreen}
+      showDesktop={!isHeadless}
+      renderActions={() => <SandboxStatusIndicator state={indicatorState} />}
+      onToggleTerminal={() => setTerminalOpen((open) => !open)}
+      terminalOpen={terminalOpen}
+      showStart={!!bot && !!onStart && !desktopRunning && !starting}
+      onStart={onStart}
+      startBusy={lifecycleBusy}
+      showStop={!!bot && !!onStop && desktopRunning}
+      onStop={onStop}
+      stopBusy={lifecycleBusy}
+      showRestart={!!bot && !!onRestart}
+      onRestart={onRestart}
+      restartBusy={lifecycleBusy}
+    />
+  )
+
+  const stoppedPlaceholder = (title: string, description: string) => (
+    <TaskSessionPlaceholder
+      tone="paused"
+      title={title}
+      description={description}
+      detail={bot?.sandbox_status_message}
+      onStart={onStart}
+      starting={starting || lifecycleBusy}
+    />
+  )
+
+  const surface = useMemo(() => {
+    switch (view) {
+      case 'chat':
+        return children
+      case 'browser':
+        return desktopRunning
+          ? <SandboxBrowser sessionId={sessionId} />
+          : stoppedPlaceholder('Sandbox not running', 'Start the agent to preview a localhost web app from its sandbox.')
+      case 'changes':
+      case 'files':
+        return (
+          <DiffViewer
+            sessionId={sessionId}
+            pollInterval={3000}
+            primarySurface={view}
+            onPrimarySurfaceChange={handleViewChange}
+            onStartDesktop={onStart}
+            desktopRunning={desktopRunning}
+            isDesktopStarting={starting || lifecycleBusy}
+            desktopUnavailableDetail={bot?.sandbox_status_message}
+          />
+        )
+      case 'details':
+        return bot
+          ? <OrgAgentDetailsPane bot={bot} sessionId={sessionId} organizationId={organizationId} indicatorState={indicatorState} />
+          : null
+      case 'desktop':
+      default:
+        if (isHeadless) {
+          return stoppedPlaceholder('Headless sandbox', 'This agent runs without a desktop. Use Diff, Files, Browser or the terminal.')
+        }
+        return (
+          <ExternalAgentDesktopViewer
+            sessionId={sessionId}
+            sandboxId={sessionId}
+            mode="stream"
+          />
+        )
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view, sessionId, organizationId, desktopRunning, starting, lifecycleBusy, isHeadless, indicatorState, bot?.sandbox_status_message, bot?.sandbox_id, bot?.sandbox_status, bot?.restart_required, bot?.effective_sandbox_runtime, bot?.effective_sandbox_resource_overrides?.vcpus, children])
+
+  const content = (
+    <Box sx={{ height: '100%', minHeight: 0, minWidth: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <Box sx={{ flexShrink: 0, borderBottom: `1px solid ${dividerColor}` }}>
+        {toolbar}
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          minWidth: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: view === 'details' ? 'auto' : 'hidden',
+          p: view === 'details' ? 2 : 0,
+        }}
+      >
+        {surface}
+      </Box>
+      {terminalOpen && sessionId && (
+        <SpecTaskTerminalDrawer
+          sessionId={sessionId}
+          running={desktopRunning}
+          height={terminalHeight}
+          onHeightChange={handleTerminalHeight}
+          onClose={() => setTerminalOpen(false)}
+          onCopyToChat={(text) => onAppendToChat?.(text)}
+        />
+      )}
     </Box>
   )
 
   if (!isBigScreen) {
-    return (
-      <Box sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        <Stack
-          direction="row"
-          spacing={0.5}
-          sx={{ px: 1.5, py: 0.75, borderBottom: `1px solid ${dividerColor}`, flexShrink: 0 }}
-        >
-          <Button
-            size="small"
-            variant={mobileView === 'chat' ? 'contained' : 'text'}
-            startIcon={<ChatOutlinedIcon />}
-            onClick={() => setMobileView('chat')}
-            sx={{ textTransform: 'none' }}
-          >
-            Chat
-          </Button>
-          <Button
-            size="small"
-            variant={mobileView === 'desktop' ? 'contained' : 'text'}
-            startIcon={<DesktopWindowsOutlinedIcon />}
-            onClick={() => setMobileView('desktop')}
-            sx={{ textTransform: 'none' }}
-          >
-            Desktop
-          </Button>
-        </Stack>
-        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-          {mobileView === 'chat' ? children : desktop}
-        </Box>
-      </Box>
-    )
+    return content
   }
 
   return (
@@ -116,7 +275,7 @@ const OrgAgentSessionWorkspace: FC<OrgAgentSessionWorkspaceProps> = ({
         minSize="30%"
         style={{ overflow: 'hidden', minWidth: 0, minHeight: 0 }}
       >
-        {desktop}
+        {content}
       </Panel>
     </PanelGroup>
   )

--- a/frontend/src/components/helix-org/OrgAgentSettingsPane.tsx
+++ b/frontend/src/components/helix-org/OrgAgentSettingsPane.tsx
@@ -1,29 +1,30 @@
-// OrgAgentDetailsPane is the "Details" view of the org agent workspace — the
-// bot's counterpart of the spec task Details view: what the agent runs in
-// (environment, size, status), where it lives (sandbox, session, project),
-// and the shareable preview URLs. Editing lives on the agent settings page;
-// this pane links there.
+// OrgAgentSettingsPane is the "Settings" view of the org agent workspace — the
+// bot's counterpart of the spec task Details view, and the same content the
+// standalone agent page shows. What the agent runs in (environment, size,
+// status), where it lives (sandbox, session, project), the agent's own
+// settings (name, harness, sandbox, instructions, tools, triggers, project
+// access), and the shareable preview URLs. Edits save in place; there is no
+// separate page to go to.
 
 import { FC, ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
-import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { Box as BoxIcon, Cpu, FolderKanban, MessageSquare, Monitor, Settings2, SquareTerminal } from 'lucide-react'
+import { Box as BoxIcon, Cpu, FolderKanban, Monitor, SquareTerminal } from 'lucide-react'
 
 import useLightTheme from '../../hooks/useLightTheme'
 import useRouter from '../../hooks/useRouter'
-import { BotDTO } from '../../services/helixOrgService'
+import { BotDTO, useHelixOrgBot } from '../../services/helixOrgService'
 import { TypesSandboxRuntime } from '../../api/api'
+import OrgAgentSettings from '../app/OrgAgentSettings'
 import CopyButton from '../common/CopyButton'
 import { SandboxIndicatorState } from '../tasks/SandboxStatusIndicator'
 import SharePreviewSection from '../tasks/SharePreviewSection'
 import { PRESENCE_OFFLINE_COLOR, PRESENCE_ONLINE_COLOR } from '../widgets/PresenceDot'
 import { sandboxRuntimeLabel, sandboxSizeLabel } from './BotSandboxForm'
 
-interface OrgAgentDetailsPaneProps {
+interface OrgAgentSettingsPaneProps {
   bot: BotDTO
   sessionId: string
   organizationId: string
@@ -104,9 +105,26 @@ const IdRow: FC<{ label: string; value: string; onOpen?: () => void; openLabel?:
   </Stack>
 )
 
-const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, organizationId, indicatorState }) => {
+// A titled settings block. The embedded OrgAgentSettings sections drop their
+// own page headings, so the pane supplies compact ones.
+const Section: FC<{ title: string; description?: string; children: ReactNode; sx: object }> = ({ title, description, children, sx }) => (
+  <Box sx={sx}>
+    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: description ? 0.25 : 1.5 }}>
+      {title}
+    </Typography>
+    {description && (
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        {description}
+      </Typography>
+    )}
+    {children}
+  </Box>
+)
+
+const OrgAgentSettingsPane: FC<OrgAgentSettingsPaneProps> = ({ bot, sessionId, organizationId, indicatorState }) => {
   const router = useRouter()
   const lightTheme = useLightTheme()
+  const { data: detail, refetch } = useHelixOrgBot(bot.id || undefined, { enabled: !!bot.id })
   const agentID = bot.agent_id ?? bot.agent_app_id
   const headless = bot.effective_sandbox_runtime === TypesSandboxRuntime.SandboxRuntimeHeadlessUbuntu
   const runtime = sandboxRuntimeLabel(bot.effective_sandbox_runtime) || 'Full Desktop'
@@ -129,11 +147,7 @@ const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, org
     backgroundColor: 'background.paper',
     p: 2,
   } as const
-
-  const openSettings = () => {
-    if (!agentID) return
-    router.navigate('org_agent', { org_id: organizationId, app_id: agentID })
-  }
+  const onSaved = () => { void refetch() }
 
   return (
     <Stack spacing={2} sx={{ maxWidth: 760 }}>
@@ -149,13 +163,6 @@ const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, org
           <Typography variant="body2" color="text.secondary">
             {statusLabel}
           </Typography>
-          <Tooltip title="Agent settings">
-            <span>
-              <IconButton size="small" aria-label="Agent settings" onClick={openSettings} disabled={!agentID}>
-                <Settings2 size={18} />
-              </IconButton>
-            </span>
-          </Tooltip>
         </Stack>
 
         {bot.sandbox_status_message && (
@@ -210,31 +217,46 @@ const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, org
           )}
         </Stack>
 
-        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-          <Button size="small" variant="outlined" startIcon={<Settings2 size={15} />} onClick={openSettings} disabled={!agentID}>
-            Agent settings
-          </Button>
-          {bot.project_id && (
+        {bot.project_id && (
+          <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
             <Button
               size="small"
-              variant="text"
+              variant="outlined"
               startIcon={<FolderKanban size={15} />}
               onClick={() => router.navigate('org_project-specs', { org_id: organizationId, id: bot.project_id! })}
             >
               Project board
             </Button>
-          )}
-          <Button
-            size="small"
-            variant="text"
-            startIcon={<MessageSquare size={15} />}
-            onClick={() => router.navigate('helix_org_bot_detail', { org_id: organizationId, bot_id: bot.id! })}
-            disabled={!bot.id}
-          >
-            Agent page
-          </Button>
-        </Stack>
+          </Stack>
+        )}
       </Box>
+
+      {agentID && detail?.bot?.id && (
+        <>
+          <Section sx={panelSx} title="Agent" description="Name, coding harness, model and reasoning effort. Changes save as you make them.">
+            <OrgAgentSettings agentID={agentID} section="basics" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+          <Section
+            sx={panelSx}
+            title="Sandbox"
+            description="Environment and compute for this agent's container, and whether its conversation survives between runs. Sandbox changes apply on the next restart."
+          >
+            <OrgAgentSettings agentID={agentID} section="runtime" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+          <Section sx={panelSx} title="Instructions" description="Markdown the agent reads on every run.">
+            <OrgAgentSettings agentID={agentID} section="instructions" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+          <Section sx={panelSx} title="Org tools" description="Helix organization capabilities available to this agent.">
+            <OrgAgentSettings agentID={agentID} section="tools" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+          <Section sx={panelSx} title="Triggers" description="What starts this agent: a Trigger directly, or the output of a Processor.">
+            <OrgAgentSettings agentID={agentID} section="subscriptions" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+          <Section sx={panelSx} title="Project access" description="Projects this agent can work in through its organization tools.">
+            <OrgAgentSettings agentID={agentID} section="access" readOnly={false} embedded detail={detail} onCanonicalUpdate={onSaved} />
+          </Section>
+        </>
+      )}
 
       <Box sx={{ ...panelSx, '& > .MuiBox-root': { mb: 0 } }}>
         <SharePreviewSection sessionId={sessionId} />
@@ -243,4 +265,4 @@ const OrgAgentDetailsPane: FC<OrgAgentDetailsPaneProps> = ({ bot, sessionId, org
   )
 }
 
-export default OrgAgentDetailsPane
+export default OrgAgentSettingsPane

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -7,16 +7,114 @@ import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 
 import AgentConfigForm, { AgentConfigValue } from './BotRuntimeForm'
+import BotSandboxForm, { BotSandboxValue } from './BotSandboxForm'
+import { DEFAULT_SANDBOX_PRESET } from '../../constants/sandboxPresets'
+import { TypesSandboxRuntime } from '../../api/api'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
 import { extractErrorMessage } from '../../hooks/useErrorCallback'
 import { useOrgCodeAgentHarnesses } from '../../services/codeAgentHarnessesService'
 import {
   SettingsSpecDTO,
+  useDeleteHelixOrgSetting,
   useHelixOrgBase,
   useHelixOrgSettings,
   useSetHelixOrgSetting,
 } from '../../services/helixOrgService'
+
+export const SANDBOX_RUNTIME_KEY = 'worker.sandbox_runtime'
+export const SANDBOX_VCPUS_KEY = 'worker.sandbox_vcpus'
+
+const decodeIntValue = (v: string): number => {
+  if (!v) return 0
+  try {
+    const parsed = JSON.parse(v)
+    return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+// DefaultSandboxPanel edits the org-wide sandbox defaults every agent
+// without its own setting inherits. Unset falls through to the Helix
+// default (full desktop, standard preset), matching spec tasks.
+export const DefaultSandboxPanel: FC<{ disabled?: boolean }> = ({ disabled = false }) => {
+  const { data, isLoading } = useHelixOrgSettings()
+  const setMut = useSetHelixOrgSetting()
+  const deleteMut = useDeleteHelixOrgSetting()
+  const snackbar = useSnackbar()
+
+  const specByKey = useMemo(() => {
+    const m = new Map<string, SettingsSpecDTO>()
+    for (const s of data?.specs ?? []) m.set(s.key, s)
+    return m
+  }, [data])
+  const stored: BotSandboxValue = {
+    runtime: decodeStringValue(specByKey.get(SANDBOX_RUNTIME_KEY)?.value ?? ''),
+    vcpus: decodeIntValue(specByKey.get(SANDBOX_VCPUS_KEY)?.value ?? ''),
+  }
+  const [value, setValue] = useState<BotSandboxValue>(stored)
+  const [dirty, setDirty] = useState(false)
+
+  useEffect(() => {
+    if (!data) return
+    setValue(stored)
+    setDirty(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  const saving = setMut.isPending || deleteMut.isPending
+  const handleSave = async () => {
+    try {
+      if (value.runtime) {
+        await setMut.mutateAsync({ key: SANDBOX_RUNTIME_KEY, value: JSON.stringify(value.runtime) })
+      } else if (specByKey.get(SANDBOX_RUNTIME_KEY)?.configured) {
+        await deleteMut.mutateAsync(SANDBOX_RUNTIME_KEY)
+      }
+      if (value.vcpus) {
+        await setMut.mutateAsync({ key: SANDBOX_VCPUS_KEY, value: JSON.stringify(value.vcpus) })
+      } else if (specByKey.get(SANDBOX_VCPUS_KEY)?.configured) {
+        await deleteMut.mutateAsync(SANDBOX_VCPUS_KEY)
+      }
+      setDirty(false)
+      snackbar.success('Default sandbox saved')
+    } catch (e: any) {
+      snackbar.error(extractErrorMessage(e) || 'save failed')
+    }
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Typography variant="subtitle1" sx={{ mb: 0.5 }}>Default sandbox</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Environment and size for agents that don't set their own. Applies on each agent's next start.
+      </Typography>
+      {isLoading ? <LoadingSpinner /> : (
+        <>
+          <BotSandboxForm
+            value={value}
+            onChange={(patch) => { setValue((current) => ({ ...current, ...patch })); setDirty(true) }}
+            disabled={disabled || saving}
+            inheritLabel="Helix default"
+            effective={{
+              runtime: TypesSandboxRuntime.SandboxRuntimeUbuntuDesktop,
+              vcpus: DEFAULT_SANDBOX_PRESET.vcpus,
+              memory_mb: DEFAULT_SANDBOX_PRESET.memory_mb,
+            }}
+          />
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={disabled || !dirty || saving}
+            sx={{ mt: 2 }}
+          >
+            {saving ? 'Saving...' : 'Save Default Sandbox'}
+          </Button>
+        </>
+      )}
+    </Paper>
+  )
+}
 
 const decodeStringValue = (v: string): string => {
   if (!v) return ''

--- a/frontend/src/components/sandboxes/SandboxSource.tsx
+++ b/frontend/src/components/sandboxes/SandboxSource.tsx
@@ -2,7 +2,7 @@ import { FC, MouseEvent } from 'react'
 import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { ListChecks, TerminalSquare } from 'lucide-react'
+import { Bot, ListChecks, TerminalSquare } from 'lucide-react'
 
 import useRouter from '../../hooks/useRouter'
 import { TypesSandbox } from '../../api/api'
@@ -19,6 +19,43 @@ interface SandboxSourceProps {
 // API. Without a marker the list reads as a pile of unexplained rows.
 const SandboxSource: FC<SandboxSourceProps> = ({ sandbox }) => {
   const router = useRouter()
+
+  if (sandbox.org_bot_id) {
+    const canNavigate = Boolean(router.params.org_id)
+    const openAgent = (e: MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!canNavigate) return
+      router.navigate('helix_org_bot_detail', {
+        org_id: router.params.org_id,
+        bot_id: sandbox.org_bot_id,
+      })
+    }
+    return (
+      <Tooltip title={canNavigate ? 'Open the org agent this sandbox belongs to' : 'Org agent sandbox'}>
+        <Box
+          component={canNavigate ? 'a' : 'span'}
+          href={canNavigate ? '#' : undefined}
+          onClick={canNavigate ? openAgent : undefined}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            minWidth: 0,
+            textDecoration: 'none',
+            color: 'text.secondary',
+            cursor: canNavigate ? 'pointer' : 'default',
+            '&:hover': canNavigate ? { color: 'text.primary' } : undefined,
+          }}
+        >
+          <Bot size={14} style={{ flexShrink: 0 }} />
+          <Typography variant="body2" color="inherit" noWrap>
+            Org agent
+          </Typography>
+        </Box>
+      </Tooltip>
+    )
+  }
 
   if (!sandbox.spec_task_id) {
     const label = sandbox.session_id ? 'Session' : 'Sandbox API'

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -15,6 +15,7 @@ import EmbeddedSessionView, { EmbeddedSessionViewHandle } from './EmbeddedSessio
 import type { ResponseEntry } from './InteractionInference'
 import { ComposerPlanProgress, planStepsFromResponseEntries } from './PlanProgress'
 import SessionPromptQueue from './SessionPromptQueue'
+import { useSessionPromptQueue } from './useSessionPromptQueue'
 import { getChatColors } from './chatStyles'
 import type { WorkspaceReviewComment } from '../workspace-inspector/workspaceReviewComments'
 
@@ -76,6 +77,10 @@ const AgentChat: FC<AgentChatProps> = ({
   )
   const latestInteraction = latestInteractionsResponse?.data?.interactions?.[0]
   const latestInteractionId = latestInteraction?.id || null
+  // Session-keyed queue for sessions without a spec task; the spec-task
+  // composer carries its own backend-backed queue instead.
+  const sessionQueue = useSessionPromptQueue(showSessionPromptQueue ? sessionId : '', isAgentBusy)
+  const hasSessionQueue = showSessionPromptQueue && sessionQueue.entries.length > 0
   const composerPlanSteps = isAgentBusy
     ? planStepsFromResponseEntries(latestInteraction?.response_entries as unknown as ResponseEntry[] | undefined)
     : []
@@ -155,8 +160,6 @@ const AgentChat: FC<AgentChatProps> = ({
         />
       </Box>
 
-      {showSessionPromptQueue && <SessionPromptQueue sessionId={sessionId} />}
-
       <Box
         sx={{
           flexShrink: 0,
@@ -186,6 +189,14 @@ const AgentChat: FC<AgentChatProps> = ({
                 }}
               />
             )}
+            {hasSessionQueue && (
+              <SessionPromptQueue
+                sessionId={sessionId}
+                entries={sessionQueue.entries}
+                onRemove={sessionQueue.remove}
+                onRestartAgent={sessionQueue.restartAgent}
+              />
+            )}
             <RobustPromptInput
               sessionId={sessionId}
               specTaskId={specTaskId}
@@ -208,7 +219,7 @@ const AgentChat: FC<AgentChatProps> = ({
               reviewComments={reviewComments}
               onRemoveReviewComment={onRemoveReviewComment}
               onReviewCommentsSent={onReviewCommentsSent}
-              hasAttachedHeader={showComposerPlan && composerPlanExpanded}
+              hasAttachedHeader={(showComposerPlan && composerPlanExpanded) || hasSessionQueue}
             />
           </Box>
           {footerContent && (

--- a/frontend/src/components/session/SessionPromptQueue.test.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SessionPromptQueue from './SessionPromptQueue'
+import { useSessionPromptQueue } from './useSessionPromptQueue'
 
 const mocks = vi.hoisted(() => ({
   deletePrompt: vi.fn(),
@@ -11,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../hooks/useApi', () => ({
   default: () => ({
-    getApiClient: () => ({ v1PromptHistoryDelete: mocks.deletePrompt }),
+    getApiClient: () => ({ v1PromptHistoryDelete: mocks.deletePrompt, v1SessionsRestartAgentCreate: vi.fn() }),
   }),
 }))
 
@@ -19,27 +20,59 @@ vi.mock('../../services/promptHistoryService', () => ({
   listSessionPromptHistory: (...args: unknown[]) => mocks.listPrompts(...args),
 }))
 
+// The composer renders the queue from the hook exactly like AgentChat does.
+const Harness = ({ busy = true }: { busy?: boolean }) => {
+  const queue = useSessionPromptQueue('session-1', busy)
+  return (
+    <SessionPromptQueue
+      sessionId="session-1"
+      entries={queue.entries}
+      onRemove={queue.remove}
+      onRestartAgent={queue.restartAgent}
+    />
+  )
+}
+
+const renderHarness = (busy?: boolean) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Harness busy={busy} />
+    </QueryClientProvider>,
+  )
+}
+
 describe('SessionPromptQueue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.deletePrompt.mockResolvedValue({})
     mocks.listPrompts.mockResolvedValue({
-      entries: [{ id: 'prompt-1', status: 'sending', content: 'stuck prompt' }],
+      entries: [
+        { id: 'prompt-1', status: 'pending', content: 'waiting prompt', created_at: '2026-09-07T00:00:00Z' },
+        // Already handed to the agent: it is the turn on screen, not queued.
+        { id: 'prompt-2', status: 'sending', content: 'in-flight prompt', created_at: '2026-09-07T00:00:01Z' },
+      ],
     })
   })
 
-  it('deletes a stuck prompt and refreshes the queue', async () => {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    render(
-      <QueryClientProvider client={queryClient}>
-        <SessionPromptQueue sessionId="session-1" />
-      </QueryClientProvider>,
-    )
+  it('lists waiting prompts, hides the in-flight one, and removes a prompt then refreshes', async () => {
+    renderHarness()
 
-    await screen.findByText('stuck prompt')
+    await screen.findByText('waiting prompt')
+    expect(screen.queryByText('in-flight prompt')).not.toBeInTheDocument()
+    expect(screen.getByText('1 queued')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Remove from queue' }))
 
     await waitFor(() => expect(mocks.deletePrompt).toHaveBeenCalledWith('prompt-1'))
     await waitFor(() => expect(mocks.listPrompts).toHaveBeenCalledTimes(2))
+  })
+
+  it('offers Restart for a crashed prompt', async () => {
+    mocks.listPrompts.mockResolvedValue({
+      entries: [{ id: 'prompt-3', status: 'failed', content: 'crashed prompt', error_message: 'Claude Agent process exited unexpectedly', retry_count: 4, created_at: '2026-09-07T00:00:00Z' }],
+    })
+    renderHarness()
+    await screen.findByText('crashed prompt')
+    expect(screen.getByRole('button', { name: /Restart/ })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/session/SessionPromptQueue.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.tsx
@@ -1,180 +1,174 @@
 /**
- * SessionPromptQueue - the single queue view for a session that has no spec
- * task (org-chat / bot sessions). It is session-keyed and DB-backed, so it is
- * the authoritative queue: it surfaces prompts still waiting for the agent
- * (pending/sending) AND failed prompts, including the ones auto-dispatched by
- * the org graph (enqueueAgentMessage). Spec-task pages use RobustPromptInput's
- * own backend-backed queue instead; plain sessions use this one.
+ * SessionPromptQueue - the queue panel for a session that has no spec task
+ * (org agents, project chats). Same chrome and rows as the spec-task queue
+ * inside RobustPromptInput — attached to the top of the composer — so the two
+ * surfaces read identically; only the data source differs (session-keyed
+ * prompt history via useSessionPromptQueue, which the org graph also feeds).
  *
- * Failed prompts are classified (via classifyPromptQueueEntry, shared with
- * RobustPromptInput) so a wedged/crashed agent surfaces the same Restart
- * affordance here as on spec-task pages.
+ * Failed prompts are classified with classifyPromptQueueEntry, shared with
+ * RobustPromptInput, so a wedged agent gets the same Restart affordance.
  */
 import React, { useState } from 'react'
-import { Box, Button, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material'
-import ScheduleIcon from '@mui/icons-material/Schedule'
-import RestartAltIcon from '@mui/icons-material/RestartAlt'
-import CloseIcon from '@mui/icons-material/Close'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import useApi from '../../hooks/useApi'
-import { listSessionPromptHistory } from '../../services/promptHistoryService'
-import { TypesPromptHistoryEntry } from '../../api/api'
+import { Box, Button, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material'
+import { alpha } from '@mui/material/styles'
+import { CircleAlert, Hourglass, ListStart, RotateCcw, X, Zap } from 'lucide-react'
+
+import { getChatColors } from './chatStyles'
 import { classifyPromptQueueEntry } from '../../utils/promptQueueStatus'
+import type { SessionPromptQueueEntry } from './useSessionPromptQueue'
 
 interface SessionPromptQueueProps {
   sessionId: string
+  entries: SessionPromptQueueEntry[]
+  onRemove: (entryId: string) => Promise<unknown>
+  onRestartAgent: () => Promise<unknown>
 }
 
-// 'pending'/'sending' are still-in-flight; 'failed' is a stalled/errored prompt
-// that needs surfacing (with Restart when the agent is wedged).
-const VISIBLE_STATUSES = new Set(['pending', 'sending', 'failed'])
+const firstLine = (content: string, maxLen = 60): string => {
+  const line = content.split('\n')[0]
+  return line.length <= maxLen ? line : `${line.substring(0, maxLen - 3)}...`
+}
 
-const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) => {
-  const api = useApi()
-  const apiClient = api.getApiClient()
-  const queryClient = useQueryClient()
+const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ entries, onRemove, onRestartAgent }) => {
   const [isRestarting, setIsRestarting] = useState(false)
-
-  const { data } = useQuery({
-    queryKey: ['session-prompt-queue', sessionId],
-    enabled: !!sessionId,
-    // Poll while open so queued items appear/clear promptly (mirrors the
-    // spec-task queue's 2s poll cadence).
-    refetchInterval: 2000,
-    queryFn: async () => listSessionPromptHistory(apiClient, sessionId),
-  })
-
-  const visible: TypesPromptHistoryEntry[] = (data?.entries || []).filter(
-    (e) => e.status && VISIBLE_STATUSES.has(e.status),
-  )
-
-  if (visible.length === 0) return null
+  if (entries.length === 0) return null
 
   const handleRestart = () => {
-    if (!apiClient || !sessionId || isRestarting) return
+    if (isRestarting) return
     setIsRestarting(true)
-    apiClient
-      .v1SessionsRestartAgentCreate(sessionId)
+    onRestartAgent()
       .catch((err: unknown) => console.error('Failed to restart agent thread:', err))
       .finally(() => setIsRestarting(false))
   }
 
-  const handleRemove = (entryId: string) => {
-    apiClient.v1PromptHistoryDelete(entryId)
-      .then(() => queryClient.invalidateQueries({ queryKey: ['session-prompt-queue', sessionId] }))
-      .catch((err: unknown) => console.warn('Failed to delete prompt from backend:', err))
-  }
-
-  const queuedCount = visible.filter((e) => e.status !== 'failed').length
-
   return (
     <Box
       sx={{
-        px: 1.5,
-        py: 1,
-        borderBottom: (theme) =>
-          `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
+        borderRadius: '20px 20px 0 0',
+        border: '1px solid',
+        borderBottom: 0,
+        borderColor: (theme) => getChatColors(theme).border,
+        bgcolor: (theme) => getChatColors(theme).composerSurface,
+        overflow: 'hidden',
       }}
     >
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
-        <ScheduleIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-        <Typography variant="caption" color="text.secondary">
-          {queuedCount > 0
-            ? `${queuedCount} queued — delivered when the agent is idle`
-            : 'Prompt queue'}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          px: 2,
+          pt: 1.25,
+          pb: 0.75,
+          color: (theme) => getChatColors(theme).subtle,
+          borderBottom: '1px solid',
+          borderColor: (theme) => getChatColors(theme).border,
+        }}
+      >
+        <ListStart size={14} />
+        <Typography variant="caption" sx={{ flex: 1, fontWeight: 500, letterSpacing: '0.01em' }}>
+          {`${entries.length} queued`}
         </Typography>
-      </Stack>
-      <Stack spacing={0.5}>
-        {visible.map((e) => {
-          const entryID = e.id
+      </Box>
+      <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
+        {entries.map((entry, index) => {
           const status = classifyPromptQueueEntry({
-            status: e.status,
-            errorMessage: e.error_message,
-            nextRetryAtMs: e.next_retry_at ? Date.parse(e.next_retry_at) : undefined,
-            retryCount: e.retry_count,
+            status: entry.status,
+            errorMessage: entry.error_message,
+            nextRetryAtMs: entry.next_retry_at ? Date.parse(entry.next_retry_at) : undefined,
+            retryCount: entry.retry_count,
           })
           const isFailed = status.isFailed
+          const isTransient = status.isTransientFailure && !status.showRestart
           return (
-            <Stack key={e.id} spacing={0.5}>
-              <Stack direction="row" alignItems="center" spacing={1}>
-                <Chip
-                  label={e.status}
-                  size="small"
-                  sx={{ height: 18, fontSize: '0.65rem' }}
-                  color={
-                    isFailed
-                      ? status.showRestart
-                        ? 'error'
-                        : 'warning'
-                      : e.status === 'sending'
-                        ? 'primary'
-                        : 'default'
-                  }
-                />
-                {e.interrupt ? (
-                  <Chip
-                    label="interrupt"
-                    size="small"
-                    color="warning"
-                    sx={{ height: 18, fontSize: '0.65rem' }}
-                  />
-                ) : null}
+            <Box
+              key={entry.id}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1.5,
+                py: 0.75,
+                borderBottom: index < entries.length - 1 ? '1px solid' : 'none',
+                borderColor: (theme) => getChatColors(theme).border,
+                bgcolor: isFailed
+                  ? (theme) => alpha(isTransient ? theme.palette.warning.main : theme.palette.error.main, 0.08)
+                  : 'transparent',
+                '&:hover': { bgcolor: (theme) => alpha(theme.palette.text.primary, 0.025) },
+              }}
+            >
+              {isFailed ? (
+                <CircleAlert size={16} style={{ flexShrink: 0, marginLeft: 20 }} />
+              ) : (
+                <Hourglass size={14} style={{ flexShrink: 0, marginLeft: 22, opacity: 0.58 }} />
+              )}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography
                   variant="body2"
-                  color="text.secondary"
-                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    color: isFailed
+                      ? (isTransient ? 'warning.main' : 'error.main')
+                      : (theme) => getChatColors(theme).assistantForeground,
+                  }}
                 >
-                  {e.content}
+                  {firstLine(entry.content || '')}
                 </Typography>
-                {entryID && (
-                  <Tooltip title="Remove from queue">
-                    <IconButton
-                      size="small"
-                      aria-label="Remove from queue"
-                      onClick={() => handleRemove(entryID)}
-                      sx={{ p: 0.5, flexShrink: 0 }}
-                    >
-                      <CloseIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </Tooltip>
-                )}
-              </Stack>
-              {isFailed && (
-                <Stack direction="row" alignItems="center" spacing={1} sx={{ pl: 0.5 }}>
+                {isFailed && (
                   <Typography
                     variant="caption"
                     sx={{
+                      display: 'block',
                       color: status.showRestart ? 'error.main' : 'warning.main',
                       fontWeight: status.showRestart ? 600 : 'inherit',
                     }}
                   >
                     {status.isCrashed
-                      ? 'The assistant stopped unexpectedly. Click Restart to recover.'
+                      ? 'The assistant stopped unexpectedly. Restart to recover.'
                       : status.isStuckTransient
-                        ? "The assistant isn't responding. Click Restart to recover."
+                        ? "The assistant isn't responding. Restart to recover."
                         : status.isTransientFailure
                           ? 'Waiting for the assistant — retrying…'
                           : 'This message failed to send.'}
                   </Typography>
-                  {status.showRestart && (
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      color="error"
-                      startIcon={<RestartAltIcon sx={{ fontSize: 16 }} />}
-                      disabled={isRestarting}
-                      onClick={handleRestart}
-                      sx={{ py: 0, minHeight: 24, fontSize: '0.7rem', textTransform: 'none' }}
-                    >
-                      {isRestarting ? 'Restarting…' : 'Restart'}
-                    </Button>
-                  )}
-                </Stack>
+                )}
+              </Box>
+              {entry.interrupt && (
+                <Tooltip title="Interrupts the current turn">
+                  <Zap size={13} style={{ flexShrink: 0, opacity: 0.7 }} />
+                </Tooltip>
               )}
-            </Stack>
+              {status.showRestart && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={isRestarting ? <CircularProgress size={12} color="inherit" /> : <RotateCcw size={14} />}
+                  disabled={isRestarting}
+                  onClick={handleRestart}
+                  sx={{ py: 0, minHeight: 24, fontSize: '0.7rem', textTransform: 'none', flexShrink: 0 }}
+                >
+                  {isRestarting ? 'Restarting…' : 'Restart'}
+                </Button>
+              )}
+              <Tooltip title="Remove from queue">
+                <IconButton
+                  size="small"
+                  aria-label="Remove from queue"
+                  onClick={() => {
+                    onRemove(entry.id).catch((err: unknown) => console.warn('Failed to delete prompt from backend:', err))
+                  }}
+                  sx={{ p: 0.5, flexShrink: 0, color: 'text.secondary' }}
+                >
+                  <X size={14} />
+                </IconButton>
+              </Tooltip>
+            </Box>
           )
         })}
-      </Stack>
+      </Box>
     </Box>
   )
 }

--- a/frontend/src/components/session/useSessionPromptQueue.ts
+++ b/frontend/src/components/session/useSessionPromptQueue.ts
@@ -1,0 +1,49 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import type { TypesPromptHistoryEntry } from '../../api/api'
+import useApi from '../../hooks/useApi'
+import { listSessionPromptHistory } from '../../services/promptHistoryService'
+import { selectVisibleQueuedPrompts } from '../../utils/promptQueueVisibility'
+
+// The prompt states a plain (non spec-task) session surfaces above its
+// composer. "sending" is deliberately absent: a prompt the agent has already
+// been handed is the turn on screen, not something still waiting — the
+// spec-task queue hides it for the same reason.
+const QUEUED_STATUSES = new Set(['pending', 'failed'])
+
+export const sessionPromptQueueKey = (sessionId: string) => ['session-prompt-queue', sessionId] as const
+
+// Session-keyed, DB-backed queue for sessions without a spec task (org agents,
+// project chats): prompts still waiting for the agent plus failed ones,
+// including prompts the org graph enqueued itself.
+export const useSessionPromptQueue = (sessionId: string, isAgentBusy: boolean) => {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: sessionPromptQueueKey(sessionId),
+    enabled: !!sessionId,
+    // Poll while open so queued items appear and clear promptly (the
+    // spec-task queue polls at the same cadence).
+    refetchInterval: 2000,
+    queryFn: async () => listSessionPromptHistory(apiClient, sessionId),
+  })
+
+  const queued = (data?.entries || [])
+    .filter((entry): entry is TypesPromptHistoryEntry & { id: string } => !!entry.id && !!entry.status && QUEUED_STATUSES.has(entry.status))
+    .map((entry) => ({ ...entry, timestamp: entry.created_at ? Date.parse(entry.created_at) : 0 }))
+  // Same grace window as the spec-task queue: a lone prompt handed to an idle
+  // agent is being delivered, not queued.
+  const entries = selectVisibleQueuedPrompts(queued, { isAgentBusy })
+
+  const remove = (entryId: string) => (
+    apiClient.v1PromptHistoryDelete(entryId)
+      .then(() => queryClient.invalidateQueries({ queryKey: sessionPromptQueueKey(sessionId) }))
+  )
+  const restartAgent = () => apiClient.v1SessionsRestartAgentCreate(sessionId)
+
+  return { entries, remove, restartAgent }
+}
+
+export type SessionPromptQueueEntry = ReturnType<typeof useSessionPromptQueue>['entries'][number]

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
@@ -198,6 +198,8 @@ export interface SpecTaskViewToolbarProps {
   onCollapsePanel?: () => void;
   /** Trailing control: close the task view. */
   onClosePanel?: () => void;
+  /** Label for the "details" view; org agents call it Settings. */
+  detailsLabel?: string;
 }
 
 /**
@@ -235,6 +237,7 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   renderMenuItems,
   onCollapsePanel,
   onClosePanel,
+  detailsLabel,
 }) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const closeMenu = () => setMenuAnchorEl(null);
@@ -249,7 +252,10 @@ const SpecTaskViewToolbar: React.FC<SpecTaskViewToolbarProps> = ({
   const iconButtonSx = toolbarIconButtonSx(density);
   const controlIconSize = ICON_BUTTON_METRICS[density].icon;
 
-  const availableTabs = VIEW_TABS.filter(
+  const viewTabs = detailsLabel
+    ? VIEW_TABS.map((t) => (t.value === "details" ? { ...t, label: detailsLabel } : t))
+    : VIEW_TABS;
+  const availableTabs = viewTabs.filter(
     (t) => (!t.sessionOnly || hasSession)
       && (!t.chatOnly || showChatTab)
       && (t.value !== "desktop" || showDesktop),

--- a/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceDiffSurface.tsx
@@ -65,7 +65,7 @@ interface WorkspaceDiffSurfaceProps {
   sessionId: string;
   workspace?: string;
   workspacePath?: string;
-  baseBranch: string;
+  baseBranch?: string;
   pollInterval: number;
   interactionId?: string;
   selectedFile?: string;

--- a/frontend/src/components/workspace-inspector/WorkspaceFileSurface.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceFileSurface.tsx
@@ -9,7 +9,7 @@ interface WorkspaceFileSurfaceProps {
   sessionId: string;
   workspace?: string;
   workspacePath?: string;
-  baseBranch: string;
+  baseBranch?: string;
   pollInterval: number;
   path: string | null;
   revealPath: string | null;

--- a/frontend/src/components/workspace-inspector/WorkspaceFileTree.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceFileTree.tsx
@@ -26,7 +26,7 @@ interface WorkspaceFileTreeProps {
   sessionId: string;
   workspace?: string;
   workspacePath?: string;
-  baseBranch: string;
+  baseBranch?: string;
   pollInterval: number;
   selectedPath: string | null;
   revealPath: string | null;

--- a/frontend/src/components/workspace-inspector/WorkspaceInspector.tsx
+++ b/frontend/src/components/workspace-inspector/WorkspaceInspector.tsx
@@ -53,7 +53,7 @@ interface TabContextMenu {
 
 const WorkspaceInspector: FC<WorkspaceInspectorProps> = ({
   sessionId,
-  baseBranch = "main",
+  baseBranch,
   pollInterval = 3_000,
   primarySurface = "changes",
   onPrimarySurfaceChange,

--- a/frontend/src/components/workspace-inspector/workspaceReviewService.ts
+++ b/frontend/src/components/workspace-inspector/workspaceReviewService.ts
@@ -137,7 +137,7 @@ export const workspaceReviewKeys = {
   review: (
     sessionId: string,
     workspace: string | undefined,
-    base: string,
+    base: string | undefined,
     ignoreWhitespace: boolean,
   ) =>
     [
@@ -185,10 +185,13 @@ export function useWorkspaces(sessionId: string | undefined, enabled = true) {
   });
 }
 
+// `base` undefined lets the desktop pick the repository's own default branch
+// (its remote HEAD) — right for sessions with no task branch, such as org
+// agents, whose repos are not necessarily on main.
 export function useWorkspaceReview(
   sessionId: string | undefined,
   workspace: string | undefined,
-  base: string,
+  base: string | undefined,
   ignoreWhitespace: boolean,
   pollInterval: number,
   enabled = true,

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -211,7 +211,7 @@ type FlatBot = {
   // Reporting is many-to-many: a Bot may report to several managers.
   parentIds: string[]
   // Desktop sandbox online-ness for the presence dot.
-  agentStatus: 'running' | 'stopped'
+  agentStatus: 'running' | 'starting' | 'stopped'
   agentRuntime: string
   agentModel: string
   projectId?: string
@@ -223,8 +223,9 @@ type FlatBot = {
 type BotNodeData = {
   botId: string
   botName: string
-  // running = desktop sandbox online; stopped (or missing) = offline.
-  agentStatus: 'running' | 'stopped'
+  // running = sandbox online; starting = container booting; stopped (or
+  // missing) = offline.
+  agentStatus: 'running' | 'starting' | 'stopped'
   agentRuntime: string
   agentModel: string
   projectId: string
@@ -546,12 +547,17 @@ export const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
   const [menuEl, setMenuEl] = useState<null | HTMLElement>(null)
 
   const online = data.agentStatus === 'running'
+  const starting = data.agentStatus === 'starting'
   const selected = !!data.selected
   const cardBorderColor = selected ? selectedBorder : idleBorder
   const cardBorderWidth = selected ? 2 : 1
   const drawerOffset = 4
-  const statusColor = online ? 'rgb(46, 160, 67)' : (lightTheme.isLight ? 'rgba(0,0,0,0.28)' : 'rgba(255,255,255,0.28)')
-  const statusLabel = online ? 'Agent sandbox online' : 'Agent sandbox stopped'
+  const statusColor = online
+    ? 'rgb(46, 160, 67)'
+    : starting
+      ? 'rgb(214, 158, 46)'
+      : (lightTheme.isLight ? 'rgba(0,0,0,0.28)' : 'rgba(255,255,255,0.28)')
+  const statusLabel = online ? 'Agent sandbox online' : starting ? 'Agent sandbox starting' : 'Agent sandbox stopped'
 
   const closeMenu = () => setMenuEl(null)
 
@@ -2436,7 +2442,9 @@ const HelixOrgChart: FC = () => {
         id: b.id ?? '',
         name: b.name ?? '',
         parentIds: b.parent_ids ?? [],
-        agentStatus: b.agent_status === 'running' ? 'running' as const : 'stopped' as const,
+        agentStatus: b.agent_status === 'running'
+          ? 'running' as const
+          : b.sandbox_status === 'pending' ? 'starting' as const : 'stopped' as const,
         agentRuntime: b.agent_runtime ?? '',
         agentModel: b.agent_model ?? '',
         projectId: projectIDByBotID.get(b.id ?? '') ?? '',

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -34,6 +34,8 @@ const EXCLUDED_KEYS = new Set<string>([
   'worker.credentials',
   'worker.provider',
   'worker.model',
+  'worker.sandbox_runtime',
+  'worker.sandbox_vcpus',
   'agent.default',
   'transport.github',
 ])

--- a/frontend/src/pages/OrgSettings.test.tsx
+++ b/frontend/src/pages/OrgSettings.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../components/system/Page', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 vi.mock('../components/common/CopyButton', () => ({ default: () => null }))
-vi.mock('../components/helix-org/WorkerRuntimePanel', () => ({ default: () => null }))
+vi.mock('../components/helix-org/WorkerRuntimePanel', () => ({ default: () => null, DefaultSandboxPanel: () => null }))
 vi.mock('./HelixOrgSettings', () => ({ default: () => null }))
 
 describe('OrgSettings autosave', () => {

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -20,7 +20,7 @@ import useRouter from "../hooks/useRouter";
 import { TypesOrganization } from "../api/api";
 import useSnackbar from "../hooks/useSnackbar";
 import CopyButton from "../components/common/CopyButton";
-import DefaultAgentConfigPanel from "../components/helix-org/WorkerRuntimePanel";
+import DefaultAgentConfigPanel, { DefaultSandboxPanel } from "../components/helix-org/WorkerRuntimePanel";
 import HelixOrgSettings from "./HelixOrgSettings";
 
 const OrgSettings: FC = () => {
@@ -360,6 +360,9 @@ const OrgSettings: FC = () => {
                   Runtime settings copied to new Bots and new projects. Existing Bots and projects are unchanged.
                 </Typography>
                 <DefaultAgentConfigPanel disabled={isReadOnly} />
+                <Box sx={{ mt: 3 }}>
+                  <DefaultSandboxPanel disabled={isReadOnly} />
+                </Box>
                 <Box sx={{ mt: 3 }}>
                   <HelixOrgSettings />
                 </Box>

--- a/frontend/src/pages/Session.orgRestartBanner.test.tsx
+++ b/frontend/src/pages/Session.orgRestartBanner.test.tsx
@@ -98,6 +98,8 @@ vi.mock('../services/helixOrgService', () => ({
     mutateAsync: mocks.restartMutateAsync,
     isPending: mocks.restartIsPending,
   }),
+  useActivateBot: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useStopBotAgent: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 vi.mock('../components/system/Page', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -295,8 +295,12 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
   // ordinary project chat) leave org_worker_id empty, so the lookup and
   // restart-required banner stay inert there.
   const orgWorkerId = (orgChatView && session?.data?.config?.org_worker_id) || ''
+  // Polled: the workspace gates Diff, Files, Browser and the terminal on the
+  // agent's sandbox status, which changes underneath an open page whenever the
+  // agent starts, stops or is restarted.
   const { data: orgBotDetail } = useHelixOrgBot(orgWorkerId || undefined, {
     enabled: !!orgWorkerId,
+    refetchInterval: 5000,
   })
   const orgBot = orgBotDetail?.bot
   const restartOrgBotAgent = useRestartBotAgent()

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -52,6 +52,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import useLightTheme from '../hooks/useLightTheme'
 import useSubscriptionGate from '../hooks/useSubscriptionGate'
 import Paywall from '../components/subscription/Paywall'
+import AgentChat from '../components/session/AgentChat'
 import AdvancedModelPicker from '../components/create/AdvancedModelPicker'
 import { useListSessionSteps } from '../services/sessionService'
 import { useGetConfig } from '../services/userService'
@@ -1598,6 +1599,46 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
       ]
     : [{ title: 'Chat', routeName: 'chat' }]
 
+  // External-agent sessions (org bots, project chat) use the same chat surface
+  // as spec tasks — AgentChat — so composer behaviour (sandbox file/image
+  // attachments, prompt queue, plan progress, cancel) is one implementation
+  // and every fix lands on both. The legacy renderer below stays for plain
+  // model chats only.
+  const externalAgentChat = isExternalAgent ? (
+    <Paywall active={paywallActive} onBillingClick={navigateToBilling}>
+      <Box sx={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {!orgChatView && !previewMode && (isOwner || account.admin) && (
+          <Box sx={{ flexShrink: 0, borderBottom: lightTheme.border, py: 1, px: 2 }}>
+            <SessionToolbar
+              session={session.data}
+              onReload={safeReloadSession}
+              onOpenMobileMenu={() => account.setMobileMenuOpen(true)}
+            />
+          </Box>
+        )}
+        <AgentChat
+          sessionId={session.data.id || sessionID}
+          projectId={sessionProjectID || undefined}
+          enableInteractionDebugCopy
+          showSessionPromptQueue
+          appendText={promptAppendText}
+          leadingActions={(
+            <CodeAgentExecutionControls
+              value={selectedCodeAgentConfig}
+              onChange={(config) => handleAgentModelChange('', {}, config)}
+              disabled={updateExecutionConfig.isPending}
+              compact
+            />
+          )}
+          placeholder={session.data.config?.paused
+            ? 'This session is paused — open the forked child to keep chatting'
+            : `Chat with ${orgBot?.name || apps.app?.config.helix.name || 'agent'}…`}
+          disabled={!!session.data.config?.paused}
+        />
+      </Box>
+    </Paywall>
+  ) : null
+
   return (
     <Page
       breadcrumbs={breadcrumbs}
@@ -1624,7 +1665,7 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
           lifecycleBusy={orgBotLifecycleBusy}
           onAppendToChat={appendToChat}
         >
-          {sessionContent}
+          {externalAgentChat}
         </OrgAgentSessionWorkspace>
       ) : sessionContent}
     </Page>

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -67,7 +67,7 @@ import {
 import { splitSystemPrefix } from '../components/session/CollapsibleSystemPrefix'
 import OrgAgentSessionWorkspace from '../components/helix-org/OrgAgentSessionWorkspace'
 import AgentRestartRequiredBanner from '../components/helix-org/AgentRestartRequiredBanner'
-import { useHelixOrgBot, useRestartBotAgent } from '../services/helixOrgService'
+import { useActivateBot, useHelixOrgBot, useRestartBotAgent, useStopBotAgent } from '../services/helixOrgService'
 
 // Add new interfaces for virtualization
 interface IInteractionBlock {
@@ -299,6 +299,16 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
   })
   const orgBot = orgBotDetail?.bot
   const restartOrgBotAgent = useRestartBotAgent()
+  const activateOrgBotAgent = useActivateBot()
+  const stopOrgBotAgent = useStopBotAgent()
+  const orgBotLifecycleBusy = restartOrgBotAgent.isPending || activateOrgBotAgent.isPending || stopOrgBotAgent.isPending
+  // Terminal "copy to chat" appends to the composer; the sequence suffix makes
+  // repeated copies of the same text distinct, as on the spec task page.
+  const chatAppendSequence = useRef(0)
+  const appendToChat = useCallback((text: string) => {
+    chatAppendSequence.current += 1
+    setPromptAppendText(`${text}#${chatAppendSequence.current}`)
+  }, [])
 
   const [visibleBlocks, setVisibleBlocks] = useState<IInteractionBlock[]>([])
   const [blockHeights, setBlockHeights] = useState<Record<string, number>>({})
@@ -1607,6 +1617,12 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
         <OrgAgentSessionWorkspace
           sessionId={session.data.id || sessionID}
           organizationId={(router.params.org_id as string) || session.data.organization_id || ''}
+          bot={orgBot}
+          onStart={orgWorkerId ? () => { void activateOrgBotAgent.mutateAsync(orgWorkerId) } : undefined}
+          onStop={orgWorkerId ? () => { void stopOrgBotAgent.mutateAsync(orgWorkerId) } : undefined}
+          onRestart={orgWorkerId ? () => { void restartOrgBotAgent.mutateAsync(orgWorkerId) } : undefined}
+          lifecycleBusy={orgBotLifecycleBusy}
+          onAppendToChat={appendToChat}
         >
           {sessionContent}
         </OrgAgentSessionWorkspace>

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -459,11 +459,12 @@ export function useListHelixOrgBots(options?: { enabled?: boolean; refetchInterv
   })
 }
 
-export function useHelixOrgBot(botId: string | undefined, options?: { enabled?: boolean }) {
+export function useHelixOrgBot(botId: string | undefined, options?: { enabled?: boolean; refetchInterval?: number | false }) {
   const api = useApi()
   const { orgID } = useHelixOrgBase()
   return useQuery({
     queryKey: QUERY_KEYS.bot(orgID, botId ?? ''),
+    refetchInterval: options?.refetchInterval,
     queryFn: async () => {
       if (!botId) return null
       const res = await api.getApiClient().v1OrgsAgentsDetail2(orgID, botId)

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -51,6 +51,10 @@ definitions:
           reset to. Detail-only: GET /bots/{id} populates it, the list does
           not (it would repeat kilobytes of prompt per row).
         type: string
+      effective_sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      effective_sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       helix_user_id:
         type: string
       id:
@@ -101,6 +105,24 @@ definitions:
           the tool list and instructions from before the last save. Drives the
           restart banner on the bot page and the org chat panel.
         type: boolean
+      sandbox_id:
+        type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+          config in the spec-task vocabulary; empty means "inherit the org
+          default". The Effective* fields are what the next container start will
+          actually use once org and global defaults are applied. SandboxID /
+          SandboxStatus come from the session-backed sandboxes row, when one
+          exists (pending, running, stopping, stopped, failed).
+      sandbox_status:
+        type: string
+      sandbox_status_message:
+        type: string
       session_id:
         type: string
       tools:
@@ -252,6 +274,10 @@ definitions:
           reset to. Detail-only: GET /bots/{id} populates it, the list does
           not (it would repeat kilobytes of prompt per row).
         type: string
+      effective_sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      effective_sandbox_runtime:
+        $ref: '#/definitions/types.SandboxRuntime'
       helix_user_id:
         type: string
       id:
@@ -308,6 +334,24 @@ definitions:
           the tool list and instructions from before the last save. Drives the
           restart banner on the bot page and the org chat panel.
         type: boolean
+      sandbox_id:
+        type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox
+          config in the spec-task vocabulary; empty means "inherit the org
+          default". The Effective* fields are what the next container start will
+          actually use once org and global defaults are applied. SandboxID /
+          SandboxStatus come from the session-backed sandboxes row, when one
+          exists (pending, running, stopping, stopped, failed).
+      sandbox_status:
+        type: string
+      sandbox_status_message:
+        type: string
       session_id:
         type: string
       tools:
@@ -395,6 +439,14 @@ definitions:
         type: string
       reasoning_effort:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.
+          Only vcpus is read from the overrides — memory follows the preset.
       tools:
         items:
           type: string
@@ -821,6 +873,16 @@ definitions:
         type: string
       reasoning_effort:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox
+          config. A present-but-empty runtime, or vcpus=0, resets that field to
+          inherit. Takes effect on the next container start; a running sandbox
+          gets restart_required.
       tools:
         items:
           type: string
@@ -3607,24 +3669,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - email
-    - local
-    - cron
     - webhook
-    - github
-    - gitlab
     - helix_events
+    - local
+    - github
     - slack
+    - gitlab
+    - email
+    - cron
     type: string
     x-enum-varnames:
-    - KindEmail
-    - KindLocal
-    - KindCron
     - KindWebhook
-    - KindGitHub
-    - KindGitLab
     - KindHelixEvents
+    - KindLocal
+    - KindGitHub
     - KindSlack
+    - KindGitLab
+    - KindEmail
+    - KindCron
   transport.ResolvedActivation:
     properties:
       address:
@@ -9748,6 +9810,12 @@ definitions:
         type: integer
       name:
         type: string
+      org_bot_id:
+        description: |-
+          OrgBotID is the helix-org bot whose session owns this container, when
+          there is one. Denormalised from the session (org_worker_id) so the bot
+          detail and the Sandboxes list can link both ways without joining sessions.
+        type: string
       organization_id:
         type: string
       owner:
@@ -10820,6 +10888,18 @@ definitions:
         type: string
       runtime_instructions:
         type: string
+      sandbox_resource_overrides:
+        $ref: '#/definitions/types.SandboxResourceOverrides'
+      sandbox_runtime:
+        allOf:
+        - $ref: '#/definitions/types.SandboxRuntime'
+        description: |-
+          SandboxRuntime and SandboxResourceOverrides are the container runtime and
+          size for an org-worker session. The org spawner writes them from the Bot
+          on every activation and StartDesktop reads them on every launch path
+          (fresh start, message auto-start, resume, auto-wake, reconciler), so a
+          headless bot never comes back as a desktop. SpecTask sessions leave both
+          empty — the task is authoritative there, as with CodeAgentConfig.
       session_rag_results:
         items:
           $ref: '#/definitions/types.SessionRAGResult'

--- a/openapi.json
+++ b/openapi.json
@@ -28185,6 +28185,12 @@
                         "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                         "type": "string"
                     },
+                    "effective_sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "effective_sandbox_runtime": {
+                        "$ref": "#/components/schemas/types.SandboxRuntime"
+                    },
                     "helix_user_id": {
                         "type": "string"
                     },
@@ -28239,6 +28245,26 @@
                     "restart_required": {
                         "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                         "type": "boolean"
+                    },
+                    "sandbox_id": {
+                        "type": "string"
+                    },
+                    "sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
+                    },
+                    "sandbox_status": {
+                        "type": "string"
+                    },
+                    "sandbox_status_message": {
+                        "type": "string"
                     },
                     "session_id": {
                         "type": "string"
@@ -28458,6 +28484,12 @@
                         "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                         "type": "string"
                     },
+                    "effective_sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "effective_sandbox_runtime": {
+                        "$ref": "#/components/schemas/types.SandboxRuntime"
+                    },
                     "helix_user_id": {
                         "type": "string"
                     },
@@ -28513,6 +28545,26 @@
                     "restart_required": {
                         "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                         "type": "boolean"
+                    },
+                    "sandbox_id": {
+                        "type": "string"
+                    },
+                    "sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
+                    },
+                    "sandbox_status": {
+                        "type": "string"
+                    },
+                    "sandbox_status_message": {
+                        "type": "string"
                     },
                     "session_id": {
                         "type": "string"
@@ -28632,6 +28684,17 @@
                     },
                     "reasoning_effort": {
                         "type": "string"
+                    },
+                    "sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "description": "SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.\nOnly vcpus is read from the overrides — memory follows the preset.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
                     },
                     "tools": {
                         "type": "array",
@@ -29224,6 +29287,17 @@
                     },
                     "reasoning_effort": {
                         "type": "string"
+                    },
+                    "sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "description": "SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox\nconfig. A present-but-empty runtime, or vcpus=0, resets that field to\ninherit. Takes effect on the next container start; a running sandbox\ngets restart_required.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
                     },
                     "tools": {
                         "type": "array",
@@ -33146,24 +33220,24 @@
             "transport.Kind": {
                 "type": "string",
                 "enum": [
-                    "email",
-                    "local",
-                    "cron",
                     "webhook",
-                    "github",
-                    "gitlab",
                     "helix_events",
-                    "slack"
+                    "local",
+                    "github",
+                    "slack",
+                    "gitlab",
+                    "email",
+                    "cron"
                 ],
                 "x-enum-varnames": [
-                    "KindEmail",
-                    "KindLocal",
-                    "KindCron",
                     "KindWebhook",
-                    "KindGitHub",
-                    "KindGitLab",
                     "KindHelixEvents",
-                    "KindSlack"
+                    "KindLocal",
+                    "KindGitHub",
+                    "KindSlack",
+                    "KindGitLab",
+                    "KindEmail",
+                    "KindCron"
                 ]
             },
             "transport.ResolvedActivation": {
@@ -41524,6 +41598,10 @@
                     "name": {
                         "type": "string"
                     },
+                    "org_bot_id": {
+                        "description": "OrgBotID is the helix-org bot whose session owns this container, when\nthere is one. Denormalised from the session (org_worker_id) so the bot\ndetail and the Sandboxes list can link both ways without joining sessions.",
+                        "type": "string"
+                    },
                     "organization_id": {
                         "type": "string"
                     },
@@ -42801,6 +42879,17 @@
                     },
                     "runtime_instructions": {
                         "type": "string"
+                    },
+                    "sandbox_resource_overrides": {
+                        "$ref": "#/components/schemas/types.SandboxResourceOverrides"
+                    },
+                    "sandbox_runtime": {
+                        "description": "SandboxRuntime and SandboxResourceOverrides are the container runtime and\nsize for an org-worker session. The org spawner writes them from the Bot\non every activation and StartDesktop reads them on every launch path\n(fresh start, message auto-start, resume, auto-wake, reconciler), so a\nheadless bot never comes back as a desktop. SpecTask sessions leave both\nempty — the task is authoritative there, as with CodeAgentConfig.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.SandboxRuntime"
+                            }
+                        ]
                     },
                     "session_rag_results": {
                         "type": "array",

--- a/sandbox/06-setup-network-policy.sh
+++ b/sandbox/06-setup-network-policy.sh
@@ -187,6 +187,10 @@ helix_apply_sandbox_network_policy() {
         -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
     helix_iptables -A "$HELIX_INPUT_CHAIN" -d "${HELIX_NETWORK_GATEWAY}/32" \
         -p tcp --dport 18080 -j RETURN
+    # Hydra mirrors the control plane's SSH proxy (asset + sandbox SSH for
+    # agents) on the gateway; the proxy itself authenticates every connection.
+    helix_iptables -A "$HELIX_INPUT_CHAIN" -d "${HELIX_NETWORK_GATEWAY}/32" \
+        -p tcp --dport 2224 -j RETURN
     helix_iptables -A "$HELIX_INPUT_CHAIN" -d "${dns_gateway}/32" \
         -p udp --dport 53 -j RETURN
     helix_iptables -A "$HELIX_INPUT_CHAIN" -d "${dns_gateway}/32" \

--- a/swagger.json
+++ b/swagger.json
@@ -23581,6 +23581,12 @@
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23635,6 +23641,26 @@
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -23854,6 +23880,12 @@
                     "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
+                "effective_sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "effective_sandbox_runtime": {
+                    "$ref": "#/definitions/types.SandboxRuntime"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -23909,6 +23941,26 @@
                 "restart_required": {
                     "description": "RestartRequired is true when the sandbox is running but still holds\nthe tool list and instructions from before the last save. Drives the\nrestart banner on the bot page and the org chat panel.",
                     "type": "boolean"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the bot's own sandbox\nconfig in the spec-task vocabulary; empty means \"inherit the org\ndefault\". The Effective* fields are what the next container start will\nactually use once org and global defaults are applied. SandboxID /\nSandboxStatus come from the session-backed sandboxes row, when one\nexists (pending, running, stopping, stopped, failed).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
+                },
+                "sandbox_status": {
+                    "type": "string"
+                },
+                "sandbox_status_message": {
+                    "type": "string"
                 },
                 "session_id": {
                     "type": "string"
@@ -24028,6 +24080,17 @@
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides are optional; see BotDTO.\nOnly vcpus is read from the overrides — memory follows the preset.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -24620,6 +24683,17 @@
                 },
                 "reasoning_effort": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime / SandboxResourceOverrides patch the bot's sandbox\nconfig. A present-but-empty runtime, or vcpus=0, resets that field to\ninherit. Takes effect on the next container start; a running sandbox\ngets restart_required.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "tools": {
                     "type": "array",
@@ -28542,24 +28616,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "email",
-                "local",
-                "cron",
                 "webhook",
-                "github",
-                "gitlab",
                 "helix_events",
-                "slack"
+                "local",
+                "github",
+                "slack",
+                "gitlab",
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindEmail",
-                "KindLocal",
-                "KindCron",
                 "KindWebhook",
-                "KindGitHub",
-                "KindGitLab",
                 "KindHelixEvents",
-                "KindSlack"
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
+                "KindGitLab",
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {
@@ -36920,6 +36994,10 @@
                 "name": {
                     "type": "string"
                 },
+                "org_bot_id": {
+                    "description": "OrgBotID is the helix-org bot whose session owns this container, when\nthere is one. Denormalised from the session (org_worker_id) so the bot\ndetail and the Sandboxes list can link both ways without joining sessions.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -38197,6 +38275,17 @@
                 },
                 "runtime_instructions": {
                     "type": "string"
+                },
+                "sandbox_resource_overrides": {
+                    "$ref": "#/definitions/types.SandboxResourceOverrides"
+                },
+                "sandbox_runtime": {
+                    "description": "SandboxRuntime and SandboxResourceOverrides are the container runtime and\nsize for an org-worker session. The org spawner writes them from the Bot\non every activation and StartDesktop reads them on every launch path\n(fresh start, message auto-start, resume, auto-wake, reconciler), so a\nheadless bot never comes back as a desktop. SpecTask sessions leave both\nempty — the task is authoritative there, as with CodeAgentConfig.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SandboxRuntime"
+                        }
+                    ]
                 },
                 "session_rag_results": {
                     "type": "array",


### PR DESCRIPTION
## Summary

Org agents (helix-org bots) ran in an uncapped full GNOME desktop with no way to choose headless or a size, an anonymous sandbox row, and a chat+desktop-only UI. This converges them onto the spec-task sandbox model in one PR, per `design/2026-09-07-org-agent-sandbox-migration.md`.

**Backend**
- Bot rows carry `sandbox_runtime` (`ubuntu-desktop` / `headless-ubuntu`) and a vCPU preset; org defaults `worker.sandbox_runtime` / `worker.sandbox_vcpus`; global default stays full desktop at the standard preset, so existing bots behave as before (now capped at what they were already billed as).
- The spawner resolves bot → org → global on every activation and stamps it on the session; the executor applies it on every launch path (start, message auto-start, resume, auto-wake, reconcile), so a headless bot never resumes as a desktop.
- The `sandboxes` row is named after the bot and linked via `org_bot_id` (backfilled); headless bots skip the desktop quota gate.
- `PATCH/GET /orgs/{org}/agents/{id}` expose `sandbox_runtime`, `sandbox_resource_overrides`, effective values, `sandbox_id`/`sandbox_status`; a change while running stamps `restart_required`. `activate` / `stop-agent` / `restart-agent` are unchanged.
- Two bugs fixed on the way: org-bot sessions were named after the first prompt when the container started (sandbox row got the prompt text), and the workspace-status endpoint had no expected branch for bot sessions so switch-agent refused to auto-commit.

**Frontend**
- The org agent session workspace gets the spec-task toolbar and surfaces: desktop, reverse-tunnel browser, diff, files, details (sandbox status/env/compute/links/share-preview URLs), terminal drawer, start/stop/restart. Desktop is hidden for headless bots.
- Environment + Compute picker on agent settings; Default sandbox panel on org settings; starting state on chart/chat; Sandboxes list links org-agent rows back to the agent.

**Follow-ups in the same PR**
- Native SSH into bot sandboxes (`sandbox_ssh_access` → proxy on :2224) was broken for every session-backed row: the org adapter asked hydra for the row id instead of `HydraOpsID()`. Fixed and verified with a minted cert into a headless bot container. The browser terminal (session-keyed drawer and the Sandboxes-page Terminal tab) already worked for both headless and desktop bots.
- External-agent sessions on the Session page (org bots, project chat) now render the spec-task `AgentChat` instead of the legacy composer, so sandbox file/image attachments, prompt queue, plan progress, cancel and execution controls are one implementation.

## Verified live (dev stack, `unmanned-org` / `b-mira`)

- PATCH validation (bad runtime, off-ladder vCPU) → 400; headless/4 vCPU persists and shows effective values.
- Activate: `headless-external-…` container, `HELIX_HEADLESS=1`, 4 vCPU / 8 GB, rootless; sandbox row `Software Engineer`, `headless-ubuntu`, `org_bot_id=b-mira`; agent turn completed.
- stop-agent → activate: same row reused, still headless at 4 vCPU (resume path).
- Switch to desktop / 8 vCPU while running → `restart_required`; restart-agent → `ubuntu-external-…` at 8 vCPU / 16 GB, flag cleared, row renamed after the bot.
- Browser walkthrough: workspace tabs, terminal, details, agent settings picker, org default panel, sandbox list link.
- `go test` for org / sandbox / external-agent / server org tests, `tsc`, `yarn build`, `vitest` (helix-org, sandboxes, app) all pass.

**NOT tested:** headless placement on a display-less host, quota caps, org-delete sweep, migration backfill on a production copy, mobile layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
