### PR TITLE
feat(frontend): guide new orgs to chief of staff

### DIFF
--- a/api/pkg/org/application/activations/activations.go
+++ b/api/pkg/org/application/activations/activations.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 )
 
 // ProjectEnsurer provisions (or fast-paths) a Worker's per-Worker Helix
@@ -24,10 +25,10 @@ type ProjectEnsurer interface {
 	Ensure(ctx context.Context, orgID string, workerID orgchart.NodeID) (projectID, agentAppID, repoID string, err error)
 }
 
-// ManualDispatcher enqueues an operator-driven activation on the
-// per-Worker queue. activationID is the pre-allocated audit-row id;
-// empty means the Spawner mints its own.
-type ManualDispatcher interface {
+// Dispatcher enqueues activations on the per-Worker queue. activationID
+// is the pre-allocated audit-row id; empty means the Spawner mints its own.
+type Dispatcher interface {
+	DispatchHire(ctx context.Context, orgID string, workerID orgchart.NodeID, activationID activation.ID)
 	DispatchManual(ctx context.Context, orgID string, workerID orgchart.NodeID, activationID activation.ID)
 }
 
@@ -71,7 +72,7 @@ type Activations struct {
 	now        func() time.Time
 	newID      func() string
 	ensurer    ProjectEnsurer
-	dispatcher ManualDispatcher
+	dispatcher Dispatcher
 	sessions   SessionResolver
 	stopper    DesktopStopper
 	resetter   SessionResetter
@@ -89,7 +90,7 @@ type Deps struct {
 	Now        func() time.Time
 	NewID      func() string
 	Ensurer    ProjectEnsurer
-	Dispatcher ManualDispatcher
+	Dispatcher Dispatcher
 	Sessions   SessionResolver
 	Stopper    DesktopStopper
 	Resetter   SessionResetter
@@ -115,7 +116,7 @@ func New(deps Deps) *Activations {
 	}
 }
 
-// ActivateResult is what a manual activation returns to the caller: the
+// ActivateResult is what an activation returns to the caller: the
 // pre-allocated activation id plus the project / agent-app / session ids
 // the UI needs to navigate to the desktop.
 type ActivateResult struct {
@@ -125,7 +126,7 @@ type ActivateResult struct {
 	SessionID    string
 }
 
-// Activate runs the manual "activate worker" command end-to-end:
+// Activate runs the "activate worker" command end-to-end:
 //
 //  1. Synchronously ensure the project + agent app (re-attaches the
 //     helix-org MCP — the immediate user-visible fix the operator clicked
@@ -141,6 +142,10 @@ type ActivateResult struct {
 // Activate's Ensure will also error on a missing Worker, but a pre-check
 // gives the cleaner status.
 func (a *Activations) Activate(ctx context.Context, orgID string, workerID orgchart.NodeID) (ActivateResult, error) {
+	return a.activate(ctx, orgID, workerID, false)
+}
+
+func (a *Activations) activate(ctx context.Context, orgID string, workerID orgchart.NodeID, forceManual bool) (ActivateResult, error) {
 	if a.ensurer == nil || a.dispatcher == nil {
 		return ActivateResult{}, ErrActivateUnavailable
 	}
@@ -152,14 +157,26 @@ func (a *Activations) Activate(ctx context.Context, orgID string, workerID orgch
 		return ActivateResult{}, fmt.Errorf("ensure project for %s: %w", workerID, err)
 	}
 	var sessionID string
+	triggerKind := activation.TriggerManual
 	if a.sessions != nil {
-		sessionID, _ = a.sessions.SessionID(ctx, orgID, workerID)
+		var sessionErr error
+		sessionID, sessionErr = a.sessions.SessionID(ctx, orgID, workerID)
+		if !forceManual && workerID == seedprompts.ChiefOfStaffBotID && sessionErr == nil && sessionID == "" && a.repo != nil {
+			rows, historyErr := a.repo.ListForWorker(ctx, orgID, workerID, 1)
+			if historyErr == nil && len(rows) == 0 {
+				triggerKind = activation.TriggerHire
+			}
+		}
 	}
-	activationID, err := a.prepareManual(ctx, orgID, workerID)
+	activationID, err := a.prepare(ctx, orgID, workerID, triggerKind)
 	if err != nil {
 		return ActivateResult{}, err
 	}
-	a.dispatcher.DispatchManual(ctx, orgID, workerID, activationID)
+	if triggerKind == activation.TriggerHire {
+		a.dispatcher.DispatchHire(ctx, orgID, workerID, activationID)
+	} else {
+		a.dispatcher.DispatchManual(ctx, orgID, workerID, activationID)
+	}
 	return ActivateResult{
 		ActivationID: activationID,
 		ProjectID:    projectID,
@@ -225,16 +242,17 @@ func (a *Activations) Restart(ctx context.Context, orgID string, workerID orgcha
 		if err := a.resetter.ResetSession(ctx, orgID, workerID, sessionID); err != nil {
 			return ActivateResult{}, fmt.Errorf("reset session: %w", err)
 		}
+		return a.activate(ctx, orgID, workerID, true)
 	}
 	return a.Activate(ctx, orgID, workerID)
 }
 
-// prepareManual pre-allocates a TriggerManual activation audit row for
-// the Worker and returns its id. Returns an empty id (and nil error)
+// prepare pre-allocates an activation audit row for the Worker and
+// returns its id. Returns an empty id (and nil error)
 // when the repository or id-generator is unwired — Activate then treats
 // that as "no pre-allocation; the Spawner mints its own", matching the
 // previous inline behaviour.
-func (a *Activations) prepareManual(ctx context.Context, orgID string, workerID orgchart.NodeID) (activation.ID, error) {
+func (a *Activations) prepare(ctx context.Context, orgID string, workerID orgchart.NodeID, triggerKind activation.TriggerKind) (activation.ID, error) {
 	if a.repo == nil || a.newID == nil {
 		return "", nil
 	}
@@ -242,15 +260,15 @@ func (a *Activations) prepareManual(ctx context.Context, orgID string, workerID 
 	act, err := activation.New(
 		id,
 		workerID,
-		[]activation.Trigger{{Kind: activation.TriggerManual}},
+		[]activation.Trigger{{Kind: triggerKind}},
 		a.now(),
 		orgID,
 	)
 	if err != nil {
-		return "", fmt.Errorf("build manual activation: %w", err)
+		return "", fmt.Errorf("build activation: %w", err)
 	}
 	if err := a.repo.Create(ctx, act); err != nil {
-		return "", fmt.Errorf("persist manual activation: %w", err)
+		return "", fmt.Errorf("persist activation: %w", err)
 	}
 	return id, nil
 }

--- a/api/pkg/org/application/activations/activations.go
+++ b/api/pkg/org/application/activations/activations.go
@@ -132,9 +132,9 @@ type ActivateResult struct {
 //     helix-org MCP — the immediate user-visible fix the operator clicked
 //     "Start Desktop" for).
 //  2. Read the persisted session id (empty on first activation).
-//  3. Pre-allocate the audit row so the response carries an activation id.
-//  4. Enqueue on the dispatcher's per-Worker queue (coalesces with any
-//     in-flight activation, so a double-click folds into one follow-up).
+//  3. Return any in-flight activation instead of dispatching a duplicate.
+//  4. Otherwise pre-allocate the audit row and enqueue it on the dispatcher's
+//     per-Worker queue.
 //
 // The worker-id is validated up front (it propagates into the
 // helix-specs git layout and topic ids — a defensive format check).
@@ -161,9 +161,17 @@ func (a *Activations) activate(ctx context.Context, orgID string, workerID orgch
 	if a.sessions != nil {
 		var sessionErr error
 		sessionID, sessionErr = a.sessions.SessionID(ctx, orgID, workerID)
-		if !forceManual && workerID == seedprompts.ChiefOfStaffBotID && sessionErr == nil && sessionID == "" && a.repo != nil {
+		if !forceManual && a.repo != nil {
 			rows, historyErr := a.repo.ListForWorker(ctx, orgID, workerID, 1)
-			if historyErr == nil && len(rows) == 0 {
+			if historyErr == nil && len(rows) > 0 && !rows[0].IsCompleted() {
+				return ActivateResult{
+					ActivationID: rows[0].ID,
+					ProjectID:    projectID,
+					AgentID:      agentAppID,
+					SessionID:    sessionID,
+				}, nil
+			}
+			if workerID == seedprompts.ChiefOfStaffBotID && sessionErr == nil && sessionID == "" && historyErr == nil && len(rows) == 0 {
 				triggerKind = activation.TriggerHire
 			}
 		}

--- a/api/pkg/org/application/activations/activations_test.go
+++ b/api/pkg/org/application/activations/activations_test.go
@@ -173,6 +173,9 @@ func TestActivate_SessionlessChiefOfStaffWithHistoryUsesManual(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build prior activation: %v", err)
 	}
+	if err := prior.Complete(activation.Outcome{Status: activation.StatusOK}, time.Date(2026, 6, 9, 12, 1, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("complete prior activation: %v", err)
+	}
 	if err := st.Activations.Create(context.Background(), prior); err != nil {
 		t.Fatalf("create prior activation: %v", err)
 	}
@@ -199,6 +202,51 @@ func TestActivate_SessionlessChiefOfStaffWithHistoryUsesManual(t *testing.T) {
 	}
 	if len(row.Triggers) != 1 || row.Triggers[0].Kind != activation.TriggerManual {
 		t.Fatalf("triggers = %+v, want [manual]", row.Triggers)
+	}
+}
+
+func TestActivate_InFlightActivationIsNotDispatchedAgain(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	inFlight, err := activation.New(
+		"a-repair-chief-of-staff",
+		seedprompts.ChiefOfStaffBotID,
+		[]activation.Trigger{{Kind: activation.TriggerHire}},
+		time.Date(2026, 6, 10, 11, 59, 0, 0, time.UTC),
+		"org-test",
+	)
+	if err != nil {
+		t.Fatalf("build in-flight activation: %v", err)
+	}
+	if err := st.Activations.Create(context.Background(), inFlight); err != nil {
+		t.Fatalf("create in-flight activation: %v", err)
+	}
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Repo:       st.Activations,
+		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
+		NewID:      func() string { return "duplicate" },
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{},
+	})
+
+	res, err := svc.Activate(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if res.ActivationID != inFlight.ID {
+		t.Fatalf("activation id = %q, want existing %q", res.ActivationID, inFlight.ID)
+	}
+	if disp.hireCalls != 0 || disp.manualCalls != 0 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 0/0", disp.hireCalls, disp.manualCalls)
+	}
+	rows, err := st.Activations.ListForWorker(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID, 10)
+	if err != nil {
+		t.Fatalf("ListForWorker: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("activation rows = %d, want 1", len(rows))
 	}
 }
 

--- a/api/pkg/org/application/activations/activations_test.go
+++ b/api/pkg/org/application/activations/activations_test.go
@@ -2,11 +2,13 @@ package activations
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 )
 
@@ -20,12 +22,23 @@ func (fakeEnsurer) Ensure(_ context.Context, _ string, _ orgchart.NodeID) (strin
 }
 
 type fakeDispatcher struct {
-	gotID  activation.ID
-	events *[]string
+	gotID       activation.ID
+	hireCalls   int
+	manualCalls int
+	events      *[]string
+}
+
+func (f *fakeDispatcher) DispatchHire(_ context.Context, _ string, _ orgchart.NodeID, activationID activation.ID) {
+	f.gotID = activationID
+	f.hireCalls++
+	if f.events != nil {
+		*f.events = append(*f.events, "dispatch")
+	}
 }
 
 func (f *fakeDispatcher) DispatchManual(_ context.Context, _ string, _ orgchart.NodeID, activationID activation.ID) {
 	f.gotID = activationID
+	f.manualCalls++
 	if f.events != nil {
 		*f.events = append(*f.events, "dispatch")
 	}
@@ -92,10 +105,150 @@ func TestActivate_NoRepoMintsNoRow(t *testing.T) {
 	}
 }
 
-type fakeSessions struct{ id string }
+type fakeSessions struct {
+	id  string
+	err error
+}
 
 func (f fakeSessions) SessionID(_ context.Context, _ string, _ orgchart.NodeID) (string, error) {
-	return f.id, nil
+	return f.id, f.err
+}
+
+func TestActivate_FirstChiefOfStaffSessionUsesHire(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Repo:       st.Activations,
+		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
+		NewID:      func() string { return "first" },
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{},
+	})
+
+	res, err := svc.Activate(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if disp.hireCalls != 1 || disp.manualCalls != 0 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 1/0", disp.hireCalls, disp.manualCalls)
+	}
+	row, err := st.Activations.Get(context.Background(), "org-test", res.ActivationID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(row.Triggers) != 1 || row.Triggers[0].Kind != activation.TriggerHire {
+		t.Fatalf("triggers = %+v, want [hire]", row.Triggers)
+	}
+}
+
+func TestActivate_OrdinaryFirstSessionUsesManual(t *testing.T) {
+	t.Parallel()
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{},
+	})
+
+	if _, err := svc.Activate(context.Background(), "org-test", "w-mark"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if disp.hireCalls != 0 || disp.manualCalls != 1 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 0/1", disp.hireCalls, disp.manualCalls)
+	}
+}
+
+func TestActivate_SessionlessChiefOfStaffWithHistoryUsesManual(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	prior, err := activation.New(
+		"a-prior",
+		seedprompts.ChiefOfStaffBotID,
+		[]activation.Trigger{{Kind: activation.TriggerHire}},
+		time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+		"org-test",
+	)
+	if err != nil {
+		t.Fatalf("build prior activation: %v", err)
+	}
+	if err := st.Activations.Create(context.Background(), prior); err != nil {
+		t.Fatalf("create prior activation: %v", err)
+	}
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Repo:       st.Activations,
+		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
+		NewID:      func() string { return "retry" },
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{},
+	})
+
+	res, err := svc.Activate(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if disp.hireCalls != 0 || disp.manualCalls != 1 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 0/1", disp.hireCalls, disp.manualCalls)
+	}
+	row, err := st.Activations.Get(context.Background(), "org-test", res.ActivationID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(row.Triggers) != 1 || row.Triggers[0].Kind != activation.TriggerManual {
+		t.Fatalf("triggers = %+v, want [manual]", row.Triggers)
+	}
+}
+
+func TestActivate_EstablishedChiefOfStaffSessionUsesManual(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Repo:       st.Activations,
+		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
+		NewID:      func() string { return "manual" },
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{id: "ses-1"},
+	})
+
+	res, err := svc.Activate(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if res.SessionID != "ses-1" {
+		t.Fatalf("session id = %q, want ses-1", res.SessionID)
+	}
+	if disp.hireCalls != 0 || disp.manualCalls != 1 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 0/1", disp.hireCalls, disp.manualCalls)
+	}
+	row, err := st.Activations.Get(context.Background(), "org-test", res.ActivationID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(row.Triggers) != 1 || row.Triggers[0].Kind != activation.TriggerManual {
+		t.Fatalf("triggers = %+v, want [manual]", row.Triggers)
+	}
+}
+
+func TestActivate_SessionLookupErrorUsesManual(t *testing.T) {
+	t.Parallel()
+	disp := &fakeDispatcher{}
+	svc := New(Deps{
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{err: errors.New("lookup failed")},
+	})
+
+	if _, err := svc.Activate(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if disp.hireCalls != 0 || disp.manualCalls != 1 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 0/1", disp.hireCalls, disp.manualCalls)
+	}
 }
 
 type fakeStopper struct{ called string }
@@ -190,12 +343,12 @@ func TestRestart_ResetsThenActivates(t *testing.T) {
 		Resetter:   resetter,
 		Canceller:  canceller,
 	})
-	res, err := svc.Restart(context.Background(), "org-test", "w-mark")
+	res, err := svc.Restart(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID)
 	if err != nil {
 		t.Fatalf("Restart: %v", err)
 	}
-	if resetter.called != "ses_old" || resetter.bot != "w-mark" {
-		t.Fatalf("resetter = %+v, want ses_old / w-mark", resetter)
+	if resetter.called != "ses_old" || resetter.bot != seedprompts.ChiefOfStaffBotID {
+		t.Fatalf("resetter = %+v, want ses_old / chief-of-staff", resetter)
 	}
 	if !canceller.called {
 		t.Fatal("outstanding activations were not cancelled before restart")
@@ -208,5 +361,33 @@ func TestRestart_ResetsThenActivates(t *testing.T) {
 	}
 	if disp.gotID != "a-restart" {
 		t.Fatalf("dispatcher got %q, want a-restart", disp.gotID)
+	}
+	if disp.manualCalls != 1 || disp.hireCalls != 0 {
+		t.Fatalf("dispatch calls manual/hire = %d/%d, want 1/0", disp.manualCalls, disp.hireCalls)
+	}
+}
+
+func TestRestart_NeverStartedUsesHire(t *testing.T) {
+	t.Parallel()
+	disp := &fakeDispatcher{}
+	resetter := &fakeResetter{}
+	svc := New(Deps{
+		Repo:       memory.New().Activations,
+		Now:        func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) },
+		NewID:      func() string { return "restart-first" },
+		Ensurer:    fakeEnsurer{},
+		Dispatcher: disp,
+		Sessions:   fakeSessions{},
+		Resetter:   resetter,
+	})
+
+	if _, err := svc.Restart(context.Background(), "org-test", seedprompts.ChiefOfStaffBotID); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if resetter.called != "" {
+		t.Fatalf("reset session = %q, want no reset", resetter.called)
+	}
+	if disp.hireCalls != 1 || disp.manualCalls != 0 {
+		t.Fatalf("dispatch calls hire/manual = %d/%d, want 1/0", disp.hireCalls, disp.manualCalls)
 	}
 }

--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -23,14 +23,15 @@ const ChiefOfStaff = `# Chief of Staff
 You are the Chief of Staff for this organization - the owner's right hand, here to support them and the team.
 
 ## First, reach the owner
-On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess, and do NOT just write the question into your own transcript (they will not see that).
+On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess.
 
 1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
-2. Use ` + "`ask_human`" + ` with that person's id to deliver the initial message through Helix notifications. Ask them, in one friendly message:
+2. Compose one friendly message asking:
    - what this organization is for and what they want to accomplish,
    - who the key people are and what they are responsible for,
    - whether future messages should arrive in Helix or Slack,
    - and anything else you need to set it up well.
+3. Use ` + "`ask_human`" + ` with that person's id and the message to deliver it through Helix notifications, then repeat the exact same message verbatim as your normal final response so it also appears in the direct chat.
 
 Keep it to a single, concise message - you can follow up once they reply.
 

--- a/api/pkg/org/domain/seedprompts/seedprompts_test.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts_test.go
@@ -1,0 +1,14 @@
+package seedprompts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChiefOfStaffOnboardingDeliversToNotificationAndChat(t *testing.T) {
+	for _, want := range []string{"`ask_human`", "repeat the exact same message verbatim as your normal final response"} {
+		if !strings.Contains(ChiefOfStaff, want) {
+			t.Fatalf("ChiefOfStaff missing %q", want)
+		}
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/sessions.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sessions.go
@@ -33,16 +33,17 @@ type SessionClient interface {
 // The adapter always sets session_role "exploratory" so it's resolvable
 // by the mirror's GetProjectExploratorySession lookup.
 type StartSessionParams struct {
-	Name           string
-	ProjectID      string
-	OrganizationID string
-	AppID          string
-	AgentType      string
-	Provider       string
-	Model          string
-	Prompt         string
-	WorkerID       string
-	Instructions   string
+	Name               string
+	ProjectID          string
+	OrganizationID     string
+	AppID              string
+	AgentType          string
+	Provider           string
+	Model              string
+	Prompt             string
+	WorkerID           string
+	Instructions       string
+	InteractionTrigger string
 }
 
 // SpawnerClient is the chat-session surface the helix Spawner uses
@@ -110,18 +111,19 @@ func checkDesktopQuota(ctx context.Context, client SessionClient) error {
 // a persistence write, a UI update) wire them in here; the helper
 // itself stays free of side-effects beyond the StartChat call.
 type SendPromptParams struct {
-	SessionID      string
-	SessionName    string
-	ProjectID      string
-	OrganizationID string
-	AppID          string
-	AgentType      string
-	Provider       string
-	Model          string
-	Prompt         string
-	WorkerID       string
-	Instructions   string
-	OnSessionID    func(sessionID string)
+	SessionID          string
+	SessionName        string
+	ProjectID          string
+	OrganizationID     string
+	AppID              string
+	AgentType          string
+	Provider           string
+	Model              string
+	Prompt             string
+	WorkerID           string
+	Instructions       string
+	InteractionTrigger string
+	OnSessionID        func(sessionID string)
 }
 
 // EnsureAndSend makes a worker's session run a prompt. A worker has one
@@ -157,16 +159,17 @@ func EnsureAndSend(ctx context.Context, client SessionClient, params SendPromptP
 		return "", false, err
 	}
 	sid, err := client.StartSession(ctx, StartSessionParams{
-		Name:           params.SessionName,
-		ProjectID:      params.ProjectID,
-		OrganizationID: params.OrganizationID,
-		AppID:          params.AppID,
-		AgentType:      params.AgentType,
-		Provider:       params.Provider,
-		Model:          params.Model,
-		Prompt:         params.Prompt,
-		WorkerID:       params.WorkerID,
-		Instructions:   params.Instructions,
+		Name:               params.SessionName,
+		ProjectID:          params.ProjectID,
+		OrganizationID:     params.OrganizationID,
+		AppID:              params.AppID,
+		AgentType:          params.AgentType,
+		Provider:           params.Provider,
+		Model:              params.Model,
+		Prompt:             params.Prompt,
+		WorkerID:           params.WorkerID,
+		Instructions:       params.Instructions,
+		InteractionTrigger: params.InteractionTrigger,
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("start helix session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -300,7 +300,11 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			return err
 		}
 		prompt := briefing.BuildPrompt(triggers)
-		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, instructions, prompt, bot.PreserveContext, publish)
+		interactionTrigger := ""
+		if triggers[0].Kind == activation.TriggerHire {
+			interactionTrigger = types.InteractionTriggerOrgHire
+		}
+		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, sessionName, instructions, prompt, interactionTrigger, bot.PreserveContext, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
@@ -415,7 +419,7 @@ func sanitizeLogValue(value string) string {
 //     connect; if it does (hadWSError) we immediately re-queue the
 //     same prompt via the durable /messages endpoint so it lands as
 //     soon as the agent dials home.
-func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
+func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.NodeID, sessionName, instructions, prompt, interactionTrigger string, preserveContext bool, _ func(string)) (string, string, error) {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return "", "", err
@@ -493,12 +497,13 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 		// is owned only by the org-service user and every other org admin
 		// gets a 403 loading the worker's chat. The owner-chat bridge path
 		// sets this via EnsureAndSend too; the activation path must match.
-		OrganizationID: orgID,
-		AppID:          state.AgentID,
-		AgentType:      AgentType,
-		Prompt:         prompt,
-		WorkerID:       string(workerID),
-		Instructions:   instructions,
+		OrganizationID:     orgID,
+		AppID:              state.AgentID,
+		AgentType:          AgentType,
+		Prompt:             prompt,
+		WorkerID:           string(workerID),
+		Instructions:       instructions,
+		InteractionTrigger: interactionTrigger,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("ensure session: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -240,6 +240,9 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	if fc.lastStartParams.WorkerID != "w-eng" {
 		t.Errorf("StartSession WorkerID = %q (want w-eng)", fc.lastStartParams.WorkerID)
 	}
+	if fc.lastStartParams.InteractionTrigger != types.InteractionTriggerOrgHire {
+		t.Errorf("StartSession InteractionTrigger = %q (want %q)", fc.lastStartParams.InteractionTrigger, types.InteractionTriggerOrgHire)
+	}
 	if !strings.Contains(fc.lastStartParams.Instructions, "=== Instructions ===\n# Role: Engineer") {
 		t.Errorf("StartSession instructions = %q", fc.lastStartParams.Instructions)
 	}

--- a/api/pkg/org/interfaces/server/api/activate_bot_test.go
+++ b/api/pkg/org/interfaces/server/api/activate_bot_test.go
@@ -42,6 +42,7 @@ func (f *fakeEnsurer) Ensure(_ context.Context, orgID string, bid orgchart.NodeI
 type fakeDispatcher struct {
 	mu              sync.Mutex
 	manualCalls     int
+	hireCalls       int
 	lastOrgID       string
 	lastBotID       orgchart.NodeID
 	lastActivation  activation.ID
@@ -63,12 +64,21 @@ func (f *fakeDispatcher) DispatchManual(_ context.Context, orgID string, bid org
 	f.lastActivation = actID
 }
 
+func (f *fakeDispatcher) DispatchHire(_ context.Context, orgID string, bid orgchart.NodeID, actID activation.ID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hireCalls++
+	f.lastOrgID = orgID
+	f.lastBotID = bid
+	f.lastActivation = actID
+}
+
 // wireActivate rebuilds deps.Activations with the test ensurer +
 // dispatcher so the activate use case (which lives in the activations
 // service now, not the handler) exercises the fakes. Optional
 // Sessions / Resetter / Stopper on deps are forwarded so restart/stop
 // tests can inject fakes without a second constructor.
-func wireActivate(deps orgapi.Deps, st *store.Store, ensurer activations.ProjectEnsurer, disp activations.ManualDispatcher) orgapi.Deps {
+func wireActivate(deps orgapi.Deps, st *store.Store, ensurer activations.ProjectEnsurer, disp activations.Dispatcher) orgapi.Deps {
 	ad := activations.Deps{
 		Repo:       st.Activations,
 		NewID:      func() string { return "act-1" },

--- a/api/pkg/org/interfaces/server/api/restart_bot_test.go
+++ b/api/pkg/org/interfaces/server/api/restart_bot_test.go
@@ -66,8 +66,8 @@ func TestRestartBotAgent_ResetsThenActivatesExistingSession(t *testing.T) {
 	if resetter.calls != 1 || resetter.lastSID != "ses_alice" {
 		t.Errorf("ResetSession calls = %d lastSID = %q, want 1 / ses_alice", resetter.calls, resetter.lastSID)
 	}
-	if disp.manualCalls != 1 {
-		t.Errorf("DispatchManual must run after the reset to start a fresh session; got %d", disp.manualCalls)
+	if disp.manualCalls != 1 || disp.hireCalls != 0 {
+		t.Errorf("dispatch calls manual/hire = %d/%d, want 1/0", disp.manualCalls, disp.hireCalls)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRestartBotAgent_ActivatesWithoutResetWhenNoSession(t *testing.T) {
 	if resetter.calls != 0 {
 		t.Errorf("ResetSession must NOT run without a live session; got %d", resetter.calls)
 	}
-	if disp.manualCalls != 1 {
-		t.Errorf("DispatchManual must run to start a fresh session; got %d", disp.manualCalls)
+	if disp.hireCalls != 0 || disp.manualCalls != 1 {
+		t.Errorf("dispatch calls hire/manual = %d/%d, want 0/1", disp.hireCalls, disp.manualCalls)
 	}
 }
 

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -966,6 +966,7 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 		AutoRestartOnCrash:  true,
 		OrgWorkerID:         params.WorkerID,
 		RuntimeInstructions: params.Instructions,
+		InteractionTrigger:  params.InteractionTrigger,
 		Messages: []*types.Message{{
 			Role:    "user",
 			Content: types.MessageContent{Parts: []any{params.Prompt}},

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -1297,6 +1297,7 @@ func appendOrOverwrite(session *types.Session, req *types.SessionChatRequest) (*
 			SystemPrompt:         session.Metadata.SystemPrompt,
 			PromptMessage:        message,
 			PromptMessageContent: messageContent,
+			Trigger:              req.InteractionTrigger,
 			State:                types.InteractionStateWaiting, // Will be updated once inference is complete
 		}
 
@@ -1349,6 +1350,7 @@ func appendOrOverwrite(session *types.Session, req *types.SessionChatRequest) (*
 			SystemPrompt:         session.Metadata.SystemPrompt,
 			PromptMessage:        message,
 			PromptMessageContent: messageContent,
+			Trigger:              req.InteractionTrigger,
 		},
 	)
 

--- a/api/pkg/server/session_handlers_test.go
+++ b/api/pkg/server/session_handlers_test.go
@@ -64,6 +64,7 @@ func (suite *AppendOrOverwriteSuite) TestAppendToEmptySession() {
 	}
 
 	req := &types.SessionChatRequest{
+		InteractionTrigger: types.InteractionTriggerOrgHire,
 		Messages: []*types.Message{
 			{
 				Role: "user",
@@ -83,6 +84,7 @@ func (suite *AppendOrOverwriteSuite) TestAppendToEmptySession() {
 
 	suite.Require().Len(session.Interactions, 1)
 	suite.Equal("Hello, how are you?", session.Interactions[0].PromptMessage)
+	suite.Equal(types.InteractionTriggerOrgHire, session.Interactions[0].Trigger)
 	suite.Equal(types.InteractionStateWaiting, session.Interactions[0].State)
 }
 

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -163,6 +163,11 @@ const (
 // not user-initiated (those use the default empty string or app-trigger
 // names like "slack", "crisp"). Used by the fork-and-pause flow.
 const (
+	// InteractionTriggerOrgHire marks the internal prompt that starts a newly
+	// hired organization worker. The prompt is sent to the agent but is not a
+	// human-authored chat message.
+	InteractionTriggerOrgHire = "org_hire"
+
 	// InteractionTriggerForkSeed marks the single synthetic divider
 	// interaction created on a forked child, carrying lineage metadata
 	// and (for the agent prepend path) a serialized blob of the parent
@@ -623,6 +628,7 @@ type SessionChatRequest struct {
 	// a Worker's identity.
 	OrgWorkerID         string `json:"-"`
 	RuntimeInstructions string `json:"-"`
+	InteractionTrigger  string `json:"-"`
 }
 
 // ExternalAgentConfig holds display configuration for external agent sessions

--- a/frontend/src/components/orgs/EditOrgWindow.test.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.test.tsx
@@ -66,7 +66,7 @@ describe('EditOrgWindow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create' }))
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(
-      'helix_org_chart',
+      'org_bot_session',
       { org_id: 'created-org', bot_id: 'chief-of-staff' },
     ))
     expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(

--- a/frontend/src/components/orgs/EditOrgWindow.test.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EditOrgWindow from './EditOrgWindow'
+
+const mockNavigate = vi.fn()
+const mockV1OrgsSettingsUpdate = vi.fn()
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => ({
+    getApiClient: () => ({
+      v1OrgsSettingsUpdate: mockV1OrgsSettingsUpdate,
+    }),
+  }),
+}))
+
+vi.mock('../../hooks/useRouter', () => ({
+  default: () => ({ navigate: mockNavigate }),
+}))
+
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ error: vi.fn() }),
+}))
+
+vi.mock('../helix-org/BotRuntimeForm', () => ({
+  default: ({ onChange }: { onChange: (value: object) => void }) => (
+    <button onClick={() => onChange({
+      runtime: 'zed_agent',
+      credentials: 'api_key',
+      provider: 'pe-1',
+      model: 'model-1',
+      reasoning_effort: 'high',
+    })}>
+      Choose runtime
+    </button>
+  ),
+}))
+
+describe('EditOrgWindow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockV1OrgsSettingsUpdate.mockResolvedValue({})
+  })
+
+  it('persists the runtime then opens the created organization Chief of Staff', async () => {
+    const onSubmit = vi.fn().mockResolvedValue({
+      id: 'org-1',
+      name: 'created-org',
+      display_name: 'Created Org',
+    })
+
+    render(
+      <EditOrgWindow
+        open
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const nameInput = screen.getByRole('textbox', { name: /^Name/ })
+    fireEvent.change(nameInput, {
+      target: { value: 'Created Org' },
+    })
+    fireEvent.blur(nameInput)
+    fireEvent.click(screen.getByRole('button', { name: 'Choose runtime' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(
+      'helix_org_chart',
+      { org_id: 'created-org', bot_id: 'chief-of-staff' },
+    ))
+    expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(
+      'agent.default',
+      'created-org',
+      { value: JSON.stringify({
+        code_agent_runtime: 'zed_agent',
+        code_agent_credential_type: 'api_key',
+        provider: 'pe-1',
+        model: 'model-1',
+        reasoning_effort: 'high',
+      }) },
+    )
+    expect(mockV1OrgsSettingsUpdate.mock.invocationCallOrder[0])
+      .toBeLessThan(mockNavigate.mock.invocationCallOrder[0])
+    expect(localStorage.getItem('selected_org')).toBe('created-org')
+  })
+
+  it('does not navigate after editing an organization', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <EditOrgWindow
+        open
+        org={{ id: 'org-1', name: 'existing-org', display_name: 'Existing Org' }}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -164,7 +164,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
       // Open the new organization's Chief of Staff.
       if (!org && created && created.name) {
         localStorage.setItem(SELECTED_ORG_STORAGE_KEY, created.name)
-        router.navigate('helix_org_chart', {
+        router.navigate('org_bot_session', {
           org_id: created.name,
           bot_id: 'chief-of-staff',
         })

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -15,7 +15,6 @@ import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
 import AgentConfigForm, { AgentConfigValue } from '../helix-org/BotRuntimeForm'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
-import { orgLandingRoute } from '../../utils/organizations'
 
 export interface EditOrgWindowProps {
   open: boolean
@@ -162,10 +161,13 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
       // backend on org create — see api/pkg/server/org_graph_seed.go. The
       // frontend no longer creates it.
 
-      // Land the operator on the default page for the new organization.
+      // Open the new organization's Chief of Staff.
       if (!org && created && created.name) {
         localStorage.setItem(SELECTED_ORG_STORAGE_KEY, created.name)
-        router.navigate(orgLandingRoute(), { org_id: created.name })
+        router.navigate('helix_org_chart', {
+          org_id: created.name,
+          bot_id: 'chief-of-staff',
+        })
       }
 
       onClose()

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -484,7 +484,7 @@ const EmbeddedSessionView = forwardRef<
 
   const navigatorItems = useMemo<ChatTurnNavigatorItem[]>(() => {
     return visibleInteractions.flatMap((interaction) => {
-      if (!interaction.id || interaction.trigger === "fork_seed" || interaction.trigger === "fork_handoff") return [];
+      if (!interaction.id || interaction.trigger === "fork_seed" || interaction.trigger === "fork_handoff" || interaction.trigger === "org_hire") return [];
       const contentText = interaction.prompt_message_content?.parts?.find(
         (part): part is { text: string } =>
           typeof part === "object" &&

--- a/frontend/src/components/session/Interaction.test.tsx
+++ b/frontend/src/components/session/Interaction.test.tsx
@@ -89,6 +89,23 @@ describe("Interaction", () => {
     expect(screen.queryByRole("button", { name: "agent debug copy" })).not.toBeInTheDocument();
   });
 
+  it("hides an organization hire prompt without hiding the agent reply", () => {
+    render(
+      <Interaction
+        {...baseProps}
+        interaction={{
+          id: "int_first_hire",
+          prompt_message: "Internal activation instructions",
+          response_message: "Hello, I am your new agent.",
+          trigger: "org_hire",
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("user-message")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agent-reply")).toHaveTextContent("Hello, I am your new agent.");
+  });
+
   it("renders workspace attachments without exposing the transport manifest", () => {
     render(
       <Interaction

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -441,7 +441,7 @@ export const Interaction: FC<InteractionProps> = ({
       onMouseLeave={() => setIsHovering(false)}
     >
       {/* User Message Container */}
-      {userMessage && (
+      {userMessage && interaction.trigger !== "org_hire" && (
         <Box
           sx={{
             display: "flex",

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -270,7 +270,7 @@ describe('Onboarding', () => {
       }),
     })
     expect(localStorage.getItem('selected_org')).toBe('my-org')
-    expect(mockNavigateReplace).toHaveBeenCalledWith('helix_org_chart', {
+    expect(mockNavigateReplace).toHaveBeenCalledWith('org_bot_session', {
       org_id: 'my-org',
       bot_id: 'chief-of-staff',
     })
@@ -320,7 +320,7 @@ describe('Onboarding', () => {
     })
 
     await waitFor(() => {
-      expect(mockNavigateReplace).toHaveBeenCalledWith('helix_org_chart', {
+      expect(mockNavigateReplace).toHaveBeenCalledWith('org_bot_session', {
         org_id: 'my-org',
         bot_id: 'chief-of-staff',
       })
@@ -415,7 +415,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
-      'helix_org_chart',
+      'org_bot_session',
       { org_id: 'my-org', bot_id: 'chief-of-staff' },
     ))
     expect(mockUpdateHarnesses).not.toHaveBeenCalled()
@@ -443,7 +443,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
-      'helix_org_chart',
+      'org_bot_session',
       { org_id: 'new-org', bot_id: 'chief-of-staff' },
     ))
   })
@@ -495,7 +495,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
-      'helix_org_chart',
+      'org_bot_session',
       { org_id: 'new-org', bot_id: 'chief-of-staff' },
     ))
   })

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -8,10 +8,13 @@ const mockSnackbarError = vi.fn()
 const mockLoadOrganizations = vi.fn()
 const mockV1UsersMeOnboardingCreate = vi.fn()
 const mockV1OrgsSettingsUpdate = vi.fn()
+const mockV1SubscriptionNewCreate = vi.fn()
 const mockCreateOrgMutateAsync = vi.fn()
 const mockUpdateHarnesses = vi.fn()
 
 const mockState = vi.hoisted(() => ({
+  edition: 'cloud',
+  billingEnabled: true,
   walletStatus: 'active',
   claudeSubscriptions: [{ id: 'claude-sub-1' }] as Array<{ id: string }>,
   codexSubscriptions: [] as Array<{ id: string }>,
@@ -57,7 +60,7 @@ vi.mock('../hooks/useApi', () => ({
     getApiClient: () => ({
       v1UsersMeOnboardingCreate: mockV1UsersMeOnboardingCreate,
       v1OrgsSettingsUpdate: mockV1OrgsSettingsUpdate,
-      v1SubscriptionNewCreate: vi.fn(),
+      v1SubscriptionNewCreate: mockV1SubscriptionNewCreate,
     }),
   }),
 }))
@@ -94,8 +97,8 @@ vi.mock('../services/orgService', () => ({
 vi.mock('../services/userService', () => ({
   useGetConfig: () => ({
     data: {
-      billing_enabled: true,
-      edition: 'cloud',
+      billing_enabled: mockState.billingEnabled,
+      edition: mockState.edition,
       onboarding_helix_model_provider: mockState.onboardingHelixDefault.provider,
       onboarding_helix_model: mockState.onboardingHelixDefault.model,
       onboarding_helix_model_effort: mockState.onboardingHelixDefault.effort,
@@ -170,10 +173,12 @@ async function goToCodingAccessStep() {
     screen.getByRole('button', { name: /continue with this organization/i }),
   )
 
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: /^continue$/i })).toBeInTheDocument()
-  })
-  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+  if (mockState.billingEnabled) {
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^continue$/i })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+  }
 
   await waitFor(() => {
     expect(screen.getByText('Choose how to run coding agents')).toBeInTheDocument()
@@ -184,6 +189,9 @@ describe('Onboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    window.history.replaceState({}, '', '/onboarding')
+    mockState.edition = 'cloud'
+    mockState.billingEnabled = true
     mockState.walletStatus = 'active'
     mockState.onboardingHelixDefault = {
       provider: 'pe_helix',
@@ -205,6 +213,8 @@ describe('Onboarding', () => {
     ]
     mockV1UsersMeOnboardingCreate.mockResolvedValue({})
     mockV1OrgsSettingsUpdate.mockResolvedValue({})
+    mockV1SubscriptionNewCreate.mockResolvedValue({})
+    mockCreateOrgMutateAsync.mockResolvedValue(undefined)
     mockUpdateHarnesses.mockResolvedValue([])
     setAccountWithOrgs([
       { id: 'org-1', name: 'my-org', display_name: 'My Org', owner: 'user-1' },
@@ -222,7 +232,7 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.getByRole('button', { name: /continue with helix credits/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
     expect(screen.getByRole('button', { name: /helix providers/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /chatgpt subscription/i })).toBeInTheDocument()
@@ -236,13 +246,13 @@ describe('Onboarding', () => {
     expect(screen.queryByText(/where is your code/i)).not.toBeInTheDocument()
   })
 
-  it('saves the selected Helix runtime and opens project creation', async () => {
+  it('saves the selected Helix runtime and opens the Chief of Staff on cloud', async () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
     await act(async () => {
       fireEvent.click(
-        screen.getByRole('button', { name: /continue with helix credits/i }),
+        screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
       )
     })
 
@@ -260,15 +270,9 @@ describe('Onboarding', () => {
       }),
     })
     expect(localStorage.getItem('selected_org')).toBe('my-org')
-    expect(mockNavigateReplace).toHaveBeenCalledWith('org_projects', {
+    expect(mockNavigateReplace).toHaveBeenCalledWith('helix_org_chart', {
       org_id: 'my-org',
-      create_project_config: JSON.stringify({
-        runtime: 'zed_agent',
-        credential_type: 'api_key',
-        provider_ref: 'pe_helix',
-        model: 'helix-model',
-        reasoning_effort: 'high',
-      }),
+      bot_id: 'chief-of-staff',
     })
     expect(mockUpdateHarnesses).not.toHaveBeenCalled()
   })
@@ -282,7 +286,7 @@ describe('Onboarding', () => {
 
     expect(screen.getByRole('button', { name: 'Connect Claude' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /continue with claude subscription/i }),
+      screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
     ).toBeDisabled()
   })
 
@@ -294,7 +298,7 @@ describe('Onboarding', () => {
 
     expect(screen.getByRole('button', { name: 'Connect ChatGPT' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /continue with chatgpt subscription/i }),
+      screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
     ).toBeDisabled()
   })
 
@@ -307,7 +311,7 @@ describe('Onboarding', () => {
     fireEvent.mouseDown(screen.getByLabelText('Codex model'))
     fireEvent.click(screen.getByRole('option', { name: 'GPT-5.6 Terra' }))
     const continueButton = screen.getByRole('button', {
-      name: /continue with chatgpt subscription/i,
+      name: 'Meet your Chief of Staff',
     })
     expect(continueButton).toBeEnabled()
 
@@ -316,13 +320,9 @@ describe('Onboarding', () => {
     })
 
     await waitFor(() => {
-      expect(mockNavigateReplace).toHaveBeenCalledWith('org_projects', {
+      expect(mockNavigateReplace).toHaveBeenCalledWith('helix_org_chart', {
         org_id: 'my-org',
-        create_project_config: JSON.stringify({
-          runtime: 'codex_cli',
-          credential_type: 'subscription',
-          model: 'gpt-5.6-terra',
-        }),
+        bot_id: 'chief-of-staff',
       })
     })
     expect(mockUpdateHarnesses).toHaveBeenCalledWith([{
@@ -341,7 +341,8 @@ describe('Onboarding', () => {
     })
   })
 
-  it('selects a Claude subscription model and passes it to project creation', async () => {
+  it('keeps project creation for an existing self-hosted organization', async () => {
+    mockState.edition = 'self-hosted'
     renderOnboarding()
     await goToCodingAccessStep()
 
@@ -379,7 +380,7 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.getByRole('button', { name: /continue with helix credits/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeDisabled()
   })
 
   it('requires a non-owner to ask the owner before changing subscription policy', async () => {
@@ -396,7 +397,7 @@ describe('Onboarding', () => {
     expect(screen.getByText(
       'Ask an organization owner to set the Default Runtime.',
     )).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /continue with claude subscription/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeDisabled()
     expect(mockUpdateHarnesses).not.toHaveBeenCalled()
   })
 
@@ -411,13 +412,92 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
     fireEvent.mouseDown(screen.getByLabelText('Claude model'))
     fireEvent.click(screen.getByRole('option', { name: /Claude Fable 5/i }))
-    fireEvent.click(screen.getByRole('button', { name: /continue with claude subscription/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
-      'org_projects',
-      expect.any(Object),
+      'helix_org_chart',
+      { org_id: 'my-org', bot_id: 'chief-of-staff' },
     ))
     expect(mockUpdateHarnesses).not.toHaveBeenCalled()
+  })
+
+  it('opens the Chief of Staff for an organization created during self-hosted onboarding', async () => {
+    mockState.edition = 'self-hosted'
+    mockState.billingEnabled = false
+    setAccountWithOrgs([])
+    mockCreateOrgMutateAsync.mockResolvedValue({
+      id: 'org-2',
+      name: 'new-org',
+      display_name: 'New Org',
+    })
+    renderOnboarding()
+
+    fireEvent.change(screen.getByLabelText('Organization name'), {
+      target: { value: 'New Org' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
+
+    await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
+      'helix_org_chart',
+      { org_id: 'new-org', bot_id: 'chief-of-staff' },
+    ))
+  })
+
+  it('restores a new self-hosted organization after Stripe returns', async () => {
+    mockState.edition = 'self-hosted'
+    mockState.walletStatus = 'not_subscribed'
+    setAccountWithOrgs([])
+    mockCreateOrgMutateAsync.mockResolvedValue({
+      id: 'org-2',
+      name: 'new-org',
+      display_name: 'New Org',
+    })
+    const firstRender = renderOnboarding()
+
+    fireEvent.change(screen.getByLabelText('Organization name'), {
+      target: { value: 'New Org' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /start subscription/i })).toBeEnabled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /start subscription/i }))
+
+    await waitFor(() => expect(mockV1SubscriptionNewCreate).toHaveBeenCalledWith({
+      org_id: 'org-2',
+      return_url: '/onboarding?org_id=org-2&created_org=true',
+    }))
+    firstRender.unmount()
+
+    mockState.walletStatus = 'active'
+    setAccountWithOrgs([
+      { id: 'org-2', name: 'new-org', display_name: 'New Org', owner: 'user-1' },
+    ])
+    window.history.replaceState(
+      {},
+      '',
+      '/onboarding?org_id=org-2&created_org=true&success=true',
+    )
+    renderOnboarding()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^continue$/i })).toBeEnabled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
+
+    await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
+      'helix_org_chart',
+      { org_id: 'new-org', bot_id: 'chief-of-staff' },
+    ))
   })
 
   it('shows benefits rather than empty billing fields before subscription', async () => {

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -467,7 +467,7 @@ export default function Onboarding() {
         account.dismissOnboarding();
         localStorage.setItem(SELECTED_ORG_STORAGE_KEY, createdOrg.name);
         if (shouldMeetChiefOfStaff) {
-          router.navigateReplace("helix_org_chart", {
+          router.navigateReplace("org_bot_session", {
             org_id: createdOrg.name,
             bot_id: "chief-of-staff",
           });

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -216,6 +216,7 @@ export default function Onboarding() {
     display_name?: string;
     viewer_is_owner: boolean;
   } | null>(null);
+  const [createdOrgDuringOnboarding, setCreatedOrgDuringOnboarding] = useState(false);
   const createOrgMutation = useCreateOrg();
 
   // Step 2: Subscription (conditional)
@@ -264,6 +265,8 @@ export default function Onboarding() {
     && helixModels.some((model) => model.id === helixModel);
   const hasConfiguredHelixDefault = !!serverConfig?.onboarding_helix_model_provider
     && !!serverConfig?.onboarding_helix_model;
+  const shouldMeetChiefOfStaff = serverConfig?.edition === "cloud"
+    || createdOrgDuringOnboarding;
 
   useEffect(() => {
     if (!hasConfiguredHelixDefault) return;
@@ -341,9 +344,8 @@ export default function Onboarding() {
   }, [refetchWallet, getStepIndexByType]);
 
   useEffect(() => {
-    const orgIdFromUrl = new URLSearchParams(window.location.search).get(
-      "org_id",
-    );
+    const searchParams = new URLSearchParams(window.location.search);
+    const orgIdFromUrl = searchParams.get("org_id");
     if (!orgIdFromUrl || createdOrg || !existingOrgs.length) return;
 
     const org = existingOrgs.find((candidate) => candidate.id === orgIdFromUrl);
@@ -358,6 +360,7 @@ export default function Onboarding() {
         || !!org.memberships?.some((membership) =>
           membership.user_id === account.user?.id && membership.role === "owner"),
     });
+    setCreatedOrgDuringOnboarding(searchParams.get("created_org") === "true");
     const orgStepIndex = getStepIndexByType("organization");
     setCompletedSteps((prev) => new Set([...prev, orgStepIndex]));
     setActiveStep(orgStepIndex + 1);
@@ -463,10 +466,17 @@ export default function Onboarding() {
         }
         account.dismissOnboarding();
         localStorage.setItem(SELECTED_ORG_STORAGE_KEY, createdOrg.name);
-        router.navigateReplace("org_projects", {
-          org_id: createdOrg.name,
-          create_project_config: JSON.stringify(codeAgentConfig),
-        });
+        if (shouldMeetChiefOfStaff) {
+          router.navigateReplace("helix_org_chart", {
+            org_id: createdOrg.name,
+            bot_id: "chief-of-staff",
+          });
+        } else {
+          router.navigateReplace("org_projects", {
+            org_id: createdOrg.name,
+            create_project_config: JSON.stringify(codeAgentConfig),
+          });
+        }
       } catch (err) {
         console.error("Failed to configure coding access:", err);
         snackbar.error("Failed to configure coding access");
@@ -487,6 +497,7 @@ export default function Onboarding() {
       helixReasoningEffort,
       helixDefaultAvailable,
       router,
+      shouldMeetChiefOfStaff,
       snackbar,
       updateCodeAgentHarnesses,
     ],
@@ -510,6 +521,7 @@ export default function Onboarding() {
         || !!org.memberships?.some((membership) =>
           membership.user_id === account.user?.id && membership.role === "owner"),
     });
+    setCreatedOrgDuringOnboarding(false);
     markStepCompleteByType("organization");
   }, [account.user?.id, selectedOrgId, existingOrgs, markStepCompleteByType, snackbar]);
 
@@ -529,6 +541,7 @@ export default function Onboarding() {
           display_name: newOrg.display_name,
           viewer_is_owner: true,
         });
+        setCreatedOrgDuringOnboarding(true);
         await account.organizationTools.loadOrganizations();
         markStepCompleteByType("organization");
       }
@@ -556,7 +569,7 @@ export default function Onboarding() {
 
       const resp = await api.getApiClient().v1SubscriptionNewCreate({
         org_id: createdOrg.id,
-        return_url: `/onboarding?org_id=${createdOrg.id}`,
+        return_url: `/onboarding?org_id=${createdOrg.id}${createdOrgDuringOnboarding ? "&created_org=true" : ""}`,
       });
       if (!resp.data) return;
 
@@ -567,7 +580,7 @@ export default function Onboarding() {
     } finally {
       setIsSubscribing(false);
     }
-  }, [api, createdOrg, snackbar]);
+  }, [api, createdOrg, createdOrgDuringOnboarding, snackbar]);
 
   const handleDismiss = useCallback(async () => {
     account.dismissOnboarding();
@@ -1331,7 +1344,11 @@ export default function Onboarding() {
                   ) : undefined
                 }
               >
-                {finishingOnboarding ? "Finishing setup..." : continueLabel}
+                {finishingOnboarding
+                  ? "Finishing setup..."
+                  : shouldMeetChiefOfStaff
+                    ? "Meet your Chief of Staff"
+                    : continueLabel}
               </Button>
             </Box>
           </Fade>

--- a/frontend/src/pages/OrgBotSessionResolver.test.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import OrgBotSessionResolver from './OrgBotSessionResolver'
+
+const mocks = vi.hoisted(() => ({
+  activate: vi.fn(),
+  list: vi.fn(),
+  refetch: vi.fn(),
+  navigateReplace: vi.fn(),
+  bots: [] as Array<{ id: string; session_id?: string }>,
+  listError: false,
+}))
+
+vi.mock('../hooks/useRouter', () => ({
+  default: () => ({
+    params: { org_id: 'my-org', bot_id: 'chief-of-staff' },
+    navigateReplace: mocks.navigateReplace,
+  }),
+}))
+
+vi.mock('../services/helixOrgService', () => ({
+  useListHelixOrgBots: (options: object) => {
+    mocks.list(options)
+    return {
+      data: mocks.bots,
+      isLoading: false,
+      isError: mocks.listError,
+      refetch: mocks.refetch,
+    }
+  },
+  useActivateBot: () => ({ mutateAsync: mocks.activate, isPending: false }),
+}))
+
+describe('OrgBotSessionResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.bots = []
+    mocks.listError = false
+    mocks.activate.mockResolvedValue({})
+    mocks.refetch.mockResolvedValue({})
+  })
+
+  it('opens an existing durable session without activating the bot', async () => {
+    mocks.bots = [{ id: 'chief-of-staff', session_id: 'ses-existing' }]
+
+    render(<OrgBotSessionResolver />)
+
+    await waitFor(() => expect(mocks.navigateReplace).toHaveBeenCalledWith(
+      'org_session',
+      { org_id: 'my-org', session_id: 'ses-existing' },
+    ))
+    expect(mocks.activate).not.toHaveBeenCalled()
+    expect(mocks.list).toHaveBeenCalledWith({
+      enabled: true,
+      refetchInterval: 2000,
+    })
+  })
+
+  it('activates once and opens the durable session when polling finds it', async () => {
+    mocks.bots = [{ id: 'chief-of-staff' }]
+    const view = render(<OrgBotSessionResolver />)
+
+    await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(1))
+    mocks.bots = [{ id: 'chief-of-staff', session_id: 'ses-started' }]
+    view.rerender(<OrgBotSessionResolver />)
+
+    await waitFor(() => expect(mocks.navigateReplace).toHaveBeenCalledWith(
+      'org_session',
+      { org_id: 'my-org', session_id: 'ses-started' },
+    ))
+    expect(mocks.activate).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows activation to be retried while no durable session exists', async () => {
+    mocks.bots = [{ id: 'chief-of-staff' }]
+    render(<OrgBotSessionResolver />)
+
+    await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Retry starting Chief of Staff',
+    }))
+
+    await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(2))
+  })
+
+  it('offers retry when activation fails', async () => {
+    mocks.bots = [{ id: 'chief-of-staff' }]
+    mocks.activate.mockRejectedValueOnce(new Error('failed'))
+    render(<OrgBotSessionResolver />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start your Chief of Staff.',
+    )
+    const retry = screen.getByRole('button', {
+      name: 'Retry starting Chief of Staff',
+    })
+    mocks.activate.mockResolvedValue({})
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(2))
+  })
+
+  it('offers query retry when the bot list fails', async () => {
+    mocks.listError = true
+    render(<OrgBotSessionResolver />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Could not find your Chief of Staff.',
+    )
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Retry finding Chief of Staff',
+    }))
+
+    expect(mocks.refetch).toHaveBeenCalledTimes(1)
+    expect(mocks.activate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/OrgBotSessionResolver.test.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.test.tsx
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
   list: vi.fn(),
   refetch: vi.fn(),
   navigateReplace: vi.fn(),
-  bots: [] as Array<{ id: string; session_id?: string }>,
+  bots: [] as Array<{ id: string; name?: string; session_id?: string }>,
   listError: false,
 }))
 
@@ -71,16 +71,18 @@ describe('OrgBotSessionResolver', () => {
     expect(mocks.activate).toHaveBeenCalledTimes(1)
   })
 
-  it('allows activation to be retried while no durable session exists', async () => {
-    mocks.bots = [{ id: 'chief-of-staff' }]
+  it('introduces the selected agent without offering a premature retry', async () => {
+    mocks.bots = [{ id: 'chief-of-staff', name: 'Chief of Staff' }]
     render(<OrgBotSessionResolver />)
 
     await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(1))
-    fireEvent.click(screen.getByRole('button', {
-      name: 'Retry starting Chief of Staff',
-    }))
-
-    await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('heading', { name: 'Meet Chief of Staff' })).toBeInTheDocument()
+    expect(screen.getByText(/new agent is getting ready/i)).toBeInTheDocument()
+    expect(screen.getByText('Preparing Chief of Staff')).toBeInTheDocument()
+    expect(screen.getByText('Finding your agent')).toBeInTheDocument()
+    expect(screen.getByText('Starting a secure workspace')).toBeInTheDocument()
+    expect(screen.getByText('Opening your conversation')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
   })
 
   it('offers retry when activation fails', async () => {
@@ -89,10 +91,10 @@ describe('OrgBotSessionResolver', () => {
     render(<OrgBotSessionResolver />)
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Could not start your Chief of Staff.',
+      'Could not start chief-of-staff.',
     )
     const retry = screen.getByRole('button', {
-      name: 'Retry starting Chief of Staff',
+      name: 'Retry starting chief-of-staff',
     })
     mocks.activate.mockResolvedValue({})
     fireEvent.click(retry)
@@ -105,10 +107,10 @@ describe('OrgBotSessionResolver', () => {
     render(<OrgBotSessionResolver />)
 
     expect(screen.getByRole('alert')).toHaveTextContent(
-      'Could not find your Chief of Staff.',
+      'Could not find this agent.',
     )
     fireEvent.click(screen.getByRole('button', {
-      name: 'Retry finding Chief of Staff',
+      name: 'Retry finding agent',
     }))
 
     expect(mocks.refetch).toHaveBeenCalledTimes(1)

--- a/frontend/src/pages/OrgBotSessionResolver.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Typography from '@mui/material/Typography'
+
+import useRouter from '../hooks/useRouter'
+import { useActivateBot, useListHelixOrgBots } from '../services/helixOrgService'
+
+export default function OrgBotSessionResolver() {
+  const router = useRouter()
+  const orgID = router.params.org_id || ''
+  const botID = router.params.bot_id || ''
+  const attemptedBot = useRef('')
+  const [activationError, setActivationError] = useState(false)
+  const {
+    data: bots = [],
+    isLoading,
+    isError: listError,
+    refetch,
+  } = useListHelixOrgBots({
+    enabled: !!orgID && !!botID,
+    refetchInterval: 2000,
+  })
+  const bot = bots.find((candidate) => candidate.id === botID)
+  const sessionID = bot?.session_id || ''
+  const activateBot = useActivateBot(orgID)
+
+  useEffect(() => {
+    if (!orgID || !sessionID) return
+    router.navigateReplace('org_session', {
+      org_id: orgID,
+      session_id: sessionID,
+    })
+  }, [orgID, sessionID]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const botKey = `${orgID}:${botID}`
+    if (!bot?.id || sessionID || attemptedBot.current === botKey) return
+    attemptedBot.current = botKey
+    setActivationError(false)
+    activateBot.mutateAsync(botID).catch(() => setActivationError(true))
+  }, [bot?.id, botID, orgID, sessionID]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const retryActivation = () => {
+    setActivationError(false)
+    activateBot.mutateAsync(botID).catch(() => setActivationError(true))
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+      }}
+    >
+      {listError ? (
+        <>
+          <Typography color="error" role="alert">
+            Could not find your Chief of Staff.
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={() => void refetch()}
+            aria-label="Retry finding Chief of Staff"
+          >
+            Retry
+          </Button>
+        </>
+      ) : activationError ? (
+        <>
+          <Typography color="error" role="alert">
+            Could not start your Chief of Staff.
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={retryActivation}
+            aria-label="Retry starting Chief of Staff"
+            disabled={activateBot.isPending}
+          >
+            Retry
+          </Button>
+        </>
+      ) : (
+        <>
+          <CircularProgress size={24} />
+          <Typography color="text.secondary">
+            {isLoading || !bot
+              ? 'Finding your Chief of Staff...'
+              : 'Starting your Chief of Staff...'}
+          </Typography>
+          {bot && !sessionID && (
+            <Button
+              variant="outlined"
+              onClick={retryActivation}
+              aria-label="Retry starting Chief of Staff"
+              disabled={activateBot.isPending}
+            >
+              Retry
+            </Button>
+          )}
+        </>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/pages/OrgBotSessionResolver.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import Typography from '@mui/material/Typography'
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
 
 import useRouter from '../hooks/useRouter'
 import { useActivateBot, useListHelixOrgBots } from '../services/helixOrgService'
@@ -15,7 +16,6 @@ export default function OrgBotSessionResolver() {
   const [activationError, setActivationError] = useState(false)
   const {
     data: bots = [],
-    isLoading,
     isError: listError,
     refetch,
   } = useListHelixOrgBots({
@@ -23,8 +23,15 @@ export default function OrgBotSessionResolver() {
     refetchInterval: 2000,
   })
   const bot = bots.find((candidate) => candidate.id === botID)
+  const agentName = bot?.name || botID
   const sessionID = bot?.session_id || ''
   const activateBot = useActivateBot(orgID)
+  const currentStage = sessionID ? 2 : bot ? 1 : 0
+  const stages = [
+    ['Finding your agent', 'Checking your organization'],
+    ['Starting a secure workspace', `Preparing ${agentName}`],
+    ['Opening your conversation', 'Taking you to the chat'],
+  ]
 
   useEffect(() => {
     if (!orgID || !sessionID) return
@@ -61,12 +68,12 @@ export default function OrgBotSessionResolver() {
       {listError ? (
         <>
           <Typography color="error" role="alert">
-            Could not find your Chief of Staff.
+            Could not find this agent.
           </Typography>
           <Button
             variant="contained"
             onClick={() => void refetch()}
-            aria-label="Retry finding Chief of Staff"
+            aria-label="Retry finding agent"
           >
             Retry
           </Button>
@@ -74,36 +81,86 @@ export default function OrgBotSessionResolver() {
       ) : activationError ? (
         <>
           <Typography color="error" role="alert">
-            Could not start your Chief of Staff.
+            Could not start {agentName}.
           </Typography>
           <Button
             variant="contained"
             onClick={retryActivation}
-            aria-label="Retry starting Chief of Staff"
+            aria-label={`Retry starting ${agentName}`}
             disabled={activateBot.isPending}
           >
             Retry
           </Button>
         </>
       ) : (
-        <>
-          <CircularProgress size={24} />
-          <Typography color="text.secondary">
-            {isLoading || !bot
-              ? 'Finding your Chief of Staff...'
-              : 'Starting your Chief of Staff...'}
+        <Box
+          sx={{
+            width: 'calc(100% - 32px)',
+            maxWidth: 440,
+            p: { xs: 3, sm: 4 },
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 3,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Typography variant="h5" sx={{ fontWeight: 650, letterSpacing: '-0.02em' }}>
+            Meet {agentName}
           </Typography>
-          {bot && !sessionID && (
-            <Button
-              variant="outlined"
-              onClick={retryActivation}
-              aria-label="Retry starting Chief of Staff"
-              disabled={activateBot.isPending}
-            >
-              Retry
-            </Button>
-          )}
-        </>
+          <Typography color="text.secondary" sx={{ mt: 1, lineHeight: 1.6 }}>
+            Your new agent is getting ready to work with your organization.
+          </Typography>
+
+          <Box component="ol" sx={{ listStyle: 'none', p: 0, m: 0, mt: 3 }}>
+            {stages.map(([label, detail], index) => {
+              const complete = index < currentStage
+              const active = index === currentStage
+              return (
+                <Box
+                  component="li"
+                  key={label}
+                  aria-current={active ? 'step' : undefined}
+                  sx={{ display: 'flex', gap: 1.5, minHeight: 58 }}
+                >
+                  <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                    <Box
+                      sx={{
+                        width: 26,
+                        height: 26,
+                        borderRadius: '50%',
+                        display: 'grid',
+                        placeItems: 'center',
+                        border: '1px solid',
+                        borderColor: complete || active ? 'secondary.main' : 'divider',
+                        bgcolor: complete ? 'secondary.main' : 'transparent',
+                        color: complete ? 'secondary.contrastText' : 'text.secondary',
+                      }}
+                    >
+                      {complete ? (
+                        <CheckRoundedIcon sx={{ fontSize: 17 }} />
+                      ) : active ? (
+                        <CircularProgress size={16} color="secondary" />
+                      ) : (
+                        <Typography variant="caption">{index + 1}</Typography>
+                      )}
+                    </Box>
+                    {index < stages.length - 1 && (
+                      <Box sx={{ width: '1px', flex: 1, bgcolor: 'divider' }} />
+                    )}
+                  </Box>
+                  <Box sx={{ pt: 0.25 }}>
+                    <Typography sx={{ fontWeight: active ? 600 : 500, color: active ? 'text.primary' : 'text.secondary' }}>
+                      {label}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {detail}
+                    </Typography>
+                  </Box>
+                </Box>
+              )
+            })}
+          </Box>
+        </Box>
       )}
     </Box>
   )

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1060,7 +1060,7 @@ const Session: FC<SessionProps> = ({ previewMode = false, orgChatView = false })
 
   const navigatorItems = useMemo<ChatTurnNavigatorItem[]>(() => {
     return navigatorInteractions.flatMap((interaction) => {
-      if (!interaction.id || interaction.trigger === 'fork_seed' || interaction.trigger === 'fork_handoff') return []
+      if (!interaction.id || interaction.trigger === 'fork_seed' || interaction.trigger === 'fork_handoff' || interaction.trigger === 'org_hire') return []
       const contentText = interaction.prompt_message_content?.parts?.find(
         (part): part is { text: string } =>
           typeof part === 'object' &&

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -44,6 +44,7 @@ import PasswordReset from './pages/PasswordReset'
 import PasswordResetComplete from './pages/PasswordResetComplete'
 import DesignDocPage from './pages/DesignDocPage'
 import Onboarding from './pages/Onboarding'
+import OrgBotSessionResolver from './pages/OrgBotSessionResolver'
 import Waitlist from './pages/Waitlist'
 import Login from './pages/Login'
 import NotFound from './pages/NotFound'
@@ -135,6 +136,15 @@ const routes: IApplicationRoute[] = [
   render: () => (
     <Home />
   ),
+}, {
+  name: 'org_bot_session',
+  path: '/orgs/:org_id/chat/agents/:bot_id',
+  meta: {
+    drawer: false,
+    topbar: false,
+    title: 'Agent Chat',
+  },
+  render: () => <OrgBotSessionResolver />,
 }, {
   name: 'org_session',
   path: '/orgs/:org_id/chat/session/:session_id',


### PR DESCRIPTION
## Summary
- route SaaS onboarding and newly created self-hosted orgs to the seeded Chief of Staff
- resolve and open the Chief of Staff durable chat session instead of the org chart
- use the hire trigger only for a genuinely fresh Chief of Staff so its onboarding playbook contacts the owner
- preserve existing project creation and manual activation behavior for every other worker

## Testing
- go test ./pkg/org/...
- focused frontend tests: Onboarding, EditOrgWindow, OrgBotSessionResolver (20 passed)
- rebuilt frontend, API, and sandbox on Prime
- verified https://prime.helix.ml returns HTTP 200

## Notes
- Full frontend build remains blocked by the pre-existing WorkspaceReviewMessage.tsx/workspaceReviewMessage.ts case-collision issue.