### PR TITLE
Automatically share Claude subscriptions configured for an organization

### DIFF
--- a/frontend/src/components/account/ClaudeSubscriptionConnect.failure.test.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.failure.test.tsx
@@ -12,6 +12,9 @@ import ClaudeSubscriptionConnect from './ClaudeSubscriptionConnect'
 // makes the catch reachable.
 const createSubscription = vi.fn()
 const deleteSubscription = vi.fn()
+const delegationUpdate = vi.fn()
+const oauthStart = vi.fn()
+const oauthComplete = vi.fn()
 const snackbarSuccess = vi.fn()
 
 vi.mock('../../hooks/useApi', () => ({
@@ -22,8 +25,9 @@ vi.mock('../../hooks/useApi', () => ({
     getApiClient: () => ({
       v1ClaudeSubscriptionsCreate: createSubscription,
       v1ClaudeSubscriptionsDelete: deleteSubscription,
-      v1ClaudeSubscriptionsOauthStartCreate: vi.fn(),
-      v1ClaudeSubscriptionsOauthCompleteCreate: vi.fn(),
+      v1ClaudeSubscriptionsDelegationUpdate: delegationUpdate,
+      v1ClaudeSubscriptionsOauthStartCreate: oauthStart,
+      v1ClaudeSubscriptionsOauthCompleteCreate: oauthComplete,
     }),
   }),
 }))
@@ -36,13 +40,13 @@ vi.mock('../../hooks/useAccount', () => ({
   default: () => ({ admin: false, user: { id: 'usr_1' }, organizationTools: { organizations: [] } }),
 }))
 
-function renderConnect() {
+function renderConnect(props: { enableForOrgId?: string } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <ClaudeSubscriptionConnect variant="button" />
+      <ClaudeSubscriptionConnect variant="button" {...props} />
     </QueryClientProvider>,
   )
 }
@@ -56,6 +60,9 @@ describe('ClaudeSubscriptionConnect — connect failures', () => {
   beforeEach(() => {
     createSubscription.mockReset()
     deleteSubscription.mockReset()
+    delegationUpdate.mockReset()
+    oauthStart.mockReset()
+    oauthComplete.mockReset()
     snackbarSuccess.mockReset()
   })
 
@@ -92,5 +99,47 @@ describe('ClaudeSubscriptionConnect — connect failures', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
 
     await waitFor(() => expect(snackbarSuccess).toHaveBeenCalledWith('Claude subscription connected'))
+  })
+
+  it('shares a setup-token subscription connected from organization settings', async () => {
+    createSubscription.mockResolvedValue({
+      data: { id: 'csub_setup', delegated_org_ids: ['org_existing'] },
+    })
+    delegationUpdate.mockResolvedValue({ data: {} })
+
+    renderConnect({ enableForOrgId: 'org_target' })
+    await openDialogOnSetupToken()
+    fireEvent.change(screen.getByLabelText(/Claude Code setup token/i), {
+      target: { value: 'sk-ant-oat01-' + 's'.repeat(60) },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await waitFor(() => expect(delegationUpdate).toHaveBeenCalledWith('csub_setup', {
+      delegated_org_ids: ['org_existing', 'org_target'],
+    }))
+  })
+
+  it('shares an OAuth subscription connected from organization settings', async () => {
+    oauthStart.mockResolvedValue({
+      data: { authorize_url: 'https://claude.ai/oauth', code_verifier: 'verifier', state: 'state' },
+    })
+    oauthComplete.mockResolvedValue({
+      data: { id: 'csub_oauth', delegated_org_ids: ['org_existing'] },
+    })
+    delegationUpdate.mockResolvedValue({ data: {} })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    renderConnect({ enableForOrgId: 'org_target' })
+    fireEvent.click(await screen.findByRole('button', { name: /connect/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Claude' }))
+    await waitFor(() => expect(oauthStart).toHaveBeenCalled())
+    fireEvent.change(screen.getByLabelText('Authorization code'), {
+      target: { value: 'oauth-code' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await waitFor(() => expect(delegationUpdate).toHaveBeenCalledWith('csub_oauth', {
+      delegated_org_ids: ['org_existing', 'org_target'],
+    }))
   })
 })

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.failure.test.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.failure.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ClaudeSubscriptionConnect from './ClaudeSubscriptionConnect'
+import { codeAgentHarnessesQueryKey } from '../../services/codeAgentHarnessesService'
 
 // The bug this file exists for: useApi().post catches errors, shows its own
 // snackbar and resolves with null instead of throwing. The connect handler
@@ -37,18 +38,27 @@ vi.mock('../../hooks/useSnackbar', () => ({
 }))
 
 vi.mock('../../hooks/useAccount', () => ({
-  default: () => ({ admin: false, user: { id: 'usr_1' }, organizationTools: { organizations: [] } }),
+  default: () => ({
+    admin: false,
+    user: { id: 'usr_1' },
+    organizationTools: {
+      organizations: [{ id: 'org_target', name: 'acme', display_name: 'Acme' }],
+    },
+  }),
 }))
 
-function renderConnect(props: { enableForOrgId?: string } = {}) {
+function renderConnect(props: { enableForOrgId?: string; onConnected?: () => void } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <ClaudeSubscriptionConnect variant="button" {...props} />
-    </QueryClientProvider>,
-  )
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <ClaudeSubscriptionConnect variant="button" {...props} />
+      </QueryClientProvider>,
+    ),
+  }
 }
 
 async function openDialogOnSetupToken() {
@@ -141,5 +151,90 @@ describe('ClaudeSubscriptionConnect — connect failures', () => {
     await waitFor(() => expect(delegationUpdate).toHaveBeenCalledWith('csub_oauth', {
       delegated_org_ids: ['org_existing', 'org_target'],
     }))
+  })
+
+  it('keeps OAuth dialog open when connection succeeds but sharing fails', async () => {
+    oauthStart.mockResolvedValue({
+      data: { authorize_url: 'https://claude.ai/oauth', code_verifier: 'verifier', state: 'state' },
+    })
+    oauthComplete.mockResolvedValue({ data: { id: 'csub_oauth' } })
+    delegationUpdate.mockRejectedValue({
+      response: { data: { message: 'organization uses API-provider mode' } },
+    })
+    vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    const onConnected = vi.fn()
+    const { queryClient } = renderConnect({ enableForOrgId: 'org_target', onConnected })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    fireEvent.click(await screen.findByRole('button', { name: /connect/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Claude' }))
+    await waitFor(() => expect(oauthStart).toHaveBeenCalled())
+    fireEvent.change(screen.getByLabelText('Authorization code'), { target: { value: 'oauth-code' } })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await screen.findByText(
+      'Connected, but not shared with Acme: organization uses API-provider mode',
+    )
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['claude-subscriptions'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: codeAgentHarnessesQueryKey('org_target'),
+    })
+    expect(snackbarSuccess).not.toHaveBeenCalled()
+    expect(onConnected).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /^Connect$/ })).toBeInTheDocument()
+  })
+
+  it('keeps setup-token dialog open when connection succeeds but sharing fails', async () => {
+    createSubscription.mockResolvedValue({ data: { id: 'csub_setup' } })
+    delegationUpdate.mockRejectedValue({ response: { data: { message: 'sharing denied' } } })
+
+    const onConnected = vi.fn()
+    const { queryClient } = renderConnect({ enableForOrgId: 'org_target', onConnected })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    await openDialogOnSetupToken()
+    fireEvent.change(screen.getByLabelText(/Claude Code setup token/i), {
+      target: { value: 'sk-ant-oat01-' + 'p'.repeat(60) },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await screen.findByText('Connected, but not shared with Acme: sharing denied')
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['claude-subscriptions'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: codeAgentHarnessesQueryKey('org_target'),
+    })
+    expect(snackbarSuccess).not.toHaveBeenCalled()
+    expect(onConnected).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /^Connect$/ })).toBeInTheDocument()
+  })
+
+  it('does not delegate without an organization target', async () => {
+    createSubscription.mockResolvedValue({ data: { id: 'csub_setup' } })
+
+    renderConnect()
+    await openDialogOnSetupToken()
+    fireEvent.change(screen.getByLabelText(/Claude Code setup token/i), {
+      target: { value: 'sk-ant-oat01-' + 'n'.repeat(60) },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await waitFor(() => expect(snackbarSuccess).toHaveBeenCalledWith('Claude subscription connected'))
+    expect(delegationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not delegate without a returned subscription ID', async () => {
+    createSubscription.mockResolvedValue({ data: {} })
+
+    renderConnect({ enableForOrgId: 'org_target' })
+    await openDialogOnSetupToken()
+    fireEvent.change(screen.getByLabelText(/Claude Code setup token/i), {
+      target: { value: 'sk-ant-oat01-' + 'm'.repeat(60) },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Connect$/ }))
+
+    await screen.findByText(
+      'Connected, but not shared with Acme: The connected subscription did not return an ID',
+    )
+    expect(delegationUpdate).not.toHaveBeenCalled()
+    expect(snackbarSuccess).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -359,6 +359,13 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
     },
   })
 
+  const delegateCreatedSubscription = async (sub: { id?: string; delegated_org_ids?: string[] }) => {
+    if (!enableForOrgId) return
+    await api.getApiClient().v1ClaudeSubscriptionsDelegationUpdate(sub.id!, {
+      delegated_org_ids: Array.from(new Set([...(sub.delegated_org_ids || []), enableForOrgId])),
+    })
+  }
+
   const toggleDelegation = (sub: ClaudeSubscriptionData, orgID: string, enabled: boolean) => {
     const current = sub.delegated_org_ids || []
     const next = enabled
@@ -490,7 +497,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
       setSubmitting(true)
       setSubmitError(null)
       try {
-        await api.getApiClient().v1ClaudeSubscriptionsOauthCompleteCreate({
+        const { data: created } = await api.getApiClient().v1ClaudeSubscriptionsOauthCompleteCreate({
           code: oauthCode.trim(),
           code_verifier: oauthChallenge.verifier,
           state: oauthChallenge.state,
@@ -500,6 +507,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
           ...(enableForOrgId ? { organization_id: enableForOrgId } : {}),
           ...(effectiveOrgIdForOauth ? { owner_type: TypesOwnerType.OwnerTypeOrg, owner_id: effectiveOrgIdForOauth } : {}),
         })
+        await delegateCreatedSubscription(created)
         queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
         if (enableForOrgId) {
           queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(enableForOrgId) })
@@ -547,12 +555,13 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
     try {
       // Use orgId prop if provided (button/inline variants), otherwise use internal state (account variant)
       const effectiveOrgId = orgId || (ownerType === 'org' ? selectedOrgId : undefined)
-      await api.getApiClient().v1ClaudeSubscriptionsCreate({
+      const { data: created } = await api.getApiClient().v1ClaudeSubscriptionsCreate({
         name: effectiveOrgId ? `${orgLabel(effectiveOrgId)} Claude Subscription` : 'My Claude Subscription',
         ...credentialPayload,
         ...(enableForOrgId ? { organization_id: enableForOrgId } : {}),
         ...(effectiveOrgId ? { owner_type: TypesOwnerType.OwnerTypeOrg, owner_id: effectiveOrgId } : {}),
       })
+      await delegateCreatedSubscription(created)
       queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
       if (enableForOrgId) {
         queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(enableForOrgId) })

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -360,10 +360,21 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   })
 
   const delegateCreatedSubscription = async (sub: { id?: string; delegated_org_ids?: string[] }) => {
-    if (!enableForOrgId) return
-    await api.getApiClient().v1ClaudeSubscriptionsDelegationUpdate(sub.id!, {
-      delegated_org_ids: Array.from(new Set([...(sub.delegated_org_ids || []), enableForOrgId])),
-    })
+    if (!enableForOrgId) return true
+    try {
+      if (!sub.id) throw new Error('The connected subscription did not return an ID')
+      await api.getApiClient().v1ClaudeSubscriptionsDelegationUpdate(sub.id, {
+        delegated_org_ids: Array.from(new Set([...(sub.delegated_org_ids || []), enableForOrgId])),
+      })
+      return true
+    } catch (error: any) {
+      queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
+      queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(enableForOrgId) })
+      setSubmitError(
+        `Connected, but not shared with ${orgLabel(enableForOrgId)}: ${error?.response?.data?.message || error?.message || 'Could not update subscription sharing'}`,
+      )
+      return false
+    }
   }
 
   const toggleDelegation = (sub: ClaudeSubscriptionData, orgID: string, enabled: boolean) => {
@@ -507,7 +518,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
           ...(enableForOrgId ? { organization_id: enableForOrgId } : {}),
           ...(effectiveOrgIdForOauth ? { owner_type: TypesOwnerType.OwnerTypeOrg, owner_id: effectiveOrgIdForOauth } : {}),
         })
-        await delegateCreatedSubscription(created)
+        if (!(await delegateCreatedSubscription(created))) return
         queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
         if (enableForOrgId) {
           queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(enableForOrgId) })
@@ -561,7 +572,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
         ...(enableForOrgId ? { organization_id: enableForOrgId } : {}),
         ...(effectiveOrgId ? { owner_type: TypesOwnerType.OwnerTypeOrg, owner_id: effectiveOrgId } : {}),
       })
-      await delegateCreatedSubscription(created)
+      if (!(await delegateCreatedSubscription(created))) return
       queryClient.invalidateQueries({ queryKey: ['claude-subscriptions'] })
       if (enableForOrgId) {
         queryClient.invalidateQueries({ queryKey: codeAgentHarnessesQueryKey(enableForOrgId) })

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -246,9 +246,6 @@ const Providers: React.FC = () => {
             onChange={handleCodeAgentChange}
             subscriptionIdentity={subscriptionIdentity}
             subscriptionAction={(runtime) => {
-              // Connecting here enables the org policy but keeps the paid
-              // credential personal. Org-owned subscriptions remain an
-              // explicit shared-credential workflow.
               if (runtime === 'claude_code') return <ClaudeSubscriptionConnect variant="button" enableForOrgId={org?.id} />
               if (runtime === 'codex_cli') return <CodexSubscriptionConnect enableForOrgId={org?.id} />
               return null


### PR DESCRIPTION
Summary:
- Automatically delegate a personal Claude subscription when it is connected from Organization Settings.
- Preserve any existing organization delegations.
- Cover setup-token and OAuth connection flows.

Testing:
- 12 focused ClaudeSubscriptionConnect tests passed.
- git diff --check passed.
- Full TypeScript validation remains blocked by the existing WorkspaceReviewMessage filename case collision.