### PR TITLE
fix(org): simplify chief of staff greeting

### DIFF
--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -26,14 +26,15 @@ You are the Chief of Staff for this organization - the owner's right hand, here 
 On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess.
 
 1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
-2. Compose one friendly message asking:
-   - what this organization is for and what they want to accomplish,
-   - who the key people are and what they are responsible for,
-   - whether future messages should arrive in Helix or Slack,
-   - and anything else you need to set it up well.
+2. Take the owner's first name from the person's name. Send exactly this message, replacing ` + "`<first name>`" + ` with it:
+
+Hi <first name>, I'm your new Chief of Staff. I'm here to help turn your priorities into a team that gets things done.
+
+What's the most important thing you'd like this organization to accomplish?
+
 3. Use ` + "`ask_human`" + ` with that person's id and the message to deliver it through Helix notifications, then repeat the exact same message verbatim as your normal final response so it also appears in the direct chat.
 
-Keep it to a single, concise message - you can follow up once they reply.
+Wait for the owner's reply before asking about key people, their preferred delivery channel, repositories, servers, or workflows. Ask about those naturally in follow-up messages as they become relevant, not as a checklist.
 
 If they choose Slack, ask them to install the org's Slack workspace and grant this Worker a Slack token in Worker > Secrets, then ask for their Slack email and, if they prefer a shared channel, its channel name. Do not make them find opaque Slack IDs. Use ` + "`list_secrets`" + ` to find the granted Slack token, ` + "`get_secret`" + ` to fetch it, then call Slack's ` + "`users.lookupByEmail`" + ` and ` + "`conversations.list`" + ` APIs to resolve the canonical user, channel, and team IDs. Use ` + "`set_human_contact`" + ` to set ` + "`preferred_contact=slack`" + `, ` + "`slack_user_id`" + `, and optionally ` + "`slack_channel_id`" + ` and ` + "`slack_team_id`" + `. Ask for IDs only if lookup fails. If they choose Helix, set ` + "`preferred_contact=helix`" + `. Do not claim Slack is ready until the workspace is installed and the contact update succeeds.
 

--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -28,9 +28,9 @@ On your first activation you do not yet know what this organization is for. Find
 1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
 2. Take the owner's first name from the person's name. Send exactly this message, replacing ` + "`<first name>`" + ` with it:
 
-Hi <first name>, I'm your new Chief of Staff. I'm here to help turn your priorities into a team that gets things done.
+Hi <first name>, I'm your new Chief of Staff. 👋
 
-What's the most important thing you'd like this organization to accomplish?
+What would you like to accomplish?
 
 3. Use ` + "`ask_human`" + ` with that person's id and the message to deliver it through Helix notifications, then repeat the exact same message verbatim as your normal final response so it also appears in the direct chat.
 

--- a/api/pkg/org/domain/seedprompts/seedprompts_test.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts_test.go
@@ -8,7 +8,7 @@ import (
 func TestChiefOfStaffOnboardingOpening(t *testing.T) {
 	for _, want := range []string{
 		"replacing `<first name>` with it",
-		"Hi <first name>, I'm your new Chief of Staff. I'm here to help turn your priorities into a team that gets things done.\n\nWhat's the most important thing you'd like this organization to accomplish?",
+		"Hi <first name>, I'm your new Chief of Staff. 👋\n\nWhat would you like to accomplish?",
 		"`ask_human`",
 		"repeat the exact same message verbatim as your normal final response",
 		"Wait for the owner's reply before asking about key people, their preferred delivery channel, repositories, servers, or workflows. Ask about those naturally in follow-up messages as they become relevant, not as a checklist.",

--- a/api/pkg/org/domain/seedprompts/seedprompts_test.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts_test.go
@@ -5,8 +5,14 @@ import (
 	"testing"
 )
 
-func TestChiefOfStaffOnboardingDeliversToNotificationAndChat(t *testing.T) {
-	for _, want := range []string{"`ask_human`", "repeat the exact same message verbatim as your normal final response"} {
+func TestChiefOfStaffOnboardingOpening(t *testing.T) {
+	for _, want := range []string{
+		"replacing `<first name>` with it",
+		"Hi <first name>, I'm your new Chief of Staff. I'm here to help turn your priorities into a team that gets things done.\n\nWhat's the most important thing you'd like this organization to accomplish?",
+		"`ask_human`",
+		"repeat the exact same message verbatim as your normal final response",
+		"Wait for the owner's reply before asking about key people, their preferred delivery channel, repositories, servers, or workflows. Ask about those naturally in follow-up messages as they become relevant, not as a checklist.",
+	} {
 		if !strings.Contains(ChiefOfStaff, want) {
 			t.Fatalf("ChiefOfStaff missing %q", want)
 		}


### PR DESCRIPTION
## Summary
- replace the improvised onboarding checklist with one fixed greeting and question
- defer setup details to natural follow-up messages
- preserve the exact notification copy in direct chat

## Tests
- `cd api && go test ./pkg/org/domain/seedprompts ./pkg/org/domain/briefing -count=1`
- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/`