### PR TITLE
fix(api): persist admin plan overrides

### DIFF
--- a/api/pkg/store/store_wallet.go
+++ b/api/pkg/store/store_wallet.go
@@ -136,7 +136,7 @@ func (s *PostgresStore) ListWallets(ctx context.Context, q *ListWalletsQuery) ([
 	return wallets, nil
 }
 
-// UpdateWallet updates subscription ID, status (does not update balance, for that use dedicated method)
+// UpdateWallet updates subscription and plan fields (does not update balance, for that use dedicated method)
 func (s *PostgresStore) UpdateWallet(ctx context.Context, wallet *types.Wallet) (*types.Wallet, error) {
 	if wallet.ID == "" {
 		return nil, fmt.Errorf("id not specified")
@@ -147,6 +147,7 @@ func (s *PostgresStore) UpdateWallet(ctx context.Context, wallet *types.Wallet) 
 	err := s.gdb.WithContext(ctx).Model(&types.Wallet{}).Where("id = ?", wallet.ID).Updates(
 		map[string]interface{}{
 			"updated_at":                        wallet.UpdatedAt,
+			"plan_override":                     wallet.PlanOverride,
 			"stripe_subscription_id":            wallet.StripeSubscriptionID,
 			"subscription_status":               wallet.SubscriptionStatus,
 			"subscription_current_period_start": wallet.SubscriptionCurrentPeriodStart,

--- a/api/pkg/store/store_wallet_test.go
+++ b/api/pkg/store/store_wallet_test.go
@@ -268,6 +268,7 @@ func (suite *WalletTestSuite) TestUpdateWallet() {
 
 	updatedWallet := &types.Wallet{
 		ID:                             createdWallet.ID,
+		PlanOverride:                   types.PlanOverridePro,
 		StripeSubscriptionID:           subscriptionID,
 		SubscriptionStatus:             subscriptionStatus,
 		SubscriptionCurrentPeriodStart: periodStart,
@@ -287,6 +288,12 @@ func (suite *WalletTestSuite) TestUpdateWallet() {
 	suite.Equal(periodEnd, result.SubscriptionCurrentPeriodEnd)
 	suite.Equal(subscriptionCreated, result.SubscriptionCreated)
 	suite.Equal(cancelAtPeriodEnd, result.SubscriptionCancelAtPeriodEnd)
+	suite.Equal(types.PlanOverridePro, result.PlanOverride)
+
+	result.PlanOverride = ""
+	result, err = suite.db.UpdateWallet(suite.ctx, result)
+	suite.NoError(err)
+	suite.Empty(result.PlanOverride)
 
 	// Verify balance was NOT changed (UpdateWallet should not update balance)
 	suite.Equal(100.0, result.Balance)


### PR DESCRIPTION
## Summary
- persist wallet plan overrides in the shared wallet update path
- verify setting and clearing an override in the store test

## Tests
- `go test ./pkg/store -run 'TestWalletTestSuite/TestUpdateWallet$' -count=1`\n- `go test ./pkg/quota -run 'TestQuotaManagerSuite/(TestGetQuotas_PlanOverrideProGrantsProWithoutSub|TestGetQuotas_PlanOverrideFreeBeatsActiveSub)$' -count=1`\n- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`\n- `git diff --check`