### PR TITLE
fix(frontend): personalize agent introduction

### DIFF
--- a/frontend/src/pages/OrgBotSessionResolver.test.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.test.tsx
@@ -76,7 +76,7 @@ describe('OrgBotSessionResolver', () => {
     render(<OrgBotSessionResolver />)
 
     await waitFor(() => expect(mocks.activate).toHaveBeenCalledTimes(1))
-    expect(screen.getByRole('heading', { name: 'Meet Chief of Staff' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Meet your Chief of Staff' })).toBeInTheDocument()
     expect(screen.getByText(/new agent is getting ready/i)).toBeInTheDocument()
     expect(screen.getByText('Preparing Chief of Staff')).toBeInTheDocument()
     expect(screen.getByText('Finding your agent')).toBeInTheDocument()

--- a/frontend/src/pages/OrgBotSessionResolver.tsx
+++ b/frontend/src/pages/OrgBotSessionResolver.tsx
@@ -105,7 +105,7 @@ export default function OrgBotSessionResolver() {
           }}
         >
           <Typography variant="h5" sx={{ fontWeight: 650, letterSpacing: '-0.02em' }}>
-            Meet {agentName}
+            Meet your {agentName}
           </Typography>
           <Typography color="text.secondary" sx={{ mt: 1, lineHeight: 1.6 }}>
             Your new agent is getting ready to work with your organization.


### PR DESCRIPTION
## Summary
- change the agent resolver heading from "Meet Chief of Staff" to "Meet your Chief of Staff"
- keep the generic agent-name behavior intact

## Tests
- `cd frontend && yarn test OrgBotSessionResolver.test.tsx --run` (5 passed)
- `cd frontend && yarn build` (blocked by pre-existing WorkspaceReviewMessage.tsx/workspaceReviewMessage.ts case collision on macOS)