### PR TITLE
Speed up and paginate the admin organizations list

### DIFF
--- a/api/pkg/server/admin_org_handlers.go
+++ b/api/pkg/server/admin_org_handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -121,15 +120,11 @@ func (apiServer *HelixAPIServer) adminListOrganizations(rw http.ResponseWriter, 
 		organizations = filtered
 	}
 
-	page := positiveQueryInt(r, "page", 1)
-	perPage := positiveQueryInt(r, "per_page", defaultAdminOrgsPerPage)
-	if perPage > maxAdminOrgsPerPage {
-		perPage = maxAdminOrgsPerPage
-	}
+	page, perPage := parsePagination(r, 1, defaultAdminOrgsPerPage, maxAdminOrgsPerPage)
 	totalCount := len(organizations)
 	totalPages := (totalCount + perPage - 1) / perPage
 	start := (page - 1) * perPage
-	if start > totalCount {
+	if start < 0 || start > totalCount {
 		start = totalCount
 	}
 	end := min(start+perPage, totalCount)
@@ -219,12 +214,4 @@ func organizationSearchName(org *types.Organization) string {
 		name = org.Name
 	}
 	return strings.ToLower(name)
-}
-
-func positiveQueryInt(r *http.Request, key string, fallback int) int {
-	value, err := strconv.Atoi(r.URL.Query().Get(key))
-	if err != nil || value < 1 {
-		return fallback
-	}
-	return value
 }

--- a/api/pkg/server/admin_org_handlers.go
+++ b/api/pkg/server/admin_org_handlers.go
@@ -3,12 +3,31 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
 )
+
+const (
+	defaultAdminOrgsPerPage = 25
+	maxAdminOrgsPerPage     = 100
+)
+
+// AdminOrganizationsResponse is the paginated response returned by the admin
+// organizations endpoint.
+type AdminOrganizationsResponse struct {
+	Organizations []types.OrgDetails `json:"organizations"`
+	Page          int                `json:"page"`
+	PageSize      int                `json:"pageSize"`
+	TotalCount    int                `json:"totalCount"`
+	TotalPages    int                `json:"totalPages"`
+}
 
 // SetOrgPlanRequest is the body for POST /admin/orgs/{id}/plan.
 type SetOrgPlanRequest struct {
@@ -66,9 +85,12 @@ func (apiServer *HelixAPIServer) adminSetOrgPlan(rw http.ResponseWriter, r *http
 
 // adminListOrganizations godoc
 // @Summary List organizations with wallets (admin only)
-// @Description List all organizations
+// @Description List organizations with server-side pagination and name search
 // @Tags    organizations
-// @Success 200 {array} types.OrgDetails
+// @Param page query int false "Page number (default: 1)"
+// @Param per_page query int false "Organizations per page (default: 25, max: 100)"
+// @Param query query string false "Search organization display name or name"
+// @Success 200 {object} AdminOrganizationsResponse
 // @Router /api/v1/admin/orgs [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) adminListOrganizations(rw http.ResponseWriter, r *http.Request) {
@@ -79,8 +101,46 @@ func (apiServer *HelixAPIServer) adminListOrganizations(rw http.ResponseWriter, 
 		return
 	}
 
+	// Sort first so pagination is stable across requests. Preserve the table's
+	// existing search behavior: prefer display_name and fall back to name.
+	sort.Slice(organizations, func(i, j int) bool {
+		left, right := organizationSearchName(organizations[i]), organizationSearchName(organizations[j])
+		if left == right {
+			return organizations[i].ID < organizations[j].ID
+		}
+		return left < right
+	})
+	search := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("query")))
+	if search != "" {
+		filtered := organizations[:0]
+		for _, org := range organizations {
+			if strings.Contains(organizationSearchName(org), search) {
+				filtered = append(filtered, org)
+			}
+		}
+		organizations = filtered
+	}
+
+	page := positiveQueryInt(r, "page", 1)
+	perPage := positiveQueryInt(r, "per_page", defaultAdminOrgsPerPage)
+	if perPage > maxAdminOrgsPerPage {
+		perPage = maxAdminOrgsPerPage
+	}
+	totalCount := len(organizations)
+	totalPages := (totalCount + perPage - 1) / perPage
+	start := (page - 1) * perPage
+	if start > totalCount {
+		start = totalCount
+	}
+	end := min(start+perPage, totalCount)
+	organizations = organizations[start:end]
+
+	response := AdminOrganizationsResponse{
+		Organizations: []types.OrgDetails{},
+		Page:          page, PageSize: perPage, TotalCount: totalCount, TotalPages: totalPages,
+	}
 	if len(organizations) == 0 {
-		writeResponse(rw, []types.OrgDetails{}, http.StatusOK)
+		writeResponse(rw, response, http.StatusOK)
 		return
 	}
 
@@ -104,43 +164,67 @@ func (apiServer *HelixAPIServer) adminListOrganizations(rw http.ResponseWriter, 
 		walletsByOrgID[wallet.OrgID] = *wallet
 	}
 
-	result := make([]types.OrgDetails, 0, len(organizations))
-	for _, org := range organizations {
-		memberships, err := apiServer.Store.ListOrganizationMemberships(r.Context(), &store.ListOrganizationMembershipsQuery{
-			OrganizationID: org.ID,
-		})
-		if err != nil {
-			log.Err(err).Msg("error listing organization memberships")
-			http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
+	result := make([]types.OrgDetails, len(organizations))
+	group, groupContext := errgroup.WithContext(r.Context())
+	group.SetLimit(8)
+	for i, org := range organizations {
+		i, org := i, org
+		group.Go(func() error {
+			memberships, err := apiServer.Store.ListOrganizationMemberships(groupContext, &store.ListOrganizationMembershipsQuery{
+				OrganizationID: org.ID,
+			})
+			if err != nil {
+				return err
+			}
 
-		members := make([]types.User, 0, len(memberships))
-		for _, membership := range memberships {
-			members = append(members, membership.User)
-		}
+			members := make([]types.User, 0, len(memberships))
+			for _, membership := range memberships {
+				members = append(members, membership.User)
+			}
 
-		projects, err := apiServer.Store.ListProjects(r.Context(), &store.ListProjectsQuery{
-			OrganizationID: org.ID,
-		})
-		if err != nil {
-			log.Err(err).Msg("error listing organization projects")
-			http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
+			projects, err := apiServer.Store.ListProjects(groupContext, &store.ListProjectsQuery{
+				OrganizationID: org.ID,
+			})
+			if err != nil {
+				return err
+			}
 
-		orgProjects := make([]types.Project, 0, len(projects))
-		for _, project := range projects {
-			orgProjects = append(orgProjects, *project)
-		}
+			orgProjects := make([]types.Project, 0, len(projects))
+			for _, project := range projects {
+				orgProjects = append(orgProjects, *project)
+			}
 
-		result = append(result, types.OrgDetails{
-			Organization: *org,
-			Wallet:       walletsByOrgID[org.ID],
-			Members:      members,
-			Projects:     orgProjects,
+			result[i] = types.OrgDetails{
+				Organization: *org,
+				Wallet:       walletsByOrgID[org.ID],
+				Members:      members,
+				Projects:     orgProjects,
+			}
+			return nil
 		})
 	}
+	if err := group.Wait(); err != nil {
+		log.Err(err).Msg("error loading organization details")
+		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-	writeResponse(rw, result, http.StatusOK)
+	response.Organizations = result
+	writeResponse(rw, response, http.StatusOK)
+}
+
+func organizationSearchName(org *types.Organization) string {
+	name := org.DisplayName
+	if name == "" {
+		name = org.Name
+	}
+	return strings.ToLower(name)
+}
+
+func positiveQueryInt(r *http.Request, key string, fallback int) int {
+	value, err := strconv.Atoi(r.URL.Query().Get(key))
+	if err != nil || value < 1 {
+		return fallback
+	}
+	return value
 }

--- a/api/pkg/server/admin_org_handlers_test.go
+++ b/api/pkg/server/admin_org_handlers_test.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestOrganizationSearchNamePrefersDisplayName(t *testing.T) {
@@ -16,23 +20,57 @@ func TestOrganizationSearchNamePrefersDisplayName(t *testing.T) {
 	assert.Equal(t, "internal-slug", organizationSearchName(org))
 }
 
-func TestPositiveQueryInt(t *testing.T) {
-	tests := []struct {
-		name string
-		url  string
-		want int
-	}{
-		{name: "valid", url: "/?page=3", want: 3},
-		{name: "missing", url: "/", want: 7},
-		{name: "invalid", url: "/?page=nope", want: 7},
-		{name: "zero", url: "/?page=0", want: 7},
-		{name: "negative", url: "/?page=-2", want: 7},
+func TestAdminListOrganizationsPaginatesFilteredResults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	organizations := []*types.Organization{
+		{ID: "org_other", DisplayName: "Other"},
+		{ID: "org_b", DisplayName: "Match B"},
+		{ID: "org_a", DisplayName: "Match A"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.url, nil)
-			assert.Equal(t, tt.want, positiveQueryInt(req, "page", 7))
-		})
-	}
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{}).Return(organizations, nil)
+	mockStore.EXPECT().ListWallets(gomock.Any(), &store.ListWalletsQuery{
+		OwnerIDs: []string{"org_b"}, OwnerType: types.OwnerTypeOrg,
+	}).Return([]*types.Wallet{}, nil)
+	mockStore.EXPECT().ListOrganizationMemberships(gomock.Any(), &store.ListOrganizationMembershipsQuery{
+		OrganizationID: "org_b",
+	}).Return([]*types.OrganizationMembership{}, nil)
+	mockStore.EXPECT().ListProjects(gomock.Any(), &store.ListProjectsQuery{
+		OrganizationID: "org_b",
+	}).Return([]*types.Project{}, nil)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/api/v1/admin/orgs?query=match&page=2&per_page=1", nil)
+	server.adminListOrganizations(recorder, request)
+
+	require.Equal(t, 200, recorder.Code)
+	var response AdminOrganizationsResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	assert.Equal(t, 2, response.Page)
+	assert.Equal(t, 1, response.PageSize)
+	assert.Equal(t, 2, response.TotalCount)
+	assert.Equal(t, 2, response.TotalPages)
+	require.Len(t, response.Organizations, 1)
+	assert.Equal(t, "org_b", response.Organizations[0].Organization.ID)
+}
+
+func TestAdminListOrganizationsHandlesOverflowingPage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{}).Return(
+		[]*types.Organization{{ID: "org_a", DisplayName: "Match A"}}, nil,
+	)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/api/v1/admin/orgs?page=4611686018427387904&per_page=4", nil)
+	server.adminListOrganizations(recorder, request)
+
+	require.Equal(t, 200, recorder.Code)
+	var response AdminOrganizationsResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	assert.Empty(t, response.Organizations)
+	assert.Equal(t, 1, response.TotalCount)
 }

--- a/api/pkg/server/admin_org_handlers_test.go
+++ b/api/pkg/server/admin_org_handlers_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrganizationSearchNamePrefersDisplayName(t *testing.T) {
+	org := &types.Organization{Name: "internal-slug", DisplayName: "Visible Name"}
+	assert.Equal(t, "visible name", organizationSearchName(org))
+
+	org.DisplayName = ""
+	assert.Equal(t, "internal-slug", organizationSearchName(org))
+}
+
+func TestPositiveQueryInt(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{name: "valid", url: "/?page=3", want: 3},
+		{name: "missing", url: "/", want: 7},
+		{name: "invalid", url: "/?page=nope", want: 7},
+		{name: "zero", url: "/?page=0", want: 7},
+		{name: "negative", url: "/?page=-2", want: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			assert.Equal(t, tt.want, positiveQueryInt(req, "page", 7))
+		})
+	}
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -28660,24 +28660,24 @@ const docTemplate = `{
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "local",
-                "email",
-                "cron",
-                "slack",
-                "github",
+                "webhook",
                 "helix_events",
+                "local",
+                "github",
+                "slack",
                 "gitlab",
-                "webhook"
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindLocal",
-                "KindEmail",
-                "KindCron",
-                "KindSlack",
-                "KindGitHub",
+                "KindWebhook",
                 "KindHelixEvents",
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
                 "KindGitLab",
-                "KindWebhook"
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -725,19 +725,36 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "List all organizations",
+                "description": "List organizations with server-side pagination and name search",
                 "tags": [
                     "organizations"
                 ],
                 "summary": "List organizations with wallets (admin only)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Organizations per page (default: 25, max: 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search organization display name or name",
+                        "name": "query",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.OrgDetails"
-                            }
+                            "$ref": "#/definitions/server.AdminOrganizationsResponse"
                         }
                     }
                 }
@@ -26028,6 +26045,29 @@ const docTemplate = `{
                 }
             }
         },
+        "server.AdminOrganizationsResponse": {
+            "type": "object",
+            "properties": {
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.OrgDetails"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
         "server.AgentConfigAppliedResponse": {
             "type": "object",
             "properties": {
@@ -28620,24 +28660,24 @@ const docTemplate = `{
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "helix_events",
                 "local",
-                "github",
-                "slack",
-                "gitlab",
                 "email",
-                "cron"
+                "cron",
+                "slack",
+                "github",
+                "helix_events",
+                "gitlab",
+                "webhook"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindHelixEvents",
                 "KindLocal",
-                "KindGitHub",
-                "KindSlack",
-                "KindGitLab",
                 "KindEmail",
-                "KindCron"
+                "KindCron",
+                "KindSlack",
+                "KindGitHub",
+                "KindHelixEvents",
+                "KindGitLab",
+                "KindWebhook"
             ]
         },
         "transport.ResolvedActivation": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -28656,24 +28656,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "local",
-                "email",
-                "cron",
-                "slack",
-                "github",
+                "webhook",
                 "helix_events",
+                "local",
+                "github",
+                "slack",
                 "gitlab",
-                "webhook"
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindLocal",
-                "KindEmail",
-                "KindCron",
-                "KindSlack",
-                "KindGitHub",
+                "KindWebhook",
                 "KindHelixEvents",
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
                 "KindGitLab",
-                "KindWebhook"
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -721,19 +721,36 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List all organizations",
+                "description": "List organizations with server-side pagination and name search",
                 "tags": [
                     "organizations"
                 ],
                 "summary": "List organizations with wallets (admin only)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Organizations per page (default: 25, max: 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search organization display name or name",
+                        "name": "query",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.OrgDetails"
-                            }
+                            "$ref": "#/definitions/server.AdminOrganizationsResponse"
                         }
                     }
                 }
@@ -26024,6 +26041,29 @@
                 }
             }
         },
+        "server.AdminOrganizationsResponse": {
+            "type": "object",
+            "properties": {
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.OrgDetails"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
         "server.AgentConfigAppliedResponse": {
             "type": "object",
             "properties": {
@@ -28616,24 +28656,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "helix_events",
                 "local",
-                "github",
-                "slack",
-                "gitlab",
                 "email",
-                "cron"
+                "cron",
+                "slack",
+                "github",
+                "helix_events",
+                "gitlab",
+                "webhook"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindHelixEvents",
                 "KindLocal",
-                "KindGitHub",
-                "KindSlack",
-                "KindGitLab",
                 "KindEmail",
-                "KindCron"
+                "KindCron",
+                "KindSlack",
+                "KindGitHub",
+                "KindHelixEvents",
+                "KindGitLab",
+                "KindWebhook"
             ]
         },
         "transport.ResolvedActivation": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3684,24 +3684,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
+    - webhook
+    - helix_events
     - local
+    - github
+    - slack
+    - gitlab
     - email
     - cron
-    - slack
-    - github
-    - helix_events
-    - gitlab
-    - webhook
     type: string
     x-enum-varnames:
+    - KindWebhook
+    - KindHelixEvents
     - KindLocal
+    - KindGitHub
+    - KindSlack
+    - KindGitLab
     - KindEmail
     - KindCron
-    - KindSlack
-    - KindGitHub
-    - KindHelixEvents
-    - KindGitLab
-    - KindWebhook
   transport.ResolvedActivation:
     properties:
       address:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1860,6 +1860,21 @@ definitions:
       hostname:
         type: string
     type: object
+  server.AdminOrganizationsResponse:
+    properties:
+      organizations:
+        items:
+          $ref: '#/definitions/types.OrgDetails'
+        type: array
+      page:
+        type: integer
+      pageSize:
+        type: integer
+      totalCount:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
   server.AgentConfigAppliedResponse:
     properties:
       status:
@@ -3669,24 +3684,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - webhook
-    - helix_events
     - local
-    - github
-    - slack
-    - gitlab
     - email
     - cron
+    - slack
+    - github
+    - helix_events
+    - gitlab
+    - webhook
     type: string
     x-enum-varnames:
-    - KindWebhook
-    - KindHelixEvents
     - KindLocal
-    - KindGitHub
-    - KindSlack
-    - KindGitLab
     - KindEmail
     - KindCron
+    - KindSlack
+    - KindGitHub
+    - KindHelixEvents
+    - KindGitLab
+    - KindWebhook
   transport.ResolvedActivation:
     properties:
       address:
@@ -14519,14 +14534,25 @@ paths:
       - organizations
   /api/v1/admin/orgs:
     get:
-      description: List all organizations
+      description: List organizations with server-side pagination and name search
+      parameters:
+      - description: 'Page number (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Organizations per page (default: 25, max: 100)'
+        in: query
+        name: per_page
+        type: integer
+      - description: Search organization display name or name
+        in: query
+        name: query
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/types.OrgDetails'
-            type: array
+            $ref: '#/definitions/server.AdminOrganizationsResponse'
       security:
       - BearerAuth: []
       summary: List organizations with wallets (admin only)

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1233,6 +1233,14 @@ export interface ServerAddDomainRequest {
   hostname?: string;
 }
 
+export interface ServerAdminOrganizationsResponse {
+  organizations?: TypesOrgDetails[];
+  page?: number;
+  pageSize?: number;
+  totalCount?: number;
+  totalPages?: number;
+}
+
 export interface ServerAgentConfigAppliedResponse {
   status?: string;
 }
@@ -2373,14 +2381,14 @@ export enum TransportFieldType {
 }
 
 export enum TransportKind {
-  KindWebhook = "webhook",
-  KindHelixEvents = "helix_events",
   KindLocal = "local",
-  KindGitHub = "github",
-  KindSlack = "slack",
-  KindGitLab = "gitlab",
   KindEmail = "email",
   KindCron = "cron",
+  KindSlack = "slack",
+  KindGitHub = "github",
+  KindHelixEvents = "helix_events",
+  KindGitLab = "gitlab",
+  KindWebhook = "webhook",
 }
 
 export interface TransportResolvedActivation {
@@ -9326,7 +9334,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description List all organizations
+     * @description List organizations with server-side pagination and name search
      *
      * @tags organizations
      * @name V1AdminOrgsList
@@ -9334,10 +9342,21 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/admin/orgs
      * @secure
      */
-    v1AdminOrgsList: (params: RequestParams = {}) =>
-      this.request<TypesOrgDetails[], any>({
+    v1AdminOrgsList: (
+      query?: {
+        /** Page number (default: 1) */
+        page?: number;
+        /** Organizations per page (default: 25, max: 100) */
+        per_page?: number;
+        /** Search organization display name or name */
+        query?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<ServerAdminOrganizationsResponse, any>({
         path: `/api/v1/admin/orgs`,
         method: "GET",
+        query: query,
         secure: true,
         ...params,
       }),

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2381,14 +2381,14 @@ export enum TransportFieldType {
 }
 
 export enum TransportKind {
+  KindWebhook = "webhook",
+  KindHelixEvents = "helix_events",
   KindLocal = "local",
+  KindGitHub = "github",
+  KindSlack = "slack",
+  KindGitLab = "gitlab",
   KindEmail = "email",
   KindCron = "cron",
-  KindSlack = "slack",
-  KindGitHub = "github",
-  KindHelixEvents = "helix_events",
-  KindGitLab = "gitlab",
-  KindWebhook = "webhook",
 }
 
 export interface TransportResolvedActivation {

--- a/frontend/src/components/dashboard/AdminOrgsTable.test.tsx
+++ b/frontend/src/components/dashboard/AdminOrgsTable.test.tsx
@@ -1,0 +1,43 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AdminOrgsTable from './AdminOrgsTable'
+
+const mocks = vi.hoisted(() => ({
+  queries: [] as Array<{ page?: number; per_page?: number; query?: string }>,
+}))
+
+vi.mock('../../services/dashboardService', () => ({
+  useListAdminOrgs: (query: { page?: number; per_page?: number; query?: string }) => {
+    mocks.queries.push(query)
+    return {
+      data: { organizations: [], totalCount: 73, page: query.page, pageSize: query.per_page, totalPages: 3 },
+      isLoading: false,
+      error: null,
+    }
+  },
+  useAdminSetOrgPlan: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('AdminOrgsTable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.queries = []
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('debounces search and resets pagination before refetching', () => {
+    render(<AdminOrgsTable />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }))
+    expect(mocks.queries.at(-1)).toMatchObject({ page: 2, per_page: 25 })
+
+    fireEvent.change(screen.getByLabelText('Search organizations'), { target: { value: 'acme' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(mocks.queries.at(-1)).toEqual({ page: 1, per_page: 25, query: 'acme' })
+  })
+})

--- a/frontend/src/components/dashboard/AdminOrgsTable.tsx
+++ b/frontend/src/components/dashboard/AdminOrgsTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useMemo } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import {
     Table,
     TableBody,
@@ -17,6 +17,7 @@ import {
     IconButton,
     Menu,
     MenuItem,
+    TablePagination,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
@@ -26,7 +27,16 @@ import { useListAdminOrgs, useAdminSetOrgPlan } from "../../services/dashboardSe
 
 const AdminOrgsTable: FC = () => {
     const [searchQuery, setSearchQuery] = useState("");
-    const { data: orgs, isLoading, error } = useListAdminOrgs();
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(25);
+    const query = useMemo(() => ({
+        page: page + 1,
+        per_page: rowsPerPage,
+        ...(debouncedSearchQuery.trim() ? { query: debouncedSearchQuery.trim() } : {}),
+    }), [page, rowsPerPage, debouncedSearchQuery]);
+    const { data, isLoading, error } = useListAdminOrgs(query);
+    const orgs = data?.organizations;
     const setOrgPlan = useAdminSetOrgPlan();
     const [planAnchor, setPlanAnchor] = useState<null | HTMLElement>(null);
     const [planOrgId, setPlanOrgId] = useState<string | null>(null);
@@ -44,15 +54,15 @@ const AdminOrgsTable: FC = () => {
         closePlanMenu();
     };
 
-    const filtered = useMemo(() => {
-        if (!orgs) return [];
-        if (!searchQuery.trim()) return orgs;
-        const q = searchQuery.trim().toLowerCase();
-        return orgs.filter((o: TypesOrgDetails) => {
-            const name = (o.organization?.display_name || o.organization?.name || "").toLowerCase();
-            return name.includes(q);
-        });
-    }, [orgs, searchQuery]);
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedSearchQuery(searchQuery);
+            setPage(0);
+        }, 300);
+        return () => clearTimeout(timer);
+    }, [searchQuery]);
+
+    const filtered = orgs ?? [];
 
     if (isLoading && !orgs) {
         return (
@@ -118,7 +128,7 @@ const AdminOrgsTable: FC = () => {
                     }}
                 />
                 <Typography variant="body2" color="text.secondary">
-                    {filtered.length} org{filtered.length !== 1 ? "s" : ""}
+                    {data?.totalCount ?? 0} org{data?.totalCount !== 1 ? "s" : ""}
                 </Typography>
             </Box>
 
@@ -249,6 +259,22 @@ const AdminOrgsTable: FC = () => {
                     </TableBody>
                 </Table>
             </TableContainer>
+
+            {(data?.totalCount ?? 0) > 0 && (
+                <TablePagination
+                    rowsPerPageOptions={[10, 25, 50, 100]}
+                    component="div"
+                    count={data?.totalCount ?? 0}
+                    rowsPerPage={rowsPerPage}
+                    page={page}
+                    onPageChange={(_event, newPage) => setPage(newPage)}
+                    onRowsPerPageChange={(event) => {
+                        setRowsPerPage(parseInt(event.target.value, 10));
+                        setPage(0);
+                    }}
+                    labelRowsPerPage="Organizations per page:"
+                />
+            )}
 
             <Menu anchorEl={planAnchor} open={Boolean(planAnchor)} onClose={closePlanMenu}>
                 <MenuItem onClick={() => applyPlan("pro")}>Set Pro (paid, no Stripe)</MenuItem>

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -37,18 +37,26 @@ export function usersQueryKey(query?: UserListQuery) {
     return ["users", query];
 }
 
-export const adminOrgsQueryKey = () => ["admin-orgs"];
+export interface AdminOrgsListQuery {
+    page?: number;
+    per_page?: number;
+    query?: string;
+}
 
-export function useListAdminOrgs() {
+export const adminOrgsQueryKey = (query?: AdminOrgsListQuery) =>
+    query ? ["admin-orgs", query] : ["admin-orgs"];
+
+export function useListAdminOrgs(query?: AdminOrgsListQuery) {
     const api = useApi();
     const apiClient = api.getApiClient();
 
     return useQuery({
-        queryKey: adminOrgsQueryKey(),
+        queryKey: adminOrgsQueryKey(query),
         queryFn: async () => {
-            const response = await apiClient.v1AdminOrgsList();
+            const response = await apiClient.v1AdminOrgsList(query);
             return response.data;
         },
+        placeholderData: (previousData) => previousData,
     });
 }
 

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3684,24 +3684,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
+    - webhook
+    - helix_events
     - local
+    - github
+    - slack
+    - gitlab
     - email
     - cron
-    - slack
-    - github
-    - helix_events
-    - gitlab
-    - webhook
     type: string
     x-enum-varnames:
+    - KindWebhook
+    - KindHelixEvents
     - KindLocal
+    - KindGitHub
+    - KindSlack
+    - KindGitLab
     - KindEmail
     - KindCron
-    - KindSlack
-    - KindGitHub
-    - KindHelixEvents
-    - KindGitLab
-    - KindWebhook
   transport.ResolvedActivation:
     properties:
       address:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1860,6 +1860,21 @@ definitions:
       hostname:
         type: string
     type: object
+  server.AdminOrganizationsResponse:
+    properties:
+      organizations:
+        items:
+          $ref: '#/definitions/types.OrgDetails'
+        type: array
+      page:
+        type: integer
+      pageSize:
+        type: integer
+      totalCount:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
   server.AgentConfigAppliedResponse:
     properties:
       status:
@@ -3669,24 +3684,24 @@ definitions:
     - FieldSlackChannel
   transport.Kind:
     enum:
-    - webhook
-    - helix_events
     - local
-    - github
-    - slack
-    - gitlab
     - email
     - cron
+    - slack
+    - github
+    - helix_events
+    - gitlab
+    - webhook
     type: string
     x-enum-varnames:
-    - KindWebhook
-    - KindHelixEvents
     - KindLocal
-    - KindGitHub
-    - KindSlack
-    - KindGitLab
     - KindEmail
     - KindCron
+    - KindSlack
+    - KindGitHub
+    - KindHelixEvents
+    - KindGitLab
+    - KindWebhook
   transport.ResolvedActivation:
     properties:
       address:
@@ -14519,14 +14534,25 @@ paths:
       - organizations
   /api/v1/admin/orgs:
     get:
-      description: List all organizations
+      description: List organizations with server-side pagination and name search
+      parameters:
+      - description: 'Page number (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Organizations per page (default: 25, max: 100)'
+        in: query
+        name: per_page
+        type: integer
+      - description: Search organization display name or name
+        in: query
+        name: query
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/types.OrgDetails'
-            type: array
+            $ref: '#/definitions/server.AdminOrganizationsResponse'
       security:
       - BearerAuth: []
       summary: List organizations with wallets (admin only)

--- a/openapi.json
+++ b/openapi.json
@@ -854,21 +854,44 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List all organizations",
+                "description": "List organizations with server-side pagination and name search",
                 "tags": [
                     "organizations"
                 ],
                 "summary": "List organizations with wallets (admin only)",
+                "parameters": [
+                    {
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Organizations per page (default: 25, max: 100)",
+                        "name": "per_page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Search organization display name or name",
+                        "name": "query",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.OrgDetails"
-                                    }
+                                    "$ref": "#/components/schemas/server.AdminOrganizationsResponse"
                                 }
                             }
                         }
@@ -30628,6 +30651,29 @@
                     }
                 }
             },
+            "server.AdminOrganizationsResponse": {
+                "type": "object",
+                "properties": {
+                    "organizations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.OrgDetails"
+                        }
+                    },
+                    "page": {
+                        "type": "integer"
+                    },
+                    "pageSize": {
+                        "type": "integer"
+                    },
+                    "totalCount": {
+                        "type": "integer"
+                    },
+                    "totalPages": {
+                        "type": "integer"
+                    }
+                }
+            },
             "server.AgentConfigAppliedResponse": {
                 "type": "object",
                 "properties": {
@@ -33220,24 +33266,24 @@
             "transport.Kind": {
                 "type": "string",
                 "enum": [
-                    "webhook",
-                    "helix_events",
                     "local",
-                    "github",
-                    "slack",
-                    "gitlab",
                     "email",
-                    "cron"
+                    "cron",
+                    "slack",
+                    "github",
+                    "helix_events",
+                    "gitlab",
+                    "webhook"
                 ],
                 "x-enum-varnames": [
-                    "KindWebhook",
-                    "KindHelixEvents",
                     "KindLocal",
-                    "KindGitHub",
-                    "KindSlack",
-                    "KindGitLab",
                     "KindEmail",
-                    "KindCron"
+                    "KindCron",
+                    "KindSlack",
+                    "KindGitHub",
+                    "KindHelixEvents",
+                    "KindGitLab",
+                    "KindWebhook"
                 ]
             },
             "transport.ResolvedActivation": {

--- a/openapi.json
+++ b/openapi.json
@@ -33266,24 +33266,24 @@
             "transport.Kind": {
                 "type": "string",
                 "enum": [
-                    "local",
-                    "email",
-                    "cron",
-                    "slack",
-                    "github",
+                    "webhook",
                     "helix_events",
+                    "local",
+                    "github",
+                    "slack",
                     "gitlab",
-                    "webhook"
+                    "email",
+                    "cron"
                 ],
                 "x-enum-varnames": [
-                    "KindLocal",
-                    "KindEmail",
-                    "KindCron",
-                    "KindSlack",
-                    "KindGitHub",
+                    "KindWebhook",
                     "KindHelixEvents",
+                    "KindLocal",
+                    "KindGitHub",
+                    "KindSlack",
                     "KindGitLab",
-                    "KindWebhook"
+                    "KindEmail",
+                    "KindCron"
                 ]
             },
             "transport.ResolvedActivation": {

--- a/swagger.json
+++ b/swagger.json
@@ -28656,24 +28656,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "local",
-                "email",
-                "cron",
-                "slack",
-                "github",
+                "webhook",
                 "helix_events",
+                "local",
+                "github",
+                "slack",
                 "gitlab",
-                "webhook"
+                "email",
+                "cron"
             ],
             "x-enum-varnames": [
-                "KindLocal",
-                "KindEmail",
-                "KindCron",
-                "KindSlack",
-                "KindGitHub",
+                "KindWebhook",
                 "KindHelixEvents",
+                "KindLocal",
+                "KindGitHub",
+                "KindSlack",
                 "KindGitLab",
-                "KindWebhook"
+                "KindEmail",
+                "KindCron"
             ]
         },
         "transport.ResolvedActivation": {

--- a/swagger.json
+++ b/swagger.json
@@ -721,19 +721,36 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List all organizations",
+                "description": "List organizations with server-side pagination and name search",
                 "tags": [
                     "organizations"
                 ],
                 "summary": "List organizations with wallets (admin only)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Organizations per page (default: 25, max: 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search organization display name or name",
+                        "name": "query",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.OrgDetails"
-                            }
+                            "$ref": "#/definitions/server.AdminOrganizationsResponse"
                         }
                     }
                 }
@@ -26024,6 +26041,29 @@
                 }
             }
         },
+        "server.AdminOrganizationsResponse": {
+            "type": "object",
+            "properties": {
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.OrgDetails"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalCount": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
         "server.AgentConfigAppliedResponse": {
             "type": "object",
             "properties": {
@@ -28616,24 +28656,24 @@
         "transport.Kind": {
             "type": "string",
             "enum": [
-                "webhook",
-                "helix_events",
                 "local",
-                "github",
-                "slack",
-                "gitlab",
                 "email",
-                "cron"
+                "cron",
+                "slack",
+                "github",
+                "helix_events",
+                "gitlab",
+                "webhook"
             ],
             "x-enum-varnames": [
-                "KindWebhook",
-                "KindHelixEvents",
                 "KindLocal",
-                "KindGitHub",
-                "KindSlack",
-                "KindGitLab",
                 "KindEmail",
-                "KindCron"
+                "KindCron",
+                "KindSlack",
+                "KindGitHub",
+                "KindHelixEvents",
+                "KindGitLab",
+                "KindWebhook"
             ]
         },
         "transport.ResolvedActivation": {


### PR DESCRIPTION
## Summary
Add server-side pagination and debounced organization search to the admin organizations table. Limit expensive organization detail loading to the current page and run membership and project lookups concurrently, substantially reducing initial load time while preserving the existing search behavior.

Regenerate the OpenAPI documentation and TypeScript API client for the paginated response, and add standard page-size and navigation controls to the UI.

## Testing
- `yarn tsc` passed.
- Focused admin organization backend tests passed.
- The full server test suite was run; unrelated SQLite tests failed because the environment uses `CGO_ENABLED=0` while `go-sqlite3` requires CGO.
- `git diff --check` passed.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m232em3qe399xh9836c8xkzp)

🚀 Built with [Helix](https://helix.ml)