### PR TITLE
fix(org): use tenant desktop quotas for agents

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/types.go
+++ b/api/pkg/org/infrastructure/runtime/helix/types.go
@@ -11,14 +11,14 @@ func IsTerminalOutput(o types.SessionOutputResponse) bool {
 	return o.Status == "complete" || o.Status == "error" || o.Status == "interrupted"
 }
 
-// ServerStatus mirrors the slice of /api/v1/config helix-org reads.
+// ServerStatus reports the resolved desktop quota for the activation context.
 type ServerStatus struct {
 	MaxConcurrentDesktops    int `json:"max_concurrent_desktops"`
 	ActiveConcurrentDesktops int `json:"active_concurrent_desktops"`
 }
 
 // HasDesktopRoom reports whether at least one desktop slot is free.
-// Max=0 means "unlimited" at the server level.
+// The quota manager uses -1 for unlimited; any non-positive maximum is treated as unlimited here.
 func (s ServerStatus) HasDesktopRoom() bool {
 	if s.MaxConcurrentDesktops <= 0 {
 		return true

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -905,18 +905,27 @@ func (c *inProcHelixClient) DeleteLinkedAgent(ctx context.Context, orgID string,
 
 // ---- runtimehelix.SpawnerClient ----
 
-// ServerStatus returns the desktop-quota slice of /api/v1/config. We
-// read directly from the same sources as
-// HelixAPIServer.getConfig — the Free-tier quota env value and the
-// in-memory active-desktop count.
+// ServerStatus returns the desktop quota for the activation's organization.
 func (c *inProcHelixClient) ServerStatus(ctx context.Context) (runtimehelix.ServerStatus, error) {
-	st := runtimehelix.ServerStatus{
-		MaxConcurrentDesktops: c.server.Cfg.SubscriptionQuotas.Projects.Free.MaxConcurrentDesktops,
+	req := &types.QuotaRequest{OrganizationID: helixorgserver.OrgIDFromContext(ctx)}
+	if req.OrganizationID == "" {
+		req.OrganizationID = runtimehelix.OrganizationIDFromContext(ctx)
 	}
-	if c.server.externalAgentExecutor != nil {
-		st.ActiveConcurrentDesktops = len(c.server.externalAgentExecutor.ListSessions())
+	if req.OrganizationID == "" {
+		user, err := c.resolveUser(ctx)
+		if err != nil {
+			return runtimehelix.ServerStatus{}, err
+		}
+		req.UserID = user.ID
 	}
-	return st, nil
+	quotas, err := c.server.quotaManager.GetQuotas(ctx, req)
+	if err != nil {
+		return runtimehelix.ServerStatus{}, err
+	}
+	return runtimehelix.ServerStatus{
+		MaxConcurrentDesktops:    quotas.MaxConcurrentDesktops,
+		ActiveConcurrentDesktops: quotas.ActiveConcurrentDesktops,
+	}, nil
 }
 
 // GetOutput returns the latest output snapshot for a session.

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -7,20 +7,24 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v76"
 	"go.uber.org/mock/gomock"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/controller"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
+	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/quota"
 	"github.com/helixml/helix/api/pkg/server/helixorg"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/store/memorystore"
@@ -60,6 +64,42 @@ func newInProcTestSetup(t *testing.T) (*HelixAPIServer, *memorystore.MemoryStore
 	client := NewInProcHelixClient(server)
 	ctx := runtimehelix.WithUser(context.Background(), user)
 	return server, store, client, user, ctx
+}
+
+func TestInProcClient_ServerStatusUsesOrganizationQuota(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	executor := external_agent.NewMockExecutor(ctrl)
+	cfg := &config.ServerConfig{}
+	cfg.SubscriptionQuotas.Projects.Free.MaxConcurrentDesktops = 2
+	cfg.SubscriptionQuotas.Projects.Pro.MaxConcurrentDesktops = 30
+	orgID := "org_trialing"
+
+	st.EXPECT().GetWalletByOrg(gomock.Any(), orgID).Return(&types.Wallet{
+		OrgID:                orgID,
+		StripeSubscriptionID: "sub_trialing",
+		SubscriptionStatus:   stripe.SubscriptionStatusTrialing,
+	}, nil)
+	st.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{EnforceQuotas: true}, nil)
+	executor.EXPECT().ListSessions().Return([]*external_agent.ZedSession{
+		{OrganizationID: "org_other_1"},
+		{OrganizationID: "org_other_2"},
+	})
+	st.EXPECT().GetProjectsCount(gomock.Any(), &helixstore.GetProjectsCountQuery{OrganizationID: orgID}).Return(int64(0), nil)
+	st.EXPECT().GetRepositoriesCount(gomock.Any(), &helixstore.GetRepositoriesCountQuery{OrganizationID: orgID}).Return(int64(0), nil)
+	st.EXPECT().GetSpecTasksCount(gomock.Any(), &helixstore.GetSpecTasksCountQuery{OrganizationID: orgID}).Return(int64(0), nil)
+	st.EXPECT().ListSandboxes(gomock.Any(), &helixstore.ListSandboxesQuery{OrganizationID: orgID}).Return(nil, nil)
+
+	server := &HelixAPIServer{Cfg: cfg, Store: st, externalAgentExecutor: executor}
+	server.quotaManager = quota.NewDefaultQuotaManager(st, cfg, executor)
+	client := NewInProcHelixClient(server)
+	ctx := helixorgserver.WithOrgID(context.Background(), orgID)
+
+	status, err := client.ServerStatus(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, 30, status.MaxConcurrentDesktops)
+	require.Zero(t, status.ActiveConcurrentDesktops)
 }
 
 func TestInProcClient_DeleteLinkedAgentPreservesConfiguredProjectAndUnsetsAgentID(t *testing.T) {


### PR DESCRIPTION
## Summary
- use the canonical quota manager for org-agent desktop preflight
- scope active desktop counts to the activating organization
- honor trialing, active, and admin-overridden quota tiers

## Testing
- `go test ./pkg/server -run '^TestInProcClient_ServerStatusUsesOrganizationQuota$' -count=1`\n- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`\n- `git diff --check`