### PR TITLE
Fix admin trial activation organization selection

### DIFF
--- a/api/pkg/notification/notification_email.go
+++ b/api/pkg/notification/notification_email.go
@@ -210,9 +210,10 @@ func (e *Email) getEmailMessage(n *Notification) (title, message string, err err
 		var buf bytes.Buffer
 
 		err = waitlistApprovedTmpl.Execute(&buf, &templateData{
-			FirstName: n.FirstName,
-			AppURL:    e.cfg.AppURL,
-			TrialDays: n.TrialDays,
+			FirstName:    n.FirstName,
+			AppURL:       e.cfg.AppURL,
+			TrialDays:    n.TrialDays,
+			TrialPending: n.TrialPending,
 		})
 		if err != nil {
 			return "", "", fmt.Errorf("failed to execute template: %w", err)

--- a/api/pkg/notification/notification_email_test.go
+++ b/api/pkg/notification/notification_email_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_getEmailMessage_WaitlistApprovedPassesTrialPending(t *testing.T) {
+	notifier := &Email{cfg: &config.Notifications{}}
+	_, message, err := notifier.getEmailMessage(&Notification{
+		Event:        types.EventWaitlistApproved,
+		TrialDays:    30,
+		TrialPending: true,
+	})
+	require.NoError(t, err)
+	require.Contains(t, message, "Your 30-day free trial will activate automatically when you create your first organization.")
+}
+
 func Test_getEmailMessage_CronTriggerComplete(t *testing.T) {
 	cfg := &config.Notifications{
 		AppURL: "https://app.helix.ai",

--- a/api/pkg/notification/templates/waitlist_approved.html
+++ b/api/pkg/notification/templates/waitlist_approved.html
@@ -132,7 +132,11 @@
                 {{ if .FirstName }}<p>Hi {{ .FirstName }},</p>{{ end }}
                 <p>Great news! Your account has been approved and you now have full access to Helix.</p>
                 {{ if gt .TrialDays 0 }}
+                {{ if .TrialPending }}
+                <p>Your {{ .TrialDays }}-day free trial will activate automatically when you create your first organization.</p>
+                {{ else }}
                 <p><strong>You're on a {{ .TrialDays }}-day free trial.</strong> No credit card required — your organization is set up with trial credits so you can start using Helix immediately. We'll let you know before the trial ends so you can add a payment method to keep going.</p>
+                {{ end }}
                 {{ else }}
                 <p>Start building with AI - safer, faster, and smarter. Explore everything Helix has to offer and turn your vision into reality.</p>
                 {{ end }}

--- a/api/pkg/server/admin_credit_handlers.go
+++ b/api/pkg/server/admin_credit_handlers.go
@@ -35,6 +35,15 @@ type OwnedOrgSummary struct {
 	DisplayName string `json:"display_name,omitempty"`
 }
 
+func findOwnedOrg(orgs []*types.Organization, orgID string) *types.Organization {
+	for _, org := range orgs {
+		if org.ID == orgID {
+			return org
+		}
+	}
+	return nil
+}
+
 // GrantCreditsResponse describes the outcome of an admin credit grant.
 //
 // Status values:
@@ -183,13 +192,7 @@ func (apiServer *HelixAPIServer) adminGrantCredits(_ http.ResponseWriter, req *h
 		return nil, system.NewHTTPError400(fmt.Sprintf("org_id is required: user owns %d organisation(s), pick which one receives the grant", len(ownedOrgs)))
 	}
 
-	var selectedOrg *types.Organization
-	for _, org := range ownedOrgs {
-		if org.ID == body.OrgID {
-			selectedOrg = org
-			break
-		}
-	}
+	selectedOrg := findOwnedOrg(ownedOrgs, body.OrgID)
 	if selectedOrg == nil {
 		return nil, system.NewHTTPError400(fmt.Sprintf("user does not own organisation %s", body.OrgID))
 	}

--- a/api/pkg/server/admin_credit_handlers_test.go
+++ b/api/pkg/server/admin_credit_handlers_test.go
@@ -119,7 +119,7 @@ func TestAdminGrantCredits_NoOrg_StashesOnUser(t *testing.T) {
 	mockStore := store.NewMockStore(ctrl)
 
 	adminUser := &types.User{ID: "admin-1", Admin: true}
-	targetUser := &types.User{ID: "target-1", Email: "t@example.com"}
+	targetUser := &types.User{ID: "target-1", Email: "t@example.com", Waitlisted: true}
 
 	mockStore.EXPECT().
 		GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).
@@ -134,6 +134,7 @@ func TestAdminGrantCredits_NoOrg_StashesOnUser(t *testing.T) {
 		DoAndReturn(func(_ interface{}, u *types.User) (*types.User, error) {
 			require.NotNil(t, u.PendingAdminCreditsOnFirstOrg)
 			assert.InDelta(t, 75.0, *u.PendingAdminCreditsOnFirstOrg, 0.0001)
+			assert.True(t, u.Waitlisted)
 			return u, nil
 		})
 
@@ -150,6 +151,7 @@ func TestAdminGrantCredits_NoOrg_StashesOnUser(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, "stashed", resp.Status)
 	assert.Empty(t, resp.OrgID)
+	assert.True(t, resp.User.Waitlisted)
 }
 
 func TestAdminGrantCredits_HasOrgWithWallet_TopsUp(t *testing.T) {

--- a/api/pkg/server/admin_trial_handlers.go
+++ b/api/pkg/server/admin_trial_handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -23,10 +22,11 @@ const (
 )
 
 // ActivateTrialRequest is the body for POST /admin/users/{id}/trial-activate.
-// All fields are optional; zero values use the defaults.
+// org_id is required when the user owns an organization. Other zero values use defaults.
 type ActivateTrialRequest struct {
 	Days    int     `json:"days"`
 	Credits float64 `json:"credits"`
+	OrgID   string  `json:"org_id,omitempty"`
 	// Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
 	// (no Stripe subscription) — for customers who paid out-of-band (bank
 	// transfer). Empty or "trial" uses the Stripe trial path (Days applies).
@@ -38,8 +38,8 @@ type ActivateTrialRequest struct {
 // Status values:
 //   - "stashed": user has no orgs yet; trial intent is parked on the user and
 //     will be applied when they create their first org.
-//   - "applied": Stripe trial subscription was created on the user's oldest
-//     owned org's wallet right now.
+//   - "applied": Stripe trial subscription was created on the selected owned
+//     org's wallet right now.
 type ActivateTrialResponse struct {
 	User   *types.User `json:"user"`
 	OrgID  string      `json:"org_id,omitempty"`
@@ -170,12 +170,12 @@ func (s *HelixAPIServer) consumeUserPlanOnFirstOrg(ctx context.Context, user *ty
 
 // adminActivateTrial godoc
 // @Summary Activate a trial for a user (Admin, cloud only)
-// @Description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
+// @Description Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
 // @Tags    users
 // @Accept  json
 // @Produce json
 // @Param id path string true "User ID"
-// @Param request body ActivateTrialRequest false "Trial parameters (days, credits)"
+// @Param request body ActivateTrialRequest false "Trial parameters and org_id (required iff the user owns an organisation)"
 // @Success 200 {object} ActivateTrialResponse
 // @Router /api/v1/admin/users/{id}/trial-activate [post]
 // @Security BearerAuth
@@ -219,20 +219,40 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 	if err != nil {
 		return nil, system.NewHTTPError404("user not found")
 	}
+	wasWaitlisted := targetUser.Waitlisted
 
-	oldestOrg, err := oldestOwnedOrg(ctx, apiServer.Store, targetUserID)
+	ownedOrgs, err := apiServer.Store.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: targetUserID})
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
+	}
+	if len(ownedOrgs) == 0 {
+		if body.OrgID != "" {
+			return nil, system.NewHTTPError400("user owns no organisations; remove org_id to stash activation for their first owned org")
+		}
+	} else if body.OrgID == "" {
+		return nil, system.NewHTTPError400(fmt.Sprintf("org_id is required: user owns %d organisation(s), pick which one to activate", len(ownedOrgs)))
+	}
+
+	var selectedOrg *types.Organization
+	for _, org := range ownedOrgs {
+		if org.ID == body.OrgID {
+			selectedOrg = org
+			break
+		}
+	}
+	if len(ownedOrgs) > 0 && selectedOrg == nil {
+		return nil, system.NewHTTPError400(fmt.Sprintf("user does not own organisation %s", body.OrgID))
 	}
 
 	// Paid plan granted out-of-band (e.g. bank transfer): set a PlanOverride,
 	// no Stripe subscription. Independent of Stripe so it is never reverted by
-	// a webhook. Applied to the oldest owned org now, or stashed for the user's
+	// a webhook. Applied to the selected owned org now, or stashed for the user's
 	// first org.
 	if body.Plan == types.PlanOverridePro {
-		if oldestOrg == nil {
+		if selectedOrg == nil {
 			plan := types.PlanOverridePro
 			targetUser.PlanOnFirstOrg = &plan
+			targetUser.Waitlisted = false
 			if body.Credits > 0 {
 				c := body.Credits
 				targetUser.PendingAdminCreditsOnFirstOrg = &c
@@ -243,11 +263,14 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 			}
 			log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).
 				Msg("admin stashed paid-plan intent on user (no org yet)")
+			if wasWaitlisted {
+				apiServer.sendActivationEmail(ctx, updated, 0, false, true)
+			}
 			return &ActivateTrialResponse{User: updated, Status: "stashed"}, nil
 		}
-		wallet, wErr := apiServer.getOrCreateWallet(ctx, targetUser, oldestOrg.ID)
+		wallet, wErr := apiServer.getOrCreateWallet(ctx, targetUser, selectedOrg.ID)
 		if wErr != nil {
-			return nil, system.NewHTTPError500("failed to get wallet for oldest owned org: " + wErr.Error())
+			return nil, system.NewHTTPError500("failed to get wallet for selected org: " + wErr.Error())
 		}
 		wallet.PlanOverride = types.PlanOverridePro
 		if _, wErr := apiServer.Store.UpdateWallet(ctx, wallet); wErr != nil {
@@ -260,18 +283,30 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 				log.Warn().Err(bErr).Str("wallet_id", wallet.ID).Msg("failed to top up wallet with credits")
 			}
 		}
-		log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).Str("org_id", oldestOrg.ID).
-			Msg("admin granted paid plan (PlanOverride=pro) on oldest owned org")
-		return &ActivateTrialResponse{User: targetUser, OrgID: oldestOrg.ID, Status: "applied"}, nil
+		if targetUser.Waitlisted {
+			targetUser.Waitlisted = false
+			updated, uErr := apiServer.Store.UpdateUser(ctx, targetUser)
+			if uErr != nil {
+				return nil, system.NewHTTPError500("failed to activate user: " + uErr.Error())
+			}
+			targetUser = updated
+		}
+		log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).Str("org_id", selectedOrg.ID).
+			Msg("admin granted paid plan (PlanOverride=pro) on selected owned org")
+		if wasWaitlisted {
+			apiServer.sendActivationEmail(ctx, targetUser, 0, false, true)
+		}
+		return &ActivateTrialResponse{User: targetUser, OrgID: selectedOrg.ID, Status: "applied"}, nil
 	}
 
 	// Path A: no owned org yet. Stash intent on the user; consumeUserTrialIntent
 	// will apply it when they create their first org.
-	if oldestOrg == nil {
+	if selectedOrg == nil {
 		days := body.Days
 		credits := body.Credits
 		targetUser.TrialDaysOnFirstOrg = &days
 		targetUser.TrialCreditsOnFirstOrg = &credits
+		targetUser.Waitlisted = false
 		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
 		if err != nil {
 			return nil, system.NewHTTPError500("failed to stash trial intent: " + err.Error())
@@ -282,17 +317,17 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 			Int("days", days).
 			Float64("credits", credits).
 			Msg("admin stashed trial intent on user (no org yet)")
-		apiServer.sendTrialActivatedEmail(ctx, updated, days, true)
+		apiServer.sendActivationEmail(ctx, updated, days, true, wasWaitlisted)
 		return &ActivateTrialResponse{User: updated, Status: "stashed"}, nil
 	}
 
 	// Path B: user already has at least one owned org. Apply directly.
-	wallet, err := apiServer.getOrCreateWallet(ctx, targetUser, oldestOrg.ID)
+	wallet, err := apiServer.getOrCreateWallet(ctx, targetUser, selectedOrg.ID)
 	if err != nil {
-		return nil, system.NewHTTPError500("failed to get wallet for oldest owned org: " + err.Error())
+		return nil, system.NewHTTPError500("failed to get wallet for selected org: " + err.Error())
 	}
 	if wallet.StripeSubscriptionID != "" && wallet.IsSubscriptionActive() {
-		return nil, system.NewHTTPError422(fmt.Sprintf("org %s already has an active subscription", oldestOrg.ID))
+		return nil, system.NewHTTPError422(fmt.Sprintf("org %s already has an active subscription", selectedOrg.ID))
 	}
 
 	sub, err := apiServer.Stripe.CreateTrialSubscription(ctx, wallet, body.Days)
@@ -316,23 +351,30 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 			log.Warn().Err(err).Str("wallet_id", wallet.ID).Float64("credits", body.Credits).Msg("failed to top up wallet with trial credits")
 		}
 	}
-
+	if targetUser.Waitlisted {
+		targetUser.Waitlisted = false
+		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
+		if err != nil {
+			return nil, system.NewHTTPError500("failed to activate user: " + err.Error())
+		}
+		targetUser = updated
+	}
 	log.Info().
 		Str("admin_id", adminUser.ID).
 		Str("target_user_id", targetUserID).
-		Str("org_id", oldestOrg.ID).
+		Str("org_id", selectedOrg.ID).
 		Str("subscription_id", sub.ID).
 		Int("days", body.Days).
 		Float64("credits", body.Credits).
-		Msg("admin activated trial subscription on oldest owned org")
+		Msg("admin activated trial subscription on selected owned org")
 
-	apiServer.sendTrialActivatedEmail(ctx, targetUser, body.Days, false)
-	return &ActivateTrialResponse{User: targetUser, OrgID: oldestOrg.ID, Status: "applied"}, nil
+	apiServer.sendActivationEmail(ctx, targetUser, body.Days, false, wasWaitlisted)
+	return &ActivateTrialResponse{User: targetUser, OrgID: selectedOrg.ID, Status: "applied"}, nil
 }
 
-// sendTrialActivatedEmail fires the trial_activated email. Best-effort: logs
-// errors but never blocks the caller's HTTP response.
-func (apiServer *HelixAPIServer) sendTrialActivatedEmail(ctx context.Context, user *types.User, days int, pending bool) {
+// sendActivationEmail sends one email for the activation. A waitlisted user
+// gets the approval email; an already-approved user gets the trial email.
+func (apiServer *HelixAPIServer) sendActivationEmail(ctx context.Context, user *types.User, days int, pending, approved bool) {
 	if user == nil || user.Email == "" {
 		return
 	}
@@ -343,8 +385,12 @@ func (apiServer *HelixAPIServer) sendTrialActivatedEmail(ctx context.Context, us
 	if user.FullName != "" {
 		firstName = strings.Split(user.FullName, " ")[0]
 	}
+	event := types.EventTrialActivated
+	if approved {
+		event = types.EventWaitlistApproved
+	}
 	err := apiServer.Controller.Options.Notifier.Notify(ctx, &types.Notification{
-		Event:        types.EventTrialActivated,
+		Event:        event,
 		Email:        user.Email,
 		FirstName:    firstName,
 		TrialDays:    days,
@@ -360,7 +406,7 @@ func (apiServer *HelixAPIServer) sendTrialActivatedEmail(ctx context.Context, us
 
 // adminRevokeTrial godoc
 // @Summary Revoke an admin-granted trial (Admin, cloud only)
-// @Description Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.
+// @Description Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.
 // @Tags    users
 // @Produce json
 // @Param id path string true "User ID"
@@ -397,14 +443,14 @@ func (apiServer *HelixAPIServer) adminRevokeTrial(_ http.ResponseWriter, req *ht
 		stashedCleared = true
 	}
 
-	oldestOrg, err := oldestOwnedOrg(ctx, apiServer.Store, targetUserID)
+	ownedOrgs, err := apiServer.Store.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: targetUserID})
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
 	}
 
 	cancelledOrgID := ""
-	if oldestOrg != nil {
-		wallet, err := apiServer.Store.GetWalletByOrg(ctx, oldestOrg.ID)
+	for _, org := range ownedOrgs {
+		wallet, err := apiServer.Store.GetWalletByOrg(ctx, org.ID)
 		if err != nil && !errors.Is(err, store.ErrNotFound) {
 			return nil, system.NewHTTPError500("failed to read org wallet: " + err.Error())
 		}
@@ -414,7 +460,8 @@ func (apiServer *HelixAPIServer) adminRevokeTrial(_ http.ResponseWriter, req *ht
 			if err := apiServer.Stripe.CancelTrialSubscription(ctx, wallet.StripeSubscriptionID); err != nil {
 				return nil, system.NewHTTPError500("failed to cancel stripe subscription: " + err.Error())
 			}
-			cancelledOrgID = oldestOrg.ID
+			cancelledOrgID = org.ID
+			break
 		}
 	}
 
@@ -437,24 +484,10 @@ func (apiServer *HelixAPIServer) adminRevokeTrial(_ http.ResponseWriter, req *ht
 	return &ActivateTrialResponse{User: targetUser, OrgID: cancelledOrgID, Status: status}, nil
 }
 
-// oldestOwnedOrg returns the user's oldest owned organization (by CreatedAt),
-// or nil if they own none.
-func oldestOwnedOrg(ctx context.Context, st store.Store, userID string) (*types.Organization, error) {
-	orgs, err := st.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: userID})
-	if err != nil {
-		return nil, err
-	}
-	if len(orgs) == 0 {
-		return nil, nil
-	}
-	sort.Slice(orgs, func(i, j int) bool { return orgs[i].CreatedAt.Before(orgs[j].CreatedAt) })
-	return orgs[0], nil
-}
-
 // enrichUserTrialDisplay sets the transient TrialStatus / TrialOrgID /
 // TrialEndsAt fields on a user for the admin users list.
 //   - "stashed" — admin granted a trial but the user has not yet created an org.
-//   - "active"  — wallet on the user's oldest owned org is currently trialing.
+//   - "active"  — wallet on one of the user's owned orgs is currently trialing.
 //   - ""        — neither (field is omitted from JSON via omitempty).
 //
 // Best-effort: errors are logged and the user is returned without enrichment.
@@ -466,25 +499,25 @@ func (apiServer *HelixAPIServer) enrichUserTrialDisplay(ctx context.Context, u *
 		u.TrialStatus = "stashed"
 		return
 	}
-	oldest, err := oldestOwnedOrg(ctx, apiServer.Store, u.ID)
+	ownedOrgs, err := apiServer.Store.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: u.ID})
 	if err != nil {
 		log.Warn().Err(err).Str("user_id", u.ID).Msg("failed to list orgs for trial enrichment")
 		return
 	}
-	if oldest == nil {
-		return
-	}
-	wallet, err := apiServer.Store.GetWalletByOrg(ctx, oldest.ID)
-	if err != nil {
-		if !errors.Is(err, store.ErrNotFound) {
-			log.Warn().Err(err).Str("user_id", u.ID).Str("org_id", oldest.ID).Msg("failed to get wallet for trial enrichment")
+	for _, org := range ownedOrgs {
+		wallet, err := apiServer.Store.GetWalletByOrg(ctx, org.ID)
+		if err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				log.Warn().Err(err).Str("user_id", u.ID).Str("org_id", org.ID).Msg("failed to get wallet for trial enrichment")
+			}
+			continue
 		}
-		return
-	}
-	if wallet.SubscriptionStatus == stripeapi.SubscriptionStatusTrialing {
-		u.TrialStatus = "active"
-		u.TrialOrgID = oldest.ID
-		end := wallet.SubscriptionCurrentPeriodEnd
-		u.TrialEndsAt = &end
+		if wallet.SubscriptionStatus == stripeapi.SubscriptionStatusTrialing {
+			u.TrialStatus = "active"
+			u.TrialOrgID = org.ID
+			end := wallet.SubscriptionCurrentPeriodEnd
+			u.TrialEndsAt = &end
+			return
+		}
 	}
 }

--- a/api/pkg/server/admin_trial_handlers.go
+++ b/api/pkg/server/admin_trial_handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -233,15 +234,17 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 		return nil, system.NewHTTPError400(fmt.Sprintf("org_id is required: user owns %d organisation(s), pick which one to activate", len(ownedOrgs)))
 	}
 
-	var selectedOrg *types.Organization
-	for _, org := range ownedOrgs {
-		if org.ID == body.OrgID {
-			selectedOrg = org
-			break
-		}
-	}
+	selectedOrg := findOwnedOrg(ownedOrgs, body.OrgID)
 	if len(ownedOrgs) > 0 && selectedOrg == nil {
 		return nil, system.NewHTTPError400(fmt.Sprintf("user does not own organisation %s", body.OrgID))
+	}
+	if selectedOrg != nil && targetUser.Waitlisted {
+		targetUser.Waitlisted = false
+		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
+		if err != nil {
+			return nil, system.NewHTTPError500("failed to activate user: " + err.Error())
+		}
+		targetUser = updated
 	}
 
 	// Paid plan granted out-of-band (e.g. bank transfer): set a PlanOverride,
@@ -282,14 +285,6 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 			}); bErr != nil {
 				log.Warn().Err(bErr).Str("wallet_id", wallet.ID).Msg("failed to top up wallet with credits")
 			}
-		}
-		if targetUser.Waitlisted {
-			targetUser.Waitlisted = false
-			updated, uErr := apiServer.Store.UpdateUser(ctx, targetUser)
-			if uErr != nil {
-				return nil, system.NewHTTPError500("failed to activate user: " + uErr.Error())
-			}
-			targetUser = updated
 		}
 		log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).Str("org_id", selectedOrg.ID).
 			Msg("admin granted paid plan (PlanOverride=pro) on selected owned org")
@@ -351,14 +346,6 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 			log.Warn().Err(err).Str("wallet_id", wallet.ID).Float64("credits", body.Credits).Msg("failed to top up wallet with trial credits")
 		}
 	}
-	if targetUser.Waitlisted {
-		targetUser.Waitlisted = false
-		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
-		if err != nil {
-			return nil, system.NewHTTPError500("failed to activate user: " + err.Error())
-		}
-		targetUser = updated
-	}
 	log.Info().
 		Str("admin_id", adminUser.ID).
 		Str("target_user_id", targetUserID).
@@ -400,13 +387,13 @@ func (apiServer *HelixAPIServer) sendActivationEmail(ctx context.Context, user *
 		log.Warn().Err(err).
 			Str("user_id", user.ID).
 			Str("email", user.Email).
-			Msg("failed to send trial activated email")
+			Msg("failed to send activation email")
 	}
 }
 
 // adminRevokeTrial godoc
 // @Summary Revoke an admin-granted trial (Admin, cloud only)
-// @Description Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.
+// @Description Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.
 // @Tags    users
 // @Produce json
 // @Param id path string true "User ID"
@@ -447,12 +434,21 @@ func (apiServer *HelixAPIServer) adminRevokeTrial(_ http.ResponseWriter, req *ht
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
 	}
+	sort.Slice(ownedOrgs, func(i, j int) bool {
+		if ownedOrgs[i].CreatedAt.Equal(ownedOrgs[j].CreatedAt) {
+			return ownedOrgs[i].ID < ownedOrgs[j].ID
+		}
+		return ownedOrgs[i].CreatedAt.Before(ownedOrgs[j].CreatedAt)
+	})
 
 	cancelledOrgID := ""
 	for _, org := range ownedOrgs {
 		wallet, err := apiServer.Store.GetWalletByOrg(ctx, org.ID)
-		if err != nil && !errors.Is(err, store.ErrNotFound) {
-			return nil, system.NewHTTPError500("failed to read org wallet: " + err.Error())
+		if err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				log.Warn().Err(err).Str("user_id", targetUserID).Str("org_id", org.ID).Msg("failed to read org wallet while revoking trial")
+			}
+			continue
 		}
 		// Only cancel a subscription that is currently trialing. Never touch a
 		// paid subscription via this endpoint.

--- a/api/pkg/server/admin_trial_handlers_test.go
+++ b/api/pkg/server/admin_trial_handlers_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/controller"
+	"github.com/helixml/helix/api/pkg/notification"
+	"github.com/helixml/helix/api/pkg/store"
+	helixstripe "github.com/helixml/helix/api/pkg/stripe"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	stripeapi "github.com/stripe/stripe-go/v76"
+	"github.com/stripe/stripe-go/v76/form"
+	"go.uber.org/mock/gomock"
+)
+
+func activateTrialRequest(t *testing.T, body ActivateTrialRequest) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target/trial-activate", bytes.NewReader(b))
+	req = mux.SetURLVars(req, map[string]string{"id": "target"})
+	return req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin", Admin: true}))
+}
+
+func TestAdminActivateTrial_NoOrgStashes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	user := &types.User{ID: "target", Waitlisted: true}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return(nil, nil)
+	db.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, got *types.User) (*types.User, error) {
+		require.False(t, got.Waitlisted)
+		require.NotNil(t, got.TrialDaysOnFirstOrg)
+		require.Equal(t, 30, *got.TrialDaysOnFirstOrg)
+		return got, nil
+	})
+
+	s := &HelixAPIServer{Store: db, Cfg: cloudBillingCfg()}
+	resp, err := s.adminActivateTrial(httptest.NewRecorder(), activateTrialRequest(t, ActivateTrialRequest{Days: 30}))
+	require.NoError(t, err)
+	require.Equal(t, "stashed", resp.Status)
+}
+
+func TestAdminActivateTrial_AppliesPaidPlanToSelectedOrg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	user := &types.User{ID: "target", Waitlisted: true}
+	orgA := &types.Organization{ID: "org-a", Owner: "target"}
+	orgB := &types.Organization{ID: "org-b", Owner: "target"}
+	walletB := &types.Wallet{ID: "wallet-b", OrgID: "org-b"}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{orgA, orgB}, nil)
+	db.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-b"}).Return(orgB, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(walletB, nil)
+	db.EXPECT().UpdateWallet(gomock.Any(), walletB).DoAndReturn(func(_ context.Context, got *types.Wallet) (*types.Wallet, error) {
+		require.Equal(t, types.PlanOverridePro, got.PlanOverride)
+		return got, nil
+	})
+	db.EXPECT().UpdateUser(gomock.Any(), user).DoAndReturn(func(_ context.Context, got *types.User) (*types.User, error) {
+		require.False(t, got.Waitlisted)
+		return got, nil
+	})
+	s := &HelixAPIServer{Store: db, Cfg: cloudBillingCfg()}
+	resp, err := s.adminActivateTrial(httptest.NewRecorder(), activateTrialRequest(t, ActivateTrialRequest{
+		OrgID: "org-b",
+		Plan:  types.PlanOverridePro,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "org-b", resp.OrgID)
+}
+
+func TestAdminActivateTrial_RequiresOwnedOrgSelection(t *testing.T) {
+	for _, orgID := range []string{"", "org-other"} {
+		t.Run(orgID, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			db := store.NewMockStore(ctrl)
+			user := &types.User{ID: "target"}
+			db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+			db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{{ID: "org-owned"}}, nil)
+
+			s := &HelixAPIServer{Store: db, Cfg: cloudBillingCfg()}
+			_, err := s.adminActivateTrial(httptest.NewRecorder(), activateTrialRequest(t, ActivateTrialRequest{OrgID: orgID}))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSendActivationEmail_UsesApprovalEventForWaitlistedUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	notifier := notification.NewMockNotifier(ctrl)
+	notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, got *types.Notification) error {
+		require.Equal(t, types.EventWaitlistApproved, got.Event)
+		require.Equal(t, 30, got.TrialDays)
+		return nil
+	})
+	s := &HelixAPIServer{Controller: &controller.Controller{Options: controller.Options{Notifier: notifier}}}
+	s.sendActivationEmail(context.Background(), &types.User{Email: "target@example.com"}, 30, false, true)
+}
+
+func TestEnrichUserTrialDisplay_FindsTrialOnNonFirstOrg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	user := &types.User{ID: "target"}
+	orgA := &types.Organization{ID: "org-a"}
+	orgB := &types.Organization{ID: "org-b"}
+
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{orgA, orgB}, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-a").Return(&types.Wallet{SubscriptionStatus: stripeapi.SubscriptionStatusActive}, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(&types.Wallet{SubscriptionStatus: stripeapi.SubscriptionStatusTrialing, SubscriptionCurrentPeriodEnd: 1234}, nil)
+
+	(&HelixAPIServer{Store: db}).enrichUserTrialDisplay(context.Background(), user)
+	require.Equal(t, "active", user.TrialStatus)
+	require.Equal(t, "org-b", user.TrialOrgID)
+	require.Equal(t, int64(1234), *user.TrialEndsAt)
+}
+
+type adminTrialStripeBackend struct {
+	t *testing.T
+}
+
+func (b *adminTrialStripeBackend) Call(method, path, _ string, _ stripeapi.ParamsContainer, out stripeapi.LastResponseSetter) error {
+	switch method {
+	case http.MethodPost:
+		require.Equal(b.t, "/v1/subscriptions", path)
+		*out.(*stripeapi.Subscription) = stripeapi.Subscription{
+			ID:                 "sub-b",
+			Status:             stripeapi.SubscriptionStatusTrialing,
+			CurrentPeriodStart: 1000,
+			CurrentPeriodEnd:   2000,
+		}
+	case http.MethodDelete:
+		require.Equal(b.t, "/v1/subscriptions/sub-b", path)
+	default:
+		return fmt.Errorf("unexpected call: %s %s", method, path)
+	}
+	return nil
+}
+
+func (*adminTrialStripeBackend) CallStreaming(string, string, string, stripeapi.ParamsContainer, stripeapi.StreamingLastResponseSetter) error {
+	return fmt.Errorf("unexpected streaming call")
+}
+func (b *adminTrialStripeBackend) CallRaw(method, path, _ string, _ *form.Values, _ *stripeapi.Params, out stripeapi.LastResponseSetter) error {
+	require.Equal(b.t, http.MethodGet, method)
+	require.Equal(b.t, "/v1/prices", path)
+	*out.(*stripeapi.PriceList) = stripeapi.PriceList{Data: []*stripeapi.Price{{ID: "price-trial"}}}
+	return nil
+}
+func (*adminTrialStripeBackend) CallMultipart(string, string, string, string, *bytes.Buffer, *stripeapi.Params, stripeapi.LastResponseSetter) error {
+	return fmt.Errorf("unexpected multipart call")
+}
+func (*adminTrialStripeBackend) SetMaxNetworkRetries(int64) {}
+
+func TestAdminActivateTrial_AppliesStripeTrialToSelectedOrgAndApprovesUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	user := &types.User{ID: "target", Waitlisted: true}
+	orgA := &types.Organization{ID: "org-a", Owner: "target"}
+	orgB := &types.Organization{ID: "org-b", Owner: "target"}
+	walletB := &types.Wallet{ID: "wallet-b", OrgID: "org-b", StripeCustomerID: "cus-b"}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{orgA, orgB}, nil)
+	db.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-b"}).Return(orgB, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(walletB, nil)
+	db.EXPECT().UpdateWallet(gomock.Any(), walletB).DoAndReturn(func(_ context.Context, got *types.Wallet) (*types.Wallet, error) {
+		require.Equal(t, "sub-b", got.StripeSubscriptionID)
+		require.Equal(t, stripeapi.SubscriptionStatusTrialing, got.SubscriptionStatus)
+		return got, nil
+	})
+	db.EXPECT().UpdateUser(gomock.Any(), user).DoAndReturn(func(_ context.Context, got *types.User) (*types.User, error) {
+		require.False(t, got.Waitlisted)
+		return got, nil
+	})
+
+	originalBackend := stripeapi.GetBackend(stripeapi.APIBackend)
+	stripeapi.SetBackend(stripeapi.APIBackend, &adminTrialStripeBackend{t: t})
+	t.Cleanup(func() { stripeapi.SetBackend(stripeapi.APIBackend, originalBackend) })
+	cfg := cloudBillingCfg()
+	cfg.Stripe.SecretKey = "sk_test"
+	cfg.Stripe.WebhookSigningSecret = "whsec_test"
+	cfg.Stripe.OrgPriceLookupKey = "org-trial"
+	s := &HelixAPIServer{Store: db, Cfg: cfg, Stripe: helixstripe.NewStripe(cfg.Stripe, db)}
+
+	resp, err := s.adminActivateTrial(httptest.NewRecorder(), activateTrialRequest(t, ActivateTrialRequest{Days: 30, OrgID: "org-b"}))
+	require.NoError(t, err)
+	require.Equal(t, "org-b", resp.OrgID)
+	require.False(t, resp.User.Waitlisted)
+}
+
+func TestAdminRevokeTrial_FindsTrialOnNonFirstOrg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	orgA := &types.Organization{ID: "org-a"}
+	orgB := &types.Organization{ID: "org-b"}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(&types.User{ID: "target"}, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{orgA, orgB}, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-a").Return(&types.Wallet{SubscriptionStatus: stripeapi.SubscriptionStatusActive}, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(&types.Wallet{StripeSubscriptionID: "sub-b", SubscriptionStatus: stripeapi.SubscriptionStatusTrialing}, nil)
+
+	originalBackend := stripeapi.GetBackend(stripeapi.APIBackend)
+	stripeapi.SetBackend(stripeapi.APIBackend, &adminTrialStripeBackend{t: t})
+	t.Cleanup(func() { stripeapi.SetBackend(stripeapi.APIBackend, originalBackend) })
+	cfg := cloudBillingCfg()
+	cfg.Stripe.SecretKey = "sk_test"
+	cfg.Stripe.WebhookSigningSecret = "whsec_test"
+	s := &HelixAPIServer{
+		Store:  db,
+		Cfg:    cfg,
+		Stripe: helixstripe.NewStripe(cfg.Stripe, db),
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/target/trial-activate", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "target"})
+	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin", Admin: true}))
+
+	resp, err := s.adminRevokeTrial(httptest.NewRecorder(), req)
+	require.NoError(t, err)
+	require.Equal(t, "cancelled", resp.Status)
+	require.Equal(t, "org-b", resp.OrgID)
+}

--- a/api/pkg/server/admin_trial_handlers_test.go
+++ b/api/pkg/server/admin_trial_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/controller"
@@ -95,6 +96,24 @@ func TestAdminActivateTrial_RequiresOwnedOrgSelection(t *testing.T) {
 	}
 }
 
+func TestAdminActivateTrial_ApprovesBeforePlanSideEffects(t *testing.T) {
+	for _, plan := range []string{"", types.PlanOverridePro} {
+		t.Run(plan, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			db := store.NewMockStore(ctrl)
+			user := &types.User{ID: "target", Waitlisted: true}
+
+			db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+			db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{{ID: "org-owned"}}, nil)
+			db.EXPECT().UpdateUser(gomock.Any(), user).Return(nil, fmt.Errorf("write failed"))
+
+			s := &HelixAPIServer{Store: db, Cfg: cloudBillingCfg()}
+			_, err := s.adminActivateTrial(httptest.NewRecorder(), activateTrialRequest(t, ActivateTrialRequest{OrgID: "org-owned", Plan: plan}))
+			require.ErrorContains(t, err, "failed to activate user")
+		})
+	}
+}
+
 func TestSendActivationEmail_UsesApprovalEventForWaitlistedUser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	notifier := notification.NewMockNotifier(ctrl)
@@ -105,6 +124,30 @@ func TestSendActivationEmail_UsesApprovalEventForWaitlistedUser(t *testing.T) {
 	})
 	s := &HelixAPIServer{Controller: &controller.Controller{Options: controller.Options{Notifier: notifier}}}
 	s.sendActivationEmail(context.Background(), &types.User{Email: "target@example.com"}, 30, false, true)
+}
+
+func TestAdminApproveUser_MarksStashedTrialPendingInEmail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	notifier := notification.NewMockNotifier(ctrl)
+	days := 30
+	user := &types.User{ID: "target", Email: "target@example.com", Waitlisted: true, TrialDaysOnFirstOrg: &days}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(user, nil)
+	db.EXPECT().UpdateUser(gomock.Any(), user).Return(user, nil)
+	notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, got *types.Notification) error {
+		require.Equal(t, types.EventWaitlistApproved, got.Event)
+		require.Equal(t, days, got.TrialDays)
+		require.True(t, got.TrialPending)
+		return nil
+	})
+
+	s := &HelixAPIServer{Store: db, Controller: &controller.Controller{Options: controller.Options{Notifier: notifier}}}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target/approve", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "target"})
+	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin", Admin: true}))
+	_, err := s.adminApproveUser(httptest.NewRecorder(), req)
+	require.NoError(t, err)
 }
 
 func TestEnrichUserTrialDisplay_FindsTrialOnNonFirstOrg(t *testing.T) {
@@ -197,15 +240,14 @@ func TestAdminActivateTrial_AppliesStripeTrialToSelectedOrgAndApprovesUser(t *te
 	require.False(t, resp.User.Waitlisted)
 }
 
-func TestAdminRevokeTrial_FindsTrialOnNonFirstOrg(t *testing.T) {
+func TestAdminRevokeTrial_CancelsOldestTrialingOrg(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	db := store.NewMockStore(ctrl)
-	orgA := &types.Organization{ID: "org-a"}
-	orgB := &types.Organization{ID: "org-b"}
+	oldOrg := &types.Organization{ID: "org-b", CreatedAt: time.Unix(1000, 0)}
+	newOrg := &types.Organization{ID: "org-c", CreatedAt: time.Unix(2000, 0)}
 
 	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(&types.User{ID: "target"}, nil)
-	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{orgA, orgB}, nil)
-	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-a").Return(&types.Wallet{SubscriptionStatus: stripeapi.SubscriptionStatusActive}, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{newOrg, oldOrg}, nil)
 	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(&types.Wallet{StripeSubscriptionID: "sub-b", SubscriptionStatus: stripeapi.SubscriptionStatusTrialing}, nil)
 
 	originalBackend := stripeapi.GetBackend(stripeapi.APIBackend)
@@ -219,6 +261,34 @@ func TestAdminRevokeTrial_FindsTrialOnNonFirstOrg(t *testing.T) {
 		Cfg:    cfg,
 		Stripe: helixstripe.NewStripe(cfg.Stripe, db),
 	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/target/trial-activate", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "target"})
+	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin", Admin: true}))
+
+	resp, err := s.adminRevokeTrial(httptest.NewRecorder(), req)
+	require.NoError(t, err)
+	require.Equal(t, "cancelled", resp.Status)
+	require.Equal(t, "org-b", resp.OrgID)
+}
+
+func TestAdminRevokeTrial_ContinuesAfterWalletReadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := store.NewMockStore(ctrl)
+	oldOrg := &types.Organization{ID: "org-a", CreatedAt: time.Unix(1000, 0)}
+	laterOrg := &types.Organization{ID: "org-b", CreatedAt: time.Unix(2000, 0)}
+
+	db.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target"}).Return(&types.User{ID: "target"}, nil)
+	db.EXPECT().ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target"}).Return([]*types.Organization{oldOrg, laterOrg}, nil)
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-a").Return(nil, fmt.Errorf("read failed"))
+	db.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(&types.Wallet{StripeSubscriptionID: "sub-b", SubscriptionStatus: stripeapi.SubscriptionStatusTrialing}, nil)
+
+	originalBackend := stripeapi.GetBackend(stripeapi.APIBackend)
+	stripeapi.SetBackend(stripeapi.APIBackend, &adminTrialStripeBackend{t: t})
+	t.Cleanup(func() { stripeapi.SetBackend(stripeapi.APIBackend, originalBackend) })
+	cfg := cloudBillingCfg()
+	cfg.Stripe.SecretKey = "sk_test"
+	cfg.Stripe.WebhookSigningSecret = "whsec_test"
+	s := &HelixAPIServer{Store: db, Cfg: cfg, Stripe: helixstripe.NewStripe(cfg.Stripe, db)}
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/target/trial-activate", nil)
 	req = mux.SetURLVars(req, map[string]string{"id": "target"})
 	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin", Admin: true}))

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -1099,7 +1099,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
+                "description": "Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],
@@ -1119,7 +1119,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Trial parameters (days, credits)",
+                        "description": "Trial parameters and org_id (required iff the user owns an organisation)",
                         "name": "request",
                         "in": "body",
                         "schema": {
@@ -1142,7 +1142,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],
@@ -25293,6 +25293,9 @@ const docTemplate = `{
                 },
                 "days": {
                     "type": "integer"
+                },
+                "org_id": {
+                    "type": "string"
                 },
                 "plan": {
                     "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -1142,7 +1142,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -1197,10 +1197,11 @@ func (apiServer *HelixAPIServer) adminApproveUser(_ http.ResponseWriter, req *ht
 		trialDays = *targetUser.TrialDaysOnFirstOrg
 	}
 	notifyErr := apiServer.Controller.Options.Notifier.Notify(ctx, &types.Notification{
-		Event:     types.EventWaitlistApproved,
-		Email:     targetUser.Email,
-		FirstName: firstName,
-		TrialDays: trialDays,
+		Event:        types.EventWaitlistApproved,
+		Email:        targetUser.Email,
+		FirstName:    firstName,
+		TrialDays:    trialDays,
+		TrialPending: trialDays > 0,
 	})
 	if notifyErr != nil {
 		log.Error().

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -1095,7 +1095,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
+                "description": "Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],
@@ -1115,7 +1115,7 @@
                         "required": true
                     },
                     {
-                        "description": "Trial parameters (days, credits)",
+                        "description": "Trial parameters and org_id (required iff the user owns an organisation)",
                         "name": "request",
                         "in": "body",
                         "schema": {
@@ -1138,7 +1138,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],
@@ -25289,6 +25289,9 @@
                 },
                 "days": {
                     "type": "integer"
+                },
+                "org_id": {
+                    "type": "string"
                 },
                 "plan": {
                     "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -1138,7 +1138,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -14639,9 +14639,10 @@ paths:
       - users
   /api/v1/admin/users/{id}/trial-activate:
     delete:
-      description: Clears any stashed trial intent on the user and cancels a trialing
-        Stripe subscription on an owned org. Paid (active) subscriptions are never
-        cancelled.
+      description: Clears any stashed trial intent on the user and cancels the trialing
+        Stripe subscription on the oldest owned org whose readable wallet is trialing.
+        At most one subscription is cancelled per call. Paid (active) subscriptions
+        are never cancelled.
       parameters:
       - description: User ID
         in: path

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1696,6 +1696,8 @@ definitions:
         type: number
       days:
         type: integer
+      org_id:
+        type: string
       plan:
         description: |-
           Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
@@ -14637,9 +14639,9 @@ paths:
       - users
   /api/v1/admin/users/{id}/trial-activate:
     delete:
-      description: Clears any stashed trial intent on the user and cancels the Stripe
-        subscription on the user's oldest owned org if it is currently in a trialing
-        state. Paid (active) subscriptions are never cancelled.
+      description: Clears any stashed trial intent on the user and cancels a trialing
+        Stripe subscription on an owned org. Paid (active) subscriptions are never
+        cancelled.
       parameters:
       - description: User ID
         in: path
@@ -14661,9 +14663,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Stash a trial intent on the user, or immediately create a Stripe
-        trial subscription on the user's oldest-owned org. Days defaults to 90; credits
-        are taken verbatim from the request (0 means no admin top-up beyond what Stripe's
+      description: Stash a trial intent when the user owns no organisations, or activate
+        the explicitly selected owned organisation. Days defaults to 90; credits are
+        taken verbatim from the request (0 means no admin top-up beyond what Stripe's
         subscription invoice contributes).
       parameters:
       - description: User ID
@@ -14671,7 +14673,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: Trial parameters (days, credits)
+      - description: Trial parameters and org_id (required iff the user owns an organisation)
         in: body
         name: request
         schema:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1118,6 +1118,7 @@ export interface OpenaiViolence {
 export interface ServerActivateTrialRequest {
   credits?: number;
   days?: number;
+  org_id?: string;
   /**
    * Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
    * (no Stripe subscription) — for customers who paid out-of-band (bank
@@ -9401,7 +9402,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.
+     * @description Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.
      *
      * @tags users
      * @name V1AdminUsersTrialActivateDelete
@@ -9419,7 +9420,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
+     * @description Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
      *
      * @tags users
      * @name V1AdminUsersTrialActivateCreate

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -9402,7 +9402,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.
+     * @description Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.
      *
      * @tags users
      * @name V1AdminUsersTrialActivateDelete

--- a/frontend/src/components/dashboard/ActivateTrialDialog.test.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ActivateTrialDialog from './ActivateTrialDialog';
+
+const mocks = vi.hoisted(() => ({
+    ownedOrgs: [] as Array<{ id: string; name: string; display_name?: string }>,
+    mutateAsync: vi.fn(),
+}));
+
+vi.mock('../../services/dashboardService', () => ({
+    useAdminActivateTrial: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+    useAdminUserOwnedOrgs: () => ({ data: mocks.ownedOrgs, isLoading: false }),
+}));
+
+vi.mock('../../hooks/useSnackbar', () => ({
+    default: () => ({ success: vi.fn() }),
+}));
+
+const user = { id: 'user-1', email: 'user@example.com' };
+
+describe('ActivateTrialDialog', () => {
+    beforeEach(() => {
+        mocks.ownedOrgs = [];
+        mocks.mutateAsync.mockReset().mockResolvedValue({ status: 'applied' });
+    });
+
+    it('keeps a manual org selection when owned org data refetches', async () => {
+        mocks.ownedOrgs = [
+            { id: 'org-a', name: 'Alpha' },
+            { id: 'org-b', name: 'Beta' },
+        ];
+        const { rerender } = render(<ActivateTrialDialog open onClose={vi.fn()} user={user} />);
+
+        fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Organisation' }));
+        fireEvent.click(screen.getByRole('option', { name: 'Beta (org-b)' }));
+
+        mocks.ownedOrgs = [
+            { id: 'org-c', name: 'Gamma' },
+            { id: 'org-b', name: 'Beta' },
+            { id: 'org-a', name: 'Alpha' },
+        ];
+        rerender(<ActivateTrialDialog open onClose={vi.fn()} user={user} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Activate trial' }));
+
+        await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org-b' })));
+    });
+
+    it('submits the sole owned org by default', async () => {
+        mocks.ownedOrgs = [{ id: 'org-a', name: 'Alpha' }];
+        render(<ActivateTrialDialog open onClose={vi.fn()} user={user} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Activate trial' }));
+
+        await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org-a' })));
+    });
+});

--- a/frontend/src/components/dashboard/ActivateTrialDialog.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.tsx
@@ -44,20 +44,18 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
     const activateTrial = useAdminActivateTrial();
     const snackbar = useSnackbar();
     const { data: ownedOrgs, isLoading: isLoadingOrgs } = useAdminUserOwnedOrgs(user?.id, open);
+    const soleOwnedOrgId = ownedOrgs?.length === 1 ? ownedOrgs[0].id : '';
+    const effectiveOrgId = orgId || soleOwnedOrgId;
 
     useEffect(() => {
         if (open) {
             setDays(String(DEFAULT_DAYS));
             setCredits(String(DEFAULT_CREDITS));
+            setOrgId('');
             setPlan('');
             setError('');
         }
-    }, [open]);
-
-    useEffect(() => {
-        if (!ownedOrgs) return;
-        setOrgId(ownedOrgs.length === 1 ? ownedOrgs[0].id : '');
-    }, [ownedOrgs]);
+    }, [open, user?.id]);
 
     const hasOrgs = (ownedOrgs?.length ?? 0) > 0;
 
@@ -74,14 +72,14 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
             setError('Credits must be zero or positive');
             return;
         }
-        if (hasOrgs && !orgId) {
+        if (hasOrgs && !effectiveOrgId) {
             setError('Pick which organisation to activate');
             return;
         }
         try {
             const result = await activateTrial.mutateAsync({
                 userId: user.id,
-                orgId: hasOrgs ? orgId : undefined,
+                orgId: hasOrgs ? effectiveOrgId : undefined,
                 days: isPaid ? 0 : daysNum,
                 credits: creditsNum,
                 plan,
@@ -136,7 +134,7 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                             <Select
                                 labelId="activate-trial-org-label"
                                 label="Organisation"
-                                value={orgId}
+                                value={effectiveOrgId}
                                 onChange={(e) => setOrgId(e.target.value as string)}
                             >
                                 {ownedOrgs!.map((org) => (
@@ -201,7 +199,7 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                     onClick={handleSubmit}
                     color="secondary"
                     variant="contained"
-                    disabled={activateTrial.isPending || isLoadingOrgs || (hasOrgs && !orgId)}
+                    disabled={activateTrial.isPending || isLoadingOrgs || (hasOrgs && !effectiveOrgId)}
                     startIcon={activateTrial.isPending ? <CircularProgress size={20} /> : null}
                 >
                     {activateTrial.isPending ? 'Activating…' : plan === 'pro' ? 'Activate paid plan' : 'Activate trial'}

--- a/frontend/src/components/dashboard/ActivateTrialDialog.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.tsx
@@ -11,11 +11,14 @@ import {
     CircularProgress,
     IconButton,
     Typography,
+    FormControl,
+    InputLabel,
+    Select,
     MenuItem,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { TypesUser } from '../../api/api';
-import { useAdminActivateTrial } from '../../services/dashboardService';
+import { useAdminActivateTrial, useAdminUserOwnedOrgs } from '../../services/dashboardService';
 import useSnackbar from '../../hooks/useSnackbar';
 
 interface ActivateTrialDialogProps {
@@ -34,11 +37,13 @@ const DEFAULT_CREDITS = 0;
 const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user }) => {
     const [days, setDays] = useState(String(DEFAULT_DAYS));
     const [credits, setCredits] = useState(String(DEFAULT_CREDITS));
+    const [orgId, setOrgId] = useState('');
     // '' = Stripe trial (uses days); 'pro' = paid plan via PlanOverride (no Stripe).
     const [plan, setPlan] = useState('');
     const [error, setError] = useState('');
     const activateTrial = useAdminActivateTrial();
     const snackbar = useSnackbar();
+    const { data: ownedOrgs, isLoading: isLoadingOrgs } = useAdminUserOwnedOrgs(user?.id, open);
 
     useEffect(() => {
         if (open) {
@@ -48,6 +53,13 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
             setError('');
         }
     }, [open]);
+
+    useEffect(() => {
+        if (!ownedOrgs) return;
+        setOrgId(ownedOrgs.length === 1 ? ownedOrgs[0].id : '');
+    }, [ownedOrgs]);
+
+    const hasOrgs = (ownedOrgs?.length ?? 0) > 0;
 
     const handleSubmit = async () => {
         if (!user?.id) return;
@@ -62,9 +74,14 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
             setError('Credits must be zero or positive');
             return;
         }
+        if (hasOrgs && !orgId) {
+            setError('Pick which organisation to activate');
+            return;
+        }
         try {
             const result = await activateTrial.mutateAsync({
                 userId: user.id,
+                orgId: hasOrgs ? orgId : undefined,
                 days: isPaid ? 0 : daysNum,
                 credits: creditsNum,
                 plan,
@@ -98,7 +115,7 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                 }}
             >
                 <Typography variant="h6" component="div">
-                    Activate
+                    Activate trial or plan
                 </Typography>
                 <IconButton aria-label="close" onClick={handleClose} disabled={activateTrial.isPending}>
                     <CloseIcon />
@@ -108,10 +125,27 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                 <Box sx={{ mt: 2 }}>
                     {user && (
                         <Alert severity="info" sx={{ mb: 2 }}>
-                            Granting trial to <strong>{user.email || user.username}</strong>. If the user has no
-                            organization yet, the trial is parked on the user and applied when they create their
-                            first org. Otherwise it is applied to their oldest owned org immediately.
+                            This approves <strong>{user.email || user.username}</strong> and applies the selected
+                            trial or plan. If they own no organisation yet, it is applied to their first one.
                         </Alert>
+                    )}
+
+                    {hasOrgs && (
+                        <FormControl fullWidth margin="normal" disabled={activateTrial.isPending}>
+                            <InputLabel id="activate-trial-org-label">Organisation</InputLabel>
+                            <Select
+                                labelId="activate-trial-org-label"
+                                label="Organisation"
+                                value={orgId}
+                                onChange={(e) => setOrgId(e.target.value as string)}
+                            >
+                                {ownedOrgs!.map((org) => (
+                                    <MenuItem key={org.id} value={org.id}>
+                                        {org.display_name || org.name} ({org.id})
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
                     )}
 
                     {error && (
@@ -167,10 +201,10 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                     onClick={handleSubmit}
                     color="secondary"
                     variant="contained"
-                    disabled={activateTrial.isPending}
+                    disabled={activateTrial.isPending || isLoadingOrgs || (hasOrgs && !orgId)}
                     startIcon={activateTrial.isPending ? <CircularProgress size={20} /> : null}
                 >
-                    {activateTrial.isPending ? 'Activating…' : 'Activate'}
+                    {activateTrial.isPending ? 'Activating…' : plan === 'pro' ? 'Activate paid plan' : 'Activate trial'}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/dashboard/GrantCreditsDialog.tsx
+++ b/frontend/src/components/dashboard/GrantCreditsDialog.tsx
@@ -109,7 +109,7 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
                 }}
             >
                 <Typography variant="h6" component="div">
-                    Grant credits
+                    Give them credits
                 </Typography>
                 <IconButton aria-label="close" onClick={handleClose} disabled={grantCredits.isPending}>
                     <CloseIcon />
@@ -177,7 +177,7 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
                     disabled={submitDisabled}
                     startIcon={grantCredits.isPending ? <CircularProgress size={20} /> : null}
                 >
-                    {grantCredits.isPending ? 'Granting…' : 'Grant credits'}
+                    {grantCredits.isPending ? 'Granting…' : 'Give credits'}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/dashboard/UsersTable.tsx
+++ b/frontend/src/components/dashboard/UsersTable.tsx
@@ -468,7 +468,7 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
                 {isCloud && !trialActiveOrStashed(menuUser) && (
                     <MenuItem onClick={handleActivateTrial}>
                         <ListItemIcon><CardGiftcardIcon fontSize="small" /></ListItemIcon>
-                        <ListItemText>Activate</ListItemText>
+                        <ListItemText>Activate trial</ListItemText>
                     </MenuItem>
                 )}
                 {isCloud && trialActiveOrStashed(menuUser) && (
@@ -480,7 +480,7 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
                 {isCloud && (
                     <MenuItem onClick={handleGrantCredits}>
                         <ListItemIcon><AttachMoneyIcon fontSize="small" /></ListItemIcon>
-                        <ListItemText>Grant credits</ListItemText>
+                        <ListItemText>Give them credits</ListItemText>
                     </MenuItem>
                 )}
                 <MenuItem onClick={handleResetPassword}>

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -247,6 +247,7 @@ export function useAdminDeleteUser() {
 
 export interface ActivateTrialInput {
     userId: string;
+    orgId?: string;
     days?: number;
     credits?: number;
     // plan "pro" grants a PAID plan via a PlanOverride (no Stripe subscription)
@@ -296,7 +297,7 @@ export function useAdminUserOwnedOrgs(userId: string | undefined, enabled: boole
  * Hook to activate a trial on a user (cloud edition, admin only).
  * If the user has no orgs yet, the intent is stashed and applied when they
  * create their first org. Otherwise the Stripe trial subscription is created
- * on the user's oldest owned org wallet immediately.
+ * on the explicitly selected owned org wallet immediately.
  */
 export function useAdminActivateTrial() {
     const api = useApi();
@@ -308,6 +309,7 @@ export function useAdminActivateTrial() {
             const response = await apiClient.v1AdminUsersTrialActivateCreate(input.userId, {
                 days: input.days ?? 0,
                 credits: input.credits ?? 0,
+                org_id: input.orgId,
                 plan: input.plan ?? "",
             });
             return response.data;

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -14639,9 +14639,10 @@ paths:
       - users
   /api/v1/admin/users/{id}/trial-activate:
     delete:
-      description: Clears any stashed trial intent on the user and cancels a trialing
-        Stripe subscription on an owned org. Paid (active) subscriptions are never
-        cancelled.
+      description: Clears any stashed trial intent on the user and cancels the trialing
+        Stripe subscription on the oldest owned org whose readable wallet is trialing.
+        At most one subscription is cancelled per call. Paid (active) subscriptions
+        are never cancelled.
       parameters:
       - description: User ID
         in: path

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1696,6 +1696,8 @@ definitions:
         type: number
       days:
         type: integer
+      org_id:
+        type: string
       plan:
         description: |-
           Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
@@ -14637,9 +14639,9 @@ paths:
       - users
   /api/v1/admin/users/{id}/trial-activate:
     delete:
-      description: Clears any stashed trial intent on the user and cancels the Stripe
-        subscription on the user's oldest owned org if it is currently in a trialing
-        state. Paid (active) subscriptions are never cancelled.
+      description: Clears any stashed trial intent on the user and cancels a trialing
+        Stripe subscription on an owned org. Paid (active) subscriptions are never
+        cancelled.
       parameters:
       - description: User ID
         in: path
@@ -14661,9 +14663,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Stash a trial intent on the user, or immediately create a Stripe
-        trial subscription on the user's oldest-owned org. Days defaults to 90; credits
-        are taken verbatim from the request (0 means no admin top-up beyond what Stripe's
+      description: Stash a trial intent when the user owns no organisations, or activate
+        the explicitly selected owned organisation. Days defaults to 90; credits are
+        taken verbatim from the request (0 means no admin top-up beyond what Stripe's
         subscription invoice contributes).
       parameters:
       - description: User ID
@@ -14671,7 +14673,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: Trial parameters (days, credits)
+      - description: Trial parameters and org_id (required iff the user owns an organisation)
         in: body
         name: request
         schema:

--- a/openapi.json
+++ b/openapi.json
@@ -1348,7 +1348,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.",
                 "tags": [
                     "users"
                 ],

--- a/openapi.json
+++ b/openapi.json
@@ -1303,7 +1303,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
+                "description": "Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "tags": [
                     "users"
                 ],
@@ -1327,7 +1327,7 @@
                             }
                         }
                     },
-                    "description": "Trial parameters (days, credits)"
+                    "description": "Trial parameters and org_id (required iff the user owns an organisation)"
                 },
                 "responses": {
                     "200": {
@@ -1348,7 +1348,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
                 "tags": [
                     "users"
                 ],
@@ -29757,6 +29757,9 @@
                     },
                     "days": {
                         "type": "integer"
+                    },
+                    "org_id": {
+                        "type": "string"
                     },
                     "plan": {
                         "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",

--- a/swagger.json
+++ b/swagger.json
@@ -1095,7 +1095,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
+                "description": "Stash a trial intent when the user owns no organisations, or activate the explicitly selected owned organisation. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],
@@ -1115,7 +1115,7 @@
                         "required": true
                     },
                     {
-                        "description": "Trial parameters (days, credits)",
+                        "description": "Trial parameters and org_id (required iff the user owns an organisation)",
                         "name": "request",
                         "in": "body",
                         "schema": {
@@ -1138,7 +1138,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels the Stripe subscription on the user's oldest owned org if it is currently in a trialing state. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],
@@ -25289,6 +25289,9 @@
                 },
                 "days": {
                     "type": "integer"
+                },
+                "org_id": {
+                    "type": "string"
                 },
                 "plan": {
                     "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",

--- a/swagger.json
+++ b/swagger.json
@@ -1138,7 +1138,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Clears any stashed trial intent on the user and cancels a trialing Stripe subscription on an owned org. Paid (active) subscriptions are never cancelled.",
+                "description": "Clears any stashed trial intent on the user and cancels the trialing Stripe subscription on the oldest owned org whose readable wallet is trialing. At most one subscription is cancelled per call. Paid (active) subscriptions are never cancelled.",
                 "produces": [
                     "application/json"
                 ],


### PR DESCRIPTION
## Summary
- let admins select the owned organization that receives a trial or paid plan
- approve waitlisted users when activating a trial while keeping approval and credit grants independent
- preserve first-organization stashing for users without an organization
- find and revoke trials on non-first organizations
- keep approval email copy accurate for stashed trials

## Testing
- `go test ./pkg/server -run 'Test(AdminActivateTrial|AdminGrantCredits_NoOrg_StashesOnUser|SendActivationEmail|EnrichUserTrialDisplay|AdminRevokeTrial)' -count=1`\n- `go test ./pkg/notification -count=1`\n- `go build ./...`\n- `git diff --check`\n\n## Known unrelated issue\n- `npm run build` reaches the pre-existing `WorkspaceReviewMessage.ts` / `workspaceReviewMessage.ts` filename case collision after transforming 22,341 modules