### PR TITLE
fix(onboarding): preserve payment and provider handoff

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -25697,6 +25697,9 @@ const docTemplate = `{
                 },
                 "org_id": {
                     "type": "string"
+                },
+                "return_url": {
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -25693,6 +25693,9 @@
                 },
                 "org_id": {
                     "type": "string"
+                },
+                "return_url": {
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1985,6 +1985,8 @@ definitions:
         type: number
       org_id:
         type: string
+      return_url:
+        type: string
     type: object
   server.DeployWebServiceRequest:
     properties:

--- a/api/pkg/server/wallet_handlers.go
+++ b/api/pkg/server/wallet_handlers.go
@@ -132,8 +132,9 @@ func (s *HelixAPIServer) getOrCreateWallet(ctx context.Context, user *types.User
 }
 
 type CreateTopUpRequest struct {
-	Amount float64 `json:"amount"`
-	OrgID  string  `json:"org_id"`
+	Amount    float64 `json:"amount"`
+	OrgID     string  `json:"org_id"`
+	ReturnURL string  `json:"return_url"`
 }
 
 // createTopUp godoc
@@ -157,6 +158,12 @@ func (s *HelixAPIServer) createTopUp(_ http.ResponseWriter, req *http.Request) (
 	if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
 		return "", fmt.Errorf("failed to decode request body: %w", err)
 	}
+	if _, err := stripe.ValidateCheckoutReturnURL(requestBody.ReturnURL); err != nil {
+		return "", err
+	}
+	if requestBody.Amount <= 0 {
+		return "", fmt.Errorf("amount must be greater than 0")
+	}
 
 	if requestBody.OrgID != "" {
 		org, err := s.lookupOrg(req.Context(), requestBody.OrgID)
@@ -172,11 +179,6 @@ func (s *HelixAPIServer) createTopUp(_ http.ResponseWriter, req *http.Request) (
 		requestBody.OrgID = org.ID
 	}
 
-	// Validate amount
-	if requestBody.Amount <= 0 {
-		return "", fmt.Errorf("amount must be greater than 0")
-	}
-
 	// Get wallet
 	wallet, err := s.getOrCreateWallet(req.Context(), user, requestBody.OrgID)
 	if err != nil {
@@ -188,6 +190,7 @@ func (s *HelixAPIServer) createTopUp(_ http.ResponseWriter, req *http.Request) (
 		OrgID:            requestBody.OrgID,
 		UserID:           user.ID,
 		Amount:           requestBody.Amount,
+		ReturnURL:        requestBody.ReturnURL,
 	}
 
 	if requestBody.OrgID != "" {
@@ -251,6 +254,9 @@ func (s *HelixAPIServer) subscriptionCreate(_ http.ResponseWriter, req *http.Req
 	var orgName string
 	orgID := req.URL.Query().Get("org_id")
 	returnURL := req.URL.Query().Get("return_url")
+	if _, err := stripe.ValidateCheckoutReturnURL(returnURL); err != nil {
+		return "", err
+	}
 
 	if orgID != "" {
 		org, err := s.lookupOrg(req.Context(), orgID)

--- a/api/pkg/server/wallet_handlers.go
+++ b/api/pkg/server/wallet_handlers.go
@@ -161,8 +161,8 @@ func (s *HelixAPIServer) createTopUp(_ http.ResponseWriter, req *http.Request) (
 	if _, err := stripe.ValidateCheckoutReturnURL(requestBody.ReturnURL); err != nil {
 		return "", err
 	}
-	if requestBody.Amount <= 0 {
-		return "", fmt.Errorf("amount must be greater than 0")
+	if requestBody.Amount < 0.50 || requestBody.Amount > 999999.99 {
+		return "", fmt.Errorf("amount must be between $0.50 and $999,999.99")
 	}
 
 	if requestBody.OrgID != "" {

--- a/api/pkg/server/wallet_handlers_test.go
+++ b/api/pkg/server/wallet_handlers_test.go
@@ -76,6 +76,29 @@ func TestCreateTopUpAcceptsArbitraryPositiveAmount(t *testing.T) {
 	}
 }
 
+func TestCreateTopUpRejectsStripeAmountBoundsBeforeStoreCalls(t *testing.T) {
+	for _, amount := range []string{"0.49", "1000000"} {
+		t.Run(amount, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := store.NewMockStore(ctrl)
+			cfg := &config.ServerConfig{}
+			cfg.Stripe.BillingEnabled = true
+			server := &HelixAPIServer{Cfg: cfg, Store: mockStore}
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/v1/top-ups/new",
+				bytes.NewBufferString(`{"amount":`+amount+`,"org_id":"org_1"}`),
+			)
+			req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "usr_1"}))
+
+			_, err := server.createTopUp(httptest.NewRecorder(), req)
+			if err == nil || !strings.Contains(err.Error(), "amount must be between") {
+				t.Fatalf("expected amount %s to be rejected before store calls, got %v", amount, err)
+			}
+		})
+	}
+}
+
 type LookupOrgSuite struct {
 	suite.Suite
 

--- a/api/pkg/server/wallet_handlers_test.go
+++ b/api/pkg/server/wallet_handlers_test.go
@@ -1,19 +1,80 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/store"
+	helixstripe "github.com/helixml/helix/api/pkg/stripe"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
+
+func TestCheckoutHandlersRejectUnsafeReturnURLBeforeWalletLookup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	cfg := &config.ServerConfig{}
+	cfg.Stripe.BillingEnabled = true
+	cfg.Stripe.SecretKey = "sk_test"
+	cfg.Stripe.WebhookSigningSecret = "whsec_test"
+	server := &HelixAPIServer{
+		Cfg:    cfg,
+		Store:  mockStore,
+		Stripe: helixstripe.NewStripe(cfg.Stripe, mockStore),
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/top-ups/new",
+		bytes.NewBufferString(`{"amount":10,"return_url":"//evil.example"}`),
+	)
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "usr_1"}))
+
+	_, err := server.createTopUp(httptest.NewRecorder(), req)
+	if err == nil {
+		t.Fatal("expected unsafe return URL to be rejected")
+	}
+
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/subscription/new?return_url=%2F%2Fevil.example",
+		nil,
+	)
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "usr_1"}))
+	_, err = server.subscriptionCreate(httptest.NewRecorder(), req)
+	if err == nil {
+		t.Fatal("expected unsafe subscription return URL to be rejected")
+	}
+}
+
+func TestCreateTopUpAcceptsArbitraryPositiveAmount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().
+		GetWalletByUser(gomock.Any(), "usr_1").
+		Return(nil, errors.New("stop before Stripe"))
+	cfg := &config.ServerConfig{}
+	cfg.Stripe.BillingEnabled = true
+	server := &HelixAPIServer{Cfg: cfg, Store: mockStore}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/top-ups/new",
+		bytes.NewBufferString(`{"amount":7,"return_url":"/onboarding"}`),
+	)
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "usr_1"}))
+
+	_, err := server.createTopUp(httptest.NewRecorder(), req)
+	if err == nil || !strings.Contains(err.Error(), "stop before Stripe") {
+		t.Fatalf("expected amount 7 to pass validation and reach wallet lookup, got %v", err)
+	}
+}
 
 type LookupOrgSuite struct {
 	suite.Suite

--- a/api/pkg/stripe/stripe_checkout_urls.go
+++ b/api/pkg/stripe/stripe_checkout_urls.go
@@ -14,6 +14,11 @@ func checkoutReturnURLs(appURL, returnURL, defaultSuccessURL, defaultCancelURL s
 	if err != nil {
 		return "", "", err
 	}
+	query := parsed.Query()
+	query.Del("success")
+	query.Del("canceled")
+	query.Del("session_id")
+	parsed.RawQuery = query.Encode()
 
 	success := *parsed
 	success.RawQuery = appendRawQuery(success.RawQuery, "success=true&session_id={CHECKOUT_SESSION_ID}")

--- a/api/pkg/stripe/stripe_checkout_urls.go
+++ b/api/pkg/stripe/stripe_checkout_urls.go
@@ -1,0 +1,48 @@
+package stripe
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func checkoutReturnURLs(appURL, returnURL, defaultSuccessURL, defaultCancelURL string) (string, string, error) {
+	if returnURL == "" {
+		return defaultSuccessURL, defaultCancelURL, nil
+	}
+	parsed, err := ValidateCheckoutReturnURL(returnURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	success := *parsed
+	success.RawQuery = appendRawQuery(success.RawQuery, "success=true&session_id={CHECKOUT_SESSION_ID}")
+	canceled := *parsed
+	canceled.RawQuery = appendRawQuery(canceled.RawQuery, "canceled=true")
+
+	return appURL + success.String(), appURL + canceled.String(), nil
+}
+
+func ValidateCheckoutReturnURL(returnURL string) (*url.URL, error) {
+	if returnURL == "" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(returnURL, "/") ||
+		strings.HasPrefix(returnURL, "//") ||
+		strings.ContainsAny(returnURL, `\#`) {
+		return nil, fmt.Errorf("return URL must be an app-relative path")
+	}
+
+	parsed, err := url.ParseRequestURI(returnURL)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("return URL must be an app-relative path")
+	}
+	return parsed, nil
+}
+
+func appendRawQuery(existing, added string) string {
+	if existing == "" {
+		return added
+	}
+	return existing + "&" + added
+}

--- a/api/pkg/stripe/stripe_checkout_urls_test.go
+++ b/api/pkg/stripe/stripe_checkout_urls_test.go
@@ -9,17 +9,17 @@ import (
 func TestCheckoutReturnURLsPreserveQuery(t *testing.T) {
 	success, canceled, err := checkoutReturnURLs(
 		"https://app.helix.ml",
-		"/onboarding?org_id=org_1&created_org=true&step=provider",
+		"/onboarding?org_id=org_1&created_org=true&step=provider&success=false&canceled=true&session_id=caller",
 		"unused",
 		"unused",
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if success != "https://app.helix.ml/onboarding?org_id=org_1&created_org=true&step=provider&success=true&session_id={CHECKOUT_SESSION_ID}" {
+	if success != "https://app.helix.ml/onboarding?created_org=true&org_id=org_1&step=provider&success=true&session_id={CHECKOUT_SESSION_ID}" {
 		t.Fatalf("unexpected success URL: %s", success)
 	}
-	if canceled != "https://app.helix.ml/onboarding?org_id=org_1&created_org=true&step=provider&canceled=true" {
+	if canceled != "https://app.helix.ml/onboarding?created_org=true&org_id=org_1&step=provider&canceled=true" {
 		t.Fatalf("unexpected cancel URL: %s", canceled)
 	}
 }

--- a/api/pkg/stripe/stripe_checkout_urls_test.go
+++ b/api/pkg/stripe/stripe_checkout_urls_test.go
@@ -1,0 +1,57 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+)
+
+func TestCheckoutReturnURLsPreserveQuery(t *testing.T) {
+	success, canceled, err := checkoutReturnURLs(
+		"https://app.helix.ml",
+		"/onboarding?org_id=org_1&created_org=true&step=provider",
+		"unused",
+		"unused",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if success != "https://app.helix.ml/onboarding?org_id=org_1&created_org=true&step=provider&success=true&session_id={CHECKOUT_SESSION_ID}" {
+		t.Fatalf("unexpected success URL: %s", success)
+	}
+	if canceled != "https://app.helix.ml/onboarding?org_id=org_1&created_org=true&step=provider&canceled=true" {
+		t.Fatalf("unexpected cancel URL: %s", canceled)
+	}
+}
+
+func TestCheckoutReturnURLsRejectUnsafePaths(t *testing.T) {
+	for _, returnURL := range []string{
+		"https://evil.example/onboarding",
+		"//evil.example/onboarding",
+		`/\evil.example/onboarding`,
+		"onboarding",
+		"/%zz",
+		"/onboarding#success-hidden",
+	} {
+		t.Run(returnURL, func(t *testing.T) {
+			_, _, err := checkoutReturnURLs("https://app.helix.ml", returnURL, "unused", "unused")
+			if err == nil {
+				t.Fatalf("expected %q to be rejected", returnURL)
+			}
+		})
+	}
+}
+
+func TestCheckoutFlowsRejectUnsafeReturnURL(t *testing.T) {
+	client := NewStripe(config.Stripe{
+		SecretKey:            "sk_test",
+		WebhookSigningSecret: "whsec_test",
+	}, nil)
+
+	if _, err := client.GetTopUpSessionURL(TopUpSessionParams{ReturnURL: "//evil.example"}); err == nil {
+		t.Fatal("top-up checkout accepted an unsafe return URL")
+	}
+	if _, err := client.GetCheckoutSessionURL(SubscriptionSessionParams{ReturnURL: "//evil.example"}); err == nil {
+		t.Fatal("subscription checkout accepted an unsafe return URL")
+	}
+}

--- a/api/pkg/stripe/stripe_subscriptions.go
+++ b/api/pkg/stripe/stripe_subscriptions.go
@@ -33,6 +33,22 @@ func (s *Stripe) GetCheckoutSessionURL(
 		return "", err
 	}
 
+	defaultSuccessURL := s.cfg.AppURL + "/account?success=true&session_id={CHECKOUT_SESSION_ID}"
+	defaultCancelURL := s.cfg.AppURL + "/account?canceled=true"
+	if params.OrgID != "" {
+		defaultSuccessURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?success=true&session_id={CHECKOUT_SESSION_ID}"
+		defaultCancelURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?canceled=true"
+	}
+	successURL, cancelURL, err := checkoutReturnURLs(
+		s.cfg.AppURL,
+		params.ReturnURL,
+		defaultSuccessURL,
+		defaultCancelURL,
+	)
+	if err != nil {
+		return "", err
+	}
+
 	priceLookupKey := s.cfg.PriceLookupKey
 	if params.OrgID != "" {
 		priceLookupKey = s.cfg.OrgPriceLookupKey
@@ -50,24 +66,6 @@ func (s *Stripe) GetCheckoutSessionURL(
 	}
 	if price == nil {
 		return "", fmt.Errorf("price not found")
-	}
-
-	var successURL, cancelURL string
-	if params.ReturnURL != "" {
-		// Use custom return URL if provided
-		successURL = s.cfg.AppURL + params.ReturnURL + "?success=true&session_id={CHECKOUT_SESSION_ID}"
-		cancelURL = s.cfg.AppURL + params.ReturnURL + "?canceled=true"
-	} else {
-		// Use default return URLs
-		successURL = s.cfg.AppURL + "/account?success=true&session_id={CHECKOUT_SESSION_ID}"
-		if params.OrgID != "" {
-			successURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?success=true&session_id={CHECKOUT_SESSION_ID}"
-		}
-
-		cancelURL = s.cfg.AppURL + "/account?canceled=true"
-		if params.OrgID != "" {
-			cancelURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?canceled=true"
-		}
 	}
 
 	checkoutParams := &stripe.CheckoutSessionParams{

--- a/api/pkg/stripe/stripe_topups.go
+++ b/api/pkg/stripe/stripe_topups.go
@@ -29,6 +29,7 @@ type TopUpSessionParams struct {
 	OrgName          string // Used for redirect URL (for example 'acme-org' for 'orgs/acme-org/billing')
 	UserID           string
 	Amount           float64
+	ReturnURL        string
 }
 
 func (s *Stripe) GetTopUpSessionURL(
@@ -43,14 +44,23 @@ func (s *Stripe) GetTopUpSessionURL(
 	amountInCents := int64(math.Round(params.Amount * 100))
 	metadata := topUpMetadata(params.UserID, params.OrgID, amountInCents)
 
-	successURL := s.cfg.AppURL + "/account?success=true&session_id={CHECKOUT_SESSION_ID}"
+	defaultSuccessURL := s.cfg.AppURL + "/account?success=true&session_id={CHECKOUT_SESSION_ID}"
 	if params.OrgID != "" {
-		successURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?success=true&session_id={CHECKOUT_SESSION_ID}"
+		defaultSuccessURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?success=true&session_id={CHECKOUT_SESSION_ID}"
 	}
 
-	cancelURL := s.cfg.AppURL + "/account?canceled=true"
+	defaultCancelURL := s.cfg.AppURL + "/account?canceled=true"
 	if params.OrgID != "" {
-		cancelURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?canceled=true"
+		defaultCancelURL = s.cfg.AppURL + "/orgs/" + params.OrgName + "/billing?canceled=true"
+	}
+	successURL, cancelURL, err := checkoutReturnURLs(
+		s.cfg.AppURL,
+		params.ReturnURL,
+		defaultSuccessURL,
+		defaultCancelURL,
+	)
+	if err != nil {
+		return "", err
 	}
 
 	checkoutParams := &stripe.CheckoutSessionParams{

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1311,6 +1311,7 @@ export interface ServerConfigurePendingSessionRequest {
 export interface ServerCreateTopUpRequest {
   amount?: number;
   org_id?: string;
+  return_url?: string;
 }
 
 export interface ServerDeployWebServiceRequest {

--- a/frontend/src/components/orgs/OrgBilling.tsx
+++ b/frontend/src/components/orgs/OrgBilling.tsx
@@ -15,7 +15,7 @@ import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
-import { useGetWallet } from '../../services/useBilling'
+import { DEFAULT_TOP_UP_AMOUNT, TOP_UP_AMOUNTS, useGetWallet } from '../../services/useBilling'
 import { useGetOrgUsage } from '../../services/orgService'
 import TokenUsage from '../usage/TokenUsage'
 import TotalCost from '../usage/TotalCost'
@@ -58,7 +58,7 @@ const OrgBilling: FC = () => {
   const { data: usage } = useGetOrgUsage(orgId || '', { enabled: !!orgId })
   const usageMetrics = usage?.metrics || []
   
-  const [topUpAmount, setTopUpAmount] = useState<number>(10)
+  const [topUpAmount, setTopUpAmount] = useState<number>(DEFAULT_TOP_UP_AMOUNT)
   const [isSubscribing, setIsSubscribing] = useState<boolean>(false)
   const [isToppingUp, setIsToppingUp] = useState<boolean>(false)
 
@@ -198,13 +198,9 @@ const OrgBilling: FC = () => {
                               label="Amount"
                               onChange={(e) => setTopUpAmount(e.target.value as number)}
                             >
-                              <MenuItem value={5}>$5</MenuItem>
-                              <MenuItem value={10}>$10</MenuItem>
-                              <MenuItem value={20}>$20</MenuItem>
-                              <MenuItem value={50}>$50</MenuItem>
-                              <MenuItem value={100}>$100</MenuItem>
-                              <MenuItem value={500}>$500</MenuItem>
-                              <MenuItem value={1000}>$1000</MenuItem>
+                              {TOP_UP_AMOUNTS.map((amount) => (
+                                <MenuItem key={amount} value={amount}>${amount}</MenuItem>
+                              ))}
                             </Select>
                           </FormControl>
                           <Button 

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -510,14 +510,14 @@ describe('Onboarding', () => {
     window.history.replaceState(
       {},
       '',
-      '/onboarding?org_id=org-1&step=provider&success=true&session_id=cs_1',
+      '/onboarding?org_id=org-1&step=provider&created_org=true&success=true&session_id=cs_1',
     )
     renderOnboarding()
 
     await screen.findByText('Choose how to run coding agents')
     expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
     expect(mockRefetchWallet).toHaveBeenCalled()
-    expect(window.location.search).toBe('')
+    expect(window.location.search).toBe('?org_id=org-1&step=provider&created_org=true')
   })
 
   it('requires a non-owner to ask the owner before changing subscription policy', async () => {

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -4,11 +4,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Onboarding from './Onboarding'
 
 const mockNavigateReplace = vi.fn()
+const mockNavigate = vi.fn()
 const mockSnackbarError = vi.fn()
 const mockLoadOrganizations = vi.fn()
 const mockV1UsersMeOnboardingCreate = vi.fn()
 const mockV1OrgsSettingsUpdate = vi.fn()
 const mockV1SubscriptionNewCreate = vi.fn()
+const mockV1TopUpsNewCreate = vi.fn()
+const mockRefetchWallet = vi.fn()
 const mockCreateOrgMutateAsync = vi.fn()
 const mockUpdateHarnesses = vi.fn()
 
@@ -16,8 +19,7 @@ const mockState = vi.hoisted(() => ({
   edition: 'cloud',
   billingEnabled: true,
   walletStatus: 'active',
-  claudeSubscriptions: [{ id: 'claude-sub-1' }] as Array<{ id: string }>,
-  codexSubscriptions: [] as Array<{ id: string }>,
+  walletBalance: 42.5,
   providers: [] as any[],
   harnesses: [] as any[],
   onboardingHelixDefault: {
@@ -61,6 +63,7 @@ vi.mock('../hooks/useApi', () => ({
       v1UsersMeOnboardingCreate: mockV1UsersMeOnboardingCreate,
       v1OrgsSettingsUpdate: mockV1OrgsSettingsUpdate,
       v1SubscriptionNewCreate: mockV1SubscriptionNewCreate,
+      v1TopUpsNewCreate: mockV1TopUpsNewCreate,
     }),
   }),
 }))
@@ -78,7 +81,7 @@ vi.mock('../hooks/useRouter', () => ({
     name: 'onboarding',
     params: {},
     meta: {},
-    navigate: vi.fn(),
+    navigate: mockNavigate,
     navigateReplace: mockNavigateReplace,
     setParams: vi.fn(),
     mergeParams: vi.fn(),
@@ -122,30 +125,31 @@ vi.mock('../services/providersService', () => ({
 }))
 
 vi.mock('../services/useBilling', () => ({
+  TOP_UP_AMOUNTS: [5, 10, 20, 50, 100],
+  DEFAULT_TOP_UP_AMOUNT: 5,
   useGetWallet: () => ({
     data: {
       subscription_status: mockState.walletStatus,
       subscription_created: 0,
       subscription_current_period_start: 0,
       subscription_current_period_end: 0,
-      balance: 42.5,
+      balance: mockState.walletBalance,
     },
-    refetch: vi.fn(),
+    refetch: mockRefetchWallet,
     isFetching: false,
   }),
 }))
 
 vi.mock('../components/account/ClaudeSubscriptionConnect', () => ({
-  default: () => <button>Connect Claude</button>,
-  useClaudeSubscriptions: () => ({ data: mockState.claudeSubscriptions }),
-}))
-
-vi.mock('../services/codexSubscriptionsService', () => ({
-  useCodexSubscriptions: () => ({ data: mockState.codexSubscriptions }),
+  default: ({ enableForOrgId }: { enableForOrgId?: string }) => (
+    <button data-enable-for-org-id={enableForOrgId}>Connect Claude</button>
+  ),
 }))
 
 vi.mock('../components/account/CodexSubscriptionConnect', () => ({
-  default: () => <button>Connect ChatGPT</button>,
+  default: ({ enableForOrgId }: { enableForOrgId?: string }) => (
+    <button data-enable-for-org-id={enableForOrgId}>Connect ChatGPT</button>
+  ),
 }))
 
 vi.mock('lucide-react', () => ({
@@ -193,13 +197,12 @@ describe('Onboarding', () => {
     mockState.edition = 'cloud'
     mockState.billingEnabled = true
     mockState.walletStatus = 'active'
+    mockState.walletBalance = 42.5
     mockState.onboardingHelixDefault = {
       provider: 'pe_helix',
       model: 'helix-model',
       effort: 'high',
     }
-    mockState.claudeSubscriptions = [{ id: 'claude-sub-1' }]
-    mockState.codexSubscriptions = []
     mockState.providers = [{
       id: 'pe_helix',
       name: 'helix',
@@ -208,12 +211,13 @@ describe('Onboarding', () => {
     }]
     mockState.harnesses = [
       { runtime: 'zed_agent', enabled: true, subscription_enabled: false },
-      { runtime: 'claude_code', enabled: false, subscription_enabled: false },
-      { runtime: 'codex_cli', enabled: false, subscription_enabled: false },
+      { runtime: 'claude_code', enabled: false, subscription_enabled: false, viewer_has_subscription: true },
+      { runtime: 'codex_cli', enabled: false, subscription_enabled: false, viewer_has_subscription: false },
     ]
     mockV1UsersMeOnboardingCreate.mockResolvedValue({})
     mockV1OrgsSettingsUpdate.mockResolvedValue({})
     mockV1SubscriptionNewCreate.mockResolvedValue({})
+    mockV1TopUpsNewCreate.mockResolvedValue({})
     mockCreateOrgMutateAsync.mockResolvedValue(undefined)
     mockUpdateHarnesses.mockResolvedValue([])
     setAccountWithOrgs([
@@ -278,16 +282,21 @@ describe('Onboarding', () => {
   })
 
   it('requires a Claude connection only when Claude is selected', async () => {
-    mockState.claudeSubscriptions = []
+    mockState.harnesses = mockState.harnesses.map((harness) =>
+      harness.runtime === 'claude_code'
+        ? { ...harness, viewer_has_subscription: false }
+        : harness)
     renderOnboarding()
     await goToCodingAccessStep()
 
     fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
 
     expect(screen.getByRole('button', { name: 'Connect Claude' })).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
-    ).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Connect Claude' })).toHaveAttribute(
+      'data-enable-for-org-id',
+      'org-1',
+    )
   })
 
   it('requires a ChatGPT connection only when ChatGPT is selected', async () => {
@@ -297,13 +306,18 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: /chatgpt subscription/i }))
 
     expect(screen.getByRole('button', { name: 'Connect ChatGPT' })).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
-    ).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Connect ChatGPT' })).toHaveAttribute(
+      'data-enable-for-org-id',
+      'org-1',
+    )
   })
 
   it('selects a Codex subscription model and enables only that harness', async () => {
-    mockState.codexSubscriptions = [{ id: 'codex-sub-1' }]
+    mockState.harnesses = mockState.harnesses.map((harness) =>
+      harness.runtime === 'codex_cli'
+        ? { ...harness, viewer_has_subscription: true }
+        : harness)
     renderOnboarding()
     await goToCodingAccessStep()
 
@@ -380,7 +394,130 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+  })
+
+  it('offers credits and provider connections instead of Chief of Staff when balance is zero', async () => {
+    mockState.walletBalance = 0
+    mockState.harnesses = mockState.harnesses.map((harness) => ({
+      ...harness,
+      viewer_has_subscription: false,
+    }))
+    renderOnboarding()
+    await goToCodingAccessStep()
+
+    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add credits' })).toBeEnabled()
+    expect(screen.getByRole('combobox', { name: 'Top-up amount' })).toHaveTextContent('$5')
+    expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /chatgpt subscription/i })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add credits' }))
+    })
+    expect(mockV1TopUpsNewCreate).toHaveBeenCalledWith({
+      amount: 5,
+      org_id: 'org-1',
+      return_url: '/onboarding?org_id=org-1&step=provider',
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('preserves newly-created organization context through top-up checkout', async () => {
+    mockState.walletBalance = 0
+    setAccountWithOrgs([])
+    mockCreateOrgMutateAsync.mockResolvedValue({
+      id: 'org-2',
+      name: 'new-org',
+      display_name: 'New Org',
+    })
+    renderOnboarding()
+
+    fireEvent.change(screen.getByLabelText('Organization name'), {
+      target: { value: 'New Org' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create organization' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /^continue$/i })).toBeEnabled())
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    fireEvent.mouseDown(await screen.findByRole('combobox', { name: 'Top-up amount' }))
+    expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual([
+      '$5',
+      '$10',
+      '$20',
+      '$50',
+      '$100',
+    ])
+    fireEvent.click(screen.getByRole('option', { name: '$100' }))
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Add credits' }))
+    })
+
+    expect(mockV1TopUpsNewCreate).toHaveBeenCalledWith({
+      amount: 100,
+      org_id: 'org-2',
+      return_url: '/onboarding?org_id=org-2&step=provider&created_org=true',
+    })
+  })
+
+  it('defaults a connected Claude model so onboarding can finish', async () => {
+    mockState.walletBalance = 0
+    renderOnboarding()
+    await goToCodingAccessStep()
+
+    fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
+    const button = await screen.findByRole('button', { name: 'Meet your Chief of Staff' })
+    fireEvent.click(button)
+
+    await waitFor(() => expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(
+      'agent.default',
+      'my-org',
+      { value: JSON.stringify({
+        code_agent_runtime: 'claude_code',
+        code_agent_credential_type: 'subscription',
+        provider: '',
+        model: 'claude-opus-5',
+        reasoning_effort: 'none',
+      }) },
+    ))
+  })
+
+  it('defaults a connected ChatGPT model so onboarding can finish', async () => {
+    mockState.harnesses = mockState.harnesses.map((harness) =>
+      harness.runtime === 'codex_cli'
+        ? { ...harness, viewer_has_subscription: true }
+        : harness)
+    renderOnboarding()
+    await goToCodingAccessStep()
+
+    fireEvent.click(screen.getByRole('button', { name: /chatgpt subscription/i }))
+    const button = await screen.findByRole('button', { name: 'Meet your Chief of Staff' })
+    fireEvent.click(button)
+
+    await waitFor(() => expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(
+      'agent.default',
+      'my-org',
+      { value: JSON.stringify({
+        code_agent_runtime: 'codex_cli',
+        code_agent_credential_type: 'subscription',
+        provider: '',
+        model: 'gpt-5.6-sol',
+        reasoning_effort: 'none',
+      }) },
+    ))
+  })
+
+  it('restores the provider step after a successful top-up', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/onboarding?org_id=org-1&step=provider&success=true&session_id=cs_1',
+    )
+    renderOnboarding()
+
+    await screen.findByText('Choose how to run coding agents')
+    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+    expect(mockRefetchWallet).toHaveBeenCalled()
+    expect(window.location.search).toBe('')
   })
 
   it('requires a non-owner to ask the owner before changing subscription policy', async () => {

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1394,7 +1394,7 @@ export default function Onboarding() {
               )}
 
               {codingAccessOption === "helix" && !hasHelixCredits ? (
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Box sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}>
                   <FormControl size="small" sx={{ minWidth: 100 }}>
                     <InputLabel id="onboarding-topup-amount-label">Top-up amount</InputLabel>
                     <Select

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -33,19 +33,22 @@ import useSnackbar from "../hooks/useSnackbar";
 import useRouter from "../hooks/useRouter";
 import { SELECTED_ORG_STORAGE_KEY } from "../utils/localStorage";
 import { useCreateOrg } from "../services/orgService";
-import ClaudeSubscriptionConnect, {
-  useClaudeSubscriptions,
-} from "../components/account/ClaudeSubscriptionConnect";
+import ClaudeSubscriptionConnect from "../components/account/ClaudeSubscriptionConnect";
 import AnthropicLogo from "../components/providers/logos/anthropic";
 import AgentHarness from "../components/agent/AgentHarness";
 import CodexSubscriptionConnect from "../components/account/CodexSubscriptionConnect";
 import { useGetConfig } from "../services/userService";
-import { useGetWallet } from "../services/useBilling";
+import {
+  DEFAULT_TOP_UP_AMOUNT,
+  TOP_UP_AMOUNTS,
+  useGetWallet,
+} from "../services/useBilling";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
-import { useCodexSubscriptions } from "../services/codexSubscriptionsService";
 import {
   CLAUDE_SUBSCRIPTION_MODELS,
   CODEX_SUBSCRIPTION_MODELS,
+  DEFAULT_CLAUDE_SUBSCRIPTION_MODEL,
+  DEFAULT_CODEX_SUBSCRIPTION_MODEL,
 } from "../components/agent/CodingAgentForm";
 import {
   findHarnessStatus,
@@ -205,6 +208,8 @@ export default function Onboarding() {
   const { data: serverConfig, isLoading: isLoadingServerConfig } =
     useGetConfig();
   const [isSubscribing, setIsSubscribing] = useState(false);
+  const [isToppingUp, setIsToppingUp] = useState(false);
+  const [topUpAmount, setTopUpAmount] = useState<number>(DEFAULT_TOP_UP_AMOUNT);
 
   // Step 1: Organization
   const [orgMode, setOrgMode] = useState<"select" | "create">("select");
@@ -284,10 +289,29 @@ export default function Onboarding() {
   const hasExistingOrgs = existingOrgs.length > 0;
 
   // External coding subscription state
-  const { data: claudeSubscriptions } = useClaudeSubscriptions();
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0;
-  const { data: codexSubscriptions } = useCodexSubscriptions();
-  const hasCodexSubscription = (codexSubscriptions?.length ?? 0) > 0;
+  const hasClaudeSubscription = !!findHarnessStatus(
+    harnesses,
+    TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
+  )?.viewer_has_subscription;
+  const hasCodexSubscription = !!findHarnessStatus(
+    harnesses,
+    TypesCodeAgentRuntime.CodeAgentRuntimeCodexCLI,
+  )?.viewer_has_subscription;
+
+  useEffect(() => {
+    if (codingAccessOption === "claude" && hasClaudeSubscription && !claudeModel) {
+      setClaudeModel(DEFAULT_CLAUDE_SUBSCRIPTION_MODEL);
+    }
+    if (codingAccessOption === "codex" && hasCodexSubscription && !codexModel) {
+      setCodexModel(DEFAULT_CODEX_SUBSCRIPTION_MODEL);
+    }
+  }, [
+    claudeModel,
+    codexModel,
+    codingAccessOption,
+    hasClaudeSubscription,
+    hasCodexSubscription,
+  ]);
 
   // Billing is optional on self-hosted installations; coding access is always
   // shown because it is the final onboarding choice.
@@ -322,26 +346,13 @@ export default function Onboarding() {
     }
   }, [createdOrg?.id, serverConfig?.billing_enabled, refetchWallet]);
 
-  // Check for successful payment return from Stripe
+  // Refresh billing state after Stripe returns.
   useEffect(() => {
     const url = new URL(window.location.href);
-    const success = url.searchParams.get("success");
-    if (success === "true") {
+    if (url.searchParams.get("success") === "true") {
       refetchWallet();
-      const subscriptionStepIndex = getStepIndexByType("subscription");
-      if (subscriptionStepIndex >= 0) {
-        setActiveStep(subscriptionStepIndex);
-        setCompletedSteps((prev) => {
-          const next = new Set(prev);
-          next.delete(subscriptionStepIndex);
-          return next;
-        });
-      }
-      url.searchParams.delete("success");
-      const nextUrl = `${url.pathname}${url.searchParams.toString() ? `?${url.searchParams.toString()}` : ""}`;
-      window.history.replaceState({}, "", nextUrl);
     }
-  }, [refetchWallet, getStepIndexByType]);
+  }, [refetchWallet]);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
@@ -362,8 +373,22 @@ export default function Onboarding() {
     });
     setCreatedOrgDuringOnboarding(searchParams.get("created_org") === "true");
     const orgStepIndex = getStepIndexByType("organization");
-    setCompletedSteps((prev) => new Set([...prev, orgStepIndex]));
-    setActiveStep(orgStepIndex + 1);
+    const requestedStep = searchParams.get("step") === "provider"
+      ? getStepIndexByType("provider")
+      : orgStepIndex + 1;
+    setCompletedSteps((prev) => {
+      const next = new Set(prev);
+      for (let index = 0; index < requestedStep; index += 1) next.add(index);
+      return next;
+    });
+    setActiveStep(requestedStep);
+    if (
+      searchParams.has("success")
+      || searchParams.has("canceled")
+      || searchParams.has("session_id")
+    ) {
+      window.history.replaceState({}, "", window.location.pathname);
+    }
   }, [account.user?.id, createdOrg, existingOrgs, getStepIndexByType]);
 
   useEffect(() => {
@@ -581,6 +606,33 @@ export default function Onboarding() {
       setIsSubscribing(false);
     }
   }, [api, createdOrg, createdOrgDuringOnboarding, snackbar]);
+
+  const handleTopUp = useCallback(async () => {
+    if (!createdOrg?.id) {
+      snackbar.error("Organization not found");
+      return;
+    }
+
+    try {
+      setIsToppingUp(true);
+      const params = new URLSearchParams({
+        org_id: createdOrg.id,
+        step: "provider",
+      });
+      if (createdOrgDuringOnboarding) params.set("created_org", "true");
+      const resp = await api.getApiClient().v1TopUpsNewCreate({
+        amount: topUpAmount,
+        org_id: createdOrg.id,
+        return_url: `/onboarding?${params.toString()}`,
+      });
+      if (resp.data) document.location = resp.data;
+    } catch (error) {
+      console.error("Top-up error:", error);
+      snackbar.error("Failed to start top-up process");
+    } finally {
+      setIsToppingUp(false);
+    }
+  }, [api, createdOrg, createdOrgDuringOnboarding, snackbar, topUpAmount]);
 
   const handleDismiss = useCallback(async () => {
     account.dismissOnboarding();
@@ -1007,9 +1059,14 @@ export default function Onboarding() {
 
       case "provider": {
         const inventoryLoading = providersLoading || harnessesLoading;
+        const hasHelixCredits = !serverConfig?.billing_enabled || (wallet?.balance ?? 0) > 0;
+        const hasSelectedAccess =
+          (codingAccessOption === "helix" && hasHelixCredits && helixDefaultAvailable) ||
+          (codingAccessOption === "claude" && hasClaudeSubscription) ||
+          (codingAccessOption === "codex" && hasCodexSubscription);
         const canFinish =
           !inventoryLoading && !!createdOrg?.viewer_is_owner && (
-            (codingAccessOption === "helix" && helixDefaultAvailable) ||
+            (codingAccessOption === "helix" && hasHelixCredits && helixDefaultAvailable) ||
             (codingAccessOption === "claude" && hasClaudeSubscription && !!claudeModel) ||
             (codingAccessOption === "codex" && hasCodexSubscription && !!codexModel)
           );
@@ -1272,7 +1329,10 @@ export default function Onboarding() {
                   >
                     Connect your personal Claude subscription before continuing.
                   </Typography>
-                  <ClaudeSubscriptionConnect variant="button" />
+                  <ClaudeSubscriptionConnect
+                    variant="button"
+                    enableForOrgId={createdOrg?.id}
+                  />
                 </Box>
               )}
 
@@ -1312,7 +1372,7 @@ export default function Onboarding() {
                   >
                     Connect your personal ChatGPT subscription before continuing.
                   </Typography>
-                  <CodexSubscriptionConnect />
+                  <CodexSubscriptionConnect enableForOrgId={createdOrg?.id} />
                 </Box>
               )}
 
@@ -1333,23 +1393,50 @@ export default function Onboarding() {
                 </FormControl>
               )}
 
-              <Button
-                variant="contained"
-                onClick={handleComplete}
-                disabled={!canFinish || finishingOnboarding}
-                sx={btnSx}
-                startIcon={
-                  finishingOnboarding ? (
-                    <CircularProgress size={14} sx={{ color: "#000" }} />
-                  ) : undefined
-                }
-              >
-                {finishingOnboarding
-                  ? "Finishing setup..."
-                  : shouldMeetChiefOfStaff
-                    ? "Meet your Chief of Staff"
-                    : continueLabel}
-              </Button>
+              {codingAccessOption === "helix" && !hasHelixCredits ? (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <FormControl size="small" sx={{ minWidth: 100 }}>
+                    <InputLabel id="onboarding-topup-amount-label">Top-up amount</InputLabel>
+                    <Select
+                      labelId="onboarding-topup-amount-label"
+                      label="Top-up amount"
+                      value={topUpAmount}
+                      onChange={(event) => setTopUpAmount(Number(event.target.value))}
+                    >
+                      {TOP_UP_AMOUNTS.map((amount) => (
+                        <MenuItem key={amount} value={amount}>${amount}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <Button
+                    variant="contained"
+                    onClick={handleTopUp}
+                    disabled={isToppingUp}
+                    sx={btnSx}
+                    startIcon={isToppingUp ? <CircularProgress size={14} sx={{ color: "#000" }} /> : undefined}
+                  >
+                    {isToppingUp ? "Opening checkout..." : "Add credits"}
+                  </Button>
+                </Box>
+              ) : hasSelectedAccess ? (
+                <Button
+                  variant="contained"
+                  onClick={handleComplete}
+                  disabled={!canFinish || finishingOnboarding}
+                  sx={btnSx}
+                  startIcon={
+                    finishingOnboarding ? (
+                      <CircularProgress size={14} sx={{ color: "#000" }} />
+                    ) : undefined
+                  }
+                >
+                  {finishingOnboarding
+                    ? "Finishing setup..."
+                    : shouldMeetChiefOfStaff
+                      ? "Meet your Chief of Staff"
+                      : continueLabel}
+                </Button>
+              ) : null}
             </Box>
           </Fade>
         );

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -387,7 +387,14 @@ export default function Onboarding() {
       || searchParams.has("canceled")
       || searchParams.has("session_id")
     ) {
-      window.history.replaceState({}, "", window.location.pathname);
+      searchParams.delete("success");
+      searchParams.delete("canceled");
+      searchParams.delete("session_id");
+      window.history.replaceState(
+        {},
+        "",
+        `${window.location.pathname}?${searchParams.toString()}`,
+      );
     }
   }, [account.user?.id, createdOrg, existingOrgs, getStepIndexByType]);
 

--- a/frontend/src/services/useBilling.ts
+++ b/frontend/src/services/useBilling.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import useApi from '../hooks/useApi';
 
+export const TOP_UP_AMOUNTS = [5, 10, 20, 50, 100] as const
+export const DEFAULT_TOP_UP_AMOUNT = TOP_UP_AMOUNTS[0]
+
 export const userWalletQueryKey = (orgId?: string) => [
   "user",
   "wallet",

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1985,6 +1985,8 @@ definitions:
         type: number
       org_id:
         type: string
+      return_url:
+        type: string
     type: object
   server.DeployWebServiceRequest:
     properties:

--- a/openapi.json
+++ b/openapi.json
@@ -30161,6 +30161,9 @@
                     },
                     "org_id": {
                         "type": "string"
+                    },
+                    "return_url": {
+                        "type": "string"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -25693,6 +25693,9 @@
                 },
                 "org_id": {
                     "type": "string"
+                },
+                "return_url": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
## Summary
- gate Chief of Staff onboarding on credits or an org-usable subscription
- return Stripe top-ups directly to the final onboarding step
- share concise USD 5, 10, 20, 50, and 100 UI choices while allowing arbitrary positive API amounts
- validate app-relative checkout return URLs and preserve their query parameters

## Tests
- `cd frontend && yarn test Onboarding.test.tsx --run`
- `cd api && go test ./pkg/stripe -run "^TestCheckout" -count=1`
- `cd api && go test ./pkg/server -run "Test(CreateTopUpAcceptsArbitraryPositiveAmount|CheckoutHandlersRejectUnsafeReturnURLBeforeWalletLookup)$" -count=1`
- `cd api && go build ./pkg/server ./pkg/store ./pkg/types`
- `git diff --check`

## Verification limitation
- local frontend build/browser startup is blocked by the pre-existing `WorkspaceReviewMessage.tsx` / `workspaceReviewMessage.ts` case-collision