### PR TITLE
fix(frontend): show default trial plan

### DIFF
--- a/frontend/src/components/dashboard/ActivateTrialDialog.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.tsx
@@ -126,6 +126,7 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                         label="Plan"
                         value={plan}
                         onChange={(e) => setPlan(e.target.value)}
+                        SelectProps={{ displayEmpty: true }}
                         margin="normal"
                         disabled={activateTrial.isPending}
                         helperText={


### PR DESCRIPTION
## Summary
- render the empty-value Trial (Stripe) option in the admin activation dialog
- preserve the existing submitted plan value and Stripe trial behavior

## Testing
- focused esbuild bundle passed
- git diff --check passed
- frontend build is blocked by the pre-existing WorkspaceReviewMessage.tsx/workspaceReviewMessage.ts case-collision import failure