### PR TITLE
feat(embed): add a minimal, customer-facing chat embed

### DIFF
--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -121,6 +121,16 @@ interface RobustPromptInputProps {
   leadingActions?: React.ReactNode
   trailingActions?: React.ReactNode
   showContextUsage?: boolean
+  /**
+   * Strip the composer back to what a non-technical person needs: a box, a
+   * send button, and nothing that asks them to reason about how the agent
+   * runs. Hides the interrupt/queue toggle.
+   *
+   * For customer-facing embeds. Someone on a job board does not have a mental
+   * model of queued versus interrupting turns, and offering the choice invites
+   * them to get it wrong on a surface where they cannot see what it did.
+   */
+  minimal?: boolean
   contextMenuAppId?: string
   formatContextMenuInsert?: (text: string) => string
   autoFocus?: boolean
@@ -559,6 +569,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   leadingActions,
   trailingActions,
   showContextUsage = false,
+  minimal = false,
   contextMenuAppId,
   formatContextMenuInsert,
   autoFocus = false,
@@ -1755,7 +1766,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
           )}
 
           {/* Interrupt mode toggle */}
-          {sendMode === 'queued' && <Tooltip
+          {sendMode === 'queued' && !minimal && <Tooltip
             title={
               <Box>
                 <Typography variant="body2" sx={{ fontWeight: 600 }}>

--- a/frontend/src/components/session/AgentChat.tsx
+++ b/frontend/src/components/session/AgentChat.tsx
@@ -11,6 +11,8 @@ import { useListInteractions } from '../../services/sessionService'
 import { useRefreshSpecTaskStatus } from '../../services/specTaskService'
 import { SESSION_TYPE_TEXT } from '../../types'
 import RobustPromptInput from '../common/RobustPromptInput'
+import ChatWelcome from './ChatWelcome'
+import { shouldShowWelcome } from './minimalChatLogic'
 import EmbeddedSessionView, { EmbeddedSessionViewHandle } from './EmbeddedSessionView'
 import type { ResponseEntry } from './InteractionInference'
 import { ComposerPlanProgress, planStepsFromResponseEntries } from './PlanProgress'
@@ -34,6 +36,21 @@ interface AgentChatProps {
   reviewComments?: readonly WorkspaceReviewComment[]
   onRemoveReviewComment?: (commentId: string) => void
   onReviewCommentsSent?: () => void
+  /**
+   * Customer-facing mode, for embedding this chat in someone else's product.
+   *
+   * Strips the surface back to a conversation: no developer controls in the
+   * composer, and the session's opening briefing is not rendered as though the
+   * customer had typed it. Before anyone has said anything it shows the
+   * welcome screen instead of an empty thread — the same one Helix's own new
+   * chat page uses, so starting a conversation looks like starting a
+   * conversation rather than like arriving in an empty log.
+   */
+  minimal?: boolean
+  /** Heading for the welcome screen. Only used in minimal mode. */
+  welcomeHeading?: string
+  /** Optional line under the welcome heading. */
+  welcomeSubheading?: string
 }
 
 /** Shared org/spec-task conversation surface. */
@@ -52,12 +69,16 @@ const AgentChat: FC<AgentChatProps> = ({
   reviewComments,
   onRemoveReviewComment,
   onReviewCommentsSent,
+  minimal = false,
+  welcomeHeading = 'What would you like to know?',
+  welcomeSubheading,
 }) => {
   const api = useApi()
   const snackbar = useSnackbar()
   const streaming = useStreaming()
   const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
   const [isCancelling, setIsCancelling] = useState(false)
+  const [hasSentInWelcome, setHasSentInWelcome] = useState(false)
   const [composerPlanExpanded, setComposerPlanExpanded] = useState(false)
   const [dismissedPlanInteractionId, setDismissedPlanInteractionId] = useState<string | null>(null)
   const apiClient = api.getApiClient()
@@ -77,6 +98,18 @@ const AgentChat: FC<AgentChatProps> = ({
   )
   const latestInteraction = latestInteractionsResponse?.data?.interactions?.[0]
   const latestInteractionId = latestInteraction?.id || null
+  // Has the customer said anything yet?
+  //
+  // One interaction means only the session's opening briefing exists — the
+  // agent was told who it is talking to, and replied with a greeting. Nobody
+  // has asked it anything, so there is no conversation to show. hasSentInWelcome
+  // covers the gap between clicking send and the count catching up on the next
+  // poll, which would otherwise flash the welcome screen back for a moment.
+  const showWelcome = shouldShowWelcome(
+    minimal,
+    hasSentInWelcome,
+    latestInteractionsResponse?.data?.totalCount ?? 0,
+  )
   // Session-keyed queue for sessions without a spec task; the spec-task
   // composer carries its own backend-backed queue instead.
   const sessionQueue = useSessionPromptQueue(showSessionPromptQueue ? sessionId : '', isAgentBusy)
@@ -88,6 +121,7 @@ const AgentChat: FC<AgentChatProps> = ({
     && dismissedPlanInteractionId !== latestInteractionId
 
   const handleSend = useCallback(async (message: string, interrupt?: boolean) => {
+    setHasSentInWelcome(true)
     setComposerPlanExpanded(false)
     setDismissedPlanInteractionId(null)
     await streaming.NewInference({
@@ -138,6 +172,56 @@ const AgentChat: FC<AgentChatProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId])
 
+  const composer = (
+    <RobustPromptInput
+      minimal={minimal}
+      sessionId={sessionId}
+      specTaskId={specTaskId}
+      projectId={projectId}
+      apiClient={apiClient}
+      onSend={handleSend}
+      onWillSend={onWillSend}
+      appendText={appendText}
+      onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
+      onFileUpload={handleFileUpload}
+      onCancel={handleCancel}
+      isAgentBusy={isAgentBusy}
+      isCancelling={isCancelling}
+      leadingActions={leadingActions}
+      showContextUsage={!minimal}
+      autoFocus
+      placeholder={placeholder}
+      disabled={disabled}
+      enableSandboxCompletions
+      reviewComments={reviewComments}
+      onRemoveReviewComment={onRemoveReviewComment}
+      onReviewCommentsSent={onReviewCommentsSent}
+      hasAttachedHeader={(showComposerPlan && composerPlanExpanded) || hasSessionQueue}
+    />
+  )
+
+  // Nothing said yet: the welcome screen IS the chat, so it gets the whole
+  // frame rather than sitting above an empty thread.
+  if (showWelcome) {
+    return (
+      <Box
+        data-agent-chat
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          minWidth: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        <ChatWelcome heading={welcomeHeading} subheading={welcomeSubheading}>
+          {composer}
+        </ChatWelcome>
+      </Box>
+    )
+  }
+
   return (
     <Box
       data-agent-chat
@@ -157,6 +241,7 @@ const AgentChat: FC<AgentChatProps> = ({
           ref={sessionViewRef}
           sessionId={sessionId}
           enableInteractionDebugCopy={enableInteractionDebugCopy}
+          minimal={minimal}
         />
       </Box>
 
@@ -197,30 +282,7 @@ const AgentChat: FC<AgentChatProps> = ({
                 onRestartAgent={sessionQueue.restartAgent}
               />
             )}
-            <RobustPromptInput
-              sessionId={sessionId}
-              specTaskId={specTaskId}
-              projectId={projectId}
-              apiClient={apiClient}
-              onSend={handleSend}
-              onWillSend={onWillSend}
-              appendText={appendText}
-              onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
-              onFileUpload={handleFileUpload}
-              onCancel={handleCancel}
-              isAgentBusy={isAgentBusy}
-              isCancelling={isCancelling}
-              leadingActions={leadingActions}
-              showContextUsage
-              autoFocus
-              placeholder={placeholder}
-              disabled={disabled}
-              enableSandboxCompletions
-              reviewComments={reviewComments}
-              onRemoveReviewComment={onRemoveReviewComment}
-              onReviewCommentsSent={onReviewCommentsSent}
-              hasAttachedHeader={(showComposerPlan && composerPlanExpanded) || hasSessionQueue}
-            />
+            {composer}
           </Box>
           {footerContent && (
             <Box

--- a/frontend/src/components/session/ChatWelcome.tsx
+++ b/frontend/src/components/session/ChatWelcome.tsx
@@ -1,0 +1,107 @@
+import { FC, ReactNode } from 'react'
+import { Box, Typography } from '@mui/material'
+
+import useIsPhone from '../../hooks/useIsPhone'
+import useLightTheme from '../../hooks/useLightTheme'
+
+/**
+ * The "nothing has been said yet" screen: a heading, a composer under it, and
+ * a lot of quiet around both.
+ *
+ * Extracted from Home so the embedded chat can be the same screen rather than a
+ * lookalike. Two implementations of this drift — one gets the phone behaviour
+ * and the other does not, one gets the font and the other does not — and the
+ * difference shows up on a customer's screen rather than ours.
+ *
+ * Pure layout. It owns no state and knows nothing about sessions, projects or
+ * sending: the caller passes the composer as `children` and anything that
+ * belongs under it as `footer`.
+ */
+const ChatWelcome: FC<{
+  heading: string
+  children: ReactNode
+  footer?: ReactNode
+  /**
+   * Sits under the heading, above the composer. For a line of context the
+   * heading alone cannot carry.
+   */
+  subheading?: string
+}> = ({ heading, children, footer, subheading }) => {
+  const isPhone = useIsPhone()
+  const lightTheme = useLightTheme()
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        minHeight: 0,
+        display: 'flex',
+        // A phone fills the screen and works top-down; a wide screen keeps
+        // the centred card.
+        alignItems: isPhone ? 'stretch' : 'center',
+        justifyContent: 'center',
+        px: { xs: 2, sm: 3 },
+        // The shell already carries the safe-area inset.
+        pb: isPhone ? 1 : { xs: 4, md: 12 },
+        pt: isPhone ? 1 : 0,
+        backgroundColor: lightTheme.isLight ? '#f7f7f8' : '#080808',
+        fontFamily: WELCOME_FONT_FAMILY,
+        '& .MuiTypography-root, & .MuiButton-root': { fontFamily: 'inherit' },
+      }}
+    >
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: 768,
+          ...(isPhone && { display: 'flex', flexDirection: 'column', minHeight: 0 }),
+        }}
+      >
+        {!isPhone && (
+          <>
+            <Typography
+              component="h1"
+              sx={{
+                mb: subheading ? 1 : 3.5,
+                color: 'text.primary',
+                fontSize: { xs: '1.65rem', sm: '1.9rem' },
+                fontWeight: 560,
+                lineHeight: 1.2,
+                letterSpacing: '-0.025em',
+                textAlign: 'center',
+              }}
+            >
+              {heading}
+            </Typography>
+            {subheading && (
+              <Typography
+                sx={{
+                  mb: 3.5,
+                  color: 'text.secondary',
+                  fontSize: '0.95rem',
+                  lineHeight: 1.5,
+                  textAlign: 'center',
+                }}
+              >
+                {subheading}
+              </Typography>
+            )}
+          </>
+        )}
+
+        {children}
+
+        {footer && (
+          <Box sx={isPhone ? { order: -1, mb: 0.5, flexShrink: 0 } : { mt: 1, px: 2 }}>
+            {footer}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+/** The system UI stack, matching the rest of the new-chat screen. */
+export const WELCOME_FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
+
+export default ChatWelcome

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -65,11 +65,23 @@ import {
 } from "./ChatTurnNavigator.logic";
 import { splitSystemPrefix } from "./CollapsibleSystemPrefix";
 import { isSandboxOffline } from "../external-agent/sandboxState";
+import { seedPromptIndex } from "./minimalChatLogic";
 
 interface EmbeddedSessionViewProps {
   sessionId: string;
   onScrollToBottom?: () => void;
   enableInteractionDebugCopy?: boolean;
+  /**
+   * Customer-facing mode: hide the session's opening prompt.
+   *
+   * The first turn of an agent session is not something the customer said — it
+   * is the agent's briefing, sent as the session's first prompt, and it renders
+   * as a user message like any other. On an embed that meant a candidate on the
+   * job board was shown the entire system prompt, the tool list, and the
+   * sandbox scaffolding (repository paths, the branch to push to) before they
+   * had typed a word. The agent's REPLY to it is kept: that is the greeting.
+   */
+  minimal?: boolean;
 }
 
 export interface EmbeddedSessionViewHandle {
@@ -89,7 +101,7 @@ export interface EmbeddedSessionViewHandle {
 const EmbeddedSessionView = forwardRef<
   EmbeddedSessionViewHandle,
   EmbeddedSessionViewProps
->(({ sessionId, onScrollToBottom, enableInteractionDebugCopy }, ref) => {
+>(({ sessionId, onScrollToBottom, enableInteractionDebugCopy, minimal = false }, ref) => {
   const account = useAccount();
   const api = useApi();
   const lightTheme = useLightTheme();
@@ -527,6 +539,8 @@ const EmbeddedSessionView = forwardRef<
   const totalPages = paginatedData?.totalPages || 1;
   const totalCount = paginatedData?.totalCount || 0;
   const hasOlderInteractions = oldestPageLoaded < totalPages - 1;
+  // The session's opening prompt, or -1 when it is not on screen.
+  const seedIndex = seedPromptIndex(minimal, hasOlderInteractions);
   const remainingOlderCount = Math.max(0, totalCount - totalInteractions);
 
   const isOwner = account.user?.id === session?.owner;
@@ -729,6 +743,7 @@ const EmbeddedSessionView = forwardRef<
                 session_id={sessionId}
                 sessionSteps={sessionSteps?.data || []}
                 enableDebugCopy={enableInteractionDebugCopy}
+                hidePrompt={index === seedIndex}
               >
                 {isLive && (isOwner || account.admin) && (
                   <InteractionLiveStream

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -184,6 +184,13 @@ const areEqual = (prevProps: InteractionProps, nextProps: InteractionProps) => {
     return false;
   }
 
+  // In practice this is fixed for the life of an interaction, but it decides
+  // whether a system prompt is on screen — too consequential to leave to a
+  // comparator that happens not to look at it.
+  if (prevProps.hidePrompt !== nextProps.hidePrompt) {
+    return false;
+  }
+
   if (
     prevProps.nextInteraction?.id !== nextProps.nextInteraction?.id ||
     prevProps.nextInteraction?.state !== nextProps.nextInteraction?.state ||
@@ -292,6 +299,16 @@ interface InteractionProps {
    * THIS one has been overtaken by events. See lastSuccessfulInteractionIndex.
    */
   recoveredLater?: boolean;
+  /**
+   * Suppress the user-prompt bubble, keeping the agent's reply.
+   *
+   * For customer-facing embeds, where the opening "user" turn is not something
+   * the customer said — it is the agent's own briefing, sent as the session's
+   * first prompt. Rendering it verbatim showed a candidate on the job board the
+   * whole system prompt, its tool list, and the sandbox scaffolding
+   * (repository paths, the branch to push to) before they had said a word.
+   */
+  hidePrompt?: boolean;
 }
 
 export const Interaction: FC<InteractionProps> = ({
@@ -307,6 +324,7 @@ export const Interaction: FC<InteractionProps> = ({
   enableDebugCopy = false,
   nextInteraction,
   recoveredLater = false,
+  hidePrompt = false,
 }) => {
   // Memoize computed values
   const displayData = useMemo(() => {
@@ -441,7 +459,7 @@ export const Interaction: FC<InteractionProps> = ({
       onMouseLeave={() => setIsHovering(false)}
     >
       {/* User Message Container */}
-      {userMessage && interaction.trigger !== "org_hire" && (
+      {userMessage && !hidePrompt && interaction.trigger !== "org_hire" && (
         <Box
           sx={{
             display: "flex",

--- a/frontend/src/components/session/minimalChatLogic.test.ts
+++ b/frontend/src/components/session/minimalChatLogic.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { seedPromptIndex, shouldShowWelcome } from './minimalChatLogic'
+
+describe('seedPromptIndex', () => {
+  it('hides the opening briefing on a fully loaded thread', () => {
+    expect(seedPromptIndex(true, false)).toBe(0)
+  })
+
+  it('hides nothing when the thread starts mid-conversation', () => {
+    // Pagination has not reached the oldest page, so index 0 is a real message
+    // the customer sent. Blanking it would be worse than showing the prompt.
+    expect(seedPromptIndex(true, true)).toBe(-1)
+  })
+
+  it('hides nothing outside minimal mode', () => {
+    // A developer watching their own task should see the prompt that started
+    // it — that is the task.
+    expect(seedPromptIndex(false, false)).toBe(-1)
+    expect(seedPromptIndex(false, true)).toBe(-1)
+  })
+})
+
+describe('shouldShowWelcome', () => {
+  it('shows the welcome screen when only the briefing exists', () => {
+    // The agent has been told who it is talking to and has greeted them. That
+    // is not a conversation.
+    expect(shouldShowWelcome(true, false, 1)).toBe(true)
+  })
+
+  it('shows it on a session with nothing in it at all', () => {
+    expect(shouldShowWelcome(true, false, 0)).toBe(true)
+  })
+
+  it('gives way as soon as the customer has asked something', () => {
+    expect(shouldShowWelcome(true, false, 2)).toBe(false)
+  })
+
+  it('gives way the instant they hit send, before the count catches up', () => {
+    // The interaction list is polled. Without this the welcome screen comes
+    // back for a beat after they have already spoken.
+    expect(shouldShowWelcome(true, true, 1)).toBe(false)
+  })
+
+  it('never shows outside minimal mode', () => {
+    expect(shouldShowWelcome(false, false, 0)).toBe(false)
+    expect(shouldShowWelcome(false, false, 1)).toBe(false)
+  })
+})

--- a/frontend/src/components/session/minimalChatLogic.ts
+++ b/frontend/src/components/session/minimalChatLogic.ts
@@ -1,0 +1,46 @@
+/**
+ * The two judgement calls behind the customer-facing chat embed.
+ *
+ * Both are one-liners at the call site and both are wrong in a way nobody sees
+ * until it is in front of a customer — one hides a message that should be
+ * visible, the other shows a system prompt that should not be. Pulled out here
+ * so they can be tested without mounting a session.
+ */
+
+/**
+ * Which rendered interaction is the session's opening briefing, or -1 for none.
+ *
+ * The first turn of an agent session is not something the customer said: it is
+ * the prompt that told the agent who it is and what it can do, and it renders
+ * as a user message like any other. On an embed it has to go.
+ *
+ * It is only safe to assume index 0 is that turn once pagination has reached
+ * the oldest page. A thread that starts mid-conversation has a real customer
+ * message at index 0, and blanking that would be worse than the problem.
+ */
+export function seedPromptIndex(minimal: boolean, hasOlderInteractions: boolean): number {
+  if (!minimal) return -1
+  if (hasOlderInteractions) return -1
+  return 0
+}
+
+/**
+ * Should the welcome screen stand in for the thread?
+ *
+ * One interaction means only the opening briefing exists — the agent was told
+ * who it is talking to and replied with a greeting. Nobody has asked it
+ * anything, so there is no conversation to show yet.
+ *
+ * `hasSent` covers the gap between the customer clicking send and the server
+ * count catching up on the next poll. Without it the welcome screen flashes
+ * back for a beat after they have already spoken.
+ */
+export function shouldShowWelcome(
+  minimal: boolean,
+  hasSent: boolean,
+  totalInteractions: number,
+): boolean {
+  if (!minimal) return false
+  if (hasSent) return false
+  return totalInteractions <= 1
+}

--- a/frontend/src/pages/EmbedTaskPage.tsx
+++ b/frontend/src/pages/EmbedTaskPage.tsx
@@ -2,23 +2,67 @@ import React, { FC } from 'react'
 import { useRoute } from 'react-router5'
 import { Box, CircularProgress, useTheme } from '@mui/material'
 import SpecTaskDetailContent from '../components/tasks/SpecTaskDetailContent'
+import AgentChat from '../components/session/AgentChat'
 import { useSpecTask } from '../services/specTaskService'
 
 const EmbedTaskPage: FC = () => {
   const { route } = useRoute()
   const theme = useTheme()
   const taskId = route.params.taskId as string
-  const { isLoading } = useSpecTask(taskId, { enabled: !!taskId })
+  const { data: task, isLoading } = useSpecTask(taskId, { enabled: !!taskId })
+
+  // Minimal mode: a conversation and nothing else.
+  //
+  // The default embed is the full task workspace — view switcher, desktop
+  // controls, model and sandbox pickers, the task's opening prompt rendered as
+  // a user message. That is right for a developer watching their own task and
+  // wrong for a product that has embedded an agent for its customers: a
+  // candidate on the Find AI job board was shown the entire system prompt, the
+  // tool list and the sandbox's repository paths before they had typed a word.
+  //
+  // Opt-in via ?minimal=1 so existing embeds are untouched. The heading and
+  // subheading let the host name its own agent; they only show on the welcome
+  // screen, before anyone has said anything.
+  const minimal = route.params.minimal === '1' || route.params.minimal === 'true'
+  const welcomeHeading = (route.params.heading as string) || undefined
+  const welcomeSubheading = (route.params.subheading as string) || undefined
 
   // Embed contexts (iframes) don't have a parent body bg, so the white iframe
-  // default leaks through anywhere SpecTaskDetailContent doesn't paint. Force
-  // the theme bg here.
+  // default leaks through anywhere the content doesn't paint. Force the theme
+  // bg here.
   const bg = theme.palette.background.default
 
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', backgroundColor: bg }}>
         <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (minimal) {
+    const sessionId = task?.planning_session_id
+    if (!sessionId) {
+      // The sandbox is still coming up. A spinner is the honest answer — the
+      // host shows its own "starting your assistant" copy around this iframe.
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100dvh', backgroundColor: bg }}>
+          <CircularProgress />
+        </Box>
+      )
+    }
+    return (
+      // display:flex is load-bearing: AgentChat sizes itself with `flex: 1` and
+      // has no height of its own, so in a plain block wrapper it collapses.
+      <Box sx={{ height: '100dvh', overflow: 'hidden', backgroundColor: bg, display: 'flex', flexDirection: 'column' }}>
+        <AgentChat
+          sessionId={sessionId}
+          specTaskId={taskId}
+          projectId={task?.project_id}
+          minimal
+          {...(welcomeHeading ? { welcomeHeading } : {})}
+          welcomeSubheading={welcomeSubheading}
+        />
       </Box>
     )
   }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import {
 } from '../api/api'
 import AdvancedModelPicker from '../components/create/AdvancedModelPicker'
 import RobustPromptInput from '../components/common/RobustPromptInput'
+import ChatWelcome, { WELCOME_FONT_FAMILY } from '../components/session/ChatWelcome'
 import CodeAgentExecutionControls from '../components/agent/CodeAgentExecutionControls'
 import { useSeedProjectCodeAgentConfig } from '../hooks/useSeedProjectCodeAgentConfig'
 import { CodeAgentConfigChangeSource } from '../utils/codeAgentExecutionConfig'
@@ -64,7 +65,7 @@ import {
   saveSpecTaskSandboxRuntimePreference,
 } from '../utils/specTaskSandboxRuntime'
 
-const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
+const T3_FONT_FAMILY = WELCOME_FONT_FAMILY
 const TASK_ATTACHMENT_ACCEPT = Object.entries(SPEC_TASK_ATTACHMENT_ACCEPTED_MIME)
   .flatMap(([mime, extensions]) => [mime, ...extensions])
   .join(',')
@@ -549,48 +550,38 @@ const Home: FC = () => {
       disableContentScroll
       px={2}
     >
-      <Box
-        sx={{
-          height: '100%',
-          minHeight: 0,
-          display: 'flex',
-          // A phone fills the screen and works top-down; a wide screen keeps
-          // the centred card.
-          alignItems: isPhone ? 'stretch' : 'center',
-          justifyContent: 'center',
-          px: { xs: 2, sm: 3 },
-          // The shell already carries the safe-area inset.
-          pb: isPhone ? 1 : { xs: 4, md: 12 },
-          pt: isPhone ? 1 : 0,
-          backgroundColor: lightTheme.isLight ? '#f7f7f8' : '#080808',
-          fontFamily: T3_FONT_FAMILY,
-          '& .MuiTypography-root, & .MuiButton-root': { fontFamily: 'inherit' },
-        }}
-      >
-        <Box
-          sx={{
-            width: '100%',
-            maxWidth: 768,
-            ...(isPhone && { display: 'flex', flexDirection: 'column', minHeight: 0 }),
-          }}
-        >
-          {!isPhone && (
-            <Typography
-              component="h1"
-              sx={{
-                mb: 3.5,
-                color: 'text.primary',
-                fontSize: { xs: '1.65rem', sm: '1.9rem' },
-                fontWeight: 560,
-                lineHeight: 1.2,
-                letterSpacing: '-0.025em',
-                textAlign: 'center',
-              }}
-            >
-              {newChatHeading(selectedProject?.name)}
-            </Typography>
-          )}
-
+      <ChatWelcome heading={newChatHeading(selectedProject?.name)} footer={(
+        <>
+              <Button
+                startIcon={isProjectContext ? <Folder size={14} /> : <MessageCircle size={14} />}
+                endIcon={<ChevronDown size={12} />}
+                onClick={(event) => setProjectMenuAnchor(event.currentTarget)}
+                sx={{ ...selectorButtonSx, fontSize: isPhone ? '0.8rem' : '0.7rem' }}
+              >
+                {selectedProject?.name || 'No project'}
+              </Button>
+              <Menu
+                anchorEl={projectMenuAnchor}
+                open={!!projectMenuAnchor}
+                onClose={() => setProjectMenuAnchor(null)}
+              >
+                <MenuItem selected={!isProjectContext} onClick={() => openProject()}>
+                  <ListItemIcon><MessageCircle size={16} /></ListItemIcon>
+                  <ListItemText primary="None" secondary="Start a normal chat" />
+                </MenuItem>
+                {projects.map((project) => (
+                  <MenuItem
+                    key={project.id}
+                    selected={project.id === selectedProjectId}
+                    onClick={() => openProject(project.id)}
+                  >
+                    <ListItemIcon><Folder size={16} /></ListItemIcon>
+                    <ListItemText primary={project.name || 'Untitled project'} />
+                  </MenuItem>
+                ))}
+              </Menu>
+        </>
+      )}>
           {requestedProjectId && projectsLoading ? (
             <Box sx={{ height: 150, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               <CircularProgress size={22} />
@@ -615,39 +606,7 @@ const Home: FC = () => {
               onSend={isProjectContext ? handleProjectTask : handleNormalChat}
             />
           )}
-
-          <Box sx={isPhone ? { order: -1, mb: 0.5, flexShrink: 0 } : { mt: 1, px: 2 }}>
-            <Button
-              startIcon={isProjectContext ? <Folder size={14} /> : <MessageCircle size={14} />}
-              endIcon={<ChevronDown size={12} />}
-              onClick={(event) => setProjectMenuAnchor(event.currentTarget)}
-              sx={{ ...selectorButtonSx, fontSize: isPhone ? '0.8rem' : '0.7rem' }}
-            >
-              {selectedProject?.name || 'No project'}
-            </Button>
-            <Menu
-              anchorEl={projectMenuAnchor}
-              open={!!projectMenuAnchor}
-              onClose={() => setProjectMenuAnchor(null)}
-            >
-              <MenuItem selected={!isProjectContext} onClick={() => openProject()}>
-                <ListItemIcon><MessageCircle size={16} /></ListItemIcon>
-                <ListItemText primary="None" secondary="Start a normal chat" />
-              </MenuItem>
-              {projects.map((project) => (
-                <MenuItem
-                  key={project.id}
-                  selected={project.id === selectedProjectId}
-                  onClick={() => openProject(project.id)}
-                >
-                  <ListItemIcon><Folder size={16} /></ListItemIcon>
-                  <ListItemText primary={project.name || 'Untitled project'} />
-                </MenuItem>
-              ))}
-            </Menu>
-          </Box>
-        </Box>
-      </Box>
+      </ChatWelcome>
     </Page>
   )
 }


### PR DESCRIPTION
/embed/task/:id renders the full task workspace: view switcher, desktop and sandbox controls, a model picker, and the session's opening prompt rendered as though the customer had typed it. That is right for a developer watching their own task and wrong for a product that has embedded an agent for its customers — a candidate on the Find AI job board was shown the entire system prompt, its tool list and the sandbox's repository paths before they had said a word.

?minimal=1 gives a conversation and nothing else. Opt-in, so existing embeds are untouched.

Before anyone has spoken it shows the welcome screen rather than an empty thread, so starting a conversation looks like starting a conversation. That screen is Helix's own new-chat screen, extracted from Home into ChatWelcome and used by both: two implementations of it drift, and the difference shows up on a customer's screen rather than ours. The host names its own agent through ?heading and ?subheading.

The opening briefing is hidden but its reply is kept — that reply is the agent's greeting. Only when pagination has reached the oldest page: a thread that starts mid-conversation has a real message at index 0, and blanking that would be worse than the problem.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Spec-Ref: helix-specs@a4b958bc:003117_what-hes-doing-from-this