### PR TITLE
fix(frontend): improve chat sidebar readability

### DIFF
--- a/design/2026-09-11-chat-sidebar-readability.md
+++ b/design/2026-09-11-chat-sidebar-readability.md
@@ -1,0 +1,26 @@
+# Chat sidebar readability
+
+## Problem
+
+The chat sidebar used the same system font and 14px task-title size as T3 Code,
+but inactive rows were materially harder to scan. Sidebar components bypassed
+the central typography configuration with fixed 10px, 11px, and 14px values,
+used regular weight for primary labels, and compounded muted colors with low
+opacity. Cross-project rows also compressed project and task identity into two
+lines while T3 uses a stable three-line card.
+
+## Target hierarchy
+
+- Primary task, project, bot, and person labels: 14px/20px, medium weight.
+- Project metadata and time: 12px/16px, medium weight where it identifies the row.
+- Section labels and compact status text: 11px.
+- Stacked cross-project rows: 78px with project, task title, and branch lines.
+- Primary, secondary, and surface colors come from shared sidebar theme tokens.
+- Sidebar font sizes come from `styles/typography.ts` and remain rem-based.
+
+## Verification
+
+- Focused sidebar component tests.
+- Production frontend build.
+- Live dark- and light-mode review in the inner Helix at
+  `http://localhost:8080`, including computed typography and row geometry.

--- a/design/2026-09-11-chat-sidebar-readability.md
+++ b/design/2026-09-11-chat-sidebar-readability.md
@@ -15,6 +15,8 @@ lines while T3 uses a stable three-line card.
 - Project metadata and time: 12px/16px, medium weight where it identifies the row.
 - Section labels and compact status text: 11px.
 - Stacked cross-project rows: 78px with project, task title, and branch lines.
+- Branch metadata truncates on the left while the harness mark stays aligned to
+  the right edge of the row.
 - Primary, secondary, and surface colors come from shared sidebar theme tokens.
 - Sidebar font sizes come from `styles/typography.ts` and remain rem-based.
 

--- a/design/2026-09-11-chat-sidebar-readability.md
+++ b/design/2026-09-11-chat-sidebar-readability.md
@@ -17,6 +17,8 @@ lines while T3 uses a stable three-line card.
 - Stacked cross-project rows: 78px with project, task title, and branch lines.
 - Branch metadata truncates on the left while the harness mark stays aligned to
   the right edge of the row.
+- Pre-implementation tasks without an assigned branch show `n/a`; its tooltip
+  explains that the task is still in planning mode.
 - Primary, secondary, and surface colors come from shared sidebar theme tokens.
 - Sidebar font sizes come from `styles/typography.ts` and remain rem-based.
 

--- a/frontend/src/components/session/ProjectChatBotsGroup.tsx
+++ b/frontend/src/components/session/ProjectChatBotsGroup.tsx
@@ -30,6 +30,8 @@ import {
   useStopBotAgent,
 } from '../../services/helixOrgService'
 import { useSpecTasks } from '../../services/specTaskService'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import { PRESENCE_OFFLINE_COLOR, PRESENCE_ONLINE_COLOR } from '../widgets/PresenceDot'
 import ProjectChatItemRow from './ProjectChatItemRow'
 import ProjectChatShowMore from './ProjectChatShowMore'
@@ -267,6 +269,7 @@ const ProjectChatBotEntry: FC<ProjectChatBotEntryProps> = ({
   onArchiveItem,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const isPhone = useIsPhone()
   const searching = !!query.trim()
   const open = !collapsed || searching
@@ -326,17 +329,11 @@ const ProjectChatBotEntry: FC<ProjectChatBotEntryProps> = ({
           cursor: 'pointer',
           position: 'relative',
           outline: 'none',
-          color: active
-            ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
-            : (lightTheme.isLight ? '#71717a' : 'rgba(163,163,163,0.80)'),
-          backgroundColor: active
-            ? (lightTheme.isLight ? '#ffffff' : 'rgba(241,243,247,0.11)')
-            : 'transparent',
+          color: active ? sidebarColors.foreground : sidebarColors.primaryLabel,
+          backgroundColor: active ? sidebarColors.rowSelected : 'transparent',
           '&:hover, &:focus-visible': {
-            color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-            backgroundColor: active
-              ? (lightTheme.isLight ? '#ffffff' : 'rgba(241,243,247,0.11)')
-              : (lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)'),
+            color: sidebarColors.foreground,
+            backgroundColor: active ? sidebarColors.rowSelected : sidebarColors.rowHover,
           },
           '&:hover .sidebar-bot-settings, &:focus-within .sidebar-bot-settings': { opacity: 1 },
           '@media (hover: none)': { '& .sidebar-bot-settings': { opacity: 1 } },
@@ -398,9 +395,9 @@ const ProjectChatBotEntry: FC<ProjectChatBotEntryProps> = ({
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
-            fontSize: '14px',
-            lineHeight: '20px',
-            fontWeight: active ? 500 : 400,
+            fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
+            lineHeight: TYPOGRAPHY.sidebar.primaryLineHeight,
+            fontWeight: 500,
           }}
         >
           {bot.name}
@@ -429,7 +426,7 @@ const ProjectChatBotEntry: FC<ProjectChatBotEntryProps> = ({
         )}
       </Box>
       {open && tasksQuery.isError && (
-        <Typography color="error" sx={{ pl: 2.15, py: 0.5, fontSize: '0.7rem' }}>
+        <Typography color="error" sx={{ pl: 2.15, py: 0.5, fontSize: TYPOGRAPHY.sidebar.statusFontSize }}>
           Failed to load tasks
         </Typography>
       )}

--- a/frontend/src/components/session/ProjectChatGroup.tsx
+++ b/frontend/src/components/session/ProjectChatGroup.tsx
@@ -19,6 +19,8 @@ import { useListSessions } from '../../services/sessionService'
 import { useSpecTasks } from '../../services/specTaskService'
 import type { SpecTask } from '../../services/specTaskService'
 import { useGetProjectRepositories } from '../../services/projectService'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import {
   buildProjectChatGroups,
   filterProjectChatGroups,
@@ -95,6 +97,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
 }) => {
   const api = useApi()
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const isPhone = useIsPhone()
   const [visibility, setVisibility] = useState<GroupVisibility>('unknown')
   const projectId = project?.id
@@ -266,14 +269,14 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
           gap: 0.65,
           borderRadius: '6px',
           backgroundColor: 'transparent',
-          color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
+          color: sidebarColors.foreground,
           cursor: manualSorting ? 'grab' : 'pointer',
           '&:active': manualSorting ? { cursor: 'grabbing' } : undefined,
           textAlign: 'left',
           font: 'inherit',
           outline: 'none',
           '&:hover': {
-            backgroundColor: lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)',
+            backgroundColor: sidebarColors.rowHover,
           },
         }}
       >
@@ -321,8 +324,8 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             fontFamily: 'inherit',
-            fontSize: '14px',
-            lineHeight: '20px',
+            fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
+            lineHeight: TYPOGRAPHY.sidebar.primaryLineHeight,
             fontWeight: 500,
           }}
         >
@@ -354,10 +357,10 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
               border: 0,
               p: 0,
               backgroundColor: 'transparent',
-              color: lightTheme.isLight ? '#52525b' : 'rgba(212,212,216,0.82)',
+              color: sidebarColors.mutedForeground,
               cursor: 'pointer',
               font: 'inherit',
-              fontSize: '10px',
+              fontSize: TYPOGRAPHY.sidebar.statusFontSize,
               fontWeight: 500,
               opacity: 1,
               display: 'flex',
@@ -376,7 +379,7 @@ const ProjectChatGroup: FC<ProjectChatGroupProps> = ({
       {!collapsed && (
         <Box sx={{ pl: 1.15 }}>
           {hasError && (
-            <Typography color="error" sx={{ px: 1, py: 0.75, fontSize: '0.7rem' }}>
+            <Typography color="error" sx={{ px: 1, py: 0.75, fontSize: TYPOGRAPHY.sidebar.statusFontSize }}>
               Failed to load chats
             </Typography>
           )}

--- a/frontend/src/components/session/ProjectChatGroupByControl.tsx
+++ b/frontend/src/components/session/ProjectChatGroupByControl.tsx
@@ -12,6 +12,8 @@ import Typography from '@mui/material/Typography'
 import { Check, Folder, LayoutList, Users } from 'lucide-react'
 
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import type { SidebarGroupBy } from './ProjectChatSidebar.logic'
 
 type ProjectChatGroupByControlProps = {
@@ -28,6 +30,7 @@ const OPTIONS: Array<{ value: SidebarGroupBy; label: string; description: string
 // sidebar shows exactly one of them, never both.
 const ProjectChatGroupByControl: FC<ProjectChatGroupByControlProps> = ({ value, onChange }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = !!anchorEl
   const surface = lightTheme.isLight ? '#ffffff' : '#191919'
@@ -48,8 +51,8 @@ const ProjectChatGroupByControl: FC<ProjectChatGroupByControlProps> = ({ value, 
           onClick={openPicker}
           sx={{
             color: value === 'person'
-              ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
-              : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.55)'),
+              ? sidebarColors.foreground
+              : sidebarColors.subtleForeground,
           }}
         >
           <LayoutList size={15} strokeWidth={1.7} />
@@ -86,11 +89,11 @@ const ProjectChatGroupByControl: FC<ProjectChatGroupByControlProps> = ({ value, 
                 px: 1.5,
                 pt: 1.25,
                 pb: 0.5,
-                fontSize: '10.5px',
+                fontSize: TYPOGRAPHY.sidebar.sectionFontSize,
                 fontWeight: 600,
                 letterSpacing: '0.08em',
                 textTransform: 'uppercase',
-                color: lightTheme.isLight ? 'rgba(113,113,122,0.9)' : 'rgba(163,163,163,0.7)',
+                color: sidebarColors.subtleForeground,
               }}
             >
               Group by
@@ -122,8 +125,8 @@ const ProjectChatGroupByControl: FC<ProjectChatGroupByControlProps> = ({ value, 
                     <ListItemText
                       primary={option.label}
                       secondary={option.description}
-                      primaryTypographyProps={{ fontSize: '13px', fontWeight: 500 }}
-                      secondaryTypographyProps={{ fontSize: '11px' }}
+                      primaryTypographyProps={{ fontSize: TYPOGRAPHY.sidebar.primaryFontSize, fontWeight: 500 }}
+                      secondaryTypographyProps={{ fontSize: TYPOGRAPHY.sidebar.metadataFontSize }}
                     />
                     <Box sx={{ width: 16, display: 'inline-flex', justifyContent: 'center', flexShrink: 0 }}>
                       {selected && <Check size={14} />}

--- a/frontend/src/components/session/ProjectChatItemBadges.tsx
+++ b/frontend/src/components/session/ProjectChatItemBadges.tsx
@@ -6,6 +6,7 @@ import { keyframes } from '@mui/material/styles'
 import { Folder, GitPullRequest } from 'lucide-react'
 
 import { useGetProjectRepositories } from '../../services/projectService'
+import { TYPOGRAPHY } from '../../styles/typography'
 import { githubOrgAvatarUrl } from './ProjectChatSidebar.logic'
 import type { SidebarPullRequestIcon, SidebarStatus } from './ProjectChatSidebar.logic'
 
@@ -36,11 +37,11 @@ export const ProjectRowIcon: FC<{ projectId?: string }> = ({ projectId }) => {
         src={avatarUrl}
         alt=""
         onError={() => setFailedUrl(avatarUrl)}
-        sx={{ width: 14, height: 14, borderRadius: '3px', flexShrink: 0, display: 'block' }}
+        sx={{ width: 16, height: 16, borderRadius: '3px', flexShrink: 0, display: 'block' }}
       />
     )
   }
-  return <Folder size={12} style={{ opacity: 0.72, flexShrink: 0 }} />
+  return <Folder size={14} style={{ opacity: 0.72, flexShrink: 0 }} />
 }
 
 // Workflow badges for a task row in the dense single-line layout: the PR
@@ -93,7 +94,14 @@ export const TaskStatusIcons: FC<{
               },
             }}
           />
-          <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
+          <Typography
+            component="span"
+            sx={{
+              fontSize: TYPOGRAPHY.sidebar.statusFontSize,
+              color: status.color,
+              lineHeight: TYPOGRAPHY.sidebar.statusLineHeight,
+            }}
+          >
             {status.label}
           </Typography>
         </Box>
@@ -147,7 +155,14 @@ export const StackedTaskStatusIcons: FC<{
             }}
           />
           {showLabel && (
-            <Typography component="span" sx={{ fontSize: '0.66rem', color: status.color, lineHeight: 1 }}>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: TYPOGRAPHY.sidebar.statusFontSize,
+                color: status.color,
+                lineHeight: TYPOGRAPHY.sidebar.statusLineHeight,
+              }}
+            >
               {status.label}
             </Typography>
           )}

--- a/frontend/src/components/session/ProjectChatItemRow.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { TYPOGRAPHY } from '../../styles/typography'
 import ProjectChatItemRow from './ProjectChatItemRow'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
 
@@ -54,14 +55,31 @@ const quietTask: SidebarItem = {
   updatedAt: '2026-09-05T12:00:00Z',
   projectId: 'prj-1',
   projectName: 'keel',
-  task: { id: 'task-1', status: 'done', sandbox_state: 'absent' } as any,
+  task: {
+    id: 'task-1',
+    status: 'done',
+    sandbox_state: 'absent',
+    branch_name: 'fix/installer',
+  } as any,
 }
 
 describe('ProjectChatItemRow', () => {
   it('stacks the project name above the title only for cross-project rows', () => {
-    renderRow(quietTask)
-    expect(screen.getByText('keel')).toBeInTheDocument()
-    expect(screen.getByText('Fix the installer')).toBeInTheDocument()
+    const { container } = renderRow(quietTask)
+    const projectName = screen.getByText('keel')
+    const title = screen.getByText('Fix the installer')
+    expect(projectName).toBeInTheDocument()
+    expect(title).toBeInTheDocument()
+    expect(projectName).toHaveStyle({
+      fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+      fontWeight: '500',
+    })
+    expect(title).toHaveStyle({
+      fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
+      fontWeight: '500',
+    })
+    expect(container.querySelector('.project-chat-item')).toHaveStyle({ minHeight: '78px' })
+    expect(screen.getByTestId('sidebar-item-metadata')).toHaveTextContent('fix/installer')
 
     renderRow({ ...quietTask, id: 'task-2', projectName: undefined })
     expect(screen.getAllByText('keel')).toHaveLength(1)

--- a/frontend/src/components/session/ProjectChatItemRow.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.test.tsx
@@ -60,6 +60,7 @@ const quietTask: SidebarItem = {
     status: 'done',
     sandbox_state: 'absent',
     branch_name: 'fix/installer',
+    code_agent_config: { runtime: 'qwen_code' },
   } as any,
 }
 
@@ -80,6 +81,8 @@ describe('ProjectChatItemRow', () => {
     })
     expect(container.querySelector('.project-chat-item')).toHaveStyle({ minHeight: '78px' })
     expect(screen.getByTestId('sidebar-item-metadata')).toHaveTextContent('fix/installer')
+    expect(screen.getByTestId('sidebar-item-harness')).toHaveStyle({ marginLeft: 'auto' })
+    expect(screen.getByRole('img', { name: 'Qwen Code' })).toBeInTheDocument()
 
     renderRow({ ...quietTask, id: 'task-2', projectName: undefined })
     expect(screen.getAllByText('keel')).toHaveLength(1)

--- a/frontend/src/components/session/ProjectChatItemRow.test.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.test.tsx
@@ -101,6 +101,28 @@ describe('ProjectChatItemRow', () => {
     expect(screen.getByText('Implementation')).toBeInTheDocument()
   })
 
+  it('explains why a planning task has no branch yet', async () => {
+    renderRow({
+      ...quietTask,
+      id: 'task-planning',
+      task: {
+        ...quietTask.task,
+        id: 'task-planning',
+        status: 'spec_generation',
+        branch_name: undefined,
+        base_branch: undefined,
+      } as any,
+    })
+
+    const branch = screen.getByTestId('sidebar-item-branch')
+    expect(branch).toHaveAttribute('data-branch-state', 'unavailable')
+    expect(branch).toHaveTextContent('n/a')
+
+    fireEvent.mouseOver(branch)
+    expect(await screen.findByText('Task is in planning mode; no branch yet.')).toBeInTheDocument()
+    expect(screen.getAllByRole('tooltip')).toHaveLength(1)
+  })
+
   it('renders the GitHub owner avatar and falls back to the folder glyph on load failure', () => {
     mocks.repositories = [{ external_type: 'github', external_url: 'https://github.com/keel-hq/keel' }]
     const { container } = renderRow(quietTask)

--- a/frontend/src/components/session/ProjectChatItemRow.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.tsx
@@ -10,6 +10,8 @@ import type { TypesOrganizationMembership, TypesUser } from '../../api/api'
 import useApps from '../../hooks/useApps'
 import useIsPhone from '../../hooks/useIsPhone'
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import AgentHarness from '../agent/AgentHarness'
 import OrganizationUserAvatar, { resolveOrganizationUser } from '../widgets/OrganizationUserAvatar'
 import ProjectChatItemTooltip from './ProjectChatItemTooltip'
@@ -59,6 +61,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
   onArchiveItem,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const { apps } = useApps()
   // No hover on a phone, so the facts the tooltip carries have to live on the
   // row itself. That makes the row two lines, and taller.
@@ -78,9 +81,9 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
   const taskPerson = resolveOrganizationUser(taskPersonId, organizationMembers, currentUser)
   const taskPersonRole = item.kind === 'session' ? 'Started by' : item.task?.assignee_id ? 'Assigned to' : 'Created by'
   const branch = resolveProjectChatItemBranch(item, defaultBranch)
-  // Only resolved for the phone layout — on desktop the tooltip does
-  // its own lookup when it actually opens.
-  const details = isPhone
+  // Stacked rows expose stable context without requiring hover; dense desktop
+  // rows keep the details in the tooltip.
+  const details = isPhone || stacked
     ? getProjectChatItemDetails({ item, apps, repository: repositoryName, branch })
     : undefined
   const subLine = details
@@ -115,8 +118,8 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
           // Without hover the overlay would hide the time forever, so
           // touch devices get the phone treatment: side by side.
           ? {
-              minWidth: 28,
-              height: 16,
+              minWidth: 32,
+              height: 20,
               flexShrink: 0,
               position: 'relative',
               display: 'flex',
@@ -124,7 +127,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
               justifyContent: 'flex-end',
               '@media (hover: none)': { gap: 0.5 },
             }
-          : { width: 28, height: 28, flexShrink: 0, position: 'relative' }}
+          : { width: 32, height: 28, flexShrink: 0, position: 'relative' }}
     >
       <Typography
         className="sidebar-item-time"
@@ -140,11 +143,9 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
           whiteSpace: 'nowrap',
           color: showStatusAsTime
             ? status!.color
-            : active
-              ? (lightTheme.isLight ? 'rgba(39,39,42,0.58)' : 'rgba(241,243,247,0.72)')
-              : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.55)'),
-          fontSize: '10px',
-          lineHeight: 1,
+            : sidebarColors.mutedForeground,
+          fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+          lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
           fontVariantNumeric: 'tabular-nums',
           transition: 'opacity 100ms ease',
           ...(showStatusAsTime && isAgentWorking && {
@@ -169,7 +170,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
           sx={{
             ...(isPhone
               ? { position: 'static', width: 28, height: 28 }
-              : { position: 'absolute', top: stacked ? -6 : 0, right: 0, bottom: stacked ? -6 : 0, width: 20, height: 28 }),
+              : { position: 'absolute', top: stacked ? -4 : 0, right: 0, bottom: stacked ? -4 : 0, width: 24, height: 28 }),
             ...(!isPhone && stacked && {
               '@media (hover: none)': { position: 'static', top: 'auto', bottom: 'auto', height: 20 },
             }),
@@ -203,14 +204,10 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
-        fontSize: '14px',
-        lineHeight: '20px',
-        fontWeight: active ? 500 : 400,
-        // The stacked row's hierarchy is carried by contrast: the title
-        // reads brighter than the muted project line above it.
-        ...(stacked && !active && {
-          color: lightTheme.isLight ? '#52525b' : 'rgba(212,212,216,0.88)',
-        }),
+        color: active ? sidebarColors.foreground : sidebarColors.primaryLabel,
+        fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
+        lineHeight: TYPOGRAPHY.sidebar.primaryLineHeight,
+        fontWeight: 500,
       }}
     >
       {item.title}
@@ -241,16 +238,16 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
     </Tooltip>
   )
 
-  const subLineNode = isPhone && subLine.length > 0 && (
+  const subLineNode = (stacked || (isPhone && subLine.length > 0)) && (
     <Box
+      data-testid="sidebar-item-metadata"
       sx={{
         display: 'flex',
         alignItems: 'center',
         gap: 1.25,
         minWidth: 0,
-        color: lightTheme.isLight
-          ? 'rgba(113,113,122,0.85)'
-          : 'rgba(163,163,163,0.72)',
+        ...(stacked && { height: 16, mt: 0.25 }),
+        color: sidebarColors.subtleForeground,
       }}
     >
       {subLine.map((entry) => (
@@ -275,8 +272,8 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
-                fontSize: '11px',
-                lineHeight: '15px',
+                fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+                lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
               }}
             >
               {entry.value}
@@ -302,8 +299,8 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
           alignItems: 'center',
           justifyContent: 'center',
           color: active
-            ? (lightTheme.isLight ? 'rgba(39,39,42,0.68)' : 'rgba(241,243,247,0.78)')
-            : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.62)'),
+            ? sidebarColors.foreground
+            : sidebarColors.subtleForeground,
           transition: 'opacity 100ms ease',
         }}
       >
@@ -336,31 +333,25 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
       sx={{
         width: '100%',
         minWidth: 0,
-        // Stacked (cross-project) and phone rows are two lines; project
-        // groups on desktop keep the dense single-line row.
+        // Cross-project rows use a stable three-line card; project groups on
+        // desktop keep the dense single-line row.
         ...(stacked
-          ? { py: 0.75, flexDirection: 'column', alignItems: 'stretch', gap: 0.4 }
+          ? { minHeight: 78, py: 1, flexDirection: 'column', alignItems: 'stretch' }
           : isPhone
             ? { minHeight: 52, py: 0.75, flexDirection: 'column', alignItems: 'stretch', gap: 0.25 }
             : { height: 32, flexDirection: 'row', alignItems: 'center', gap: 0.75 }),
         px: 1,
         borderRadius: '6px',
         display: 'flex',
-        color: active
-          ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
-          : (lightTheme.isLight ? '#71717a' : 'rgba(163,163,163,0.80)'),
-        backgroundColor: active
-          ? (lightTheme.isLight ? '#ffffff' : 'rgba(241,243,247,0.11)')
-          : 'transparent',
+        color: active ? sidebarColors.foreground : sidebarColors.primaryLabel,
+        backgroundColor: active ? sidebarColors.rowSelected : 'transparent',
         cursor: 'pointer',
         textAlign: 'left',
         outline: 'none',
         position: 'relative',
         '&:hover, &:focus-visible': {
-          color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-          backgroundColor: active
-            ? (lightTheme.isLight ? '#ffffff' : 'rgba(241,243,247,0.11)')
-            : (lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)'),
+          color: sidebarColors.foreground,
+          backgroundColor: active ? sidebarColors.rowSelected : sidebarColors.rowHover,
         },
         '&:hover .sidebar-item-time, &:focus-within .sidebar-item-time': { opacity: 0 },
         '&:hover .sidebar-item-archive, &:focus-within .sidebar-item-archive': { opacity: 1 },
@@ -387,7 +378,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
     >
       {stacked ? (
         <>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6, minWidth: 0, width: '100%' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, width: '100%', height: 20 }}>
             <ProjectRowIcon projectId={item.projectId} />
             <Typography
               component="span"
@@ -397,19 +388,17 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
-                fontSize: '11px',
-                lineHeight: '14px',
-                fontWeight: 400,
-                color: active
-                  ? (lightTheme.isLight ? 'rgba(39,39,42,0.68)' : 'rgba(241,243,247,0.72)')
-                  : (lightTheme.isLight ? 'rgba(113,113,122,0.8)' : 'rgba(200,200,206,0.8)'),
+                fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+                lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
+                fontWeight: 500,
+                color: sidebarColors.mutedForeground,
               }}
             >
               {projectName}
             </Typography>
             {timeAndArchive}
           </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, width: '100%' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, width: '100%', mt: 0.5 }}>
             {titleNode}
             {avatarNode}
             {pinNode}

--- a/frontend/src/components/session/ProjectChatItemRow.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, ReactElement } from 'react'
+import { FC, MouseEvent } from 'react'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -86,17 +86,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
   const details = isPhone || stacked
     ? getProjectChatItemDetails({ item, apps, repository: repositoryName, branch })
     : undefined
-  const subLine = details
-    ? [
-        details.branch && { key: 'branch', icon: <GitBranch size={11} />, value: details.branch },
-        // Icon only — the mark identifies the harness, the name just
-        // ate horizontal space on a phone.
-        details.harness && {
-          key: 'harness',
-          icon: <AgentHarness runtime={details.runtime || ''} variant="short" size={11} />,
-        },
-      ].filter(Boolean) as Array<{ key: string; icon: ReactElement; value?: string }>
-    : []
+  const hasSubLineDetails = !!(details?.branch || details?.harness)
 
   // Active tasks trade their timestamp for the live status label (t3-style):
   // "24 minutes ago" says nothing while the agent is mid-implementation, and
@@ -238,49 +228,55 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
     </Tooltip>
   )
 
-  const subLineNode = (stacked || (isPhone && subLine.length > 0)) && (
+  const subLineNode = (stacked || (isPhone && hasSubLineDetails)) && (
     <Box
       data-testid="sidebar-item-metadata"
       sx={{
         display: 'flex',
         alignItems: 'center',
-        gap: 1.25,
+        gap: 1,
         minWidth: 0,
+        width: '100%',
         ...(stacked && { height: 16, mt: 0.25 }),
         color: sidebarColors.subtleForeground,
       }}
     >
-      {subLine.map((entry) => (
+      {details?.branch && (
         <Box
-          key={entry.key}
           sx={{
             display: 'flex',
             alignItems: 'center',
             gap: 0.5,
             minWidth: 0,
-            // The branch takes the slack; the other entries are
-            // icon-sized and should stay whole.
-            flexShrink: entry.key === 'branch' ? 1 : 0,
+            flex: 1,
           }}
         >
-          <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>{entry.icon}</Box>
-          {entry.value && (
-            <Typography
-              component="span"
-              sx={{
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
-                lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
-              }}
-            >
-              {entry.value}
-            </Typography>
-          )}
+          <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
+            <GitBranch size={11} />
+          </Box>
+          <Typography
+            component="span"
+            sx={{
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+              lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
+            }}
+          >
+            {details.branch}
+          </Typography>
         </Box>
-      ))}
+      )}
+      {details?.harness && (
+        <Box
+          data-testid="sidebar-item-harness"
+          sx={{ ml: 'auto', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}
+        >
+          <AgentHarness runtime={details.runtime || ''} variant="short" size={11} />
+        </Box>
+      )}
     </Box>
   )
 

--- a/frontend/src/components/session/ProjectChatItemRow.tsx
+++ b/frontend/src/components/session/ProjectChatItemRow.tsx
@@ -86,7 +86,9 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
   const details = isPhone || stacked
     ? getProjectChatItemDetails({ item, apps, repository: repositoryName, branch })
     : undefined
-  const hasSubLineDetails = !!(details?.branch || details?.harness)
+  const branchUnavailable = item.kind === 'spec-task' && !details?.branch
+  const branchLabel = details?.branch || (branchUnavailable ? 'n/a' : undefined)
+  const hasSubLineDetails = !!(branchLabel || details?.harness)
 
   // Active tasks trade their timestamp for the live status label (t3-style):
   // "24 minutes ago" says nothing while the agent is mid-implementation, and
@@ -228,6 +230,46 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
     </Tooltip>
   )
 
+  const branchMetadataNode = branchLabel && (
+    <Box
+      data-testid="sidebar-item-branch"
+      data-branch-state={branchUnavailable ? 'unavailable' : 'available'}
+      onMouseOver={(event) => event.stopPropagation()}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        minWidth: 0,
+        flex: 1,
+      }}
+    >
+      <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
+        <GitBranch size={11} />
+      </Box>
+      <Typography
+        component="span"
+        sx={{
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+          lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
+        }}
+      >
+        {branchLabel}
+      </Typography>
+    </Box>
+  )
+
+  const branchNode = branchUnavailable
+    ? (
+        <Tooltip title="Task is in planning mode; no branch yet." placement="bottom-start">
+          {branchMetadataNode}
+        </Tooltip>
+      )
+    : branchMetadataNode
+
   const subLineNode = (stacked || (isPhone && hasSubLineDetails)) && (
     <Box
       data-testid="sidebar-item-metadata"
@@ -241,34 +283,7 @@ const ProjectChatItemRow: FC<ProjectChatItemRowProps> = ({
         color: sidebarColors.subtleForeground,
       }}
     >
-      {details?.branch && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            minWidth: 0,
-            flex: 1,
-          }}
-        >
-          <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
-            <GitBranch size={11} />
-          </Box>
-          <Typography
-            component="span"
-            sx={{
-              minWidth: 0,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
-              lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
-            }}
-          >
-            {details.branch}
-          </Typography>
-        </Box>
-      )}
+      {branchNode}
       {details?.harness && (
         <Box
           data-testid="sidebar-item-harness"

--- a/frontend/src/components/session/ProjectChatItemTooltip.tsx
+++ b/frontend/src/components/session/ProjectChatItemTooltip.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography'
 import { BrainCircuit, Cpu, Folder, FolderGit2, GitBranch, Monitor, SquareTerminal } from 'lucide-react'
 
 import useApps from '../../hooks/useApps'
+import { TYPOGRAPHY } from '../../styles/typography'
 import AgentHarness from '../agent/AgentHarness'
 import { getProjectChatItemDetails } from './projectChatItemDetails'
 import type { SidebarItem } from './ProjectChatSidebar.logic'
@@ -79,7 +80,14 @@ const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
       }}
       title={(
         <Box sx={{ minWidth: 170 }}>
-          <Typography sx={{ mb: rows.length ? 0.75 : 0, fontSize: '12px', fontWeight: 600, lineHeight: 1.35 }}>
+          <Typography
+            sx={{
+              mb: rows.length ? 0.75 : 0,
+              fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+              fontWeight: 600,
+              lineHeight: 1.35,
+            }}
+          >
             {item.title}
           </Typography>
           {rows.map((row) => (
@@ -87,7 +95,16 @@ const ProjectChatItemTooltip: FC<ProjectChatItemTooltipProps> = ({
               <Box sx={{ width: 14, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                 {row.icon}
               </Box>
-              <Typography sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '11px', lineHeight: 1.35 }}>
+              <Typography
+                sx={{
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: TYPOGRAPHY.sidebar.statusFontSize,
+                  lineHeight: 1.35,
+                }}
+              >
                 {row.value}
               </Typography>
             </Box>

--- a/frontend/src/components/session/ProjectChatPeopleSection.tsx
+++ b/frontend/src/components/session/ProjectChatPeopleSection.tsx
@@ -4,6 +4,8 @@ import Typography from '@mui/material/Typography'
 
 import type { TypesOrganizationMembership, TypesPinnedChat, TypesProject, TypesUser } from '../../api/api'
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import ProjectChatPersonGroup from './ProjectChatPersonGroup'
 import { visibleSidebarMembers } from './ProjectChatSidebar.logic'
 import type { SidebarItem, SidebarMember, SidebarThreadSortOrder } from './ProjectChatSidebar.logic'
@@ -58,14 +60,14 @@ const ProjectChatPeopleSection: FC<ProjectChatPeopleSectionProps> = ({
   onArchiveItem,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const [showAll, setShowAll] = useState(false)
   const selected = new Set(selectedUserIds)
   const visible = visibleSidebarMembers(members, selected, query, showAll)
-  const mutedColor = lightTheme.isLight ? 'rgba(113,113,122,0.8)' : 'rgba(163,163,163,0.65)'
 
   if (members.length === 0) {
     return (
-      <Typography sx={{ px: 1.25, py: 0.75, fontSize: '12px', color: mutedColor }}>
+      <Typography sx={{ px: 1.25, py: 0.75, fontSize: TYPOGRAPHY.sidebar.metadataFontSize, color: sidebarColors.subtleForeground }}>
         No one else in this organization yet
       </Typography>
     )
@@ -99,7 +101,7 @@ const ProjectChatPeopleSection: FC<ProjectChatPeopleSectionProps> = ({
         />
       ))}
       {query && visible.members.length === 0 && (
-        <Typography sx={{ px: 1.25, py: 0.75, fontSize: '12px', color: mutedColor }}>
+        <Typography sx={{ px: 1.25, py: 0.75, fontSize: TYPOGRAPHY.sidebar.metadataFontSize, color: sidebarColors.subtleForeground }}>
           No members match
         </Typography>
       )}
@@ -114,11 +116,11 @@ const ProjectChatPeopleSection: FC<ProjectChatPeopleSectionProps> = ({
             height: 30,
             px: 1,
             backgroundColor: 'transparent',
-            color: mutedColor,
+            color: sidebarColors.subtleForeground,
             cursor: 'pointer',
             font: 'inherit',
-            fontSize: '12px',
-            '&:hover': { color: lightTheme.isLight ? '#27272a' : '#f1f3f7' },
+            fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+            '&:hover': { color: sidebarColors.foreground },
           }}
         >
           {showAll ? 'Show fewer' : `Show ${visible.hiddenCount} more offline`}

--- a/frontend/src/components/session/ProjectChatPersonGroup.tsx
+++ b/frontend/src/components/session/ProjectChatPersonGroup.tsx
@@ -10,6 +10,8 @@ import useIsPhone from '../../hooks/useIsPhone'
 import useLightTheme from '../../hooks/useLightTheme'
 import { useListSessions } from '../../services/sessionService'
 import { useSpecTasks } from '../../services/specTaskService'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import { getUserInitials } from '../../utils/user'
 import PresenceDot from '../widgets/PresenceDot'
 import ProjectChatItemRow from './ProjectChatItemRow'
@@ -79,6 +81,7 @@ const ProjectChatPersonGroup: FC<ProjectChatPersonGroupProps> = ({
   onArchiveItem,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const isPhone = useIsPhone()
   const searching = !!query.trim()
   const open = expanded || searching
@@ -157,11 +160,11 @@ const ProjectChatPersonGroup: FC<ProjectChatPersonGroupProps> = ({
           alignItems: 'center',
           gap: 0.65,
           borderRadius: '6px',
-          color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
+          color: sidebarColors.foreground,
           cursor: 'pointer',
           outline: 'none',
           '&:hover, &:focus-visible': {
-            backgroundColor: lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)',
+            backgroundColor: sidebarColors.rowHover,
           },
         }}
       >
@@ -200,8 +203,8 @@ const ProjectChatPersonGroup: FC<ProjectChatPersonGroupProps> = ({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             fontFamily: 'inherit',
-            fontSize: '14px',
-            lineHeight: '20px',
+            fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
+            lineHeight: TYPOGRAPHY.sidebar.primaryLineHeight,
             fontWeight: 500,
           }}
         >
@@ -213,7 +216,7 @@ const ProjectChatPersonGroup: FC<ProjectChatPersonGroupProps> = ({
       {open && (
         <Box sx={{ pl: 1.15 }}>
           {hasError && (
-            <Typography color="error" sx={{ px: 1, py: 0.75, fontSize: '0.7rem' }}>
+            <Typography color="error" sx={{ px: 1, py: 0.75, fontSize: TYPOGRAPHY.sidebar.statusFontSize }}>
               Failed to load their work
             </Typography>
           )}
@@ -222,8 +225,9 @@ const ProjectChatPersonGroup: FC<ProjectChatPersonGroupProps> = ({
               sx={{
                 px: 1,
                 py: 0.75,
-                fontSize: '12px',
-                color: lightTheme.isLight ? 'rgba(113,113,122,0.8)' : 'rgba(163,163,163,0.65)',
+                fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
+                lineHeight: TYPOGRAPHY.sidebar.metadataLineHeight,
+                color: sidebarColors.subtleForeground,
               }}
             >
               {searching ? 'No matching work' : 'Nothing you can see yet'}

--- a/frontend/src/components/session/ProjectChatSectionHeader.tsx
+++ b/frontend/src/components/session/ProjectChatSectionHeader.tsx
@@ -4,6 +4,8 @@ import Typography from '@mui/material/Typography'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 
 type ProjectChatSectionHeaderProps = {
   label: string
@@ -23,7 +25,7 @@ const ProjectChatSectionHeader: FC<ProjectChatSectionHeaderProps> = ({
   actions,
 }) => {
   const lightTheme = useLightTheme()
-  const color = lightTheme.isLight ? 'rgba(113,113,122,0.9)' : 'rgba(163,163,163,0.7)'
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   return (
     <Box
       sx={{
@@ -33,7 +35,7 @@ const ProjectChatSectionHeader: FC<ProjectChatSectionHeaderProps> = ({
         display: 'flex',
         alignItems: 'center',
         gap: 0.25,
-        color,
+        color: sidebarColors.subtleForeground,
       }}
     >
       <Box
@@ -59,7 +61,7 @@ const ProjectChatSectionHeader: FC<ProjectChatSectionHeaderProps> = ({
           cursor: 'pointer',
           font: 'inherit',
           borderRadius: '4px',
-          '&:hover': { color: lightTheme.isLight ? '#27272a' : '#f1f3f7' },
+          '&:hover': { color: sidebarColors.foreground },
         }}
       >
         {collapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
@@ -67,11 +69,11 @@ const ProjectChatSectionHeader: FC<ProjectChatSectionHeaderProps> = ({
           component="span"
           sx={{
             fontFamily: 'inherit',
-            fontSize: '10.5px',
+            fontSize: TYPOGRAPHY.sidebar.sectionFontSize,
             fontWeight: 600,
             letterSpacing: '0.08em',
             textTransform: 'uppercase',
-            lineHeight: 1,
+            lineHeight: TYPOGRAPHY.sidebar.sectionLineHeight,
           }}
         >
           {label}

--- a/frontend/src/components/session/ProjectChatShowMore.tsx
+++ b/frontend/src/components/session/ProjectChatShowMore.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react'
 import Box from '@mui/material/Box'
 
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import type { SidebarItemPagination } from './useSidebarItemPagination'
 
 type ProjectChatShowMoreProps = {
@@ -13,6 +15,7 @@ type ProjectChatShowMoreProps = {
 // The "Show more / Show less" footer under a sidebar group.
 const ProjectChatShowMore: FC<ProjectChatShowMoreProps> = ({ pagination, hasMore, fetching }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   if (!pagination.canShowLess && !hasMore) return null
   const buttonSx = {
     appearance: 'none',
@@ -20,13 +23,13 @@ const ProjectChatShowMore: FC<ProjectChatShowMoreProps> = ({ pagination, hasMore
     height: 30,
     px: 1,
     backgroundColor: 'transparent',
-    color: lightTheme.isLight ? 'rgba(113,113,122,0.75)' : 'rgba(163,163,163,0.75)',
+    color: sidebarColors.subtleForeground,
     cursor: fetching ? 'default' : 'pointer',
     font: 'inherit',
-    fontSize: '12px',
+    fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
     '&:hover': {
-      color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-      backgroundColor: lightTheme.isLight ? '#fdfdfd' : 'rgba(241,243,247,0.08)',
+      color: sidebarColors.foreground,
+      backgroundColor: sidebarColors.rowHover,
     },
   }
   return (

--- a/frontend/src/components/session/ProjectChatSidebar.tsx
+++ b/frontend/src/components/session/ProjectChatSidebar.tsx
@@ -34,6 +34,8 @@ import { useListProjects } from '../../services/projectService'
 import { useArchiveSession } from '../../services/sessionService'
 import { useArchiveSpecTask } from '../../services/specTaskService'
 import { usePinnedChats } from '../../services/chatPinService'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { APP_FONT_FAMILY, TYPOGRAPHY } from '../../styles/typography'
 import NewBotDialog from '../helix-org/NewBotDialog'
 import CreateProjectDialog from '../project/CreateProjectDialog'
 import SimpleConfirmWindow from '../widgets/SimpleConfirmWindow'
@@ -79,7 +81,6 @@ import type { NewChatTarget } from './NewChatProjectDialog'
 import ProjectChatSidebarMobileBar, { MOBILE_BAR_CLEARANCE } from './ProjectChatSidebarMobileBar'
 
 const RELATIVE_TIME_REFRESH_MS = 15000
-const T3_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif'
 
 const readCollapsedGroups = (storageKey: string): Set<string> => {
   try {
@@ -121,6 +122,7 @@ const ProjectChatSidebar: FC<{
   const router = useRouter()
   const isPhone = useIsPhone()
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const snackbar = useSnackbar()
   const { openDialog } = useSettingsDialog()
   const orgSlug = router.params.org_id || ''
@@ -579,8 +581,8 @@ const ProjectChatSidebar: FC<{
             aria-pressed={showArchived}
             sx={{
               color: showArchived
-                ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
-                : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.55)'),
+                ? sidebarColors.foreground
+                : sidebarColors.subtleForeground,
             }}
           >
             <Archive size={15} strokeWidth={1.7} />
@@ -594,11 +596,7 @@ const ProjectChatSidebar: FC<{
                 onClick={() => setCreateProjectOpen(true)}
                 disabled={!account.user?.id || !orgId}
                 aria-label="New project"
-                sx={{
-                  color: lightTheme.isLight
-                    ? 'rgba(113,113,122,0.65)'
-                    : 'rgba(163,163,163,0.55)',
-                }}
+                sx={{ color: sidebarColors.subtleForeground }}
               >
                 <FolderPlus size={15} strokeWidth={1.7} />
               </IconButton>
@@ -628,9 +626,9 @@ const ProjectChatSidebar: FC<{
         flexDirection: 'column',
         // Positioning context for the phone's floating bottom bar.
         position: 'relative',
-        fontFamily: T3_FONT_FAMILY,
-        color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-        backgroundColor: lightTheme.isLight ? '#fafafa' : '#000000',
+        fontFamily: APP_FONT_FAMILY,
+        color: sidebarColors.foreground,
+        backgroundColor: sidebarColors.background,
         '& .MuiTypography-root': { fontFamily: 'inherit' },
         '&[data-chat-shortcuts-visible="true"] .project-chat-item[data-chat-shortcut]::after': {
           content: 'attr(data-chat-shortcut)',
@@ -643,9 +641,9 @@ const ProjectChatSidebar: FC<{
           alignItems: 'center',
           justifyContent: 'center',
           borderRadius: '4px',
-          color: lightTheme.isLight ? '#52525b' : '#d4d4d8',
-          backgroundColor: lightTheme.isLight ? 'rgba(39,39,42,0.08)' : 'rgba(241,243,247,0.12)',
-          fontSize: '10px',
+          color: sidebarColors.primaryLabel,
+          backgroundColor: sidebarColors.rowSelected,
+          fontSize: TYPOGRAPHY.sidebar.statusFontSize,
           fontWeight: 600,
           lineHeight: 1,
           fontVariantNumeric: 'tabular-nums',
@@ -682,10 +680,10 @@ const ProjectChatSidebar: FC<{
               minWidth: 0,
               color: 'inherit',
               fontFamily: 'inherit',
-              fontSize: '14px',
+              fontSize: TYPOGRAPHY.sidebar.primaryFontSize,
               fontWeight: 500,
               '& input::placeholder': {
-                color: lightTheme.isLight ? '#71717a' : '#a3a3a3',
+                color: sidebarColors.mutedForeground,
                 opacity: 1,
               },
             }}
@@ -727,8 +725,8 @@ const ProjectChatSidebar: FC<{
               aria-pressed={showArchived}
               sx={{
                 color: showArchived
-                  ? (lightTheme.isLight ? '#27272a' : '#f1f3f7')
-                  : (lightTheme.isLight ? 'rgba(113,113,122,0.65)' : 'rgba(163,163,163,0.55)'),
+                  ? sidebarColors.foreground
+                  : sidebarColors.subtleForeground,
               }}
             >
               <Archive size={15} strokeWidth={1.7} />
@@ -743,9 +741,7 @@ const ProjectChatSidebar: FC<{
                   disabled={!account.user?.id || !orgId}
                   aria-label="New project"
                   sx={{
-                    color: lightTheme.isLight
-                      ? 'rgba(113,113,122,0.65)'
-                      : 'rgba(163,163,163,0.55)',
+                    color: sidebarColors.subtleForeground,
                   }}
                 >
                   <FolderPlus size={15} strokeWidth={1.7} />
@@ -798,8 +794,8 @@ const ProjectChatSidebar: FC<{
                         px: 0.5,
                         py: 0,
                         color: 'inherit',
-                        fontSize: '10.5px',
-                        lineHeight: 1,
+                        fontSize: TYPOGRAPHY.sidebar.sectionFontSize,
+                        lineHeight: TYPOGRAPHY.sidebar.sectionLineHeight,
                         textTransform: 'none',
                         '& .MuiButton-startIcon': { mr: 0.25 },
                       }}

--- a/frontend/src/components/session/ProjectChatSidebarOptions.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarOptions.tsx
@@ -9,6 +9,8 @@ import Typography from '@mui/material/Typography'
 import { ArrowUpDown, Minus, Plus } from 'lucide-react'
 
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import {
   MAX_VISIBLE_THREAD_COUNT,
   MIN_VISIBLE_THREAD_COUNT,
@@ -47,9 +49,9 @@ const ProjectChatSidebarOptions: FC<ProjectChatSidebarOptionsProps> = ({
   onVisibleThreadCountChange,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = !!anchorEl
-  const muted = lightTheme.isLight ? '#71717a' : '#8f8f94'
   const surface = lightTheme.isLight ? '#ffffff' : '#191919'
   const selected = lightTheme.isLight ? 'rgba(24,24,27,0.07)' : 'rgba(255,255,255,0.08)'
 
@@ -59,8 +61,8 @@ const ProjectChatSidebarOptions: FC<ProjectChatSidebarOptionsProps> = ({
     px: 1,
     pt: 0.75,
     pb: 0.4,
-    color: muted,
-    fontSize: '12px',
+    color: sidebarColors.mutedForeground,
+    fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
     fontWeight: 500,
     lineHeight: 1.4,
   }
@@ -79,7 +81,7 @@ const ProjectChatSidebarOptions: FC<ProjectChatSidebarOptionsProps> = ({
     color: 'inherit',
     cursor: 'pointer',
     font: 'inherit',
-    fontSize: '13px',
+    fontSize: TYPOGRAPHY.sidebar.controlFontSize,
     textAlign: 'left',
     '&:hover, &:focus-visible': { backgroundColor: selected, outline: 'none' },
   }
@@ -93,11 +95,7 @@ const ProjectChatSidebarOptions: FC<ProjectChatSidebarOptionsProps> = ({
           aria-haspopup="menu"
           aria-expanded={open || undefined}
           onClick={openMenu}
-          sx={{
-            color: lightTheme.isLight
-              ? 'rgba(113,113,122,0.65)'
-              : 'rgba(163,163,163,0.55)',
-          }}
+          sx={{ color: sidebarColors.subtleForeground }}
         >
           <ArrowUpDown size={15} strokeWidth={1.7} />
         </IconButton>
@@ -189,7 +187,11 @@ const ProjectChatSidebarOptions: FC<ProjectChatSidebarOptionsProps> = ({
               </IconButton>
               <Typography
                 aria-label="Visible thread count"
-                sx={{ textAlign: 'center', fontSize: '13px', fontVariantNumeric: 'tabular-nums' }}
+                sx={{
+                  textAlign: 'center',
+                  fontSize: TYPOGRAPHY.sidebar.controlFontSize,
+                  fontVariantNumeric: 'tabular-nums',
+                }}
               >
                 {visibleThreadCount}
               </Typography>

--- a/frontend/src/components/session/ProjectChatSidebarProjectFilter.tsx
+++ b/frontend/src/components/session/ProjectChatSidebarProjectFilter.tsx
@@ -8,6 +8,8 @@ import { Check, ChevronDown } from 'lucide-react'
 
 import type { TypesProject } from '../../api/api'
 import useLightTheme from '../../hooks/useLightTheme'
+import { getSidebarColors } from '../../styles/themeTokens'
+import { TYPOGRAPHY } from '../../styles/typography'
 import { ALL_PROJECTS_FILTER } from './ProjectChatSidebar.logic'
 
 type ProjectChatSidebarProjectFilterProps = {
@@ -24,6 +26,7 @@ const ProjectChatSidebarProjectFilter: FC<ProjectChatSidebarProjectFilterProps> 
   onChange,
 }) => {
   const lightTheme = useLightTheme()
+  const sidebarColors = getSidebarColors(lightTheme.isLight)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const selectedProject = projects.find((project) => project.id === selectedProjectId)
   const selectedLabel = selectedProject?.name || 'All projects'
@@ -50,16 +53,16 @@ const ProjectChatSidebarProjectFilter: FC<ProjectChatSidebarProjectFilterProps> 
           height: 30,
           px: 0.75,
           justifyContent: 'space-between',
-          color: lightTheme.isLight ? 'rgba(113,113,122,0.80)' : 'rgba(163,163,163,0.80)',
+          color: sidebarColors.mutedForeground,
           fontFamily: 'inherit',
-          fontSize: '12px',
+          fontSize: TYPOGRAPHY.sidebar.metadataFontSize,
           fontWeight: 500,
           lineHeight: 1,
           textTransform: 'none',
           '& .MuiButton-endIcon': { ml: 0.5, flexShrink: 0 },
           '&:hover': {
-            color: lightTheme.isLight ? '#27272a' : '#f1f3f7',
-            backgroundColor: lightTheme.isLight ? 'rgba(39,39,42,0.04)' : 'rgba(241,243,247,0.08)',
+            color: sidebarColors.foreground,
+            backgroundColor: sidebarColors.rowHover,
           },
         }}
       >
@@ -91,7 +94,7 @@ const ProjectChatSidebarProjectFilter: FC<ProjectChatSidebarProjectFilterProps> 
         <MenuItem
           selected={selectedProjectId === ALL_PROJECTS_FILTER}
           onClick={() => selectProject(ALL_PROJECTS_FILTER)}
-          sx={{ gap: 1, fontSize: '13px' }}
+          sx={{ gap: 1, fontSize: TYPOGRAPHY.sidebar.controlFontSize }}
         >
           <Box sx={{ width: 16, display: 'inline-flex' }}>
             {selectedProjectId === ALL_PROJECTS_FILTER && <Check size={14} />}
@@ -105,14 +108,18 @@ const ProjectChatSidebarProjectFilter: FC<ProjectChatSidebarProjectFilterProps> 
               key={project.id}
               selected={selectedProjectId === project.id}
               onClick={() => selectProject(project.id!)}
-              sx={{ gap: 1, fontSize: '13px' }}
+              sx={{ gap: 1, fontSize: TYPOGRAPHY.sidebar.controlFontSize }}
             >
               <Box sx={{ width: 16, display: 'inline-flex' }}>
                 {selectedProjectId === project.id && <Check size={14} />}
               </Box>
               <Typography
                 component="span"
-                sx={{ overflow: 'hidden', textOverflow: 'ellipsis', fontSize: '13px' }}
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  fontSize: TYPOGRAPHY.sidebar.controlFontSize,
+                }}
               >
                 {project.name || 'Untitled project'}
               </Typography>

--- a/frontend/src/styles/themeTokens.ts
+++ b/frontend/src/styles/themeTokens.ts
@@ -3,10 +3,29 @@ export const DARK_APP_BACKGROUND = '#0a0a0a'
 export const LIGHT_SIDEBAR_COLORS = {
   background: '#fafafa',
   foreground: '#27272a',
+  primaryLabel: 'rgba(39, 39, 42, 0.92)',
   mutedForeground: '#71717a',
+  subtleForeground: 'rgba(113, 113, 122, 0.78)',
   icon: '#a1a1aa',
   controlSurface: '#f4f4f5',
   rowHover: '#fdfdfd',
   rowSelected: '#ffffff',
   border: '#e4e4e7',
 } as const
+
+export const DARK_SIDEBAR_COLORS = {
+  background: '#000000',
+  foreground: '#f1f3f7',
+  primaryLabel: 'rgba(241, 243, 247, 0.90)',
+  mutedForeground: '#a3a3a3',
+  subtleForeground: 'rgba(163, 163, 163, 0.78)',
+  icon: '#a1a1aa',
+  controlSurface: '#0a0a0a',
+  rowHover: 'rgba(241, 243, 247, 0.08)',
+  rowSelected: 'rgba(241, 243, 247, 0.11)',
+  border: 'rgba(255, 255, 255, 0.08)',
+} as const
+
+export const getSidebarColors = (isLight: boolean) => (
+  isLight ? LIGHT_SIDEBAR_COLORS : DARK_SIDEBAR_COLORS
+)

--- a/frontend/src/styles/typography.ts
+++ b/frontend/src/styles/typography.ts
@@ -62,6 +62,23 @@ export const TYPOGRAPHY = {
   codeChromeFontSize: '0.6875rem',
 
   /**
+   * Chat sidebar hierarchy. These stay rem-based so interface scaling changes
+   * the navigation as one coherent surface rather than leaving fixed-pixel
+   * labels behind.
+   */
+  sidebar: {
+    sectionFontSize: '0.6875rem',
+    sectionLineHeight: 1,
+    primaryFontSize: '0.875rem',
+    primaryLineHeight: '1.25rem',
+    metadataFontSize: '0.75rem',
+    metadataLineHeight: '1rem',
+    controlFontSize: '0.8125rem',
+    statusFontSize: '0.6875rem',
+    statusLineHeight: 1,
+  },
+
+  /**
    * Grayscale antialiasing (thinner strokes) instead of the heavier platform
    * default. Only macOS engines honour it. `false` restores stem darkening.
    */
@@ -85,5 +102,7 @@ export const typographyCssVariables = (): Record<string, string> => ({
   '--helix-font-size-body': `${TYPOGRAPHY.bodyFontSize}px`,
   '--helix-font-size-chat': TYPOGRAPHY.chatFontSize,
   '--helix-font-size-code': `${TYPOGRAPHY.codeFontSize}px`,
+  '--helix-font-size-sidebar-primary': TYPOGRAPHY.sidebar.primaryFontSize,
+  '--helix-font-size-sidebar-metadata': TYPOGRAPHY.sidebar.metadataFontSize,
   '--helix-line-height-chat': `${TYPOGRAPHY.chatLineHeight}`,
 })


### PR DESCRIPTION
## Summary
- centralize chat-sidebar typography and contrast tokens
- use readable three-line cross-project task rows with trailing harness marks
- explain pre-implementation tasks without branches using an n/a tooltip

## Verification
- focused sidebar tests
- TypeScript compilation
- production frontend build
- live dark/light browser verification, including the branchless OpenCode planning task