### PR TITLE
fix(frontend): clarify onboarding credit usage

### DIFF
--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -24,7 +24,7 @@ const mockState = vi.hoisted(() => ({
   harnesses: [] as any[],
   onboardingHelixDefault: {
     provider: 'pe_helix',
-    model: 'helix-model',
+    model: 'qwen3.8-flash-next',
     effort: 'high',
   },
 }))
@@ -154,6 +154,7 @@ vi.mock('../components/account/CodexSubscriptionConnect', () => ({
 
 vi.mock('lucide-react', () => ({
   Bot: () => <span data-testid="bot-icon" />,
+  Coins: () => <span data-testid="coins-icon" />,
   Server: () => <span data-testid="server-icon" />,
 }))
 
@@ -200,14 +201,19 @@ describe('Onboarding', () => {
     mockState.walletBalance = 42.5
     mockState.onboardingHelixDefault = {
       provider: 'pe_helix',
-      model: 'helix-model',
+      model: 'qwen3.8-flash-next',
       effort: 'high',
     }
     mockState.providers = [{
       id: 'pe_helix',
       name: 'helix',
       status: 'ok',
-      available_models: [{ id: 'helix-model', enabled: true, type: 'chat' }],
+      available_models: [{
+        id: 'qwen3.8-flash-next',
+        model_info: { name: 'Qwen: Qwen3.8 Flash Next' },
+        enabled: true,
+        type: 'chat',
+      }],
     }]
     mockState.harnesses = [
       { runtime: 'zed_agent', enabled: true, subscription_enabled: false },
@@ -240,10 +246,16 @@ describe('Onboarding', () => {
     expect(screen.getByRole('button', { name: /helix providers/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /chatgpt subscription/i })).toBeInTheDocument()
-    expect(screen.getByText(/You have 42.50 Helix credits/)).toBeInTheDocument()
-    expect(screen.getByText(/Claude Code or Codex to use your own subscription/)).toBeInTheDocument()
-    expect(screen.getByText(/those runs do not use Helix credits/)).toBeInTheDocument()
-    expect(screen.getByText('Recommended model: helix-model')).toBeInTheDocument()
+    const balance = screen.getByLabelText('Helix credit balance')
+    expect(within(balance).getByText('42.50 Helix credits')).toBeVisible()
+    expect(within(balance).getByText(/pay for AI model usage when your coding agents run through Helix Providers/)).toBeVisible()
+    expect(screen.getByText(
+      'Helix Providers is selected by default. You can also connect Claude Code or Codex and use your own subscription. Those runs do not use Helix credits.',
+    )).toBeVisible()
+    expect(screen.queryByText(/Recommended model:/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Meet your Chief of Staff' })).toBeVisible()
+    expect(screen.getByText(/use Qwen: Qwen3.8 Flash Next by default/)).toBeVisible()
+    expect(screen.getByText(/change this later in organization settings/)).toBeVisible()
     expect(screen.queryByLabelText('Helix provider')).not.toBeInTheDocument()
     expect(screen.queryByText(/create your first project/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/create your first task/i)).not.toBeInTheDocument()
@@ -263,7 +275,7 @@ describe('Onboarding', () => {
     expect(helix).toHaveAttribute('aria-pressed', 'true')
     expect(claude).toHaveAttribute('aria-pressed', 'false')
     expect(codex).toHaveAttribute('aria-pressed', 'false')
-    expect(within(helix).getByText('Selected')).toBeVisible()
+    expect(within(helix).getByText('Selected')).toHaveStyle({ color: '#1a1a2e' })
     expect(within(claude).getByText('Select')).toBeVisible()
     expect(within(codex).getByText('Select')).toBeVisible()
 
@@ -294,7 +306,7 @@ describe('Onboarding', () => {
         code_agent_runtime: 'zed_agent',
         code_agent_credential_type: 'api_key',
         provider: 'pe_helix',
-        model: 'helix-model',
+        model: 'qwen3.8-flash-next',
         reasoning_effort: 'high',
       }),
     })
@@ -432,6 +444,9 @@ describe('Onboarding', () => {
     await goToCodingAccessStep()
 
     expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    const balance = screen.getByLabelText('Helix credit balance')
+    expect(within(balance).getByText('0.00 Helix credits')).toBeVisible()
+    expect(within(balance).getByTestId('coins-icon')).toBeVisible()
     expect(screen.getByRole('button', { name: 'Add credits' })).toBeEnabled()
     expect(screen.getByRole('combobox', { name: 'Top-up amount' })).toHaveTextContent('$5')
     expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -28,6 +28,7 @@ const mockState = vi.hoisted(() => ({
     model: 'qwen3.8-flash-next',
     effort: 'high',
   },
+  isLight: true,
 }))
 
 let mockAccountValue: any
@@ -89,6 +90,10 @@ vi.mock('../hooks/useRouter', () => ({
     replaceParams: vi.fn(),
     removeParams: vi.fn(),
   }),
+}))
+
+vi.mock('../hooks/useLightTheme', () => ({
+  default: () => ({ isLight: mockState.isLight }),
 }))
 
 vi.mock('../services/orgService', () => ({
@@ -156,7 +161,6 @@ vi.mock('../components/account/CodexSubscriptionConnect', () => ({
 vi.mock('lucide-react', () => ({
   Bot: () => <span data-testid="bot-icon" />,
   Coins: () => <span data-testid="coins-icon" />,
-  Server: () => <span data-testid="server-icon" />,
 }))
 
 function renderOnboarding() {
@@ -187,7 +191,7 @@ async function goToCodingAccessStep() {
   }
 
   await waitFor(() => {
-    expect(screen.getByText('Choose how to run coding agents')).toBeInTheDocument()
+    expect(screen.getByText('Choose how to run your agents')).toBeInTheDocument()
   })
 }
 
@@ -200,6 +204,7 @@ describe('Onboarding', () => {
     mockState.billingEnabled = true
     mockState.walletStatus = 'active'
     mockState.walletBalance = 42.5
+    mockState.isLight = true
     mockState.onboardingHelixDefault = {
       provider: 'pe_helix',
       model: 'qwen3.8-flash-next',
@@ -243,20 +248,23 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
-    expect(screen.getByRole('button', { name: /helix providers/i })).toBeInTheDocument()
+    expect(screen.getByText('Helix needs an LLM to run your agents.')).toBeVisible()
+    expect(screen.getByText(
+      'Use a Helix model or connect your Claude or ChatGPT subscription. Helix models require credits.',
+    )).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Launch Helix' })).toBeEnabled()
+    const helix = screen.getByRole('button', { name: /helix models/i })
+    expect(helix).toBeInTheDocument()
+    expect(within(helix).getByText('Use a Helix model. Add credits to get started.')).toBeVisible()
+    expect(helix.querySelector('img[src="/img/logo.png"]')).toHaveAttribute('alt', '')
     expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /chatgpt subscription/i })).toBeInTheDocument()
-    const balance = screen.getByLabelText('Helix credit balance')
+    const balance = screen.getByRole('group', { name: 'Helix credit balance' })
     expect(within(balance).getByText('42.50 Helix credits')).toBeVisible()
-    expect(within(balance).getByText(/pay for AI model usage when your coding agents run through Helix Providers/)).toBeVisible()
-    expect(screen.getByText(
-      'Helix Providers is selected by default. You can also connect Claude Code or Codex and use your own subscription. Those runs do not use Helix credits.',
-    )).toBeVisible()
+    expect(within(balance).queryByText(/pay for AI model usage/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Recommended model:/)).not.toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Meet your Chief of Staff' })).toBeVisible()
-    expect(screen.getByText(/use Qwen: Qwen3.8 Flash Next by default/)).toBeVisible()
-    expect(screen.getByText(/change this later in organization settings/)).toBeVisible()
+    expect(screen.queryByRole('heading', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.queryByText(/Qwen: Qwen3.8 Flash Next/)).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Helix provider')).not.toBeInTheDocument()
     expect(screen.queryByText(/create your first project/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/create your first task/i)).not.toBeInTheDocument()
@@ -269,7 +277,7 @@ describe('Onboarding', () => {
     expect(screen.queryByTestId('CloseIcon')).not.toBeInTheDocument()
     await goToCodingAccessStep()
 
-    const helix = screen.getByRole('button', { name: /helix providers/i })
+    const helix = screen.getByRole('button', { name: /helix models/i })
     const claude = screen.getByRole('button', { name: /claude subscription/i })
     const codex = screen.getByRole('button', { name: /chatgpt subscription/i })
 
@@ -277,6 +285,7 @@ describe('Onboarding', () => {
     expect(claude).toHaveAttribute('aria-pressed', 'false')
     expect(codex).toHaveAttribute('aria-pressed', 'false')
     expect(within(helix).getByText('Selected')).toHaveStyle({ color: '#1a1a2e' })
+    expect(within(claude).getByText('Connected')).toHaveStyle({ color: '#1a1a2e' })
     expect(within(claude).getByText('Select')).toBeVisible()
     expect(within(codex).getByText('Select')).toBeVisible()
 
@@ -296,7 +305,7 @@ describe('Onboarding', () => {
 
     await act(async () => {
       fireEvent.click(
-        screen.getByRole('button', { name: 'Meet your Chief of Staff' }),
+        screen.getByRole('button', { name: 'Launch Helix' }),
       )
     })
 
@@ -343,7 +352,7 @@ describe('Onboarding', () => {
 
     renderOnboarding()
 
-    await screen.findByText('Choose how to run coding agents')
+    await screen.findByText('Choose how to run your agents')
     expect(screen.getByRole('button', { name: /claude subscription/i })).toHaveAttribute(
       'aria-pressed',
       'true',
@@ -362,7 +371,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
 
     expect(screen.getByRole('button', { name: 'Connect Claude' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Launch Helix' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Connect Claude' })).toHaveAttribute(
       'data-enable-for-org-id',
       'org-1',
@@ -376,7 +385,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: /chatgpt subscription/i }))
 
     expect(screen.getByRole('button', { name: 'Connect ChatGPT' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Launch Helix' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Connect ChatGPT' })).toHaveAttribute(
       'data-enable-for-org-id',
       'org-1',
@@ -395,7 +404,7 @@ describe('Onboarding', () => {
     fireEvent.mouseDown(screen.getByLabelText('Codex model'))
     fireEvent.click(screen.getByRole('option', { name: 'GPT-5.6 Terra' }))
     const continueButton = screen.getByRole('button', {
-      name: 'Meet your Chief of Staff',
+      name: 'Launch Helix',
     })
     expect(continueButton).toBeEnabled()
 
@@ -464,7 +473,9 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Launch Helix' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
+    expect(screen.getByText(/selected Helix model is not available/)).toBeVisible()
   })
 
   it('offers credits and provider connections instead of Chief of Staff when balance is zero', async () => {
@@ -476,10 +487,11 @@ describe('Onboarding', () => {
     renderOnboarding()
     await goToCodingAccessStep()
 
-    expect(screen.queryByRole('button', { name: 'Meet your Chief of Staff' })).not.toBeInTheDocument()
-    const balance = screen.getByLabelText('Helix credit balance')
-    expect(within(balance).getByText('0.00 Helix credits')).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Launch Helix' })).not.toBeInTheDocument()
+    const balance = screen.getByRole('group', { name: 'Helix credit balance' })
+    expect(within(balance).getByText('0.00 Helix credits')).toHaveStyle({ color: '#c2410c' })
     expect(within(balance).getByTestId('coins-icon')).toBeVisible()
+    expect(within(balance).getByTestId('coins-icon').parentElement).toHaveStyle({ color: '#c2410c' })
     expect(screen.getByRole('button', { name: 'Add credits' })).toBeEnabled()
     expect(screen.getByRole('combobox', { name: 'Top-up amount' })).toHaveTextContent('$5')
     expect(screen.getByRole('button', { name: /claude subscription/i })).toBeInTheDocument()
@@ -494,6 +506,17 @@ describe('Onboarding', () => {
       return_url: '/onboarding?org_id=org-1&step=provider',
     })
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('retains accent labels in dark mode', async () => {
+    mockState.isLight = false
+    renderOnboarding()
+    await goToCodingAccessStep()
+
+    const helix = screen.getByRole('button', { name: /helix models/i })
+    const claude = screen.getByRole('button', { name: /claude subscription/i })
+    expect(within(helix).getByText('Selected')).toHaveStyle({ color: '#00e891' })
+    expect(within(claude).getByText('Connected')).toHaveStyle({ color: '#00e891' })
   })
 
   it('preserves newly-created organization context through top-up checkout', async () => {
@@ -538,7 +561,7 @@ describe('Onboarding', () => {
     await goToCodingAccessStep()
 
     fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
-    const button = await screen.findByRole('button', { name: 'Meet your Chief of Staff' })
+    const button = await screen.findByRole('button', { name: 'Launch Helix' })
     fireEvent.click(button)
 
     await waitFor(() => expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(
@@ -563,7 +586,7 @@ describe('Onboarding', () => {
     await goToCodingAccessStep()
 
     fireEvent.click(screen.getByRole('button', { name: /chatgpt subscription/i }))
-    const button = await screen.findByRole('button', { name: 'Meet your Chief of Staff' })
+    const button = await screen.findByRole('button', { name: 'Launch Helix' })
     fireEvent.click(button)
 
     await waitFor(() => expect(mockV1OrgsSettingsUpdate).toHaveBeenCalledWith(
@@ -587,8 +610,8 @@ describe('Onboarding', () => {
     )
     renderOnboarding()
 
-    await screen.findByText('Choose how to run coding agents')
-    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+    await screen.findByText('Choose how to run your agents')
+    expect(screen.getByRole('button', { name: 'Launch Helix' })).toBeEnabled()
     expect(mockRefetchWallet).toHaveBeenCalled()
     expect(window.location.search).toBe('?org_id=org-1&step=provider&created_org=true')
   })
@@ -607,7 +630,7 @@ describe('Onboarding', () => {
     expect(screen.getByText(
       'Ask an organization owner to set the Default Runtime.',
     )).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Launch Helix' })).toBeDisabled()
     expect(mockUpdateHarnesses).not.toHaveBeenCalled()
   })
 
@@ -622,7 +645,7 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: /claude subscription/i }))
     fireEvent.mouseDown(screen.getByLabelText('Claude model'))
     fireEvent.click(screen.getByRole('option', { name: /Claude Fable 5/i }))
-    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Helix' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
       'org_bot_session',
@@ -648,9 +671,9 @@ describe('Onboarding', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create organization' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Launch Helix' })).toBeEnabled()
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Helix' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
       'org_bot_session',
@@ -700,9 +723,9 @@ describe('Onboarding', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Meet your Chief of Staff' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Launch Helix' })).toBeEnabled()
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Meet your Chief of Staff' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Launch Helix' }))
 
     await waitFor(() => expect(mockNavigateReplace).toHaveBeenCalledWith(
       'org_bot_session',

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -22,7 +22,7 @@ import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import BusinessIcon from "@mui/icons-material/Business";
 import PersonIcon from "@mui/icons-material/Person";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
-import { Server } from "lucide-react";
+import { Coins, Server } from "lucide-react";
 
 import useAccount from "../hooks/useAccount";
 import useApi from "../hooks/useApi";
@@ -264,6 +264,7 @@ export default function Onboarding() {
   const selectedHelixProvider = helixProviders.find((provider) => providerRef(provider) === helixProvider);
   const helixModels = (selectedHelixProvider?.available_models || []).filter((model) =>
     model.id && model.enabled && (!model.type || model.type === "chat" || model.type === "text"));
+  const selectedHelixModel = helixModels.find((model) => model.id === helixModel);
   const helixDefaultAvailable = !!selectedHelixProvider
     && helixModels.some((model) => model.id === helixModel);
   const hasConfiguredHelixDefault = !!serverConfig?.onboarding_helix_model_provider
@@ -1105,21 +1106,42 @@ export default function Onboarding() {
                   mb: 2,
                 }}
               >
-                Helix Providers is selected by default. You can instead connect
-                Claude Code or Codex to use your own subscription; those runs do
-                not use Helix credits.
+                Helix Providers is selected by default. You can also connect
+                Claude Code or Codex and use your own subscription. Those runs
+                do not use Helix credits.
               </Typography>
-              {wallet && (
-                <Typography
+              {codingAccessOption === "helix" && wallet && (
+                <Box
+                  aria-label="Helix credit balance"
                   sx={{
-                    color: palette.TEXT_SECONDARY,
-                    fontSize: "0.85rem",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.25,
+                    p: 1.5,
+                    borderRadius: 1.5,
+                    border: `1px solid ${palette.CARD_BORDER}`,
+                    bgcolor: palette.OVERLAY_FAINT,
                     mb: 2,
                   }}
                 >
-                  You have {wallet.balance?.toFixed(2) || "0.00"} Helix credits.
-                  Helix credits pay for AI model usage through Helix Providers.
-                </Typography>
+                  <Box sx={{ color: hasHelixCredits ? ACCENT : "warning.main", display: "flex" }}>
+                    <Coins size={22} />
+                  </Box>
+                  <Box>
+                    <Typography
+                      sx={{
+                        color: hasHelixCredits ? palette.TEXT_PRIMARY : "warning.main",
+                        fontSize: "1.1rem",
+                        fontWeight: 700,
+                      }}
+                    >
+                      {wallet.balance?.toFixed(2) || "0.00"} Helix credits
+                    </Typography>
+                    <Typography sx={{ color: palette.TEXT_FADED, fontSize: "0.8rem", mt: 0.25 }}>
+                      Helix credits pay for AI model usage when your coding agents run through Helix Providers.
+                    </Typography>
+                  </Box>
+                </Box>
               )}
               {codingAccessOption === "helix" && !inventoryLoading && helixProvider && helixModel && !helixDefaultAvailable && (
                 <Typography color="error" sx={{ fontSize: "0.82rem", mb: 2 }}>
@@ -1234,7 +1256,9 @@ export default function Onboarding() {
                       )}
                       <Typography
                         sx={{
-                          color: ACCENT,
+                          color: selected && lightTheme.isLight
+                            ? palette.TEXT_PRIMARY
+                            : ACCENT,
                           fontSize: "0.8rem",
                           fontWeight: 700,
                           mt: "auto",
@@ -1259,11 +1283,11 @@ export default function Onboarding() {
                         bgcolor: palette.OVERLAY_FAINT,
                       }}
                     >
-                      <Typography sx={{ color: palette.TEXT_PRIMARY, fontSize: "0.85rem", fontWeight: 600 }}>
-                        Recommended model: {helixModel}
+                      <Typography component="h3" sx={{ color: palette.TEXT_PRIMARY, fontSize: "0.85rem", fontWeight: 600 }}>
+                        Meet your Chief of Staff
                       </Typography>
                       <Typography sx={{ color: palette.TEXT_FADED, fontSize: "0.8rem", mt: 0.5 }}>
-                        Helix has selected the provider and reasoning settings for you.
+                        Your Chief of Staff will use {selectedHelixModel?.model_info?.name || selectedHelixModel?.name || helixModel} by default. You can change this later in organization settings.
                       </Typography>
                     </Box>
                   ) : (

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -23,7 +23,7 @@ import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import BusinessIcon from "@mui/icons-material/Business";
 import PersonIcon from "@mui/icons-material/Person";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
-import { Coins, Server } from "lucide-react";
+import { Coins } from "lucide-react";
 
 import useAccount from "../hooks/useAccount";
 import useApi from "../hooks/useApi";
@@ -105,7 +105,7 @@ function getOnboardingPalette(isLight: boolean) {
       "&.Mui-focused fieldset": { borderColor: ACCENT },
     },
     labelSx: { color: isLight ? "rgba(0,0,0,0.55)" : "rgba(255,255,255,0.7)", fontSize: "0.82rem" },
-    helperSx: { color: isLight ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.7)", fontSize: "0.8rem" },
+    helperSx: { color: isLight ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.7)", fontSize: "0.72rem" },
     selectSx: {
       color: isLight ? "#1a1a2e" : "#fff",
       fontSize: "0.82rem",
@@ -200,9 +200,9 @@ const ALL_STEPS: StepConfig[] = [
   },
   {
     type: "provider",
-    icon: <Server size={20} />,
-    title: "Choose how to run coding agents",
-    subtitle: "Use Helix credits or connect an existing coding subscription.",
+    icon: <img src="/img/logo.png" alt="" width={20} height={20} />,
+    title: "Choose how to run your agents",
+    subtitle: "Helix needs an LLM to run your agents.",
   },
 ];
 
@@ -287,7 +287,6 @@ export default function Onboarding() {
   const selectedHelixProvider = helixProviders.find((provider) => providerRef(provider) === helixProvider);
   const helixModels = (selectedHelixProvider?.available_models || []).filter((model) =>
     model.id && model.enabled && (!model.type || model.type === "chat" || model.type === "text"));
-  const selectedHelixModel = helixModels.find((model) => model.id === helixModel);
   const helixDefaultAvailable = !!selectedHelixProvider
     && helixModels.some((model) => model.id === helixModel);
   const hasConfiguredHelixDefault = !!serverConfig?.onboarding_helix_model_provider
@@ -884,7 +883,7 @@ export default function Onboarding() {
                         sx={{
                           color: palette.TEXT_PRIMARY,
                           fontWeight: 500,
-                          fontSize: "0.82rem",
+                          fontSize: "0.78rem",
                         }}
                       >
                         Existing organization
@@ -893,7 +892,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.7rem",
                       }}
                     >
                       Use one of your organizations
@@ -934,7 +933,7 @@ export default function Onboarding() {
                         sx={{
                           color: palette.TEXT_PRIMARY,
                           fontWeight: 500,
-                          fontSize: "0.82rem",
+                          fontSize: "0.78rem",
                         }}
                       >
                         New organization
@@ -943,7 +942,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.7rem",
                       }}
                     >
                       Create a new organization
@@ -1091,7 +1090,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.75rem",
                         mb: 0.5,
                       }}
                     >
@@ -1100,7 +1099,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.75rem",
                         mb: 0.5,
                       }}
                     >
@@ -1110,7 +1109,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.75rem",
                         mb: 0.5,
                       }}
                     >
@@ -1122,7 +1121,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.75rem",
                         mb: 0.5,
                       }}
                     >
@@ -1134,7 +1133,7 @@ export default function Onboarding() {
                     <Typography
                       sx={{
                         color: palette.TEXT_DIM,
-                        fontSize: "0.8rem",
+                        fontSize: "0.75rem",
                       }}
                     >
                       Current balance: ${wallet.balance?.toFixed(2) || "0.00"}{" "}
@@ -1206,7 +1205,7 @@ export default function Onboarding() {
                   sx={{
                     color: palette.TEXT_DIM,
                     textTransform: "none",
-                    fontSize: "0.82rem",
+                    fontSize: "0.78rem",
                     "&:hover": { color: palette.TEXT_SECONDARY },
                   }}
                 >
@@ -1220,6 +1219,7 @@ export default function Onboarding() {
       case "provider": {
         const inventoryLoading = providersLoading || harnessesLoading;
         const hasHelixCredits = !serverConfig?.billing_enabled || (wallet?.balance ?? 0) > 0;
+        const zeroCreditColor = lightTheme.isLight ? "#c2410c" : "warning.main";
         const hasSelectedAccess =
           (codingAccessOption === "helix" && hasHelixCredits && helixDefaultAvailable) ||
           (codingAccessOption === "claude" && hasClaudeSubscription) ||
@@ -1245,9 +1245,8 @@ export default function Onboarding() {
         }> = [
           {
             id: "helix",
-            title: "Helix Providers",
-            description:
-              "Use Helix credits for coding models. No external account required.",
+            title: "Helix Models",
+            description: "Use a Helix model. Add credits to get started.",
           },
           {
             id: "claude",
@@ -1269,16 +1268,16 @@ export default function Onboarding() {
               <Typography
                 sx={{
                   color: palette.TEXT_SECONDARY,
-                  fontSize: "0.85rem",
+                  fontSize: "0.78rem",
                   mb: 2,
                 }}
               >
-                Helix Providers is selected by default. You can also connect
-                Claude Code or Codex and use your own subscription. Those runs
-                do not use Helix credits.
+                Use a Helix model or connect your Claude or ChatGPT subscription.
+                Helix models require credits.
               </Typography>
               {codingAccessOption === "helix" && wallet && (
                 <Box
+                  role="group"
                   aria-label="Helix credit balance"
                   sx={{
                     display: "flex",
@@ -1291,32 +1290,27 @@ export default function Onboarding() {
                     mb: 2,
                   }}
                 >
-                  <Box sx={{ color: hasHelixCredits ? ACCENT : "warning.main", display: "flex" }}>
+                  <Box sx={{ color: hasHelixCredits ? ACCENT : zeroCreditColor, display: "flex" }}>
                     <Coins size={22} />
                   </Box>
-                  <Box>
-                    <Typography
-                      sx={{
-                        color: hasHelixCredits ? palette.TEXT_PRIMARY : "warning.main",
-                        fontSize: "1.1rem",
-                        fontWeight: 700,
-                      }}
-                    >
-                      {wallet.balance?.toFixed(2) || "0.00"} Helix credits
-                    </Typography>
-                    <Typography sx={{ color: palette.TEXT_FADED, fontSize: "0.8rem", mt: 0.25 }}>
-                      Helix credits pay for AI model usage when your coding agents run through Helix Providers.
-                    </Typography>
-                  </Box>
+                  <Typography
+                    sx={{
+                      color: hasHelixCredits ? palette.TEXT_PRIMARY : zeroCreditColor,
+                      fontSize: "1.1rem",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {wallet.balance?.toFixed(2) || "0.00"} Helix credits
+                  </Typography>
                 </Box>
               )}
               {codingAccessOption === "helix" && !inventoryLoading && helixProvider && helixModel && !helixDefaultAvailable && (
-                <Typography color="error" sx={{ fontSize: "0.82rem", mb: 2 }}>
+                <Typography color="error" sx={{ fontSize: "0.78rem", mb: 2 }}>
                   The selected Helix model is not available for Zed Agent in this organization.
                 </Typography>
               )}
               {!inventoryLoading && !createdOrg?.viewer_is_owner && (
-                <Typography color="error" sx={{ fontSize: "0.82rem", mb: 2 }}>
+                <Typography color="error" sx={{ fontSize: "0.78rem", mb: 2 }}>
                   Ask an organization owner to set the Default Runtime.
                 </Typography>
               )}
@@ -1368,9 +1362,11 @@ export default function Onboarding() {
                         }}
                       >
                         {option.id === "helix" ? (
-                          <Server
-                            size={18}
-                            color={selected ? ACCENT : palette.TEXT_FADED}
+                          <Box
+                            component="img"
+                            src="/img/logo.png"
+                            alt=""
+                            sx={{ width: 18, height: 18, objectFit: "contain" }}
                           />
                         ) : option.id === "claude" ? (
                           <AnthropicLogo
@@ -1392,7 +1388,7 @@ export default function Onboarding() {
                           sx={{
                             color: palette.TEXT_PRIMARY,
                             fontWeight: 600,
-                            fontSize: "0.85rem",
+                            fontSize: "0.78rem",
                           }}
                         >
                           {option.title}
@@ -1401,7 +1397,7 @@ export default function Onboarding() {
                       <Typography
                         sx={{
                           color: palette.TEXT_FADED,
-                          fontSize: "0.8rem",
+                          fontSize: "0.68rem",
                           lineHeight: 1.45,
                         }}
                       >
@@ -1411,9 +1407,11 @@ export default function Onboarding() {
                         <Typography
                           sx={{
                             color: option.connected
-                              ? ACCENT
+                              ? lightTheme.isLight
+                                ? palette.TEXT_PRIMARY
+                                : ACCENT
                               : palette.TEXT_DIM,
-                            fontSize: "0.8rem",
+                            fontSize: "0.65rem",
                             fontWeight: 600,
                             mt: 0.75,
                           }}
@@ -1426,7 +1424,7 @@ export default function Onboarding() {
                           color: selected && lightTheme.isLight
                             ? palette.TEXT_PRIMARY
                             : ACCENT,
-                          fontSize: "0.8rem",
+                          fontSize: "0.65rem",
                           fontWeight: 700,
                           mt: "auto",
                           pt: 1,
@@ -1439,26 +1437,8 @@ export default function Onboarding() {
                 })}
               </Box>
 
-              {codingAccessOption === "helix" && (
+              {codingAccessOption === "helix" && !hasConfiguredHelixDefault && (
                 <Stack spacing={2} sx={{ mb: 2 }}>
-                  {hasConfiguredHelixDefault ? (
-                    <Box
-                      sx={{
-                        p: 1.5,
-                        borderRadius: 1.5,
-                        border: `1px solid ${palette.BORDER_SUBTLE}`,
-                        bgcolor: palette.OVERLAY_FAINT,
-                      }}
-                    >
-                      <Typography component="h3" sx={{ color: palette.TEXT_PRIMARY, fontSize: "0.85rem", fontWeight: 600 }}>
-                        Meet your Chief of Staff
-                      </Typography>
-                      <Typography sx={{ color: palette.TEXT_FADED, fontSize: "0.8rem", mt: 0.5 }}>
-                        Your Chief of Staff will use {selectedHelixModel?.model_info?.name || selectedHelixModel?.name || helixModel} by default. You can change this later in organization settings.
-                      </Typography>
-                    </Box>
-                  ) : (
-                    <>
                   <FormControl fullWidth>
                     <InputLabel id="onboarding-helix-provider-label">Helix provider</InputLabel>
                     <Select
@@ -1506,8 +1486,6 @@ export default function Onboarding() {
                       <MenuItem value="high">High</MenuItem>
                     </Select>
                   </FormControl>
-                    </>
-                  )}
                 </Stack>
               )}
 
@@ -1524,7 +1502,7 @@ export default function Onboarding() {
                   <Typography
                     sx={{
                       color: palette.TEXT_SECONDARY,
-                      fontSize: "0.8rem",
+                      fontSize: "0.75rem",
                       mb: 1,
                     }}
                   >
@@ -1567,7 +1545,7 @@ export default function Onboarding() {
                   <Typography
                     sx={{
                       color: palette.TEXT_SECONDARY,
-                      fontSize: "0.8rem",
+                      fontSize: "0.75rem",
                       mb: 1,
                     }}
                   >
@@ -1634,7 +1612,7 @@ export default function Onboarding() {
                   {finishingOnboarding
                     ? "Finishing setup..."
                     : shouldMeetChiefOfStaff
-                      ? "Meet your Chief of Staff"
+                      ? "Launch Helix"
                       : continueLabel}
                 </Button>
               ) : null}
@@ -1754,7 +1732,7 @@ export default function Onboarding() {
                       <Typography
                         sx={{
                           color: completed || active ? palette.TEXT_SECONDARY : palette.TEXT_DIM,
-                          fontSize: "0.82rem",
+                          fontSize: "0.76rem",
                           mt: 0.2,
                         }}
                       >


### PR DESCRIPTION
## Summary

- explain that Helix models require credits and keep a zero balance prominent
- use the sales-call language, remove the model recommendation, and finish with Launch Helix
- restore compact Helix typography and fix light/dark contrast and balance accessibility

## Screenshots

### Light mode - zero credits

![Compact light mode with zero credits](https://github.com/user-attachments/assets/c335b19e-4299-4354-b9ba-ccb039772a74)

### Dark mode - zero credits

![Compact dark mode with zero credits](https://github.com/user-attachments/assets/47088f2d-b248-4151-826c-deb3d17f3d78)

### Light mode - funded

![Compact light mode with Launch Helix](https://github.com/user-attachments/assets/685db710-1d7a-4afe-9362-4ad6fac4c6a6)

## Verification

- yarn test Onboarding.test.tsx --run (21 tests passed)
- Docker Linux frontend production build passed
- standalone Playwright verification at 1440x900 in light and dark modes