### PR TITLE
fix(frontend): reposition agents task view

### DIFF
--- a/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.test.tsx
@@ -36,9 +36,22 @@ describe("SpecTaskViewToolbar", () => {
       <SpecTaskViewToolbar currentView="chat" onViewChange={vi.fn()} hasSession showChatTab />,
     );
 
-    for (const label of ["Chat", "Agents", "Desktop", "Browser", "Diff", "Files", "Details"]) {
+    for (const label of ["Chat", "Desktop", "Browser", "Diff", "Files", "Agents", "Details"]) {
       expect(screen.getByRole("button", { name: `${label} view` })).toBeInTheDocument();
     }
+    expect(
+      screen.getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label"))
+        .filter((label) => label?.endsWith(" view")),
+    ).toEqual([
+      "Chat view",
+      "Desktop view",
+      "Browser view",
+      "Diff view",
+      "Files view",
+      "Agents view",
+      "Details view",
+    ]);
   });
 
   it("folds the deliberate views into the menu on a phone", () => {
@@ -54,17 +67,17 @@ describe("SpecTaskViewToolbar", () => {
     );
 
     // Only the views you flick between stay inline.
-    for (const label of ["Chat", "Agents", "Browser", "Diff"]) {
+    for (const label of ["Chat", "Browser", "Diff"]) {
       expect(screen.getByRole("button", { name: `${label} view` })).toBeInTheDocument();
     }
-    for (const label of ["Desktop", "Files", "Details"]) {
+    for (const label of ["Desktop", "Files", "Agents", "Details"]) {
       expect(screen.queryByRole("button", { name: `${label} view` })).not.toBeInTheDocument();
     }
 
     fireEvent.click(screen.getByRole("button", { name: "More actions" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Files" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Agents" }));
 
-    expect(onViewChange).toHaveBeenCalledWith("files");
+    expect(onViewChange).toHaveBeenCalledWith("agents");
   });
 
   it("drops the close button on a phone, where the panel is the whole screen", () => {

--- a/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
+++ b/frontend/src/components/tasks/SpecTaskViewToolbar.tsx
@@ -113,7 +113,7 @@ interface ViewTab {
   chatOnly?: boolean;
   /**
    * Folded into the overflow menu on a phone. Six tabs plus the lifecycle
-   * controls do not fit across 390px, and these three are the ones you visit
+   * controls do not fit across 390px, and these views are the ones you visit
    * deliberately rather than flick between.
    */
   foldOnPhone?: boolean;
@@ -127,11 +127,11 @@ const VIEW_TABS: ViewTab[] = [
     sessionOnly: true,
     chatOnly: true,
   },
-  { value: "agents", label: "Agents", icon: Bot, sessionOnly: true },
   { value: "desktop", label: "Desktop", icon: MonitorPlay, sessionOnly: true, foldOnPhone: true },
   { value: "browser", label: "Browser", icon: Globe2, sessionOnly: true },
   { value: "changes", label: "Diff", icon: GitCompare, sessionOnly: true },
   { value: "files", label: "Files", icon: Files, sessionOnly: true, foldOnPhone: true },
+  { value: "agents", label: "Agents", icon: Bot, sessionOnly: true, foldOnPhone: true },
   {
     value: "details",
     label: "Details",


### PR DESCRIPTION
## Summary
- place Agents immediately to the right of Files in the desktop task toolbar
- fold Agents into the vertical-dot menu on phone layouts
- cover desktop ordering and mobile menu navigation

## Verification
- focused toolbar tests: 4 passed
- TypeScript project build
- production frontend build
- authenticated inner-Helix browser check at 1600px and 390px