### PR TITLE
Enforce organization scope for organization API keys

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -268,6 +268,9 @@ func (s *HelixAPIServer) listAgents(_ http.ResponseWriter, r *http.Request) ([]*
 	ctx := r.Context()
 	user := getRequestUser(r)
 	orgID := r.URL.Query().Get("organization_id") // If filtering for a specific organization
+	if orgID == "" && user.TokenType == types.TokenTypeAPIKey {
+		orgID = user.OrganizationID
+	}
 
 	if orgID != "" {
 		orgApps, err := s.listOrganizationApps(ctx, user, orgID)

--- a/api/pkg/server/auth_middleware.go
+++ b/api/pkg/server/auth_middleware.go
@@ -226,7 +226,10 @@ func (auth *authMiddleware) getUserFromToken(ctx context.Context, token string) 
 		user.APIKeyType = apiKey.Type
 		user.ID = apiKey.Owner
 		user.Type = apiKey.OwnerType
-		user.Admin = auth.isAdminWithContext(ctx, user.ID)
+		// Organization-scoped credentials must not inherit the creator's global
+		// administrator privileges. Their authority is bounded by the organization
+		// recorded on the key, regardless of who created it.
+		user.Admin = apiKey.OrganizationID == "" && auth.isAdminWithContext(ctx, user.ID)
 		if apiKey.AppID != nil && apiKey.AppID.Valid {
 			user.AppID = apiKey.AppID.String
 		}

--- a/api/pkg/server/auth_middleware_test.go
+++ b/api/pkg/server/auth_middleware_test.go
@@ -27,6 +27,29 @@ func TestIsAdminWithContext_EmptyUserID(t *testing.T) {
 	assert.False(t, result, "empty userID should return false")
 }
 
+func TestGetUserFromToken_OrganizationAPIKeyDoesNotInheritAdmin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	key := types.APIKeyPrefix + "org-scoped"
+
+	mockStore.EXPECT().GetAPIKey(gomock.Any(), &types.ApiKey{Key: key}).Return(&types.ApiKey{
+		Key: key, Owner: "admin-user", OwnerType: types.OwnerTypeUser, OrganizationID: "org-1",
+	}, nil)
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "admin-user"}).Return(&types.User{
+		ID: "admin-user", Admin: true,
+	}, nil)
+	mockStore.EXPECT().EnsureUserMeta(gomock.Any(), types.UserMeta{ID: "admin-user"}).Return(&types.UserMeta{}, nil)
+
+	auth := newAuthMiddleware(nil, nil, mockStore, authMiddlewareConfig{
+		adminUserIDs: []string{"admin-user"},
+	}, nil, nil)
+
+	user, err := auth.getUserFromToken(context.Background(), key)
+	assert.NoError(t, err)
+	assert.False(t, user.Admin)
+	assert.Equal(t, "org-1", user.OrganizationID)
+}
+
 func TestIsAdminWithContext_DevMode_EveryoneIsAdmin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/api/pkg/server/authz.go
+++ b/api/pkg/server/authz.go
@@ -19,11 +19,17 @@ func (apiServer *HelixAPIServer) orgAuthorizer() *orgstore.Authorizer {
 
 // authorizeOrgOwner checks if the user is an owner of the organization.
 func (apiServer *HelixAPIServer) authorizeOrgOwner(ctx context.Context, user *types.User, orgID string) (*types.OrganizationMembership, error) {
+	if err := enforceKeyOrganizationScope(user, orgID); err != nil {
+		return nil, err
+	}
 	return apiServer.orgAuthorizer().AuthorizeOrgOwner(ctx, user, orgID)
 }
 
 // authorizeOrgMember checks if the user is a member of the organization.
 func (apiServer *HelixAPIServer) authorizeOrgMember(ctx context.Context, user *types.User, orgID string) (*types.OrganizationMembership, error) {
+	if err := enforceKeyOrganizationScope(user, orgID); err != nil {
+		return nil, err
+	}
 	return apiServer.orgAuthorizer().AuthorizeOrgMember(ctx, user, orgID)
 }
 
@@ -65,6 +71,9 @@ func (apiServer *HelixAPIServer) authorizeUserToAppAccessGrants(ctx context.Cont
 // authorizeUserToApp checks if a user has access to an app
 // This is a server-level method that centralizes the authorization logic
 func (apiServer *HelixAPIServer) authorizeUserToApp(ctx context.Context, user *types.User, app *types.App, action types.Action) error {
+	if err := enforceKeyOrganizationScope(user, app.OrganizationID); err != nil {
+		return err
+	}
 	// If the organization ID is not set and the user is not the app owner, then error
 	if app.OrganizationID == "" {
 		// This is the old style app logic, where the app is owned by a user and optionally made global
@@ -156,6 +165,15 @@ func (apiServer *HelixAPIServer) authorizeUserToProjectByID(ctx context.Context,
 // against a different project.
 var errProjectScopedKey = errors.New("credential is scoped to another project")
 
+var errOrganizationScopedKey = errors.New("credential is scoped to another organization")
+
+func enforceKeyOrganizationScope(user *types.User, organizationID string) error {
+	if user == nil || user.TokenType != types.TokenTypeAPIKey || user.OrganizationID == "" || user.OrganizationID == organizationID {
+		return nil
+	}
+	return fmt.Errorf("%w: key is scoped to organization %s, request targets %s", errOrganizationScopedKey, user.OrganizationID, organizationID)
+}
+
 // enforceKeyProjectScope confines a project-scoped credential to its own
 // project.
 //
@@ -179,6 +197,9 @@ func enforceKeyProjectScope(user *types.User, projectID string) error {
 }
 
 func (apiServer *HelixAPIServer) authorizeUserToProject(ctx context.Context, user *types.User, project *types.Project, action types.Action) error {
+	if err := enforceKeyOrganizationScope(user, project.OrganizationID); err != nil {
+		return err
+	}
 	// Scope check first: a project-scoped key must not reach another project
 	// even when its owner would otherwise be authorized.
 	if err := enforceKeyProjectScope(user, project.ID); err != nil {
@@ -222,6 +243,9 @@ func (apiServer *HelixAPIServer) authorizeUserToProject(ctx context.Context, use
 }
 
 func (apiServer *HelixAPIServer) authorizeUserToRepository(ctx context.Context, user *types.User, repository *types.GitRepository, action types.Action) error {
+	if err := enforceKeyOrganizationScope(user, repository.OrganizationID); err != nil {
+		return err
+	}
 	// If the organization ID is not set, only the owner can access
 	if repository.OrganizationID == "" {
 		if user.ID == repository.OwnerID {
@@ -284,6 +308,9 @@ func (apiServer *HelixAPIServer) authorizeUserToRepository(ctx context.Context, 
 }
 
 func (apiServer *HelixAPIServer) authorizeUserToSession(ctx context.Context, user *types.User, session *types.Session, action types.Action) error {
+	if err := enforceKeyOrganizationScope(user, session.OrganizationID); err != nil {
+		return err
+	}
 	// If the organization ID is not set and the user is not the project owner, then error
 	if session.OrganizationID == "" {
 		// This is the old style project logic, where the project is owned by a user and optionally made global
@@ -332,5 +359,8 @@ func (apiServer *HelixAPIServer) authorizeUserToSession(ctx context.Context, use
 // authorizeUserToResource evaluates the user's team + direct access grants for a
 // resource. Delegates to the shared orgstore authorizer.
 func (apiServer *HelixAPIServer) authorizeUserToResource(ctx context.Context, user *types.User, orgID, resourceID string, resourceType types.Resource, action types.Action) error {
+	if err := enforceKeyOrganizationScope(user, orgID); err != nil {
+		return err
+	}
 	return apiServer.orgAuthorizer().AuthorizeUserToResource(ctx, user, orgID, resourceID, resourceType, action)
 }

--- a/api/pkg/server/authz_test.go
+++ b/api/pkg/server/authz_test.go
@@ -460,6 +460,26 @@ func (s *AuthzAppSuite) TestNoOrg_OwnerAllowed() {
 	s.NoError(err)
 }
 
+func (s *AuthzAppSuite) TestOrganizationKeyCannotAccessPersonalApp() {
+	app := &types.App{ID: "app1", Owner: s.userID}
+	user := &types.User{
+		ID: s.userID, TokenType: types.TokenTypeAPIKey, OrganizationID: s.orgID,
+	}
+
+	err := s.server.authorizeUserToApp(context.Background(), user, app, types.ActionGet)
+	s.ErrorIs(err, errOrganizationScopedKey)
+}
+
+func (s *AuthzAppSuite) TestOrganizationKeyCannotAccessAnotherOrganization() {
+	app := &types.App{ID: "app1", Owner: s.userID, OrganizationID: "org-other"}
+	user := &types.User{
+		ID: s.userID, TokenType: types.TokenTypeAPIKey, OrganizationID: s.orgID,
+	}
+
+	err := s.server.authorizeUserToApp(context.Background(), user, app, types.ActionGet)
+	s.ErrorIs(err, errOrganizationScopedKey)
+}
+
 func (s *AuthzAppSuite) TestNoOrg_NonOwnerDenied() {
 	app := &types.App{ID: "app1", Owner: "someone_else"}
 	user := &types.User{ID: s.userID}

--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -339,6 +339,9 @@ func (s *HelixAPIServer) listGitRepositories(w http.ResponseWriter, r *http.Requ
 	projectID := r.URL.Query().Get("project_id")
 
 	user := getRequestUser(r)
+	if orgID == "" && user.TokenType == types.TokenTypeAPIKey {
+		orgID = user.OrganizationID
+	}
 
 	var orgMembership *types.OrganizationMembership
 	if orgID != "" {

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -46,6 +46,9 @@ func (s *HelixAPIServer) listProjects(_ http.ResponseWriter, r *http.Request) ([
 	user := getRequestUser(r)
 
 	orgID := r.URL.Query().Get("organization_id")
+	if orgID == "" && user.TokenType == types.TokenTypeAPIKey {
+		orgID = user.OrganizationID
+	}
 
 	if orgID != "" {
 		return s.listOrganizationProjects(r.Context(), user, orgID)

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -206,6 +206,9 @@ func (apiServer *HelixAPIServer) listSessions(_ http.ResponseWriter, req *http.R
 
 	// Extract organization_id query parameter if present
 	orgID := req.URL.Query().Get("org_id")
+	if orgID == "" && user.TokenType == types.TokenTypeAPIKey {
+		orgID = user.OrganizationID
+	}
 	if orgID != "" {
 		// Lookup org
 		org, err := apiServer.lookupOrg(ctx, orgID)


### PR DESCRIPTION
## Summary
Organization API keys now enforce the organization recorded on the credential, regardless of the permissions of the user who created the key. Organization-scoped credentials no longer inherit global administrator privileges, cannot access personal resources or resources in another organization, and default unfiltered project, session, repository, and agent listings to their organization. The restriction applies to existing organization keys without requiring migration or rotation.

## Testing
Added regression coverage proving that organization API keys do not inherit administrator access and cannot access personal or cross-organization resources. Focused server authentication, authorization, and listing tests pass. The complete server package was also run; only two pre-existing SQLite tests failed because the environment uses `CGO_ENABLED=0`, which causes the standard go-sqlite3 stub error.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/probably/projects/prj_01m0e1w5d39dy6j90ydthcnk1x/tasks/spt_01m1xy2xy0xqt51vpjk2jrm6ka)

🚀 Built with [Helix](https://helix.ml)